### PR TITLE
fix: Negative bar chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 .ipynb_checkpoints/
 *.egg-info/
 _static/
+.cursor/debug.log

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -299,15 +299,20 @@ export class GoFishNode {
 
   public place(pos: FancyPosition): void {
     const elabPos = elaboratePosition(pos);
-    /* for each dimension, if intrinsic dim is not defined, assign pos to that. otherwise assign it
-    to corresponding translation */
+    /* For each dimension, if intrinsic dim is not defined, assign pos to that.
+     * Otherwise, compute translation to position the implicit anchor point.
+     *
+     * The anchor point is always the local origin (0). Shapes set up their
+     * intrinsic dimensions so that one edge is at 0:
+     * - For positive sizes: min = 0 (anchor at bottom)
+     * - For negative sizes: max = 0 (anchor at top)
+     */
     for (let i = 0; i < elabPos.length; i++) {
       if (elabPos[i] === undefined) continue;
       if (this.intrinsicDims?.[i]?.min === undefined) {
         this.intrinsicDims![i].min = elabPos[i]!;
       } else if (this.transform?.translate?.[i] === undefined) {
-        this.transform!.translate![i] =
-          elabPos[i]! - (this.intrinsicDims![i].min ?? 0);
+        this.transform!.translate![i] = elabPos[i]!;
       } else {
         // console.warn(
         //   "placing node with both intrinsic and transform defined:",

--- a/packages/gofish-graphics/src/ast/_ref.tsx
+++ b/packages/gofish-graphics/src/ast/_ref.tsx
@@ -199,15 +199,20 @@ export class GoFishRef {
 
   public place(pos: FancyPosition): void {
     const elabPos = elaboratePosition(pos);
-    /* for each dimension, if intrinsic dim is not defined, assign pos to that. otherwise assign it
-    to corresponding translation */
+    /* For each dimension, if intrinsic dim is not defined, assign pos to that.
+     * Otherwise, compute translation to position the implicit anchor point.
+     *
+     * The anchor point is always the local origin (0). Shapes set up their
+     * intrinsic dimensions so that one edge is at 0:
+     * - For positive sizes: min = 0 (anchor at bottom)
+     * - For negative sizes: max = 0 (anchor at top)
+     */
     for (let i = 0; i < elabPos.length; i++) {
       if (elabPos[i] === undefined) continue;
       if (this.intrinsicDims?.[i]?.min === undefined) {
         this.intrinsicDims![i].min = elabPos[i]!;
       } else {
-        this.transform!.translate![i] =
-          elabPos[i]! - (this.intrinsicDims![i].min ?? 0);
+        this.transform!.translate![i] = elabPos[i]!;
       }
     }
   }

--- a/packages/gofish-graphics/src/ast/domain.ts
+++ b/packages/gofish-graphics/src/ast/domain.ts
@@ -8,7 +8,13 @@ export type ContinuousDomain = {
   measure: Measure;
 };
 
-export const continuous = ({ value, measure }: { value: [number, number]; measure: Measure }): ContinuousDomain => ({
+export const continuous = ({
+  value,
+  measure,
+}: {
+  value: [number, number];
+  measure: Measure;
+}): ContinuousDomain => ({
   type: "continuous",
   value,
   measure,
@@ -26,11 +32,16 @@ export const aesthetic = (value: any): AestheticDomain => ({
 
 export const canUnifyDomains = (domains: Domain[]) => {
   return domains.every(
-    (domain) => domain !== undefined && domain.type === "continuous" && domain.measure === domains[0].measure
+    (domain) =>
+      domain !== undefined &&
+      domain.type === "continuous" &&
+      domain.measure === domains[0].measure
   );
 };
 
-export const unifyContinuousDomains = (domains: ContinuousDomain[]): ContinuousDomain => {
+export const unifyContinuousDomains = (
+  domains: ContinuousDomain[]
+): ContinuousDomain => {
   const measure = domains[0].measure;
   const mins = domains.map((domain) => domain.value[0]);
   const maxs = domains.map((domain) => domain.value[1]);
@@ -41,8 +52,13 @@ export const unifyContinuousDomains = (domains: ContinuousDomain[]): ContinuousD
 };
 
 // creates an affine scale transforming the domain to [0, size] or [size, 0] if reverse is true
-export const computePosScale = (domain: ContinuousDomain, size: number, reverse: boolean = false) => {
+export const computePosScale = (
+  domain: ContinuousDomain,
+  size: number,
+  reverse: boolean = false
+) => {
   const [min, max] = domain.value;
   const scale = size / (max - min);
-  return (pos: number) => (reverse ? size - (pos - min) * scale : (pos - min) * scale);
+  return (pos: number) =>
+    reverse ? size - (pos - min) * scale : (pos - min) * scale;
 };

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -324,22 +324,29 @@ export const stack = withGoFish(
           );
 
           /* align */
-          // For "start" alignment with mixed positive/negative bars, we need to align at the baseline (0 in data space)
-          // Use the position scale to map data value 0 to pixel position
-          const baselinePos = posScales?.[alignDir]
-            ? posScales[alignDir](0)
-            : 0;
           if (alignment === "start") {
+            // For "start" alignment with mixed positive/negative bars, align at the baseline (0 in data space)
+            // Use the position scale to map data value 0 to pixel position
+            const baselinePos = posScales?.[alignDir]
+              ? posScales[alignDir](0)
+              : 0;
             for (const child of childPlaceables) {
               child.place({ [alignDir]: baselinePos });
             }
           } else if (alignment === "middle") {
+            // For "middle" alignment, center children in the available space
+            const centerPos = size[alignDir] / 2;
             for (const child of childPlaceables) {
               child.place({
-                [alignDir]: baselinePos - child.dims[alignDir].size! / 2,
+                [alignDir]: centerPos - child.dims[alignDir].size! / 2,
               });
             }
           } else if (alignment === "end") {
+            // For "end" alignment with mixed positive/negative bars, align at the baseline (0 in data space)
+            // Use the position scale to map data value 0 to pixel position
+            const baselinePos = posScales?.[alignDir]
+              ? posScales[alignDir](0)
+              : 0;
             for (const child of childPlaceables) {
               child.place({
                 [alignDir]: baselinePos - child.dims[alignDir].size!,

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -126,9 +126,8 @@ export const rect = ({
         } else {
           const min = isValue(dims[0].min) ? getValue(dims[0].min) : 0;
           const size = isValue(dims[0].size) ? getValue(dims[0].size) : 0;
-          underlyingSpaceX = POSITION(
-            size >= 0 ? [min, min + size] : [min + size, min]
-          );
+          const domain = size >= 0 ? [min, min + size] : [min + size, min];
+          underlyingSpaceX = POSITION(domain);
         }
 
         let underlyingSpaceY = UNDEFINED;
@@ -141,9 +140,8 @@ export const rect = ({
         } else {
           const min = isValue(dims[1].min) ? getValue(dims[1].min) : 0;
           const size = isValue(dims[1].size) ? getValue(dims[1].size) : 0;
-          underlyingSpaceY = POSITION(
-            size >= 0 ? [min, min + size] : [min + size, min]
-          );
+          const domain = size >= 0 ? [min, min + size] : [min + size, min];
+          underlyingSpaceY = POSITION(domain);
         }
 
         // const w = computeIntrinsicSize(dims[0].size);
@@ -205,6 +203,12 @@ export const rect = ({
             undefined
           );
           w = max - min;
+        } else if (isValue(dims[0].size) && posScales?.[0]) {
+          // If we have size but no min, and posScales exists, use position scale
+          // Treat min as 0 (baseline) and compute width from position scale
+          const minPos = posScales[0](0);
+          const maxPos = posScales[0](getValue(dims[0].size)!);
+          w = maxPos - minPos;
         } else {
           w = computeSize(dims[0].size, scaleFactors?.[0]!, size[0]);
         }
@@ -219,6 +223,12 @@ export const rect = ({
             undefined
           );
           h = max - min;
+        } else if (isValue(dims[1].size) && posScales?.[1]) {
+          // If we have size but no min, and posScales exists, use position scale
+          // Treat min as 0 (baseline) and compute height from position scale
+          const minPos = posScales[1](0);
+          const maxPos = posScales[1](getValue(dims[1].size)!);
+          h = maxPos - minPos;
         } else {
           h = computeSize(dims[1].size, scaleFactors?.[1]!, size[1]);
         }
@@ -226,17 +236,17 @@ export const rect = ({
         return {
           intrinsicDims: [
             {
-              min: 0,
+              min: w >= 0 ? 0 : w,
               size: w,
               center: w / 2,
-              max: w,
+              max: w >= 0 ? w : 0,
               embedded: dims[0].embedded,
             },
             {
-              min: 0,
+              min: h >= 0 ? 0 : h,
               size: h,
               center: h / 2,
-              max: h,
+              max: h >= 0 ? h : 0,
               embedded: dims[1].embedded,
             },
           ],

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -331,18 +331,24 @@ export const rect = ({
 
           // For linear spaces, we can render a simple line
           if (space.type === "linear") {
-            const x = isXEmbedded
+            const baseX = isXEmbedded
               ? (displayDims[0].min ?? 0)
               : aestheticMid - thickness / 2;
-            const y = isXEmbedded
+            const baseY = isXEmbedded
               ? aestheticMid - thickness / 2
               : (displayDims[1].min ?? 0);
-            const width = isXEmbedded
+            const rawWidth = isXEmbedded
               ? (displayDims[0].max ?? 0) - (displayDims[0].min ?? 0)
               : thickness;
-            const height = isXEmbedded
+            const rawHeight = isXEmbedded
               ? thickness
               : (displayDims[1].max ?? 0) - (displayDims[1].min ?? 0);
+
+            // Handle negative dimensions by using absolute values and adjusting positions
+            const width = Math.abs(rawWidth);
+            const height = Math.abs(rawHeight);
+            const x = rawWidth < 0 ? baseX + rawWidth : baseX;
+            const y = rawHeight < 0 ? baseY + rawHeight : baseY;
 
             return (
               <rect
@@ -393,10 +399,17 @@ export const rect = ({
 
         // If we're in a linear space, render as a rect element
         if (space.type === "linear") {
-          const x = displayDims[0].min ?? 0;
-          const y = displayDims[1].min ?? 0;
-          const width = (displayDims[0].max ?? 0) - x;
-          const height = (displayDims[1].max ?? 0) - y;
+          const baseX = displayDims[0].min ?? 0;
+          const baseY = displayDims[1].min ?? 0;
+          const rawWidth = (displayDims[0].max ?? 0) - baseX;
+          const rawHeight = (displayDims[1].max ?? 0) - baseY;
+
+          // Handle negative dimensions by using absolute values and adjusting positions
+          const width = Math.abs(rawWidth);
+          const height = Math.abs(rawHeight);
+          const x = rawWidth < 0 ? baseX + rawWidth : baseX;
+          const y = rawHeight < 0 ? baseY + rawHeight : baseY;
+
           return (
             <rect
               transform={`scale(1, -1)`}

--- a/packages/gofish-graphics/stories/ForwardSyntaxV3.stories.tsx
+++ b/packages/gofish-graphics/stories/ForwardSyntaxV3.stories.tsx
@@ -64,6 +64,32 @@ export const BarChart: StoryObj<Args> = {
   },
 };
 
+export const NegativeBarChart: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    const testData = [
+      { category: "A", value: -30 },
+      { category: "B", value: 80 },
+      { category: "C", value: 45 },
+      { category: "D", value: 60 },
+      { category: "E", value: 20 },
+    ];
+
+    chart(testData)
+      .flow(spread("category", { dir: "x" }))
+      .mark(rect({ h: "value" }))
+      .render(container, {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      });
+
+    return container;
+  },
+};
+
 export const HorizontalBarChart: StoryObj<Args> = {
   args: { w: 400, h: 400 },
   render: (args: Args) => {


### PR DESCRIPTION
Closes #26.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves handling of negative values in bar-like visuals and alignment behavior.
> 
> - Adjusts `place` logic in `GoFishNode` and `GoFishRef` to treat the local origin as the anchor, simplifying translation when intrinsic dims exist
> - In `rect`: compute width/height via position scales when only size is provided; set intrinsic `min/max` based on sign to support negative extents; normalize rendering by using absolute sizes and adjusted `x/y` for negative dimensions
> - In `stack`: align `start/end` to the baseline using `posScales(0)`; center for `middle`; compute align extents from children `min/max` to cover mixed positive/negative bars
> - Minor refactors/formatting in `domain` and small cleanups
> - Storybook: adds `NegativeBarChart` to demonstrate and verify negative bars
> - `.gitignore`: ignores `.cursor/debug.log`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98fbb2f07c8a4485cfa323e56db5199287388301. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->