### PR TITLE
Underlying Space Refactoring

### DIFF
--- a/notes/size-resolution.md
+++ b/notes/size-resolution.md
@@ -20,3 +20,20 @@ between bars) so we can't compute a scale function right away. Instead, we assum
 some linear scale factor (data could be scaled using a non-linear scale function before this) and we have to figure
 out how to scale the shapes that are being placed by creating a function from the scale factor to
 the output size if we use that scale factor. Then we solve.
+
+A shape can have three kinds of sizes:
+
+- fixed (eg, `rect({w: 10})`)
+- inferred (eg, `rect({w: undefined})`)
+- data-driven (eg, `rect({w: 'foo'})`)
+
+These correspond to three kinds of intrinsic sizes
+
+- fixed. constant, non-zero size, no dependency on scale factor
+- inferred. constant, zero size, no dependency on scale factor (this seems a bit weird and may be
+  changed later)
+- data-driven. size depends on scale factor
+
+In truth, data-driven sizes seem to act like the inferred case as well, because they can take on any
+size given to them (although they sometimes have a minimum size, such as a spread operator where
+even if the shapes have 0 size, the spacing between the shapes yields some minimum overall size)

--- a/notes/size-resolution.md
+++ b/notes/size-resolution.md
@@ -1,0 +1,22 @@
+# Size Resolution
+
+To map data to screen space, we need to figure out how to scale it to fit. As a rule of thumb, we
+want all of underlying space to be visible. As a consequence, bar charts should never be truncated,
+because each bar is fully embedded in the underlying space. On the other hand, a scatterplot's
+points may be truncated on the edges of the frame since their sizes are not embedded in the
+underlying space of the graphic.
+
+## Continuous Space Resolution
+
+For position and interval spaces, we are basically mapping some interval of minimum and maximum
+values to available physical space. This can be performed by a traditional scale function. For now,
+we assume these scales are always linear and lean on data pre-processing and coordinate transforms
+to introduce non-linearities.
+
+## Discrete Space Resolution
+
+Layouts like `spread`'s arrange things using pixel-based spacing (like putting 8 pixels of spacing
+between bars) so we can't compute a scale function right away. Instead, we assume we are looking for
+some linear scale factor (data could be scaled using a non-linear scale function before this) and we have to figure
+out how to scale the shapes that are being placed by creating a function from the scale factor to
+the output size if we use that scale factor. Then we solve.

--- a/notes/space-resolution.md
+++ b/notes/space-resolution.md
@@ -96,13 +96,14 @@ Notes
 
 - [x] Add DataSpace types
 - [x] Add resolveUnderlyingSpace method signatures
-- [-] Implement inferSpaces for core operators - (rect, layer, stack)
+- [-] Implement resolveUnderlyingSpace for all shapes and operators - (rect, layer, stack)
   - [x] Stub out resolveUnderlyingSpace
   - [x] Split resolveUnderlyingSpace return into two axes
   - [x] Test abstract resolution kind on existing examples
   - [ ] Implement resolved values
+  - [ ] replace inferPosDomains completely with resolveUnderlyingSpace
   - [ ] Test specific values on existing examples
