### PR TITLE
feat: high-level charting API (bar chart only)

### DIFF
--- a/packages/gofish-graphics/src/charts/bar.ts
+++ b/packages/gofish-graphics/src/charts/bar.ts
@@ -1,31 +1,47 @@
-import { chart, rect, spread } from "../lib";
+import { chart, rect, spread, Mark } from "../lib";
 
-export const bar = (
-  data: any,
-  options: { x?: string; y?: string; w?: string; h?: string }
+export const bar = <T extends Record<string, any>>(
+  data: T[],
+  options: {
+    x?: keyof T;
+    y?: keyof T;
+    w?: keyof T;
+    h?: keyof T;
+    fill?: keyof T | string;
+    mark?: (options: {
+      h?: string | number | keyof T;
+      w?: string | number | keyof T;
+      fill?: string | keyof T;
+      [key: string]: any;
+    }) => Mark<T | T[] | { item: T | T[]; key: number | string }>;
+  }
 ) => {
   // Error if both x and y are provided (ambiguous)
+  // COMBAK: probably this should do a grid
   if (options.x && options.y) {
     throw new Error(
       "bar chart cannot have both 'x' and 'y' encoding channels. Use 'x' for vertical bars or 'y' for horizontal bars"
     );
   }
 
+  const markFn = options.mark ?? rect;
+
   // Vertical bar chart: if x is provided, spread along x-axis and use h for height
   if (options.x) {
     return chart(data)
       .flow(spread(options.x, { dir: "x" }))
-      .mark(rect({ h: options.h }));
+      .mark(markFn({ h: options.h, fill: options.fill }));
   }
 
   // Horizontal bar chart: if y is provided, spread along y-axis and use w for width
   if (options.y) {
     return chart(data)
       .flow(spread(options.y, { dir: "y" }))
-      .mark(rect({ w: options.w }));
+      .mark(markFn({ w: options.w, fill: options.fill }));
   }
 
   // Error if neither x nor y is provided
+  // COMBAK: probably this should render a single rectangle at the origin
   throw new Error(
     "bar chart requires either 'x' (for vertical bars) or 'y' (for horizontal bars) encoding channel"
   );

--- a/packages/gofish-graphics/src/charts/bar.ts
+++ b/packages/gofish-graphics/src/charts/bar.ts
@@ -45,7 +45,6 @@ class BarChartBuilder<TInput, TOutput = TInput>
       y?: number;
       w?: number | keyof TOutput;
       h?: number | keyof TOutput;
-      spacing?: number;
       alignment?: "start" | "middle" | "end";
     }
   ): BarChartBuilder<TInput, TOutput> {

--- a/packages/gofish-graphics/src/charts/bar.ts
+++ b/packages/gofish-graphics/src/charts/bar.ts
@@ -1,0 +1,32 @@
+import { chart, rect, spread } from "../lib";
+
+export const bar = (
+  data: any,
+  options: { x?: string; y?: string; w?: string; h?: string }
+) => {
+  // Error if both x and y are provided (ambiguous)
+  if (options.x && options.y) {
+    throw new Error(
+      "bar chart cannot have both 'x' and 'y' encoding channels. Use 'x' for vertical bars or 'y' for horizontal bars"
+    );
+  }
+
+  // Vertical bar chart: if x is provided, spread along x-axis and use h for height
+  if (options.x) {
+    return chart(data)
+      .flow(spread(options.x, { dir: "x" }))
+      .mark(rect({ h: options.h }));
+  }
+
+  // Horizontal bar chart: if y is provided, spread along y-axis and use w for width
+  if (options.y) {
+    return chart(data)
+      .flow(spread(options.y, { dir: "y" }))
+      .mark(rect({ w: options.w }));
+  }
+
+  // Error if neither x nor y is provided
+  throw new Error(
+    "bar chart requires either 'x' (for vertical bars) or 'y' (for horizontal bars) encoding channel"
+  );
+};

--- a/packages/gofish-graphics/src/charts/bar.ts
+++ b/packages/gofish-graphics/src/charts/bar.ts
@@ -1,4 +1,81 @@
-import { chart, rect, spread, Mark } from "../lib";
+import { chart, rect, spread, stack, Mark, ChartBuilder } from "../lib";
+import { Stackable } from "./stackable";
+
+// Wrapper class that adds .stack() method to ChartBuilder
+class BarChartBuilder<TInput, TOutput = TInput>
+  implements Stackable<TInput, TOutput>
+{
+  private builder: ChartBuilder<TInput, TOutput>;
+  private readonly barOrientation: "x" | "y";
+  private readonly markOptions: {
+    h?: string | number;
+    w?: string | number;
+    fill?: string;
+  };
+  private readonly markFn?: (options: any) => Mark<any>;
+
+  constructor(
+    builder: ChartBuilder<TInput, TOutput>,
+    barOrientation: "x" | "y",
+    markOptions: {
+      h?: string | number;
+      w?: string | number;
+      fill?: string;
+    },
+    markFn?: (options: any) => Mark<any>
+  ) {
+    this.builder = builder;
+    this.barOrientation = barOrientation;
+    this.markOptions = markOptions;
+    this.markFn = markFn;
+  }
+
+  flow<T1>(op1: any): BarChartBuilder<TInput, T1> {
+    return new BarChartBuilder(
+      this.builder.flow(op1) as any,
+      this.barOrientation,
+      this.markOptions as any,
+      this.markFn
+    );
+  }
+
+  mark(mark?: Mark<TOutput>): any {
+    const finalMark =
+      mark ??
+      (this.markFn ? this.markFn(this.markOptions) : rect(this.markOptions));
+    return this.builder.mark(finalMark as Mark<TOutput>);
+  }
+
+  stack<K extends keyof TOutput>(
+    field: K,
+    options: {
+      x?: number;
+      y?: number;
+      w?: number | keyof TOutput;
+      h?: number | keyof TOutput;
+      spacing?: number;
+      alignment?: "start" | "middle" | "end";
+    }
+  ): BarChartBuilder<TInput, TOutput> {
+    // Stack in the bar orientation direction:
+    // - Vertical bars (x orientation) stack vertically (y direction)
+    // - Horizontal bars (y orientation) stack horizontally (x direction)
+    const stackOptions = {
+      ...options,
+      dir: this.barOrientation === "x" ? ("y" as const) : ("x" as const),
+    };
+
+    // Vertical bars, stacking vertically - use stack operator
+    return new BarChartBuilder(
+      this.builder.flow(
+        stack(field as any, stackOptions) as any
+      ) as ChartBuilder<TInput, TOutput>,
+      this.barOrientation,
+      this.markOptions,
+      this.markFn
+    );
+  }
+}
 
 export const bar = <T extends Record<string, any>>(
   data: T[],
@@ -28,16 +105,30 @@ export const bar = <T extends Record<string, any>>(
 
   // Vertical bar chart: if x is provided, spread along x-axis and use h for height
   if (options.x) {
-    return chart(data)
-      .flow(spread(options.x, { dir: "x" }))
-      .mark(markFn({ h: options.h, fill: options.fill }));
+    const builder = chart(data).flow(spread(options.x, { dir: "x" }));
+    return new BarChartBuilder(
+      builder as ChartBuilder<T[], T[]>,
+      "x",
+      {
+        h: options.h as string | number | undefined,
+        fill: options.fill as string | undefined,
+      },
+      markFn
+    );
   }
 
   // Horizontal bar chart: if y is provided, spread along y-axis and use w for width
   if (options.y) {
-    return chart(data)
-      .flow(spread(options.y, { dir: "y" }))
-      .mark(markFn({ w: options.w, fill: options.fill }));
+    const builder = chart(data).flow(spread(options.y, { dir: "y" }));
+    return new BarChartBuilder(
+      builder as ChartBuilder<T[], T[]>,
+      "y",
+      {
+        w: options.w as string | number | undefined,
+        fill: options.fill as string | undefined,
+      },
+      markFn
+    );
   }
 
   // Error if neither x nor y is provided

--- a/packages/gofish-graphics/src/charts/bar.ts
+++ b/packages/gofish-graphics/src/charts/bar.ts
@@ -24,14 +24,6 @@ class BarChartBuilder<TInput, TOutput = TInput>
     this.barOrientation = barOrientation;
   }
 
-  // Delegate all ChartBuilder methods
-  flow<T1>(op1: Operator<TInput, T1>): BarChartBuilder<TInput, T1> {
-    return new BarChartBuilder(
-      this.builder.flow(op1) as ChartBuilder<TInput, T1>,
-      this.barOrientation
-    );
-  }
-
   as(name: string): BarChartBuilder<TInput, TOutput> {
     return new BarChartBuilder(this.builder.as(name), this.barOrientation);
   }
@@ -49,24 +41,22 @@ class BarChartBuilder<TInput, TOutput = TInput>
   stack<K extends keyof TOutput>(
     field: K,
     options?: {
+      x?: number;
+      y?: number;
+      w?: number | keyof TOutput;
+      h?: number | keyof TOutput;
       spacing?: number;
       alignment?: "start" | "middle" | "end";
     }
   ): BarChartBuilder<TInput, TOutput> {
-    // Stack in the bar orientation direction:
-    // - Vertical bars (x orientation) stack vertically (y direction)
-    // - Horizontal bars (y orientation) stack horizontally (x direction)
     const stackOptions = {
       ...options,
       dir: this.barOrientation,
     };
 
-    // stack() returns Operator<T[], T[]>, and in bar chart context TOutput is T[]
-    // TypeScript has trouble with overload resolution here, so we bypass it
-    const builderAny = this.builder as any;
-    const stackOp = stack(field as any, stackOptions);
+    const stackOp = stack(field, stackOptions);
     return new BarChartBuilder(
-      builderAny.flow(stackOp) as ChartBuilder<TInput, TOutput>,
+      this.builder.flow(stackOp as unknown as Operator<TInput, TOutput>),
       this.barOrientation
     );
   }

--- a/packages/gofish-graphics/src/charts/design.md
+++ b/packages/gofish-graphics/src/charts/design.md
@@ -1,0 +1,30 @@
+# Design of the High-Level Chart API
+
+This level is the closest to the original GoG. But because we also have the mid- and low-level APIs,
+we can make this level much more restrictive and less compositional. Our goal at this level is to
+match user intentions of the form "I want to make a bar chart."
+
+That being said, these charts still produce GoFish scenegraphs so they can be transformed by
+coordinate systems, layered, added as marks to `chart` pipelines, etc. This preserves a lot (all?)
+of the compositional power of the GoG.
+
+## Do Less
+
+The name of the game here is _do less_. Do less inference than you think. Cover fewer chart types
+with one function call than you might want to. This keeps things readable and predictable. It also
+makes contributing examples easier, because they don't have to be as general.
+
+Inference at this level of abstraction also breaks down really quickly. What might work well for bar
+charts or bars, lines, and areas, quickly breaks down for more complex charts like waffles, boxes,
+and mosaics.
+
+Chart names at this level carry semantic/pragmatic meaning. If we allow too much flexibility in e.g.
+a bar chart, then the name "bar chart" loses its meaning.
+
+## Leave Space for Chart-Type DSLs
+
+Don't try to do too much in a flat API for things like waffles or mosaics. That's a nice space for a
+domain-specific language (DSL) to express these charts. For example, the Atom grammar for unit
+charts could be ported. Or we could port productplots. These are useful for collections of charts
+that have hierarchical structure, but have domain-specific primitives with more restrictive
+structure than the mid-level API.

--- a/packages/gofish-graphics/src/charts/design.md
+++ b/packages/gofish-graphics/src/charts/design.md
@@ -28,3 +28,64 @@ domain-specific language (DSL) to express these charts. For example, the Atom gr
 charts could be ported. Or we could port productplots. These are useful for collections of charts
 that have hierarchical structure, but have domain-specific primitives with more restrictive
 structure than the mid-level API.
+
+# Forks Not Taken
+
+## The Road to Gantt Charts
+
+One thing we might naturally want to try is changing the traditional encoding style:
+
+```ts
+barChart(data, { x: "x", y: "y" });
+```
+
+to
+
+```ts
+barChart(data, { x: "x", h: "y" });
+```
+
+since bars really use height to encode information. This makes switching between vertical and
+horizontal bars a little harder, because we also have to switch `x` and `h` to `y` and `w`. But also
+this affords a spec like:
+
+```ts
+barChart(data, { x: "x", h: "y", y: "group" });
+```
+
+And what should that mean? Maybe something like a Gantt chart, except that Gantt charts can have
+multiple bars in the same group whereas a bar chart can't (except for stacking, which isn't the same
+thing).
+
+I checked ggplot2 and plotnine and actually a lot of charts do just fine with `x` and `y` without
+resorting to `x` and `h`, which might be slightly higher cognitive load at this level of
+abstraction. `x` and `y` act more like axes than dimensions at this level (also consistent with
+ggplot2 where if you give `x` and `y`, but no marks, it will still render an empty coordinate space
+of the proper size). Moreover, at a later time we can still stuff more data into each axis by giving
+it an option like this: `x: { ... }`. That works well for e.g. box and whisker charts, which can
+take quartile information.
+
+It's possible we'll revisit and modify this decision later, but right now I like erring on the side
+of familiarity, because (i) I don't think we should take advantage of the Gantt chart affordance and
+(ii) the mid- and low-level APIs do a good job at being explicit about visual structure, so if you
+really wanna be aware that a bar chart encodes data with height, then look at those abstraction
+levels!
+
+## The Road to `Auto`
+
+Another thing I tried is the Vega-Lite approach. Suppose we don't just have encoding channels, but
+we also know the types associated with those channels. Then we might ask, for example, what happens
+if we have a bar chart where `x` and `y` are both continuous values? Or both discrete? Maybe we'd
+get a scatterplot and a heatmap, respectively. This road leads to the `auto` mark like in Observable
+Plot.
+
+I looked back on this design option, and I realized that I'd misunderstood how Vega-Lite's bar mark
+works. I thought that it made a scatterplot if you use two continuous values, but that's only if the
+two values are the same field! (And in that case it still ends up stacking the y-axis...) So there
+are really a lot of heuristics going on inside that bar mark. I'd like to avoid that complexity, but
+I think we can still be fairly predictable in how we handle other data types. For example, we could,
+like Vega-Lite when the fields are different, make a bar chart with continuous positioning on the
+x-axis when both fields are continuous.
+
+For now we will just error on data types we don't expect (or treat them as the types we _do_ expect)
+and revisit this decision when we have more complex examples to look at.

--- a/packages/gofish-graphics/src/charts/examples.md
+++ b/packages/gofish-graphics/src/charts/examples.md
@@ -1,0 +1,93 @@
+# Examples
+
+All examples will end in
+
+```ts
+.render(container, {
+  w: 500,
+  h: 300,
+  axes: true,
+});
+```
+
+so we can omit it from the examples.
+
+## Bar Charts
+
+### Vertical Bar Chart
+
+```ts
+barChart(data, { x: "x", y: "y" });
+```
+
+desugars to (no complex inference so readable w/o type annotations):
+
+```ts
+barChart(data, { x: "x", y: "y", orientation: "y" });
+```
+
+### Horizontal Bar Chart
+
+```ts
+barChart(data, { x: "x", y: "y", orientation: "x" });
+```
+
+### Stacked Bar Chart
+
+```ts
+barChart(data, { x: "x", y: "y" }).stack("group");
+```
+
+### Grouped Bar Chart
+
+```ts
+barChart(data, { x: "x", y: "y" }).group("group");
+```
+
+## Line Charts
+
+```ts
+lineChart(data, { x: "x", y: "y" });
+```
+
+## Scatter Plots
+
+```ts
+scatterChart(data, { x: "x", y: "y" });
+```
+
+## Area Charts
+
+```ts
+areaChartY(data, { x: "x", y: "y" });
+```
+
+## Stacked Area Charts
+
+```ts
+areaChart(data, { x: "x", y: "y" }).stack("group");
+```
+
+## Streamgraph
+
+```ts
+areaChart(data, { x: "x", y: "y", alignment: "middle" }).stack("group");
+```
+
+## Ribbon Charts
+
+```ts
+ribbonChart(data, { x: "x", y: "y" }).stack("group");
+```
+
+## Pie Charts
+
+```ts
+pieChart(data, { theta: "category", size: "value" });
+```
+
+## Rose Charts
+
+```ts
+roseChart(data, { theta: "category", r: "value" }).stack("group");
+```

--- a/packages/gofish-graphics/src/charts/stackable.ts
+++ b/packages/gofish-graphics/src/charts/stackable.ts
@@ -6,7 +6,6 @@ export interface Stackable<TInput, TOutput> {
       y?: number;
       w?: number | keyof TOutput;
       h?: number | keyof TOutput;
-      spacing?: number;
       alignment?: "start" | "middle" | "end";
     }
   ): Stackable<TInput, TOutput>;

