### PR TITLE
Rename INTERVAL underlying space type to DIFFERENCE

### DIFF
--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -30,7 +30,7 @@ import { color6 } from "../color";
 import * as Monotonic from "../util/monotonic";
 import { findTargetMonotonic } from "../util";
 import {
-  isINTERVAL,
+  isDIFFERENCE,
   isORDINAL,
   isPOSITION,
   isUNDEFINED,
@@ -490,8 +490,8 @@ export const debugUnderlyingSpaceTree = (
         .map((s) => {
           if (isPOSITION(s)) {
             return `position(${toJSON(s.domain)})`;
-          } else if (isINTERVAL(s)) {
-            return `interval(${s.width})`;
+          } else if (isDIFFERENCE(s)) {
+            return `difference(${s.width})`;
           } else if (isORDINAL(s)) {
             return `ordinal(${s.spacing})`;
           } else if (isUNDEFINED(s)) {
@@ -504,8 +504,8 @@ export const debugUnderlyingSpaceTree = (
     } else {
       if (isPOSITION(space)) {
         return `position(${toJSON(space.domain)})`;
-      } else if (isINTERVAL(space)) {
-        return `interval(${space.width})`;
+      } else if (isDIFFERENCE(space)) {
+        return `difference(${space.width})`;
       } else if (isORDINAL(space)) {
         return `ordinal(${space.spacing})`;
       } else if (isUNDEFINED(space)) {

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -12,7 +12,7 @@ import { computePosScale } from "./domain";
 import { tickIncrement, ticks, nice } from "d3-array";
 import { isConstant } from "../util/monotonic";
 import {
-  isINTERVAL,
+  isDIFFERENCE,
   isPOSITION,
   type UnderlyingSpace,
 } from "./underlyingSpace";
@@ -405,7 +405,7 @@ export const render = (
             </Show>
             <Show
               when={
-                isINTERVAL(underlyingSpaceY) &&
+                isDIFFERENCE(underlyingSpaceY) &&
                 scaleContext?.y &&
                 "scaleFactor" in scaleContext.y
               }
@@ -528,10 +528,10 @@ export const render = (
               })()}
             </Show>
 
-            {/* x axis (interval) */}
+            {/* x axis (difference) */}
             <Show
               when={
-                isINTERVAL(underlyingSpaceX) &&
+                isDIFFERENCE(underlyingSpaceX) &&
                 scaleContext?.x &&
                 "scaleFactor" in scaleContext.x
               }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -17,7 +17,7 @@ import { getScaleContext } from "../gofish";
 import { withGoFish } from "../withGoFish";
 import * as Monotonic from "../../util/monotonic";
 import {
-  INTERVAL,
+  DIFFERENCE,
   ORDINAL,
   POSITION,
   UNDEFINED,
@@ -97,7 +97,7 @@ export const stack = withGoFish(
             const domain = Interval.unionAll(...childDomains);
             alignSpace = POSITION([domain.min, domain.max]);
           }
-          // if children are all UNDEFINED or POSITION and alignment is middle, return INTERVAL
+          // if children are all UNDEFINED or POSITION and alignment is middle, return DIFFERENCE
           else if (
             children.every((child) => isPOSITION(child[alignDir])) &&
             alignment === "middle"
@@ -105,7 +105,7 @@ export const stack = withGoFish(
             const domain = Interval.unionAll(
               ...children.map((child) => child[alignDir].domain!)
             );
-            alignSpace = INTERVAL(Interval.width(domain));
+            alignSpace = DIFFERENCE(Interval.width(domain));
           } else {
             alignSpace = UNDEFINED;
           }

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -32,7 +32,7 @@ import { aesthetic, continuous, Domain } from "../domain";
 import { scaleContext } from "../gofish";
 import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic, computeSize } from "../../util";
-import { INTERVAL, ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
+import { DIFFERENCE, ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
 
 const computeIntrinsicSize = (
   input: MaybeValue<number> | undefined
@@ -121,8 +121,8 @@ export const rect = ({
           // nothing is data-driven
           underlyingSpaceX = ORDINAL;
         } else if (isAesthetic(dims[0].min) && isValue(dims[0].size)) {
-          // the best we can do is interval
-          underlyingSpaceX = INTERVAL;
+          // the best we can do is difference
+          underlyingSpaceX = DIFFERENCE(getValue(dims[0].size)!);
         } else {
           const min = isValue(dims[0].min) ? getValue(dims[0].min) : 0;
           const size = isValue(dims[0].size) ? getValue(dims[0].size) : 0;
@@ -135,8 +135,8 @@ export const rect = ({
           // nothing is data-driven
           underlyingSpaceY = ORDINAL;
         } else if (isAesthetic(dims[1].min) && isValue(dims[1].size)) {
-          // the best we can do is interval
-          underlyingSpaceY = INTERVAL;
+          // the best we can do is difference
+          underlyingSpaceY = DIFFERENCE(getValue(dims[1].size)!);
         } else {
           const min = isValue(dims[1].min) ? getValue(dims[1].min) : 0;
           const size = isValue(dims[1].size) ? getValue(dims[1].size) : 0;

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -3,7 +3,7 @@ import { interval, Interval } from "../util/interval";
 
 export type UnderlyingSpaceKind =
   | "position"
-  | "interval"
+  | "difference"
   | "ordinal"
   | "undefined";
 
@@ -15,8 +15,8 @@ export type POSITION_TYPE = {
   source?: string;
 };
 
-export type INTERVAL_TYPE = {
-  kind: "interval";
+export type DIFFERENCE_TYPE = {
+  kind: "difference";
   width: number;
   spacing?: number;
   ordinalGroupId?: string;
@@ -39,7 +39,7 @@ export type UNDEFINED_TYPE = {
 
 export type UnderlyingSpace =
   | POSITION_TYPE
-  | INTERVAL_TYPE
+  | DIFFERENCE_TYPE
   | ORDINAL_TYPE
   | UNDEFINED_TYPE;
 
@@ -51,12 +51,12 @@ export const POSITION = (domain: [number, number]): UnderlyingSpace => ({
 export const isPOSITION = (space: UnderlyingSpace): space is POSITION_TYPE =>
   space.kind === "position";
 
-export const INTERVAL = (width: number): UnderlyingSpace => ({
-  kind: "interval",
+export const DIFFERENCE = (width: number): UnderlyingSpace => ({
+  kind: "difference",
   width,
 });
-export const isINTERVAL = (space: UnderlyingSpace): space is INTERVAL_TYPE =>
-  space.kind === "interval";
+export const isDIFFERENCE = (space: UnderlyingSpace): space is DIFFERENCE_TYPE =>
+  space.kind === "difference";
 
 export const ORDINAL: UnderlyingSpace = { kind: "ordinal" };
 export const isORDINAL = (space: UnderlyingSpace): space is ORDINAL_TYPE =>


### PR DESCRIPTION
This renames the INTERVAL underlying space type to DIFFERENCE to remove
the name collision with the Interval data structure from util/interval.

Changes:
- INTERVAL_TYPE -> DIFFERENCE_TYPE
- INTERVAL() -> DIFFERENCE()
- isINTERVAL() -> isDIFFERENCE()
- kind 'interval' -> 'difference'

Updated all usages across the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes the underlying space naming by replacing `interval` with `difference` across the AST and rendering layers.
> 
> - Updates `underlyingSpace.ts`: `INTERVAL_TYPE`→`DIFFERENCE_TYPE`, `INTERVAL()`→`DIFFERENCE()`, `isINTERVAL()`→`isDIFFERENCE()`, and kind `"interval"`→`"difference"`
> - Replaces all usages in `_node.ts`, `gofish.tsx`, `graphicalOperators/stack.tsx`, and `shapes/rect.tsx`, including display formatting (e.g., `difference(width)`), axis checks, and comments
> - In `rect.tsx` and `stack.tsx`, constructs `DIFFERENCE(width)` where appropriate; in `gofish.tsx`, axis rendering conditions now check `isDIFFERENCE` for difference-based axes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ac70b6278eac209731c2f2b07de2671b09c757e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->