### PR TITLE
fix box and whisker

### DIFF
--- a/notes/underlying-space.md
+++ b/notes/underlying-space.md
@@ -13,12 +13,25 @@ this logic organized that we call "underlying space."
 Underlying space is a tree of spaces where each space currently has one of the following tags:
 
 - position
-- interval
+- difference
+- size
 - ordinal
 - undefined
 
 (These map closely to Stevens's statistical data types, which is probably not a coincidence, but the
 relationship isn't clear yet.)
+
+## Space Types
+
+**POSITION**: Represents data-driven positions. Each position space has a domain (interval) that maps data values to screen positions.
+
+**DIFFERENCE**: Represents spaces where differences/distances are meaningful, but absolute locations are not. This is a weakening of POSITION - once a space is DIFFERENCE, it cannot be converted back to POSITION. (Speculative: DIFFERENCE may be aesthetic position + data-driven size, whereas POSITION is data-driven position. This is not yet confirmed and should not be used for implementation.)
+
+**SIZE**: Represents shapes with data-driven sizes but undetermined positions. SIZE tracks a single numeric value (which can be negative, e.g., for negative bars). Unlike DIFFERENCE, SIZE spaces can be merged into POSITION spaces when alignment is determined (e.g., when bars are aligned to a baseline). Example: individual bars in a bar chart have SIZE, but the stack operator merges them into POSITION space for baseline alignment.
+
+**ORDINAL**: Represents nominal/ordinal spaces where relative positions are meaningful (like above, below, left, right), but not quantitatively meaningful.
+
+**UNDEFINED**: Represents spaces with no data-driven information.
 
 ## Why?
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -182,6 +182,16 @@ export const layer = withGoFishSequential(
           const scaleX = options.transform?.scale?.x ?? 1;
           const scaleY = options.transform?.scale?.y ?? 1;
 
+          const childYPositions = childPlaceables.map((cp, i) => ({
+            index: i,
+            min: cp.dims[1].min,
+            max: cp.dims[1].max,
+            center: cp.dims[1].center,
+            size: cp.dims[1].size,
+          }));
+
+          const translateY = dims[1].min !== undefined ? dims[1].min - minY : undefined;
+
           return {
             intrinsicDims: [
               {
@@ -200,7 +210,7 @@ export const layer = withGoFishSequential(
             transform: {
               translate: [
                 dims[0].min !== undefined ? dims[0].min - minX : undefined,
-                dims[1].min !== undefined ? dims[1].min - minY : undefined,
+                translateY,
               ],
               scale: [scaleX, scaleY],
             },

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -263,33 +263,30 @@ export const stack = withGoFish(
           );
 
           /* align */
-          if (alignment === "start") {
-            // For "start" alignment with mixed positive/negative bars, align at the baseline (0 in data space)
-            // Use the position scale to map data value 0 to pixel position
-            const baselinePos = posScales?.[alignDir]
-              ? posScales[alignDir](0)
-              : 0;
-            for (const child of childPlaceables) {
-              child.place({ [alignDir]: baselinePos });
-            }
-          } else if (alignment === "middle") {
-            // For "middle" alignment, center children in the available space
-            const centerPos = size[alignDir] / 2;
-            for (const child of childPlaceables) {
-              child.place({
-                [alignDir]: centerPos - child.dims[alignDir].size! / 2,
-              });
-            }
-          } else if (alignment === "end") {
-            // For "end" alignment with mixed positive/negative bars, align at the baseline (0 in data space)
-            // Use the position scale to map data value 0 to pixel position
-            const baselinePos = posScales?.[alignDir]
-              ? posScales[alignDir](0)
-              : 0;
-            for (const child of childPlaceables) {
-              child.place({
-                [alignDir]: baselinePos - child.dims[alignDir].size!,
-              });
+          // Skip alignment if children have position scales (they already have data-driven positions)
+          if (!posScales?.[alignDir]) {
+            if (alignment === "start") {
+              // For "start" alignment with mixed positive/negative bars, align at the baseline (0 in data space)
+              const baselinePos = 0;
+              for (const child of childPlaceables) {
+                child.place({ [alignDir]: baselinePos });
+              }
+            } else if (alignment === "middle") {
+              // For "middle" alignment, center children in the available space
+              const centerPos = size[alignDir] / 2;
+              for (const child of childPlaceables) {
+                child.place({
+                  [alignDir]: centerPos - child.dims[alignDir].size! / 2,
+                });
+              }
+            } else if (alignment === "end") {
+              // For "end" alignment with mixed positive/negative bars, align at the baseline (0 in data space)
+              const baselinePos = 0;
+              for (const child of childPlaceables) {
+                child.place({
+                  [alignDir]: baselinePos - child.dims[alignDir].size!,
+                });
+              }
             }
           }
 
@@ -315,6 +312,9 @@ export const stack = withGoFish(
             ...childPlaceables.map((child) => child.dims[alignDir].max!)
           );
           const alignSize = alignMax - alignMin;
+          const translateAlign =
+            alignPos !== undefined ? alignPos - alignMin : undefined;
+
           return {
             intrinsicDims: {
               [alignDir]: {
@@ -331,8 +331,7 @@ export const stack = withGoFish(
             },
             transform: {
               translate: {
-                [alignDir]:
-                  alignPos !== undefined ? alignPos - alignMin : undefined,
+                [alignDir]: translateAlign,
                 [stackDir]: stackPos !== undefined ? stackPos : undefined,
               },
             },

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -132,6 +132,8 @@ export const stack = withGoFish(
 
           /* SPACING RULES */
           let stackSpace = UNDEFINED;
+          const stackSpaces = children.map((child) => child[stackDir]);
+
           // if children are all UNDEFINED or POSITION and spacing is 0, return POSITION
           if (
             children.every(
@@ -150,7 +152,14 @@ export const stack = withGoFish(
               .reduce((a, b) => a + b, 0);
             stackSpace = POSITION(Interval.interval(0, totalWidth));
           }
-
+          // if children are all SIZE and spacing is 0, return POSITION (sum of sizes)
+          else if (stackSpaces.every((s) => isSIZE(s)) && spacing === 0) {
+            const sizeValues = stackSpaces.map(
+              (s) => (s as any).value as number
+            );
+            const totalSize = sizeValues.reduce((a, b) => a + b, 0);
+            stackSpace = POSITION(Interval.interval(0, totalSize));
+          }
           // if children are all UNDEFINED or POSITION and spacing is > 0, return ORDINAL
           else if (
             children.every(

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -207,7 +207,7 @@ export const rect = ({
           h = computeSize(dims[1].size, scaleFactors?.[1]!, size[1]);
         }
 
-        return {
+        const result = {
           intrinsicDims: [
             {
               min: w >= 0 ? 0 : w,
@@ -228,6 +228,7 @@ export const rect = ({
             translate: [x, y],
           },
         };
+        return result;
       },
       render: ({
         intrinsicDims,

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -32,7 +32,13 @@ import { aesthetic, continuous, Domain } from "../domain";
 import { scaleContext } from "../gofish";
 import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic, computeSize } from "../../util";
-import { DIFFERENCE, ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
+import {
+  DIFFERENCE,
+  ORDINAL,
+  POSITION,
+  SIZE,
+  UNDEFINED,
+} from "../underlyingSpace";
 import { interval } from "../../util/interval";
 
 const computeIntrinsicSize = (
@@ -122,9 +128,13 @@ export const rect = ({
           // nothing is data-driven
           underlyingSpaceX = ORDINAL;
         } else if (isAesthetic(dims[0].min) && isValue(dims[0].size)) {
-          // the best we can do is difference
+          // aesthetic position + data-driven size -> DIFFERENCE
           underlyingSpaceX = DIFFERENCE(getValue(dims[0].size)!);
+        } else if (!isValue(dims[0].min) && isValue(dims[0].size)) {
+          // no position, but has data-driven size -> SIZE
+          underlyingSpaceX = SIZE(getValue(dims[0].size)!);
         } else {
+          // has position (and possibly size) -> POSITION
           const min = isValue(dims[0].min) ? getValue(dims[0].min) : 0;
           const size = isValue(dims[0].size) ? getValue(dims[0].size) : 0;
           const domain = interval(min, min + size);
@@ -136,11 +146,15 @@ export const rect = ({
           // nothing is data-driven
           underlyingSpaceY = ORDINAL;
         } else if (isAesthetic(dims[1].min) && isValue(dims[1].size)) {
-          // the best we can do is difference
+          // aesthetic position + data-driven size -> DIFFERENCE
           underlyingSpaceY = DIFFERENCE(getValue(dims[1].size)!);
+        } else if (!isValue(dims[1].min) && isValue(dims[1].size)) {
+          // no position, but has data-driven size -> SIZE
+          underlyingSpaceY = SIZE(getValue(dims[1].size)!);
         } else {
-          const min = isValue(dims[1].min) ? getValue(dims[1].min) : 0;
-          const size = isValue(dims[1].size) ? getValue(dims[1].size) : 0;
+          // has position (and possibly size) -> POSITION
+          const min = getValue(dims[1].min) ?? 0;
+          const size = getValue(dims[1].size) ?? 0;
           const domain = interval(min, min + size);
           underlyingSpaceY = POSITION(domain);
         }

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -4,6 +4,7 @@ import { interval, Interval } from "../util/interval";
 export type UnderlyingSpaceKind =
   | "position"
   | "difference"
+  | "size"
   | "ordinal"
   | "undefined";
 
@@ -18,6 +19,14 @@ export type POSITION_TYPE = {
 export type DIFFERENCE_TYPE = {
   kind: "difference";
   width: number;
+  spacing?: number;
+  ordinalGroupId?: string;
+  source?: string;
+};
+
+export type SIZE_TYPE = {
+  kind: "size";
+  value: number;
   spacing?: number;
   ordinalGroupId?: string;
   source?: string;
@@ -40,6 +49,7 @@ export type UNDEFINED_TYPE = {
 export type UnderlyingSpace =
   | POSITION_TYPE
   | DIFFERENCE_TYPE
+  | SIZE_TYPE
   | ORDINAL_TYPE
   | UNDEFINED_TYPE;
 
@@ -55,8 +65,16 @@ export const DIFFERENCE = (width: number): UnderlyingSpace => ({
   kind: "difference",
   width,
 });
-export const isDIFFERENCE = (space: UnderlyingSpace): space is DIFFERENCE_TYPE =>
-  space.kind === "difference";
+export const isDIFFERENCE = (
+  space: UnderlyingSpace
+): space is DIFFERENCE_TYPE => space.kind === "difference";
+
+export const SIZE = (value: number): UnderlyingSpace => ({
+  kind: "size",
+  value,
+});
+export const isSIZE = (space: UnderlyingSpace): space is SIZE_TYPE =>
+  space.kind === "size";
 
 export const ORDINAL: UnderlyingSpace = { kind: "ordinal" };
 export const isORDINAL = (space: UnderlyingSpace): space is ORDINAL_TYPE =>

--- a/packages/gofish-graphics/src/tests/boxwhisker.ts
+++ b/packages/gofish-graphics/src/tests/boxwhisker.ts
@@ -43,6 +43,49 @@ const boxAndWhisker = ({
   ]);
 };
 
+export const testSingleBoxWhisker = () => {
+  const data = genderPayGap[0];
+  return boxAndWhisker({
+    median: data.Median,
+    min: data.Min,
+    max: data.Max,
+    q1: data["25-Percentile"],
+    q3: data["75-Percentile"],
+    fill: v(data.Gender as string),
+  });
+};
+
+export const testPairBoxWhisker = () => {
+  const payGradeFive = genderPayGap.filter((d) => d["Pay Grade"] === "Five");
+  const male = payGradeFive.find((d) => d.Gender === "Male")!;
+  const female = payGradeFive.find((d) => d.Gender === "Female")!;
+
+  return StackX(
+    {
+      spacing: 8,
+      sharedScale: true,
+    },
+    [
+      boxAndWhisker({
+        median: male.Median,
+        min: male.Min,
+        max: male.Max,
+        q1: male["25-Percentile"],
+        q3: male["75-Percentile"],
+        fill: v(male.Gender as string),
+      }) as any,
+      boxAndWhisker({
+        median: female.Median,
+        min: female.Min,
+        max: female.Max,
+        q1: female["25-Percentile"],
+        q3: female["75-Percentile"],
+        fill: v(female.Gender as string),
+      }),
+    ]
+  );
+};
+
 export const testBoxWhiskerPlot = () =>
   StackX(
     {

--- a/packages/gofish-graphics/stories/LowLevelCharts.stories.tsx
+++ b/packages/gofish-graphics/stories/LowLevelCharts.stories.tsx
@@ -3,7 +3,11 @@ import { rect } from "../src/ast/marks/chart";
 import { initializeContainer } from "./helper";
 import { catchData } from "../src/data/catch";
 import { orderBy } from "../src/lib";
-import { testBoxWhiskerPlot } from "../src/tests/boxwhisker";
+import {
+  testBoxWhiskerPlot,
+  testSingleBoxWhisker,
+  testPairBoxWhisker,
+} from "../src/tests/boxwhisker";
 
 const meta: Meta = {
   title: "Charts/LowLevel",
@@ -20,15 +24,47 @@ export default meta;
 
 type Args = { w: number; h: number };
 
+export const SingleBoxWhisker: StoryObj<Args> = {
+  args: { w: 320, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    testSingleBoxWhisker().render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
+export const PairBoxWhisker: StoryObj<Args> = {
+  args: { w: 320, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    testPairBoxWhisker().render(container, {
+      w: args.w,
+      h: args.h,
+      axes: true,
+    });
+
+    return container;
+  },
+};
+
 export const BoxWhisker: StoryObj<Args> = {
   args: { w: 320, h: 400 },
   render: (args: Args) => {
     const container = initializeContainer();
 
-    return testBoxWhiskerPlot().render(container, {
+    testBoxWhiskerPlot().render(container, {
       w: args.w,
       h: args.h,
       axes: true,
     });
+
+    return container;
   },
 };


### PR DESCRIPTION
Closes #3.

fix box and whisker

fix: ensure box + whisker and negative bar charts work by introducing SIZE and fixing bugs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes sizing/alignment for box-and-whisker and negative bars by extending underlying space and operators.
> 
> - Add `SIZE` to `underlyingSpace` (types, constructors, type guards) and document it in `notes/underlying-space.md`
> - Update `rect`: emit `SIZE` when only size is data-driven, `DIFFERENCE` for aesthetic position + size, compute sizes via pos scales when available, and handle negative dimensions
> - Update `stack`: new resolve rules for `SIZE`/`DIFFERENCE`; merge sizes into `POSITION` for spacing=0, center via `DIFFERENCE` on middle, and baseline-align even with posScales when `SIZE`-derived; translate fixes for align axis
> - Update `connect`: derive intrinsic dimensions from connected childrens’ bbox (supports center-to-center) and default to zero when no paths
> - Update `layer`: minor translate computation for Y
> - Add single/pair box-whisker tests and Storybook stories
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90ecd5db8636cb06f37e35c16cf2757947ef5bca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->