--- a/packages/gofish-graphics/src/charts/stackable.ts
+++ b/packages/gofish-graphics/src/charts/stackable.ts
@@ -1,0 +1,13 @@
+export interface Stackable<TInput, TOutput> {
+  stack<K extends keyof TOutput>(
+    field: K,
+    options: {
+      x?: number;
+      y?: number;
+      w?: number | keyof TOutput;
+      h?: number | keyof TOutput;
+      spacing?: number;
+      alignment?: "start" | "middle" | "end";
+    }
+  ): Stackable<TInput, TOutput>;
+}

--- a/packages/gofish-graphics/stories/charts/Bar.stories.tsx
+++ b/packages/gofish-graphics/stories/charts/Bar.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/html";
 import { initializeContainer } from "../helper";
-import { bar } from "../../src/charts/bar";
+import { barChart } from "../../src/charts/bar";
 import { circle } from "../../src/lib";
 
 const meta: Meta = {
@@ -32,7 +32,7 @@ export const Vertical: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, { x: "category", h: "value" }).render(container, {
+    barChart(testData, { x: "category", y: "value" }).render(container, {
       w: args.w,
       h: args.h,
       axes: true,
@@ -47,7 +47,11 @@ export const Horizontal: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, { y: "category", w: "value" }).render(container, {
+    barChart(testData, {
+      x: "value",
+      y: "category",
+      orientation: "x",
+    }).render(container, {
       w: args.w,
       h: args.h,
       axes: true,
@@ -62,14 +66,15 @@ export const VerticalWithFillColor: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, { x: "category", h: "value", fill: "#4ecdc4" }).render(
-      container,
-      {
-        w: args.w,
-        h: args.h,
-        axes: true,
-      }
-    );
+    barChart(testData, {
+      x: "category",
+      y: "value",
+      fill: "#4ecdc4",
+    }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
 
     return container;
   },
@@ -80,14 +85,16 @@ export const HorizontalWithFillColor: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, { y: "category", w: "value", fill: "#ff6b6b" }).render(
-      container,
-      {
-        w: args.w,
-        h: args.h,
-        axes: true,
-      }
-    );
+    barChart(testData, {
+      x: "value",
+      y: "category",
+      orientation: "x",
+      fill: "#ff6b6b",
+    }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
 
     return container;
   },
@@ -98,9 +105,9 @@ export const VerticalWithFillField: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, {
+    barChart(testData, {
       x: "category",
-      h: "value",
+      y: "value",
       fill: "color",
     }).render(container, {
       w: args.w,
@@ -117,9 +124,10 @@ export const HorizontalWithFillField: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, {
+    barChart(testData, {
+      x: "value",
       y: "category",
-      w: "value",
+      orientation: "x",
       fill: "color",
     }).render(container, {
       w: args.w,
@@ -136,9 +144,9 @@ export const VerticalWithCustomMark: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, {
+    barChart(testData, {
       x: "category",
-      h: "value",
+      y: "value",
       mark: circle,
     }).render(container, {
       w: args.w,
@@ -155,9 +163,10 @@ export const HorizontalWithCustomMark: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, {
+    barChart(testData, {
+      x: "value",
       y: "category",
-      w: "value",
+      orientation: "x",
       mark: circle,
     }).render(container, {
       w: args.w,
@@ -174,9 +183,9 @@ export const VerticalWithCustomMarkAndFill: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, {
+    barChart(testData, {
       x: "category",
-      h: "value",
+      y: "value",
       fill: "#6c5ce7",
       mark: circle,
     }).render(container, {
@@ -194,9 +203,10 @@ export const HorizontalWithCustomMarkAndFill: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    bar(testData, {
+    barChart(testData, {
+      x: "value",
       y: "category",
-      w: "value",
+      orientation: "x",
       fill: "#f9ca24",
       mark: circle,
     }).render(container, {

--- a/packages/gofish-graphics/stories/charts/Bar.stories.tsx
+++ b/packages/gofish-graphics/stories/charts/Bar.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/html";
 import { initializeContainer } from "../helper";
 import { bar } from "../../src/charts/bar";
+import { circle } from "../../src/lib";
 
 const meta: Meta = {
   title: "Charts/Bar",
@@ -17,13 +18,13 @@ export default meta;
 
 type Args = { w: number; h: number };
 
-// Simple test data for bar charts
+// Test data for bar charts
 const testData = [
-  { category: "A", value: 30 },
-  { category: "B", value: 80 },
-  { category: "C", value: 45 },
-  { category: "D", value: 60 },
-  { category: "E", value: 20 },
+  { category: "A", value: 30, color: "#ff6b6b" },
+  { category: "B", value: 80, color: "#4ecdc4" },
+  { category: "C", value: 45, color: "#45b7d1" },
+  { category: "D", value: 60, color: "#f9ca24" },
+  { category: "E", value: 20, color: "#6c5ce7" },
 ];
 
 export const Vertical: StoryObj<Args> = {
@@ -47,6 +48,158 @@ export const Horizontal: StoryObj<Args> = {
     const container = initializeContainer();
 
     bar(testData, { y: "category", w: "value" }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
+export const VerticalWithFillColor: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, { x: "category", h: "value", fill: "#4ecdc4" }).render(
+      container,
+      {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      }
+    );
+
+    return container;
+  },
+};
+
+export const HorizontalWithFillColor: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, { y: "category", w: "value", fill: "#ff6b6b" }).render(
+      container,
+      {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      }
+    );
+
+    return container;
+  },
+};
+
+export const VerticalWithFillField: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, {
+      x: "category",
+      h: "value",
+      fill: "color",
+    }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
+export const HorizontalWithFillField: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, {
+      y: "category",
+      w: "value",
+      fill: "color",
+    }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
+export const VerticalWithCustomMark: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, {
+      x: "category",
+      h: "value",
+      mark: circle,
+    }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
+export const HorizontalWithCustomMark: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, {
+      y: "category",
+      w: "value",
+      mark: circle,
+    }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
+export const VerticalWithCustomMarkAndFill: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, {
+      x: "category",
+      h: "value",
+      fill: "#6c5ce7",
+      mark: circle,
+    }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
+export const HorizontalWithCustomMarkAndFill: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, {
+      y: "category",
+      w: "value",
+      fill: "#f9ca24",
+      mark: circle,
+    }).render(container, {
       w: args.w,
       h: args.h,
       axes: true,

--- a/packages/gofish-graphics/stories/charts/Bar.stories.tsx
+++ b/packages/gofish-graphics/stories/charts/Bar.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import { bar } from "../../src/charts/bar";
+
+const meta: Meta = {
+  title: "Charts/Bar",
+  argTypes: {
+    w: {
+      control: { type: "number", min: 100, max: 1000, step: 10 },
+    },
+    h: {
+      control: { type: "number", min: 100, max: 1000, step: 10 },
+    },
+  },
+};
+export default meta;
+
+type Args = { w: number; h: number };
+
+// Simple test data for bar charts
+const testData = [
+  { category: "A", value: 30 },
+  { category: "B", value: 80 },
+  { category: "C", value: 45 },
+  { category: "D", value: 60 },
+  { category: "E", value: 20 },
+];
+
+export const Vertical: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, { x: "category", h: "value" }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
+export const Horizontal: StoryObj<Args> = {
+  args: { w: 500, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    bar(testData, { y: "category", w: "value" }).render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};


### PR DESCRIPTION
Progress towards #35.

Known issue: The tests use `circle`, but the circle mark doesn't work properly so the result looks weird. This isn't a problem with this part of the system, but with the circle mark itself so we'll keep the "broken" test for now.

See `design.md` for an explanation of the design of this level.
See `examples.md` for current and future syntax examples.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a high-level `barChart` API with orientation, fill, and custom mark support, a `BarChartBuilder` enabling `.stack()`, plus docs and Storybook examples.
> 
> - **High-level Bar Chart API**
>   - Add `barChart(data, { x, y, orientation?, fill?, mark? })` in `src/charts/bar.ts`.
>   - Supports vertical/horizontal orientation via `orientation: 'y' | 'x'`, fill by field or color, and custom marks (default `rect`).
>   - Errors if `x` or `y` are missing.
>   - Introduce `BarChartBuilder` wrapper providing `.stack()`; preserves builder methods (`as`, `resolve`, `render`).
> - **Stacking Infrastructure**
>   - Add `Stackable` interface in `src/charts/stackable.ts` and use `stack(...)` with orientation-aware `dir`.
> - **Docs & Examples**
>   - Add `design.md` outlining the high-level chart API philosophy and trade-offs.
>   - Add `examples.md` with usage patterns for bar and other chart types.
> - **Storybook**
>   - New `stories/charts/Bar.stories.tsx` showcasing vertical/horizontal bars, fill by color/field, and custom mark variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42cf7e6f259cce87cebbc225e9e06b7c71bca43a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->