### PR TITLE
chore: Use Interval data type in POSITION and normalize Intervals when they are created

### DIFF
--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -82,7 +82,7 @@ export const layer = withGoFishSequential(
             const domain = Interval.unionAll(
               ...xChildrenPositionSpaces.map((child) => child[0].domain)
             );
-            xSpace = POSITION([domain.min, domain.max]);
+            xSpace = POSITION(domain);
           } else if (xChildrenOrdinalSpaces.length > 0) {
             xSpace = ORDINAL;
           }
@@ -107,7 +107,7 @@ export const layer = withGoFishSequential(
             const domain = Interval.unionAll(
               ...yChildrenPositionSpaces.map((child) => child[1].domain)
             );
-            ySpace = POSITION([domain.min, domain.max]);
+            ySpace = POSITION(domain);
           } else if (yChildrenOrdinalSpaces.length > 0) {
             ySpace = ORDINAL;
           }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/position.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/position.tsx
@@ -2,6 +2,7 @@ import { GoFishNode } from "../_node";
 import { Size, elaborateDims, FancyDims } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import { POSITION, UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
+import { interval } from "../../util/interval";
 import { withGoFish } from "../withGoFish";
 import { GoFishAST } from "../_ast";
 
@@ -24,10 +25,10 @@ export const position = withGoFish(
         resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
           return [
             isValue(options.x)
-              ? POSITION([getValue(options.x)!, getValue(options.x)!])
+              ? POSITION(interval(getValue(options.x)!, getValue(options.x)!))
               : UNDEFINED,
             isValue(options.y)
-              ? POSITION([getValue(options.y)!, getValue(options.y)!])
+              ? POSITION(interval(getValue(options.y)!, getValue(options.y)!))
               : UNDEFINED,
           ];
         },

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -128,9 +128,7 @@ export const stack = withGoFish(
                 return domain ? Interval.width(domain) : 0;
               })
               .reduce((a, b) => a + b, 0);
-            stackSpace = POSITION(
-              totalWidth >= 0 ? Interval.interval(0, totalWidth) : Interval.interval(totalWidth, 0)
-            );
+            stackSpace = POSITION(Interval.interval(0, totalWidth));
           }
 
           // if children are all UNDEFINED or POSITION and spacing is > 0, return ORDINAL

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -95,7 +95,7 @@ export const stack = withGoFish(
               (child) => child[alignDir].domain!
             );
             const domain = Interval.unionAll(...childDomains);
-            alignSpace = POSITION([domain.min, domain.max]);
+            alignSpace = POSITION(domain);
           }
           // if children are all UNDEFINED or POSITION and alignment is middle, return DIFFERENCE
           else if (
@@ -129,7 +129,7 @@ export const stack = withGoFish(
               })
               .reduce((a, b) => a + b, 0);
             stackSpace = POSITION(
-              totalWidth >= 0 ? [0, totalWidth] : [totalWidth, 0]
+              totalWidth >= 0 ? Interval.interval(0, totalWidth) : Interval.interval(totalWidth, 0)
             );
           }
 

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -33,6 +33,7 @@ import { scaleContext } from "../gofish";
 import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic, computeSize } from "../../util";
 import { DIFFERENCE, ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
+import { interval } from "../../util/interval";
 
 const computeIntrinsicSize = (
   input: MaybeValue<number> | undefined
@@ -126,7 +127,7 @@ export const rect = ({
         } else {
           const min = isValue(dims[0].min) ? getValue(dims[0].min) : 0;
           const size = isValue(dims[0].size) ? getValue(dims[0].size) : 0;
-          const domain = size >= 0 ? [min, min + size] : [min + size, min];
+          const domain = size >= 0 ? interval(min, min + size) : interval(min + size, min);
           underlyingSpaceX = POSITION(domain);
         }
 
@@ -140,7 +141,7 @@ export const rect = ({
         } else {
           const min = isValue(dims[1].min) ? getValue(dims[1].min) : 0;
           const size = isValue(dims[1].size) ? getValue(dims[1].size) : 0;
-          const domain = size >= 0 ? [min, min + size] : [min + size, min];
+          const domain = size >= 0 ? interval(min, min + size) : interval(min + size, min);
           underlyingSpaceY = POSITION(domain);
         }
 

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -127,7 +127,7 @@ export const rect = ({
         } else {
           const min = isValue(dims[0].min) ? getValue(dims[0].min) : 0;
           const size = isValue(dims[0].size) ? getValue(dims[0].size) : 0;
-          const domain = size >= 0 ? interval(min, min + size) : interval(min + size, min);
+          const domain = interval(min, min + size);
           underlyingSpaceX = POSITION(domain);
         }
 
@@ -141,7 +141,7 @@ export const rect = ({
         } else {
           const min = isValue(dims[1].min) ? getValue(dims[1].min) : 0;
           const size = isValue(dims[1].size) ? getValue(dims[1].size) : 0;
-          const domain = size >= 0 ? interval(min, min + size) : interval(min + size, min);
+          const domain = interval(min, min + size);
           underlyingSpaceY = POSITION(domain);
         }
 

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -43,9 +43,9 @@ export type UnderlyingSpace =
   | ORDINAL_TYPE
   | UNDEFINED_TYPE;
 
-export const POSITION = (domain: [number, number]): UnderlyingSpace => ({
+export const POSITION = (domain: Interval): UnderlyingSpace => ({
   kind: "position",
-  domain: interval(domain[0], domain[1]),
+  domain,
 });
 
 export const isPOSITION = (space: UnderlyingSpace): space is POSITION_TYPE =>

--- a/packages/gofish-graphics/src/util/interval.ts
+++ b/packages/gofish-graphics/src/util/interval.ts
@@ -4,10 +4,12 @@ export type Interval = {
 };
 
 /**
- * Creates an interval from min and max values
+ * Creates a normalized interval from two values.
+ * The values can be provided in any order; the function will always
+ * return an interval where min <= max.
  */
-export function interval(min: number, max: number): Interval {
-  return { min, max };
+export function interval(a: number, b: number): Interval {
+  return { min: Math.min(a, b), max: Math.max(a, b) };
 }
 
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Refactor to Interval-based POSITION and normalized intervals**
> 
> - Changes `POSITION` to take an `Interval` object and propagates this through `layer`, `stack`, `position`, and `rect` by passing `domain` directly and using `interval(...)`/`Interval.unionAll`/`Interval.width`
> - Normalizes interval creation (`interval(a, b)` now orders bounds) and centralizes interval helpers in `util/interval` (union, unionAll, width, etc.)
> - Simplifies domain calculations (e.g., stacking total width, rect domains) by removing manual [min, max] arrays and negative-width handling at creation time
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8798c323ba1dc185b26daf771addb22da1d274a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->