-- [ ] Update main layout loop to use unified space resolution instead of the infer calls
-- [ ] Add continuous axes. (And discrete axes if we decide to split ordinal from something else)
-- [ ] Migrate remaining operators
-- [ ] Remove old inferPosDomains/inferSizeDomains methods
+  - [ ] Test continuous axes on all charts that currently have them. (And make sure they no longer
+        appear where they shouldn't be.)
+- [ ] **SHIP PR**
+- [ ] Replace inferSizeDomains with discrete cases in resolveUnderlyingSpace

--- a/notes/space-resolution.md
+++ b/notes/space-resolution.md
@@ -98,8 +98,8 @@ Notes
 - [x] Add resolveUnderlyingSpace method signatures
 - [-] Implement inferSpaces for core operators - (rect, layer, stack)
   - [x] Stub out resolveUnderlyingSpace
-  - [ ] Split resolveUnderlyingSpace return into two axes
-  - [ ] Test abstract resolution kind on existing examples
+  - [x] Split resolveUnderlyingSpace return into two axes
+  - [x] Test abstract resolution kind on existing examples
   - [ ] Implement resolved values
   - [ ] Test specific values on existing examples
 - [ ] Update main layout loop to use unified space resolution instead of the infer calls

--- a/notes/underlying-space.md
+++ b/notes/underlying-space.md
@@ -1,0 +1,50 @@
+# Underlying Space
+
+## What?
+
+A data-driven graphic maps data space to visual space. Typically data space is described by a data
+schema like `{lake: string, count: number}`. Visual space is typically described using shapes and
+screen positions (i.e., SVG or Canvas attributes).
+
+Most of the logic in GoFish lives in between data and visual space, for example computing scales and
+performing layout. We use a data structure to keep
+this logic organized that we call "underlying space."
+
+Underlying space is a tree of spaces where each space currently has one of the following tags:
+
+- position
+- interval
+- ordinal
+- undefined
+
+(These map closely to Stevens's statistical data types, which is probably not a coincidence, but the
+relationship isn't clear yet.)
+
+## Why?
+
+Here are some kinds of things we need to figure out about a graphic that underlying space helps us
+answer:
+
+If we overlay a scatterplot and a line chart in the same region of the screen (such as
+drawing regression line), what should the axis domains be? What about when the two charts have
+different data spaces on one axis (like in a dual axis chart)?
+
+If we draw a bar chart with vertically centered bars, what is the y-axis?
+
+If we create faceted chart regions, how should those faceted regions relate to each other?
+
+What if an operator arranges shapes in free space, but those objects have data-driven sizes that
+need to be scaled to fit the available screen space? (As when using the spread operator.)
+
+In all of these cases, we have some information about data spaces and their encodings to positions
+and sizes of shapes. Operators compose this information together to create more complex
+relationships between data and visual space.
+
+Underlying space keeps track of this information explicitly so that we can more easily write
+algorithms that resolve scales and draw axes.
+
+For example, to resolve scale domains in the case of the overlaid scatterplot and line chart, we
+first have to determine whether the two charts' domains can be merged and then we can merge the
+domains. This information is later used to draw axes for the combined chart. We need to store
+intermediate results about these domains, and that's basically the role of the "underlying space" data
+structure.

--- a/src/ast/_node.ts
+++ b/src/ast/_node.ts
@@ -99,6 +99,7 @@ export class GoFishNode {
   public parent?: GoFishNode;
   // private inferDomains: (childDomains: Size<Domain>[]) => FancySize<Domain | undefined>;
   private _resolveUnderlyingSpace: ResolveUnderlyingSpace;
+  private _underlyingSpace?: Size<UnderlyingSpace> = undefined;
   private _inferPosDomains: (
     childPosDomains: Size<ContinuousDomain>[]
   ) => FancySize<ContinuousDomain | undefined>;
@@ -200,11 +201,15 @@ export class GoFishNode {
   }
 
   public resolveUnderlyingSpace(): Size<UnderlyingSpace> {
-    return elaborateSize(
+    if (this._underlyingSpace) {
+      return this._underlyingSpace;
+    }
+    this._underlyingSpace = elaborateSize(
       this._resolveUnderlyingSpace(
         this.children.map((child) => child.resolveUnderlyingSpace())
       )
     );
+    return this._underlyingSpace;
   }
 
   public inferPosDomains(): Size<ContinuousDomain | undefined> {

--- a/src/ast/_node.ts
+++ b/src/ast/_node.ts
@@ -29,7 +29,13 @@ import { getValue, isValue, MaybeValue } from "./data";
 import { color6 } from "../color";
 import * as Monotonic from "../util/monotonic";
 import { findTargetMonotonic } from "../util";
-import { UnderlyingSpace } from "./underlyingSpace";
+import {
+  isINTERVAL,
+  isORDINAL,
+  isPOSITION,
+  isUNDEFINED,
+  UnderlyingSpace,
+} from "./underlyingSpace";
 import { toJSON } from "../util/interval";
 
 export type ScaleFactorFunction = Monotonic.Monotonic;
@@ -486,17 +492,31 @@ export const debugUnderlyingSpaceTree = (
     if (Array.isArray(space)) {
       return `[${space
         .map((s) => {
-          if (s.kind === "position" && s.domain) {
+          if (isPOSITION(s)) {
             return `position(${toJSON(s.domain)})`;
+          } else if (isINTERVAL(s)) {
+            return `interval(${s.width})`;
+          } else if (isORDINAL(s)) {
+            return `ordinal(${s.spacing})`;
+          } else if (isUNDEFINED(s)) {
+            return `undefined`;
+          } else {
+            return s.kind;
           }
-          return s.kind;
         })
         .join(", ")}]`;
     } else {
-      if (space.kind === "position" && space.domain) {
+      if (isPOSITION(space)) {
         return `position(${toJSON(space.domain)})`;
+      } else if (isINTERVAL(space)) {
+        return `interval(${space.width})`;
+      } else if (isORDINAL(space)) {
+        return `ordinal(${space.spacing})`;
+      } else if (isUNDEFINED(space)) {
+        return `undefined`;
+      } else {
+        return space.kind;
       }
-      return space.kind;
     }
   };
 

--- a/src/ast/_node.ts
+++ b/src/ast/_node.ts
@@ -30,6 +30,7 @@ import { color6 } from "../color";
 import * as Monotonic from "../util/monotonic";
 import { findTargetMonotonic } from "../util";
 import { UnderlyingSpace } from "./underlyingSpace";
+import { toJSON } from "../util/interval";
 
 export type ScaleFactorFunction = Monotonic.Monotonic;
 
@@ -483,8 +484,18 @@ export const debugUnderlyingSpaceTree = (
     space: UnderlyingSpace | Size<UnderlyingSpace>
   ): string => {
     if (Array.isArray(space)) {
-      return `[${space.map((s) => s.kind).join(", ")}]`;
+      return `[${space
+        .map((s) => {
+          if (s.kind === "position" && s.domain) {
+            return `position(${toJSON(s.domain)})`;
+          }
+          return s.kind;
+        })
+        .join(", ")}]`;
     } else {
+      if (space.kind === "position" && space.domain) {
+        return `position(${toJSON(space.domain)})`;
+      }
       return space.kind;
     }
   };

--- a/src/ast/_ref.tsx
+++ b/src/ast/_ref.tsx
@@ -19,10 +19,14 @@ import { getScopeContext } from "./gofish";
 import { GoFishNode } from "./_node";
 import { GoFishAST } from "./_ast";
 import { MaybeValue } from "./data";
+import { ORDINAL, POSITION, UnderlyingSpace } from "./underlyingSpace";
 
 /* TODO: resolveMeasures and layout feel pretty similar... */
 
-export type Placeable = { dims: Dimensions; place: (pos: FancyPosition) => void };
+export type Placeable = {
+  dims: Dimensions;
+  place: (pos: FancyPosition) => void;
+};
 
 export type Measure = (
   shared: Size<boolean>,
@@ -35,7 +39,9 @@ export type Layout = (
   shared: Size<boolean>,
   size: Size,
   scaleFactors: Size<number | undefined>,
-  children: { layout: (size: Size, scaleFactors: Size<number | undefined>) => Placeable }[],
+  children: {
+    layout: (size: Size, scaleFactors: Size<number | undefined>) => Placeable;
+  }[],
   measurement: (scaleFactors: Size) => Size
 ) => { intrinsicDims: FancyDims; transform: FancyTransform };
 
@@ -87,6 +93,11 @@ export class GoFishRef {
     return this.selectedNode?.inferPosDomains() ?? [undefined, undefined];
   }
 
+  /* TODO: what should the default be? */
+  public resolveUnderlyingSpace(): UnderlyingSpace {
+    return this.selectedNode?.resolveUnderlyingSpace() ?? ORDINAL;
+  }
+
   /* TODO: I'm not really sure what this should do */
   public measure(size: Size): (scaleFactors: Size) => Size {
     const measurement = (scaleFactors: Size) =>
@@ -120,8 +131,10 @@ export class GoFishRef {
     current = this;
     while (current && current !== lca) {
       if (current.transform) {
-        downwardTransform.translate![0] += current.transform.translate?.[0] ?? 0;
-        downwardTransform.translate![1] += current.transform.translate?.[1] ?? 0;
+        downwardTransform.translate![0] +=
+          current.transform.translate?.[0] ?? 0;
+        downwardTransform.translate![1] +=
+          current.transform.translate?.[1] ?? 0;
       }
       current = current.parent!;
     }
@@ -143,15 +156,27 @@ export class GoFishRef {
     // combine inrinsicDims and transform into a single object
     return [
       {
-        min: (this.intrinsicDims?.[0]?.min ?? 0) + (this.transform?.translate?.[0] ?? 0),
-        center: (this.intrinsicDims?.[0]?.center ?? 0) + (this.transform?.translate?.[0] ?? 0),
-        max: (this.intrinsicDims?.[0]?.max ?? 0) + (this.transform?.translate?.[0] ?? 0),
+        min:
+          (this.intrinsicDims?.[0]?.min ?? 0) +
+          (this.transform?.translate?.[0] ?? 0),
+        center:
+          (this.intrinsicDims?.[0]?.center ?? 0) +
+          (this.transform?.translate?.[0] ?? 0),
+        max:
+          (this.intrinsicDims?.[0]?.max ?? 0) +
+          (this.transform?.translate?.[0] ?? 0),
         size: this.intrinsicDims?.[0]?.size ?? 0,
       },
       {
-        min: (this.intrinsicDims?.[1]?.min ?? 0) + (this.transform?.translate?.[1] ?? 0),
-        center: (this.intrinsicDims?.[1]?.center ?? 0) + (this.transform?.translate?.[1] ?? 0),
-        max: (this.intrinsicDims?.[1]?.max ?? 0) + (this.transform?.translate?.[1] ?? 0),
+        min:
+          (this.intrinsicDims?.[1]?.min ?? 0) +
+          (this.transform?.translate?.[1] ?? 0),
+        center:
+          (this.intrinsicDims?.[1]?.center ?? 0) +
+          (this.transform?.translate?.[1] ?? 0),
+        max:
+          (this.intrinsicDims?.[1]?.max ?? 0) +
+          (this.transform?.translate?.[1] ?? 0),
         size: this.intrinsicDims?.[1]?.size ?? 0,
       },
     ];
@@ -166,7 +191,8 @@ export class GoFishRef {
       if (this.intrinsicDims?.[i]?.min === undefined) {
         this.intrinsicDims![i].min = elabPos[i]!;
       } else {
-        this.transform!.translate![i] = elabPos[i]! - (this.intrinsicDims![i].min ?? 0);
+        this.transform!.translate![i] =
+          elabPos[i]! - (this.intrinsicDims![i].min ?? 0);
       }
     }
   }
@@ -186,7 +212,10 @@ export const findPathToRoot = (node: GoFishAST): GoFishNode[] => {
   return path;
 };
 
-export const findLeastCommonAncestor = (node1: GoFishAST, node2: GoFishAST): GoFishNode => {
+export const findLeastCommonAncestor = (
+  node1: GoFishAST,
+  node2: GoFishAST
+): GoFishNode => {
   const path1 = findPathToRoot(node1);
   const path2 = findPathToRoot(node2);
 

--- a/src/ast/coordinateTransforms/coord.tsx
+++ b/src/ast/coordinateTransforms/coord.tsx
@@ -6,6 +6,12 @@ import { GoFishNode } from "../_node";
 import { elaborateDims, FancyDims, Interval, Size } from "../dims";
 import { black } from "../../color";
 import { canUnifyDomains, Domain, unifyContinuousDomains } from "../domain";
+import {
+  UnderlyingSpace,
+  UNDEFINED,
+  POSITION,
+  ORDINAL,
+} from "../underlyingSpace";
 
 export type CoordinateTransform = {
   type: string;
@@ -100,6 +106,43 @@ export const coord = (
       type: "coord",
       key,
       name,
+      resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+        let xSpace = UNDEFINED;
+        const xChildrenPositionSpaces = children.filter(
+          (child) => child[0].kind === "position"
+        );
+        const xChildrenOrdinalSpaces = children.filter(
+          (child) => child[0].kind === "ordinal"
+        );
+
+        if (
+          xChildrenPositionSpaces.length > 0 &&
+          xChildrenOrdinalSpaces.length === 0
+        ) {
+          xSpace = POSITION;
+        } else if (xChildrenOrdinalSpaces.length > 0) {
+          xSpace = ORDINAL;
+        }
+
+        let ySpace = UNDEFINED;
+        const yChildrenPositionSpaces = children.filter(
+          (child) => child[1].kind === "position"
+        );
+        const yChildrenOrdinalSpaces = children.filter(
+          (child) => child[1].kind === "ordinal"
+        );
+
+        if (
+          yChildrenPositionSpaces.length > 0 &&
+          yChildrenOrdinalSpaces.length === 0
+        ) {
+          ySpace = POSITION;
+        } else if (yChildrenOrdinalSpaces.length > 0) {
+          ySpace = ORDINAL;
+        }
+
+        return [xSpace, ySpace];
+      },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {
         // unify continuous domains of children for each direction
         return [

--- a/src/ast/data.ts
+++ b/src/ast/data.ts
@@ -13,13 +13,21 @@ export const value = <T>(datum: T, measure?: Measure): Value<any> => ({
   measure,
 });
 
-export const isValue = <T>(value: MaybeValue<T>): value is Value<T> => {
+export const isValue = <T>(
+  value: MaybeValue<T>
+): value is Exclude<Value<T>, undefined> => {
   return (
     typeof value === "object" &&
     value !== null &&
     "type" in value &&
     value.type === "datum"
   );
+};
+
+export const isAesthetic = <T>(
+  value: MaybeValue<T>
+): value is Exclude<T, undefined> => {
+  return !isValue(value) && value !== undefined;
 };
 
 export const getValue = <T>(value: MaybeValue<T>): T => {

--- a/src/ast/gofish.tsx
+++ b/src/ast/gofish.tsx
@@ -92,11 +92,12 @@ export const gofish = (
     const [posDomainX, posDomainY] = child.inferPosDomains();
     const sizeDomains = child.inferSizeDomains();
     const [underlyingSpaceX, underlyingSpaceY] = child.resolveUnderlyingSpace();
-    console.log("underlyingSpace", { underlyingSpaceX, underlyingSpaceY });
 
     // Debug: Print the tree of underlying spaces
-    console.log("🌳 Underlying Space Tree:");
-    debugUnderlyingSpaceTree(child);
+    if (debug) {
+      console.log("🌳 Underlying Space Tree:");
+      debugUnderlyingSpaceTree(child);
+    }
 
     const posScales = [
       underlyingSpaceX.kind === "position"

--- a/src/ast/gofish.tsx
+++ b/src/ast/gofish.tsx
@@ -1,6 +1,11 @@
 import { For, Show, type JSX } from "solid-js";
 import { render as solidRender } from "solid-js/web";
-import { debugNodeTree, findPathToRoot, type GoFishNode } from "./_node";
+import {
+  debugNodeTree,
+  debugUnderlyingSpaceTree,
+  findPathToRoot,
+  type GoFishNode,
+} from "./_node";
 import { ScopeContext } from "./scopeContext";
 import { computePosScale } from "./domain";
 import { tickIncrement, ticks, nice } from "d3-array";
@@ -76,6 +81,13 @@ export const gofish = (
     child.resolveKeys();
     const [posDomainX, posDomainY] = child.inferPosDomains();
     const sizeDomains = child.inferSizeDomains();
+    const [underlyingSpaceX, underlyingSpaceY] = child.resolveUnderlyingSpace();
+    console.log("underlyingSpace", { underlyingSpaceX, underlyingSpaceY });
+
+    // Debug: Print the tree of underlying spaces
+    console.log("🌳 Underlying Space Tree:");
+    debugUnderlyingSpaceTree(child);
+
     child.layout(
       [w, h],
       [undefined, undefined],

--- a/src/ast/gofish.tsx
+++ b/src/ast/gofish.tsx
@@ -10,6 +10,7 @@ import { ScopeContext } from "./scopeContext";
 import { computePosScale } from "./domain";
 import { tickIncrement, ticks, nice } from "d3-array";
 import { isConstant } from "../util/monotonic";
+import { type UnderlyingSpace } from "./underlyingSpace";
 
 /* scope context */
 let scopeContext: ScopeContext | null = null;
@@ -21,7 +22,11 @@ export const getScopeContext = (): ScopeContext => {
   return scopeContext;
 };
 
-type ScaleContext = { [measure: string]: { color: Map<any, string> } };
+type ScaleContext = {
+  [measure: string]:
+    | { color: Map<any, string> }
+    | { domain: [number, number]; scaleFactor: number };
+};
 
 /* scale context */
 export let scaleContext: ScaleContext | null = null;
@@ -114,6 +119,8 @@ export const gofish = (
             scaleContext,
             keyContext,
             sizeDomains,
+            underlyingSpaceX,
+            underlyingSpaceY,
           },
           child
         ),
@@ -144,21 +151,33 @@ export const render = (
     scaleContext,
     keyContext,
     sizeDomains,
+    underlyingSpaceX,
+    underlyingSpaceY,
   }: {
     width: number;
     height: number;
     transform?: string;
     defs?: JSX.Element[];
     axes?: boolean;
-    scaleContext: ScaleContext;
-    keyContext: KeyContext;
+    scaleContext: ScaleContext | null;
+    keyContext: KeyContext | null;
     sizeDomains?: [any, any];
+    underlyingSpaceX: UnderlyingSpace;
+    underlyingSpaceY: UnderlyingSpace;
   },
   child: GoFishNode
 ): JSX.Element => {
   let yTicks: number[] = [];
   let xTicks: number[] = [];
-  if (axes) {
+  if (
+    axes &&
+    scaleContext?.x &&
+    scaleContext?.y &&
+    "domain" in scaleContext.x &&
+    "scaleFactor" in scaleContext.x &&
+    "domain" in scaleContext.y &&
+    "scaleFactor" in scaleContext.y
+  ) {
     const [xMin, xMax] = nice(
       scaleContext.x.domain[0],
       scaleContext.x.domain[1],
@@ -200,87 +219,113 @@ export const render = (
               stroke="gray"
               stroke-width="1px"
             /> */}
-            {/* y axis (continuous for now) */}
-            <Show when={sizeDomains && !isConstant(sizeDomains[1])}>
-              <g>
-                <line
-                  x1={-PADDING}
-                  y1={yTicks[0] * scaleContext.y.scaleFactor - 0.5}
-                  x2={-PADDING}
-                  y2={
-                    yTicks[yTicks.length - 1] * scaleContext.y.scaleFactor + 0.5
-                  }
-                  stroke="gray"
-                  stroke-width="1px"
-                />
-                <For each={yTicks}>
-                  {(tick) => (
-                    <>
-                      <text
-                        transform="scale(1, -1)"
-                        x={-PADDING * 1.75}
-                        y={-tick * scaleContext.y.scaleFactor}
-                        text-anchor="end"
-                        dominant-baseline="middle"
-                        font-size="10px"
-                        fill="gray"
-                      >
-                        {tick}
-                      </text>
-                      <line
-                        x1={-PADDING * 1.5}
-                        y1={tick * scaleContext.y.scaleFactor}
-                        x2={-PADDING}
-                        y2={tick * scaleContext.y.scaleFactor}
-                        stroke="gray"
-                      />
-                    </>
-                  )}
-                </For>
-              </g>
+            {/* y axis (continuous) */}
+            <Show
+              when={
+                (underlyingSpaceY.kind === "position" ||
+                  underlyingSpaceY.kind === "interval") &&
+                scaleContext?.y &&
+                "scaleFactor" in scaleContext.y
+              }
+            >
+              {(() => {
+                const yScale = scaleContext!.y as {
+                  domain: [number, number];
+                  scaleFactor: number;
+                };
+                return (
+                  <g>
+                    <line
+                      x1={-PADDING}
+                      y1={yTicks[0] * yScale.scaleFactor - 0.5}
+                      x2={-PADDING}
+                      y2={yTicks[yTicks.length - 1] * yScale.scaleFactor + 0.5}
+                      stroke="gray"
+                      stroke-width="1px"
+                    />
+                    <For each={yTicks}>
+                      {(tick) => (
+                        <>
+                          <text
+                            transform="scale(1, -1)"
+                            x={-PADDING * 1.75}
+                            y={-tick * yScale.scaleFactor}
+                            text-anchor="end"
+                            dominant-baseline="middle"
+                            font-size="10px"
+                            fill="gray"
+                          >
+                            {tick}
+                          </text>
+                          <line
+                            x1={-PADDING * 1.5}
+                            y1={tick * yScale.scaleFactor}
+                            x2={-PADDING}
+                            y2={tick * yScale.scaleFactor}
+                            stroke="gray"
+                          />
+                        </>
+                      )}
+                    </For>
+                  </g>
+                );
+              })()}
             </Show>
-            <Show when={sizeDomains && !isConstant(sizeDomains[0])}>
-              <g>
-                <line
-                  x1={xTicks[0] * scaleContext.x.scaleFactor - 0.5}
-                  y1={-PADDING}
-                  x2={
-                    xTicks[xTicks.length - 1] * scaleContext.x.scaleFactor + 0.5
-                  }
-                  y2={-PADDING}
-                  stroke="gray"
-                  stroke-width="1px"
-                />
-                <For each={xTicks}>
-                  {(tick) => (
-                    <>
-                      <text
-                        transform="scale(1, -1)"
-                        x={tick * scaleContext.x.scaleFactor}
-                        y={PADDING * 1.75}
-                        text-anchor="middle"
-                        dominant-baseline="hanging"
-                        font-size="10px"
-                        fill="gray"
-                      >
-                        {tick}
-                      </text>
-                      <line
-                        x1={tick * scaleContext.x.scaleFactor}
-                        y1={-PADDING}
-                        x2={tick * scaleContext.x.scaleFactor}
-                        y2={-PADDING * 1.5}
-                        stroke="gray"
-                      />
-                    </>
-                  )}
-                </For>
-              </g>
+            <Show
+              when={
+                (underlyingSpaceX.kind === "position" ||
+                  underlyingSpaceX.kind === "interval") &&
+                scaleContext?.x &&
+                "scaleFactor" in scaleContext.x
+              }
+            >
+              {(() => {
+                const xScale = scaleContext!.x as {
+                  domain: [number, number];
+                  scaleFactor: number;
+                };
+                return (
+                  <g>
+                    <line
+                      x1={xTicks[0] * xScale.scaleFactor - 0.5}
+                      y1={-PADDING}
+                      x2={xTicks[xTicks.length - 1] * xScale.scaleFactor + 0.5}
+                      y2={-PADDING}
+                      stroke="gray"
+                      stroke-width="1px"
+                    />
+                    <For each={xTicks}>
+                      {(tick) => (
+                        <>
+                          <text
+                            transform="scale(1, -1)"
+                            x={tick * xScale.scaleFactor}
+                            y={PADDING * 1.75}
+                            text-anchor="middle"
+                            dominant-baseline="hanging"
+                            font-size="10px"
+                            fill="gray"
+                          >
+                            {tick}
+                          </text>
+                          <line
+                            x1={tick * xScale.scaleFactor}
+                            y1={-PADDING}
+                            x2={tick * xScale.scaleFactor}
+                            y2={-PADDING * 1.5}
+                            stroke="gray"
+                          />
+                        </>
+                      )}
+                    </For>
+                  </g>
+                );
+              })()}
             </Show>
-            {/* x axis (discrete for now) */}
-            <Show when={sizeDomains && isConstant(sizeDomains[0])}>
+            {/* x axis (discrete) */}
+            <Show when={underlyingSpaceX.kind === "ordinal" && keyContext}>
               <g>
-                <For each={Object.entries(keyContext)}>
+                <For each={Object.entries(keyContext ?? {})}>
                   {([key, value]) => {
                     const pathToRoot = findPathToRoot(value);
                     const accumulatedTransform = pathToRoot.reduce(
@@ -335,7 +380,7 @@ export const render = (
                 </For>
               </g>
             </Show>
-            <Show when={sizeDomains && isConstant(sizeDomains[1])}>
+            <Show when={underlyingSpaceY.kind === "ordinal"}>
               {/* Vertical (Y axis) labels */}
               <g>
                 <For each={child.children ?? []}>
@@ -404,7 +449,14 @@ export const render = (
             </Show>
             {/* legend (discrete color for now) */}
             <g>
-              <For each={Array.from(scaleContext.unit.color.entries())}>
+              <For
+                each={Array.from(
+                  (scaleContext?.unit && "color" in scaleContext.unit
+                    ? scaleContext.unit.color
+                    : new Map()
+                  ).entries()
+                )}
+              >
                 {([key, value], i) => (
                   <g
                     transform={`translate(${width + PADDING * 3}, ${height - i() * 20})`}

--- a/src/ast/graphicalOperators/connect.tsx
+++ b/src/ast/graphicalOperators/connect.tsx
@@ -15,6 +15,7 @@ import { getValue, isValue, MaybeValue } from "../data";
 import { scaleContext } from "../gofish";
 import { Domain } from "../domain";
 import * as Monotonic from "../../util/monotonic";
+import { UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
 
 export const connect = (
   {
@@ -46,6 +47,9 @@ export const connect = (
       type: "connect",
       shared: [false, false],
       color: fill,
+      resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+        return [UNDEFINED, UNDEFINED];
+      },
       inferSizeDomains: (shared, children) => {
         return {
           w: Monotonic.linear(0, 0),

--- a/src/ast/graphicalOperators/enclose.tsx
+++ b/src/ast/graphicalOperators/enclose.tsx
@@ -5,6 +5,7 @@ import { GoFishAST } from "../_ast";
 import { black, gray, tailwindColors } from "../../color";
 import { Domain } from "../domain";
 import * as Monotonic from "../../util/monotonic";
+import { UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
 
 export const enclose = (
   {
@@ -18,6 +19,9 @@ export const enclose = (
     {
       type: "enclose",
       shared: [false, false],
+      resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+        return [UNDEFINED, UNDEFINED];
+      },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {
         return [undefined, undefined];
       },

--- a/src/ast/graphicalOperators/layer.tsx
+++ b/src/ast/graphicalOperators/layer.tsx
@@ -48,7 +48,7 @@ export const layer = (
           xChildrenPositionSpaces.length > 0 &&
           xChildrenOrdinalSpaces.length === 0
         ) {
-          xSpace = POSITION;
+          xSpace = POSITION([0, 0]);
         } else if (xChildrenOrdinalSpaces.length > 0) {
           xSpace = ORDINAL;
         }
@@ -65,7 +65,7 @@ export const layer = (
           yChildrenPositionSpaces.length > 0 &&
           yChildrenOrdinalSpaces.length === 0
         ) {
-          ySpace = POSITION;
+          ySpace = POSITION([0, 0]);
         } else if (yChildrenOrdinalSpaces.length > 0) {
           ySpace = ORDINAL;
         }

--- a/src/ast/graphicalOperators/layer.tsx
+++ b/src/ast/graphicalOperators/layer.tsx
@@ -13,6 +13,7 @@ import {
   UnderlyingSpace,
   ORDINAL,
 } from "../underlyingSpace";
+import * as Interval from "../../util/interval";
 
 export const layer = (
   childrenOrOptions:
@@ -48,7 +49,10 @@ export const layer = (
           xChildrenPositionSpaces.length > 0 &&
           xChildrenOrdinalSpaces.length === 0
         ) {
-          xSpace = POSITION([0, 0]);
+          const domain = Interval.unionAll(
+            ...xChildrenPositionSpaces.map((child) => child[0].domain!)
+          );
+          xSpace = POSITION([domain.min, domain.max]);
         } else if (xChildrenOrdinalSpaces.length > 0) {
           xSpace = ORDINAL;
         }
@@ -65,7 +69,10 @@ export const layer = (
           yChildrenPositionSpaces.length > 0 &&
           yChildrenOrdinalSpaces.length === 0
         ) {
-          ySpace = POSITION([0, 0]);
+          const domain = Interval.unionAll(
+            ...yChildrenPositionSpaces.map((child) => child[1].domain!)
+          );
+          ySpace = POSITION([domain.min, domain.max]);
         } else if (yChildrenOrdinalSpaces.length > 0) {
           ySpace = ORDINAL;
         }

--- a/src/ast/graphicalOperators/layer.tsx
+++ b/src/ast/graphicalOperators/layer.tsx
@@ -7,6 +7,12 @@ import {
   unifyContinuousDomains,
   ContinuousDomain,
 } from "../domain";
+import {
+  UNDEFINED,
+  POSITION,
+  UnderlyingSpace,
+  ORDINAL,
+} from "../underlyingSpace";
 
 export const layer = (
   childrenOrOptions:
@@ -29,6 +35,43 @@ export const layer = (
       type: options.box === true ? "box" : "layer",
       key: options.key,
       shared: [false, false],
+      resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+        let xSpace = UNDEFINED;
+        const xChildrenPositionSpaces = children.filter(
+          (child) => child[0].kind === "position"
+        );
+        const xChildrenOrdinalSpaces = children.filter(
+          (child) => child[0].kind === "ordinal"
+        );
+
+        if (
+          xChildrenPositionSpaces.length > 0 &&
+          xChildrenOrdinalSpaces.length === 0
+        ) {
+          xSpace = POSITION;
+        } else if (xChildrenOrdinalSpaces.length > 0) {
+          xSpace = ORDINAL;
+        }
+
+        let ySpace = UNDEFINED;
+        const yChildrenPositionSpaces = children.filter(
+          (child) => child[1].kind === "position"
+        );
+        const yChildrenOrdinalSpaces = children.filter(
+          (child) => child[1].kind === "ordinal"
+        );
+
+        if (
+          yChildrenPositionSpaces.length > 0 &&
+          yChildrenOrdinalSpaces.length === 0
+        ) {
+          ySpace = POSITION;
+        } else if (yChildrenOrdinalSpaces.length > 0) {
+          ySpace = ORDINAL;
+        }
+
+        return [xSpace, ySpace];
+      },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {
         // unify continuous domains of children for each direction
 

--- a/src/ast/graphicalOperators/position.tsx
+++ b/src/ast/graphicalOperators/position.tsx
@@ -2,6 +2,7 @@ import { GoFishNode } from "../_node";
 import { Size, elaborateDims, FancyDims } from "../dims";
 import { Domain, continuous } from "../domain";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
+import { POSITION, UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
 
 export const position = (
   childrenOrOptions:
@@ -18,6 +19,12 @@ export const position = (
       type: "position",
       key: options.key,
       shared: [false, false],
+      resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+        return [
+          options.x ? POSITION : UNDEFINED,
+          options.y ? POSITION : UNDEFINED,
+        ];
+      },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {
         return [
           isValue(options.x)

--- a/src/ast/graphicalOperators/position.tsx
+++ b/src/ast/graphicalOperators/position.tsx
@@ -21,8 +21,12 @@ export const position = (
       shared: [false, false],
       resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
         return [
-          options.x ? POSITION : UNDEFINED,
-          options.y ? POSITION : UNDEFINED,
+          isValue(options.x)
+            ? POSITION([getValue(options.x)!, getValue(options.x)!])
+            : UNDEFINED,
+          isValue(options.y)
+            ? POSITION([getValue(options.y)!, getValue(options.y)!])
+            : UNDEFINED,
         ];
       },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {

--- a/src/ast/graphicalOperators/stack.tsx
+++ b/src/ast/graphicalOperators/stack.tsx
@@ -122,7 +122,9 @@ export const stack = withGoFish(
                 return domain ? Interval.width(domain) : 0;
               })
               .reduce((a, b) => a + b, 0);
-            stackSpace = POSITION([0, totalWidth]);
+            stackSpace = POSITION(
+              totalWidth >= 0 ? [0, totalWidth] : [totalWidth, 0]
+            );
           }
 
           // if children are all UNDEFINED or POSITION and spacing is > 0, return ORDINAL

--- a/src/ast/graphicalOperators/stack.tsx
+++ b/src/ast/graphicalOperators/stack.tsx
@@ -100,11 +100,11 @@ export const stack = withGoFish(
           ) {
             alignSpace = INTERVAL;
           } else {
-            alignSpace = ORDINAL;
+            alignSpace = UNDEFINED;
           }
 
           /* SPACING RULES */
-          let stackSpace = ORDINAL;
+          let stackSpace = UNDEFINED;
           // if children are all UNDEFINED or POSITION and spacing is 0, return POSITION
           if (
             children.every(

--- a/src/ast/graphicalOperators/stack.tsx
+++ b/src/ast/graphicalOperators/stack.tsx
@@ -100,7 +100,7 @@ export const stack = withGoFish(
           ) {
             alignSpace = INTERVAL;
           } else {
-            alignSpace = UNDEFINED;
+            alignSpace = ORDINAL;
           }
 
           /* SPACING RULES */

--- a/src/ast/graphicalOperators/stack.tsx
+++ b/src/ast/graphicalOperators/stack.tsx
@@ -23,7 +23,13 @@ import { GoFishAST } from "../_ast";
 import { getScaleContext } from "../gofish";
 import { withGoFish } from "../withGoFish";
 import * as Monotonic from "../../util/monotonic";
-import { INTERVAL, ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
+import {
+  INTERVAL,
+  ORDINAL,
+  POSITION,
+  UNDEFINED,
+  isPOSITION,
+} from "../underlyingSpace";
 import { UnderlyingSpace } from "../underlyingSpace";
 import * as Interval from "../../util/interval";
 
@@ -78,11 +84,7 @@ export const stack = withGoFish(
 
           // if children are all UNDEFINED or POSITION and alignment is start or end, return POSITION
           if (
-            children.every(
-              (child) =>
-                // child[alignDir].kind === "undefined" ||
-                child[alignDir].kind === "position"
-            ) &&
+            children.every((child) => isPOSITION(child[alignDir])) &&
             (alignment === "start" || alignment === "end")
           ) {
             const domain = Interval.unionAll(
@@ -92,14 +94,13 @@ export const stack = withGoFish(
           }
           // if children are all UNDEFINED or POSITION and alignment is middle, return INTERVAL
           else if (
-            children.every(
-              (child) =>
-                child[alignDir].kind === "undefined" ||
-                child[alignDir].kind === "position"
-            ) &&
+            children.every((child) => isPOSITION(child[alignDir])) &&
             alignment === "middle"
           ) {
-            alignSpace = INTERVAL;
+            const domain = Interval.unionAll(
+              ...children.map((child) => child[alignDir].domain!)
+            );
+            alignSpace = INTERVAL(Interval.width(domain));
           } else {
             alignSpace = UNDEFINED;
           }

--- a/src/ast/graphicalOperators/stack.tsx
+++ b/src/ast/graphicalOperators/stack.tsx
@@ -353,13 +353,15 @@ export const stack = withGoFish(
             }
           }
 
+          const alignSize = Math.max(
+            ...childPlaceables.map((child) => child.dims[alignDir].size!)
+          );
           return {
             intrinsicDims: {
               [alignDir]: {
                 min: alignMin,
-                size: Math.max(
-                  ...childPlaceables.map((child) => child.dims[alignDir].size!)
-                ),
+                size: alignSize,
+                max: alignMin + alignSize,
               },
               [stackDir]: {
                 min: 0,

--- a/src/ast/graphicalOperators/stack.tsx
+++ b/src/ast/graphicalOperators/stack.tsx
@@ -188,15 +188,6 @@ export const stack = withGoFish(
 
           return result;
         },
-        /* TODO:
-      Nodes are either:
-      - fixed size
-      - scaled (b/c data-driven) (eg bar chart bar heights). equal scale? shared scale?
-      - (uniform) flexed? or maybe grow to whatever size the parent gives them? (eg bar chart
-        bar widths) equal size? shared size?
-
-      child.size[0].mode = "fixed" | "scaled" | "grow"
-*/
         inferSizeDomains: (shared, children) => {
           const childSizeDomains = children.map((child) =>
             child.inferSizeDomains()

--- a/src/ast/graphicalOperators/stack.tsx
+++ b/src/ast/graphicalOperators/stack.tsx
@@ -71,22 +71,30 @@ export const stack = withGoFish(
         key,
         name,
         shared: [sharedScale, sharedScale],
-        resolveUnderlyingSpace: (children: UnderlyingSpace[]) => {
+        resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
           /* ALIGNMENT RULES */
           let alignSpace = UNDEFINED;
+
           // if children are all UNDEFINED or POSITION and alignment is start or end, return POSITION
           if (
             children.every(
-              (child) => child.kind === "undefined" || child.kind === "position"
+              (child) =>
+                child[alignDir].kind === "undefined" ||
+                child[alignDir].kind === "position"
             ) &&
             (alignment === "start" || alignment === "end")
           ) {
+            console.log(
+              "stack.resolveUnderlyingSpace alignment is start or end"
+            );
             alignSpace = POSITION;
           }
           // if children are all UNDEFINED or POSITION and alignment is middle, return INTERVAL
           else if (
             children.every(
-              (child) => child.kind === "undefined" || child.kind === "position"
+              (child) =>
+                child[alignDir].kind === "undefined" ||
+                child[alignDir].kind === "position"
             ) &&
             alignment === "middle"
           ) {
@@ -100,7 +108,9 @@ export const stack = withGoFish(
           // if children are all UNDEFINED or POSITION and spacing is 0, return POSITION
           if (
             children.every(
-              (child) => child.kind === "undefined" || child.kind === "position"
+              (child) =>
+                child[stackDir].kind === "undefined" ||
+                child[stackDir].kind === "position"
             ) &&
             spacing === 0
           ) {
@@ -110,7 +120,9 @@ export const stack = withGoFish(
           // if children are all UNDEFINED or POSITION and spacing is > 0, return ORDINAL
           else if (
             children.every(
-              (child) => child.kind === "undefined" || child.kind === "position"
+              (child) =>
+                child[stackDir].kind === "undefined" ||
+                child[stackDir].kind === "position"
             ) &&
             spacing > 0
           ) {

--- a/src/ast/marks/chart.ts
+++ b/src/ast/marks/chart.ts
@@ -119,6 +119,7 @@ export class _Chart<T> {
       mode?: "edge" | "center";
       strokeWidth?: number;
       debug?: boolean;
+      mixBlendMode?: "normal" | "multiply";
     }
   ) {
     return new _Chart(this._data, (d: T[], k: number | string) => {
@@ -145,6 +146,7 @@ export class _Chart<T> {
                   opacity: options?.opacity,
                   mode: options?.mode ? connectXMode[options?.mode] : undefined,
                   strokeWidth: options?.strokeWidth,
+                  mixBlendMode: options?.mixBlendMode,
                 },
                 For(groupBy(items, options?.over?.toString()), (item, i) =>
                   Ref(`${k}-${i}-${o}`)
@@ -157,6 +159,7 @@ export class _Chart<T> {
                 opacity: options?.opacity,
                 mode: options?.mode ? connectXMode[options?.mode] : undefined,
                 strokeWidth: options?.strokeWidth,
+                mixBlendMode: options?.mixBlendMode,
               },
               For(groupBy(d, key.toString()), (items, i) => Ref(`${k}-${i}`))
             ),

--- a/src/ast/shapes/ellipse.tsx
+++ b/src/ast/shapes/ellipse.tsx
@@ -29,6 +29,7 @@ import {
 } from "../dims";
 import { aesthetic, continuous } from "../domain";
 import { scaleContext } from "../gofish";
+import { ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
 
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
 export const ellipse = ({
@@ -51,6 +52,30 @@ export const ellipse = ({
       name,
       type: "ellipse",
       color: fill,
+      resolveUnderlyingSpace: () => {
+        let underlyingSpaceX = ORDINAL;
+        if (isValue(dims[0].min)) {
+          // position. treat it like a position space w/ a single element
+          underlyingSpaceX = POSITION;
+        } else {
+          // undefined
+          underlyingSpaceX = UNDEFINED;
+        }
+
+        let underlyingSpaceY = ORDINAL;
+        if (isValue(dims[1].min)) {
+          // position. treat it like a position space w/ a single element
+          underlyingSpaceY = POSITION;
+        } else {
+          // undefined
+          underlyingSpaceY = UNDEFINED;
+        }
+
+        // const w = computeIntrinsicSize(dims[0].size);
+        // const h = computeIntrinsicSize(dims[1].size);
+
+        return [underlyingSpaceX, underlyingSpaceY];
+      },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {
         return [
           isValue(dims[0].min)

--- a/src/ast/shapes/petal.tsx
+++ b/src/ast/shapes/petal.tsx
@@ -30,6 +30,7 @@ import {
 import { aesthetic, continuous, Domain } from "../domain";
 import * as Monotonic from "../../util/monotonic";
 import { Linear } from "../../lib";
+import { ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
 
 /* Implementation inspired by https://web.archive.org/web/20220808041640/http://bl.ocks.org/herrstucki/6199768 */
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
@@ -70,6 +71,30 @@ export const petal = ({
       //       : undefined,
       //   ];
       // },
+      resolveUnderlyingSpace: () => {
+        let underlyingSpaceX = ORDINAL;
+        if (isValue(dims[0].min)) {
+          // position. treat it like a position space w/ a single element
+          underlyingSpaceX = POSITION;
+        } else {
+          // undefined
+          underlyingSpaceX = UNDEFINED;
+        }
+
+        let underlyingSpaceY = ORDINAL;
+        if (isValue(dims[1].min)) {
+          // position. treat it like a position space w/ a single element
+          underlyingSpaceY = POSITION;
+        } else {
+          // undefined
+          underlyingSpaceY = UNDEFINED;
+        }
+
+        // const w = computeIntrinsicSize(dims[0].size);
+        // const h = computeIntrinsicSize(dims[1].size);
+
+        return [underlyingSpaceX, underlyingSpaceY];
+      },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {
         return [
           isValue(dims[0].min)

--- a/src/ast/shapes/rect.tsx
+++ b/src/ast/shapes/rect.tsx
@@ -78,18 +78,22 @@ export const rect = ({
         if (isValue(dims[0].min)) {
           // position. treat it like a position space w/ a single element
           underlyingSpaceX = POSITION;
+        } else if (isValue(dims[0].size)) {
+          underlyingSpaceX = POSITION;
         } else {
           // undefined
-          underlyingSpaceX = UNDEFINED;
+          underlyingSpaceX = ORDINAL;
         }
 
         let underlyingSpaceY = ORDINAL;
         if (isValue(dims[1].min)) {
           // position. treat it like a position space w/ a single element
           underlyingSpaceY = POSITION;
+        } else if (isValue(dims[1].size)) {
+          underlyingSpaceY = POSITION;
         } else {
           // undefined
-          underlyingSpaceY = UNDEFINED;
+          underlyingSpaceY = ORDINAL;
         }
 
         const w = computeIntrinsicSize(dims[0].size);

--- a/src/ast/shapes/rect.tsx
+++ b/src/ast/shapes/rect.tsx
@@ -70,6 +70,10 @@ export const rect = ({
       type: "rect",
       color: fill,
       resolveUnderlyingSpace: () => {
+        /* TODO: maybe it should be INTERVAL if it doesn't have position, but does have data-driven
+        size */
+        // that might not work right b/c then stack will need to turn intervals into positions will
+        // doesn't work if you have a stack of centered-aligned stacks of rectangles
         let underlyingSpaceX = ORDINAL;
         if (isValue(dims[0].min)) {
           // position. treat it like a position space w/ a single element

--- a/src/ast/shapes/rect.tsx
+++ b/src/ast/shapes/rect.tsx
@@ -31,6 +31,7 @@ import { aesthetic, continuous, Domain } from "../domain";
 import { scaleContext } from "../gofish";
 import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic, computeSize } from "../../util";
+import { ORDINAL } from "../underlyingSpace";
 
 const computeIntrinsicSize = (
   input: MaybeValue<number> | undefined
@@ -59,7 +60,7 @@ export const rect = ({
   strokeWidth?: number;
   rx?: number;
   ry?: number;
-  filter?: string
+  filter?: string;
 } & FancyDims<MaybeValue<number>>) => {
   const dims = elaborateDims(fancyDims).map(inferEmbedded);
   return new GoFishNode(
@@ -68,6 +69,24 @@ export const rect = ({
       key,
       type: "rect",
       color: fill,
+      resolveUnderlyingSpace: () => {
+        if (isValue(dims[0].min)) {
+          // position. treat it like a position space w/ a single element
+        } else {
+          // undefined
+        }
+
+        if (isValue(dims[1].min)) {
+          // position. treat it like a position space w/ a single element
+        } else {
+          // undefined
+        }
+
+        const w = computeIntrinsicSize(dims[0].size);
+        const h = computeIntrinsicSize(dims[1].size);
+
+        return [ORDINAL, ORDINAL];
+      },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {
         const result = [
           isValue(dims[0].min)
@@ -242,7 +261,7 @@ export const rect = ({
 
           return (
             <rect
-               transform={`scale(1, -1)`}
+              transform={`scale(1, -1)`}
               x={transformedX - width / 2}
               y={-(transformedY - height / 2) - height}
               rx={rx}
@@ -287,7 +306,7 @@ export const rect = ({
               <rect
                 transform={`scale(1, -1)`}
                 x={x}
-                y={- y - height}
+                y={-y - height}
                 width={width}
                 height={height}
                 fill={fill}
@@ -336,7 +355,16 @@ export const rect = ({
           const y = displayDims[1].min ?? 0;
           const width = (displayDims[0].max ?? 0) - x;
           const height = (displayDims[1].max ?? 0) - y;
-          return <rect transform={`scale(1, -1)`} x={x} y={- y - height} width={width} height={height} fill={fill} />;
+          return (
+            <rect
+              transform={`scale(1, -1)`}
+              x={x}
+              y={-y - height}
+              width={width}
+              height={height}
+              fill={fill}
+            />
+          );
         }
 
         const corners = path(

--- a/src/ast/shapes/rect.tsx
+++ b/src/ast/shapes/rect.tsx
@@ -31,7 +31,7 @@ import { aesthetic, continuous, Domain } from "../domain";
 import { scaleContext } from "../gofish";
 import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic, computeSize } from "../../util";
-import { ORDINAL } from "../underlyingSpace";
+import { ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
 
 const computeIntrinsicSize = (
   input: MaybeValue<number> | undefined
@@ -70,22 +70,28 @@ export const rect = ({
       type: "rect",
       color: fill,
       resolveUnderlyingSpace: () => {
+        let underlyingSpaceX = ORDINAL;
         if (isValue(dims[0].min)) {
           // position. treat it like a position space w/ a single element
+          underlyingSpaceX = POSITION;
         } else {
           // undefined
+          underlyingSpaceX = UNDEFINED;
         }
 
+        let underlyingSpaceY = ORDINAL;
         if (isValue(dims[1].min)) {
           // position. treat it like a position space w/ a single element
+          underlyingSpaceY = POSITION;
         } else {
           // undefined
+          underlyingSpaceY = UNDEFINED;
         }
 
         const w = computeIntrinsicSize(dims[0].size);
         const h = computeIntrinsicSize(dims[1].size);
 
-        return [ORDINAL, ORDINAL];
+        return [underlyingSpaceX, underlyingSpaceY];
       },
       inferPosDomains: (childPosDomains: Size<Domain>[]) => {
         const result = [

--- a/src/ast/underlyingSpace.ts
+++ b/src/ast/underlyingSpace.ts
@@ -1,0 +1,17 @@
+export type UnderlyingSpaceKind =
+  | "position"
+  | "interval"
+  | "ordinal"
+  | "undefined";
+
+export type UnderlyingSpace = {
+  kind: UnderlyingSpaceKind;
+  spacing?: number;
+  ordinalGroupId?: string;
+  source?: string;
+};
+
+export const POSITION: UnderlyingSpace = { kind: "position" };
+export const INTERVAL: UnderlyingSpace = { kind: "interval" };
+export const ORDINAL: UnderlyingSpace = { kind: "ordinal" };
+export const UNDEFINED: UnderlyingSpace = { kind: "undefined" };

--- a/src/ast/underlyingSpace.ts
+++ b/src/ast/underlyingSpace.ts
@@ -1,3 +1,6 @@
+// import { ContinuousDomain } from "./domain";
+import { interval, Interval } from "../util/interval";
+
 export type UnderlyingSpaceKind =
   | "position"
   | "interval"
@@ -9,9 +12,13 @@ export type UnderlyingSpace = {
   spacing?: number;
   ordinalGroupId?: string;
   source?: string;
+  domain?: Interval;
 };
 
-export const POSITION: UnderlyingSpace = { kind: "position" };
+export const POSITION = (domain: [number, number]): UnderlyingSpace => ({
+  kind: "position",
+  domain: interval(domain[0], domain[1]),
+});
 export const INTERVAL: UnderlyingSpace = { kind: "interval" };
 export const ORDINAL: UnderlyingSpace = { kind: "ordinal" };
 export const UNDEFINED: UnderlyingSpace = { kind: "undefined" };

--- a/src/ast/underlyingSpace.ts
+++ b/src/ast/underlyingSpace.ts
@@ -7,18 +7,61 @@ export type UnderlyingSpaceKind =
   | "ordinal"
   | "undefined";
 
-export type UnderlyingSpace = {
-  kind: UnderlyingSpaceKind;
+export type POSITION_TYPE = {
+  kind: "position";
+  domain: Interval;
   spacing?: number;
   ordinalGroupId?: string;
   source?: string;
-  domain?: Interval;
 };
+
+export type INTERVAL_TYPE = {
+  kind: "interval";
+  width: number;
+  spacing?: number;
+  ordinalGroupId?: string;
+  source?: string;
+};
+
+export type ORDINAL_TYPE = {
+  kind: "ordinal";
+  spacing?: number;
+  ordinalGroupId?: string;
+  source?: string;
+};
+
+export type UNDEFINED_TYPE = {
+  kind: "undefined";
+  spacing?: number;
+  ordinalGroupId?: string;
+  source?: string;
+};
+
+export type UnderlyingSpace =
+  | POSITION_TYPE
+  | INTERVAL_TYPE
+  | ORDINAL_TYPE
+  | UNDEFINED_TYPE;
 
 export const POSITION = (domain: [number, number]): UnderlyingSpace => ({
   kind: "position",
   domain: interval(domain[0], domain[1]),
 });
-export const INTERVAL: UnderlyingSpace = { kind: "interval" };
+
+export const isPOSITION = (space: UnderlyingSpace): space is POSITION_TYPE =>
+  space.kind === "position";
+
+export const INTERVAL = (width: number): UnderlyingSpace => ({
+  kind: "interval",
+  width,
+});
+export const isINTERVAL = (space: UnderlyingSpace): space is INTERVAL_TYPE =>
+  space.kind === "interval";
+
 export const ORDINAL: UnderlyingSpace = { kind: "ordinal" };
+export const isORDINAL = (space: UnderlyingSpace): space is ORDINAL_TYPE =>
+  space.kind === "ordinal";
+
 export const UNDEFINED: UnderlyingSpace = { kind: "undefined" };
+export const isUNDEFINED = (space: UnderlyingSpace): space is UNDEFINED_TYPE =>
+  space.kind === "undefined";

--- a/src/tests/nestedMosaic.ts
+++ b/src/tests/nestedMosaic.ts
@@ -45,6 +45,7 @@ export const testNestedMosaic = () =>
         (items, cls) =>
           stack(
             {
+              key: cls,
               h: _(items).sumBy("count") / 10,
               direction: "x",
               spacing: 2,

--- a/src/util/interval.ts
+++ b/src/util/interval.ts
@@ -1,0 +1,68 @@
+export type Interval = {
+  min: number;
+  max: number;
+};
+
+/**
+ * Creates an interval from min and max values
+ */
+export function interval(min: number, max: number): Interval {
+  return { min, max };
+}
+
+/**
+ * Checks if an interval is valid (min <= max)
+ */
+export const isValid = (interval: Interval): boolean => {
+  return interval.min <= interval.max;
+};
+
+/**
+ * Checks if an interval is empty (min > max)
+ */
+export const isEmpty = (interval: Interval): boolean => {
+  return interval.min > interval.max;
+};
+
+/**
+ * Gets the width of an interval
+ */
+export const width = (interval: Interval): number => {
+  return interval.max - interval.min;
+};
+
+/**
+ * Checks if a value is contained within an interval
+ */
+export const contains = (interval: Interval, value: number): boolean => {
+  return value >= interval.min && value <= interval.max;
+};
+
+/**
+ * Checks if two intervals overlap
+ */
+export const overlaps = (a: Interval, b: Interval): boolean => {
+  return a.min <= b.max && b.min <= a.max;
+};
+
+/**
+ * Computes the union of two intervals
+ */
+export const union = (a: Interval, b: Interval): Interval => {
+  return interval(Math.min(a.min, b.min), Math.max(a.max, b.max));
+};
+
+/**
+ * Computes the union of multiple intervals
+ */
+export const unionAll = (...intervals: Interval[]): Interval => {
+  if (intervals.length === 0) {
+    return interval(0, 0);
+  }
+
+  return intervals.reduce((acc, interval) => union(acc, interval));
+};
+
+export const toJSON = (interval: Interval): string => {
+  return `[${interval.min}, ${interval.max}]`;
+};

--- a/stories/Area.stories.tsx
+++ b/stories/Area.stories.tsx
@@ -24,8 +24,42 @@ export const Area: StoryObj<Args> = {
     const container = initializeContainer();
 
     return guide(catchData, { h: "count", fill: "species" })
-    .spreadX("lake", { spacing: 60 })
-    .connectX("lake", { opacity: 0.7 })
+      .spreadX("lake", { spacing: 60 })
+      .connectX("lake", { opacity: 0.7 })
+      .render(container, {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      });
+  },
+};
+
+export const Ridgeline: StoryObj<Args> = {
+  args: { w: 320, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    return guide(catchData, { h: "count", fill: "species" })
+      .spreadX("lake", { spacing: 80 })
+      .connectX("lake", { mixBlendMode: "normal" })
+      .spreadY("species", { spacing: -16 })
+      .render(container, {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      });
+  },
+};
+
+export const RidgelineNoSpacing: StoryObj<Args> = {
+  args: { w: 320, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    return guide(catchData, { h: "count", fill: "species" })
+      .spreadX("lake", { spacing: 80 })
+      .connectX("lake", { mixBlendMode: "normal" })
+      .spreadY("species", { spacing: 0 })
       .render(container, {
         w: args.w,
         h: args.h,

--- a/stories/BarChart.stories.tsx
+++ b/stories/BarChart.stories.tsx
@@ -126,3 +126,19 @@ export const StackedWithSpacing: StoryObj<Args> = {
       });
   },
 };
+
+export const Grouped: StoryObj<Args> = {
+  args: { w: 420, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    return rect(catchData, { fill: "species", h: "count" })
+      .stackX("species")
+      .transform((d) => orderBy(d, "count", "asc"))
+      .spreadX("lake", { alignment: "start" })
+      .render(container, {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      });
+  },
+};

--- a/stories/BarChart.stories.tsx
+++ b/stories/BarChart.stories.tsx
@@ -40,6 +40,32 @@ export const Vertical: StoryObj<Args> = {
   },
 };
 
+export const Negative: StoryObj<Args> = {
+  args: { w: 320, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    const testData = [
+      { category: "A", value: -30 },
+      { category: "B", value: 80 },
+      { category: "C", value: 45 },
+      { category: "D", value: 60 },
+      { category: "E", value: 20 },
+    ];
+
+    return rect(testData, {
+      fill: "category",
+      h: "value",
+    })
+      .spreadX("category")
+      .render(container, {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      });
+  },
+};
+
 export const Horizontal: StoryObj<Args> = {
   args: { w: 420, h: 400 },
   render: (args: Args) => {

--- a/stories/BarChart.stories.tsx
+++ b/stories/BarChart.stories.tsx
@@ -70,3 +70,19 @@ export const Stacked: StoryObj<Args> = {
       });
   },
 };
+
+export const StackedWithSpacing: StoryObj<Args> = {
+  args: { w: 420, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    return rect(catchData, { fill: "species", h: "count" })
+      .spreadY("species", { spacing: 4 })
+      .transform((d) => orderBy(d, "count", "asc"))
+      .spreadX("lake", { alignment: "start" })
+      .render(container, {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      });
+  },
+};

--- a/stories/BarChart.stories.tsx
+++ b/stories/BarChart.stories.tsx
@@ -55,6 +55,20 @@ export const Horizontal: StoryObj<Args> = {
   },
 };
 
+export const MiddleAligned: StoryObj<Args> = {
+  args: { w: 320, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    return rect(catchData, { fill: "lake", h: "count" })
+      .spreadX("lake", { alignment: "middle" })
+      .render(container, {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      });
+  },
+};
+
 export const Stacked: StoryObj<Args> = {
   args: { w: 420, h: 400 },
   render: (args: Args) => {

--- a/stories/LowLevelCharts.stories.tsx
+++ b/stories/LowLevelCharts.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { rect } from "../src/ast/marks/chart";
+import { initializeContainer } from "./helper";
+import { catchData } from "../src/data/catch";
+import { orderBy } from "../src/lib";
+import { testBoxWhiskerPlot } from "../src/tests/boxwhisker";
+
+const meta: Meta = {
+  title: "Charts/LowLevel",
+  argTypes: {
+    w: {
+      control: { type: "number", min: 100, max: 1000, step: 10 },
+    },
+    h: {
+      control: { type: "number", min: 100, max: 1000, step: 10 },
+    },
+  },
+};
+export default meta;
+
+type Args = { w: number; h: number };
+
+export const BoxWhisker: StoryObj<Args> = {
+  args: { w: 320, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    return testBoxWhiskerPlot().render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+  },
+};

--- a/stories/Scatter.stories.tsx
+++ b/stories/Scatter.stories.tsx
@@ -33,7 +33,7 @@ export const Scatter: StoryObj<Args> = {
       .render(container, {
         w: args.w,
         h: args.h,
-        // axes: true,
+        axes: true,
       });
     return container;
   },


### PR DESCRIPTION
Closes #13. Makes progress towards #3, #22, and #26.

Begins the merge of the `inferPosDomains` and `inferSizeDomains` into a unified `resolveUnderlyingSpace` pass. This pass recursively builds up a tree of nested spaces. For example, these are some of the space corresponding to a stacked bar chart. (Underlying space will be console logged when `debug` is true.)

<img width="478" height="463" alt="Screenshot 2025-10-06 at 6 02 40 PM" src="https://github.com/user-attachments/assets/8cb17717-6aa4-4135-90e1-0b60ad457eaa" />

<img width="531" height="404" alt="Screenshot 2025-10-06 at 6 02 19 PM" src="https://github.com/user-attachments/assets/70640bfe-727c-4554-a73a-33bb2b250088" />

This information lets us more easily create appropriate continuous axes since we can read this information directly off the structure. And we don't erroneously add axes where there shouldn't be any.

There are four underlying spaces in this PR:
- position
- interval
- ordinal
- undefined

Currently position is pretty well-defined and maintains a min-max interval. Interval maintains a width. It's used for a middle-aligned bar chart and a streamgraph, for example.

<img width="435" height="452" alt="Screenshot 2025-10-06 at 6 06 03 PM" src="https://github.com/user-attachments/assets/720044db-2865-4c70-97f7-fca76793affe" />

<img width="452" height="152" alt="Screenshot 2025-10-06 at 6 07 41 PM" src="https://github.com/user-attachments/assets/04fd02e5-3675-47a7-808a-ad10e5374839" />

This PR also allows axes to start at non-zero values such as scatterplots and negative bar charts (though this PR doesn't make them render correctly).

<img width="429" height="501" alt="Screenshot 2025-10-06 at 6 06 23 PM" src="https://github.com/user-attachments/assets/789d4c4f-4d59-4308-b9ab-73eceea44643" />

<img width="490" height="277" alt="Screenshot 2025-10-06 at 6 08 06 PM" src="https://github.com/user-attachments/assets/f3544d97-5985-4b8b-910c-c78fd1f2821c" />

<img width="439" height="469" alt="Screenshot 2025-10-06 at 6 06 47 PM" src="https://github.com/user-attachments/assets/51980fef-ecc1-4ceb-bda5-139dab56462d" />

<img width="420" height="130" alt="Screenshot 2025-10-06 at 6 08 21 PM" src="https://github.com/user-attachments/assets/d87c8574-bf60-46c3-9768-556904cf6685" />