### PR TITLE
Fix labeling ordinal axis

### DIFF
--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -96,7 +96,8 @@ export type Render = (
 ) => JSX.Element;
 
 export type ResolveUnderlyingSpace = (
-  childSpaces: Size<UnderlyingSpace>[]
+  childSpaces: Size<UnderlyingSpace>[],
+  childNodes: (GoFishNode | GoFishRef)[]
 ) => FancySize<UnderlyingSpace>;
 
 export class GoFishNode {
@@ -214,7 +215,8 @@ export class GoFishNode {
     }
     this._underlyingSpace = elaborateSize(
       this._resolveUnderlyingSpace(
-        this.children.map((child) => child.resolveUnderlyingSpace())
+        this.children.map((child) => child.resolveUnderlyingSpace()),
+        this.children
       )
     );
     return this._underlyingSpace;
@@ -411,7 +413,7 @@ export const debugNodeTree = (
   // Get the name for display (handle both GoFishNode and GoFishRef)
   const nodeName = isGoFishNode(node) ? node._name : node.name;
 
-  // Create a group for this node
+  p; // Create a group for this node
   console.group(
     `${indent}Node: ${node.type}${nodeName ? ` (${nodeName})` : ""}`
   );

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -413,7 +413,7 @@ export const debugNodeTree = (
   // Get the name for display (handle both GoFishNode and GoFishRef)
   const nodeName = isGoFishNode(node) ? node._name : node.name;
 
-  p; // Create a group for this node
+  // Create a group for this node
   console.group(
     `${indent}Node: ${node.type}${nodeName ? ` (${nodeName})` : ""}`
   );

--- a/packages/gofish-graphics/src/ast/_ref.tsx
+++ b/packages/gofish-graphics/src/ast/_ref.tsx
@@ -106,7 +106,7 @@ export class GoFishRef {
 
   /* TODO: what should the default be? */
   public resolveUnderlyingSpace(): UnderlyingSpace {
-    return this.selectedNode?.resolveUnderlyingSpace() ?? ORDINAL;
+    return this.selectedNode?.resolveUnderlyingSpace() ?? ORDINAL([]);
   }
 
   /* TODO: I'm not really sure what this should do */

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -13,6 +13,7 @@ import { tickIncrement, ticks, nice } from "d3-array";
 import { isConstant } from "../util/monotonic";
 import {
   isDIFFERENCE,
+  isORDINAL,
   isPOSITION,
   type UnderlyingSpace,
 } from "./underlyingSpace";
@@ -59,6 +60,64 @@ export const getKeyContext = (): KeyContext => {
   return keyContext;
 };
 
+type OrdinalScale = (key: string) => number | undefined;
+
+function buildOrdinalScaleX(
+  keyContext: KeyContext,
+  root: GoFishNode
+): OrdinalScale {
+  const keyToPosition = new Map<string, number>();
+
+  for (const [key, node] of Object.entries(keyContext)) {
+    if (!("intrinsicDims" in node) || !node.intrinsicDims) continue;
+
+    const pathToRoot = findPathToRoot(node);
+    const accumulatedTransform = pathToRoot.reduce(
+      (acc, n) => {
+        return {
+          x: acc.x + (n.transform?.translate?.[0] ?? 0),
+          y: acc.y + (n.transform?.translate?.[1] ?? 0),
+        };
+      },
+      { x: 0, y: 0 }
+    );
+
+    const centerX =
+      accumulatedTransform.x + (node.intrinsicDims[0]?.center ?? 0);
+    keyToPosition.set(key, centerX);
+  }
+
+  return (key: string) => keyToPosition.get(key);
+}
+
+function buildOrdinalScaleY(
+  keyContext: KeyContext,
+  root: GoFishNode
+): OrdinalScale {
+  const keyToPosition = new Map<string, number>();
+
+  for (const [key, node] of Object.entries(keyContext)) {
+    if (!("intrinsicDims" in node) || !node.intrinsicDims) continue;
+
+    const pathToRoot = findPathToRoot(node);
+    const accumulatedTransform = pathToRoot.reduce(
+      (acc, n) => {
+        return {
+          x: acc.x + (n.transform?.translate?.[0] ?? 0),
+          y: acc.y + (n.transform?.translate?.[1] ?? 0),
+        };
+      },
+      { x: 0, y: 0 }
+    );
+
+    const centerY =
+      accumulatedTransform.y + (node.intrinsicDims[1]?.center ?? 0);
+    keyToPosition.set(key, centerY);
+  }
+
+  return (key: string) => keyToPosition.get(key);
+}
+
 export async function layout(
   {
     w,
@@ -90,6 +149,7 @@ export async function layout(
   underlyingSpaceX: UnderlyingSpace;
   underlyingSpaceY: UnderlyingSpace;
   posScales: [(pos: number) => number, (pos: number) => number];
+  ordinalScales: [OrdinalScale | undefined, OrdinalScale | undefined];
   child: GoFishNode;
 }> {
   child = await child;
@@ -153,11 +213,21 @@ export async function layout(
     debugNodeTree(child);
   }
 
+  const ordinalScales: [OrdinalScale | undefined, OrdinalScale | undefined] = [
+    isORDINAL(underlyingSpaceX) && keyContext
+      ? buildOrdinalScaleX(keyContext, child)
+      : undefined,
+    isORDINAL(underlyingSpaceY) && keyContext
+      ? buildOrdinalScaleY(keyContext, child)
+      : undefined,
+  ];
+
   return {
     sizeDomains,
     underlyingSpaceX,
     underlyingSpaceY,
     posScales,
+    ordinalScales,
     child,
   };
 }
@@ -191,6 +261,7 @@ export const gofish = (
     underlyingSpaceX: UnderlyingSpace;
     underlyingSpaceY: UnderlyingSpace;
     posScales: [(pos: number) => number, (pos: number) => number];
+    ordinalScales: [OrdinalScale | undefined, OrdinalScale | undefined];
     child: GoFishNode;
     scaleContext: ScaleContext;
     keyContext: KeyContext;
@@ -259,6 +330,7 @@ export const gofish = (
               underlyingSpaceX: data.underlyingSpaceX,
               underlyingSpaceY: data.underlyingSpaceY,
               posScales: data.posScales,
+              ordinalScales: data.ordinalScales,
             },
             data.child
           );
@@ -284,6 +356,7 @@ export const render = (
     underlyingSpaceX,
     underlyingSpaceY,
     posScales,
+    ordinalScales,
   }: {
     width: number;
     height: number;
@@ -296,6 +369,7 @@ export const render = (
     underlyingSpaceX: UnderlyingSpace;
     underlyingSpaceY: UnderlyingSpace;
     posScales: [(pos: number) => number, (pos: number) => number];
+    ordinalScales: [OrdinalScale | undefined, OrdinalScale | undefined];
   },
   child: GoFishNode
 ): JSX.Element => {
@@ -606,129 +680,113 @@ export const render = (
               })()}
             </Show>
             {/* x axis (discrete) */}
-            <Show when={underlyingSpaceX.kind === "ordinal" && keyContext}>
-              <g>
-                <For each={Object.entries(keyContext ?? {})}>
-                  {([key, value]) => {
-                    const pathToRoot = findPathToRoot(value);
-                    const accumulatedTransform = pathToRoot.reduce(
-                      (acc, node) => {
-                        return {
-                          x: acc.x + (node.transform?.translate?.[0] ?? 0),
-                          y: acc.y + (node.transform?.translate?.[1] ?? 0),
-                        };
-                      },
-                      { x: 0, y: 0 }
-                    );
-                    const displayDims = [
-                      {
-                        min:
-                          (accumulatedTransform.x ?? 0) +
-                          (value.intrinsicDims?.[0]?.min ?? 0),
-                        size: value.intrinsicDims?.[0]?.size ?? 0,
-                        center:
-                          (accumulatedTransform.x ?? 0) +
-                          (value.intrinsicDims?.[0]?.center ?? 0),
-                        max:
-                          (accumulatedTransform.x ?? 0) +
-                          (value.intrinsicDims?.[0]?.max ?? 0),
-                      },
-                      {
-                        min:
-                          (accumulatedTransform.y ?? 0) +
-                          (value.intrinsicDims?.[1]?.min ?? 0),
-                        size: value.intrinsicDims?.[1]?.size ?? 0,
-                        center:
-                          (accumulatedTransform.y ?? 0) +
-                          (value.intrinsicDims?.[1]?.center ?? 0),
-                        max:
-                          (accumulatedTransform.y ?? 0) +
-                          (value.intrinsicDims?.[1]?.max ?? 0),
-                      },
-                    ];
-                    return (
-                      <text
-                        transform="scale(1, -1)"
-                        x={displayDims[0].center ?? 0}
-                        y={-(displayDims[1].min ?? 0) + 5}
-                        text-anchor="middle"
-                        dominant-baseline="hanging"
-                        font-size="10px"
-                        fill="gray"
-                      >
-                        {key}
-                      </text>
-                    );
-                  }}
-                </For>
-              </g>
+            <Show
+              when={
+                axes &&
+                isORDINAL(underlyingSpaceX) &&
+                ordinalScales[0] &&
+                keyContext
+              }
+            >
+              {(() => {
+                const scale = ordinalScales[0]!;
+                const entries = Object.entries(keyContext ?? {});
+                // Get the minimum Y position for label placement
+                const minY = entries.reduce((min, [, node]) => {
+                  if (!("intrinsicDims" in node) || !node.intrinsicDims)
+                    return min;
+                  const pathToRoot = findPathToRoot(node);
+                  const accumulatedTransform = pathToRoot.reduce(
+                    (acc, n) => {
+                      return {
+                        x: acc.x + (n.transform?.translate?.[0] ?? 0),
+                        y: acc.y + (n.transform?.translate?.[1] ?? 0),
+                      };
+                    },
+                    { x: 0, y: 0 }
+                  );
+                  const yPos =
+                    accumulatedTransform.y + (node.intrinsicDims[1]?.min ?? 0);
+                  return Math.min(min, yPos);
+                }, Infinity);
+                return (
+                  <g>
+                    <For each={entries}>
+                      {([key]) => {
+                        const xPos = scale(key);
+                        if (xPos === undefined) return null;
+                        return (
+                          <text
+                            transform="scale(1, -1)"
+                            x={xPos}
+                            y={-minY + 5}
+                            text-anchor="middle"
+                            dominant-baseline="hanging"
+                            font-size="10px"
+                            fill="gray"
+                          >
+                            {key}
+                          </text>
+                        );
+                      }}
+                    </For>
+                  </g>
+                );
+              })()}
             </Show>
-            <Show when={underlyingSpaceY.kind === "ordinal" && keyContext}>
-              {/* Vertical (Y axis) labels */}
-              <g>
-                <For each={Object.values(keyContext ?? {})}>
-                  {(value, i) => {
-                    // Only render for GoFishNode (not GoFishRef)
-                    if (!("intrinsicDims" in value) || !("key" in value))
-                      return null;
-                    // Accumulate transforms up the tree for correct label placement
-                    const accumulatedTransform = findPathToRoot(
-                      value as GoFishNode
-                    ).reduce(
-                      (acc, node) => {
-                        return {
-                          x: acc.x + (node.transform?.translate?.[0] ?? 0),
-                          y: acc.y + (node.transform?.translate?.[1] ?? 0),
-                        };
-                      },
-                      { x: 0, y: 0 }
-                    );
-                    const displayDims = [
-                      {
-                        min:
-                          (accumulatedTransform.x ?? 0) +
-                          ((value as GoFishNode).intrinsicDims?.[0]?.min ?? 0),
-                        size:
-                          (value as GoFishNode).intrinsicDims?.[0]?.size ?? 0,
-                        center:
-                          (accumulatedTransform.x ?? 0) +
-                          ((value as GoFishNode).intrinsicDims?.[0]?.center ??
-                            0),
-                        max:
-                          (accumulatedTransform.x ?? 0) +
-                          ((value as GoFishNode).intrinsicDims?.[0]?.max ?? 0),
-                      },
-                      {
-                        min:
-                          (accumulatedTransform.y ?? 0) +
-                          ((value as GoFishNode).intrinsicDims?.[1]?.min ?? 0),
-                        size:
-                          (value as GoFishNode).intrinsicDims?.[1]?.size ?? 0,
-                        center:
-                          (accumulatedTransform.y ?? 0) +
-                          ((value as GoFishNode).intrinsicDims?.[1]?.center ??
-                            0),
-                        max:
-                          (accumulatedTransform.y ?? 0) +
-                          ((value as GoFishNode).intrinsicDims?.[1]?.max ?? 0),
-                      },
-                    ];
-                    return (
-                      <text
-                        transform="scale(1, -1)"
-                        x={displayDims[0].min - 5}
-                        y={-(displayDims[1].center ?? 0)}
-                        text-anchor="end"
-                        dominant-baseline="middle"
-                        font-size="10px"
-                        fill="gray"
-                      >
-                        {(value as GoFishNode).key}
-                      </text>
-                    );
-                  }}
-                </For>
-              </g>
+            <Show
+              when={
+                axes &&
+                isORDINAL(underlyingSpaceY) &&
+                ordinalScales[1] &&
+                keyContext
+              }
+            >
+              {(() => {
+                const scale = ordinalScales[1]!;
+                const entries = Object.entries(keyContext ?? {});
+                // Get the minimum X position for label placement
+                const minX = entries.reduce((min, [, node]) => {
+                  if (!("intrinsicDims" in node) || !node.intrinsicDims)
+                    return min;
+                  const pathToRoot = findPathToRoot(node);
+                  const accumulatedTransform = pathToRoot.reduce(
+                    (acc, n) => {
+                      return {
+                        x: acc.x + (n.transform?.translate?.[0] ?? 0),
+                        y: acc.y + (n.transform?.translate?.[1] ?? 0),
+                      };
+                    },
+                    { x: 0, y: 0 }
+                  );
+                  const xPos =
+                    accumulatedTransform.x + (node.intrinsicDims[0]?.min ?? 0);
+                  return Math.min(min, xPos);
+                }, Infinity);
+                return (
+                  <g>
+                    <For each={entries}>
+                      {([key]) => {
+                        const yPos = scale(key);
+                        if (yPos === undefined) return null;
+                        return (
+                          <text
+                            transform="scale(1, -1)"
+                            x={minX - 5}
+                            y={-yPos}
+                            text-anchor="end"
+                            dominant-baseline="middle"
+                            font-size="10px"
+                            fill="gray"
+                          >
+                            {key}
+                          </text>
+                        );
+                      }}
+                    </For>
+                  </g>
+                );
+              })()}
             </Show>
             {/* legend (discrete color for now) */}
             <g>

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -690,8 +690,13 @@ export const render = (
             >
               {(() => {
                 const scale = ordinalScales[0]!;
-                const entries = Object.entries(keyContext ?? {});
+                // Use domain from ORDINAL space for top-level keys
+                const domain = isORDINAL(underlyingSpaceX)
+                  ? underlyingSpaceX.domain
+                  : undefined;
+                const labelKeys = domain && domain.length > 0 ? domain : [];
                 // Get the minimum Y position for label placement
+                const entries = Object.entries(keyContext ?? {});
                 const minY = entries.reduce((min, [, node]) => {
                   if (!("intrinsicDims" in node) || !node.intrinsicDims)
                     return min;
@@ -711,8 +716,8 @@ export const render = (
                 }, Infinity);
                 return (
                   <g>
-                    <For each={entries}>
-                      {([key]) => {
+                    <For each={labelKeys}>
+                      {(key) => {
                         const xPos = scale(key);
                         if (xPos === undefined) return null;
                         return (
@@ -744,8 +749,13 @@ export const render = (
             >
               {(() => {
                 const scale = ordinalScales[1]!;
-                const entries = Object.entries(keyContext ?? {});
+                // Use domain from ORDINAL space for top-level keys
+                const domain = isORDINAL(underlyingSpaceY)
+                  ? underlyingSpaceY.domain
+                  : undefined;
+                const labelKeys = domain && domain.length > 0 ? domain : [];
                 // Get the minimum X position for label placement
+                const entries = Object.entries(keyContext ?? {});
                 const minX = entries.reduce((min, [, node]) => {
                   if (!("intrinsicDims" in node) || !node.intrinsicDims)
                     return min;
@@ -765,8 +775,8 @@ export const render = (
                 }, Infinity);
                 return (
                   <g>
-                    <For each={entries}>
-                      {([key]) => {
+                    <For each={labelKeys}>
+                      {(key) => {
                         const yPos = scale(key);
                         if (yPos === undefined) return null;
                         return (

--- a/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
@@ -49,7 +49,7 @@ export const connect = withGoFish(
         type: "connect",
         shared: [false, false],
         color: fill,
-        resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+        resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[], _childNodes: GoFishAST[]) => {
           return [UNDEFINED, UNDEFINED];
         },
         inferSizeDomains: (shared, children) => {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx
@@ -21,7 +21,7 @@ export const enclose = withGoFish(
     {
       type: "enclose",
       shared: [false, false],
-      resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+      resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[], _childNodes: GoFishAST[]) => {
         return [UNDEFINED, UNDEFINED];
       },
       inferSizeDomains: (shared, children) => {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/position.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/position.tsx
@@ -22,7 +22,7 @@ export const position = withGoFish(
         type: "position",
         key: options.key,
         shared: [false, false],
-        resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+        resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[], _childNodes: GoFishAST[]) => {
           return [
             isValue(options.x)
               ? POSITION(interval(getValue(options.x)!, getValue(options.x)!))

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -382,6 +382,7 @@ export const stack = withGoFish(
               [alignDir]: {
                 min: alignMin,
                 size: alignSize,
+                center: alignMin + alignSize / 2,
                 max: alignMax,
               },
               [stackDir]: {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -86,7 +86,10 @@ export const stack = withGoFish(
         key,
         name,
         shared: [sharedScale, sharedScale],
-        resolveUnderlyingSpace: (children: Size<UnderlyingSpace>[]) => {
+        resolveUnderlyingSpace: (
+          children: Size<UnderlyingSpace>[],
+          childNodes: GoFishAST[]
+        ) => {
           /* ALIGNMENT RULES */
           let alignSpace = UNDEFINED;
 
@@ -153,7 +156,9 @@ export const stack = withGoFish(
             // position's domain should be [0, sum(widths of child intervals)] using the interval library
             const totalWidth = children
               .map((child) => {
-                const domain = child[stackDir].domain;
+                const domain = isPOSITION(child[stackDir])
+                  ? child[stackDir].domain
+                  : undefined;
                 return domain ? Interval.width(domain) : 0;
               })
               .reduce((a, b) => a + b, 0);
@@ -177,9 +182,19 @@ export const stack = withGoFish(
             ) &&
             spacing > 0
           ) {
-            stackSpace = ORDINAL;
+            // Extract top-level keys from child nodes for ordinal domain
+            const topLevelKeys = childNodes
+              .filter((node): node is GoFishNode => node instanceof GoFishNode)
+              .map((node) => node.key)
+              .filter((key): key is string => key !== undefined);
+            stackSpace = ORDINAL(topLevelKeys);
           } else {
-            stackSpace = ORDINAL;
+            // Extract top-level keys from child nodes for ordinal domain
+            const topLevelKeys = childNodes
+              .filter((node): node is GoFishNode => node instanceof GoFishNode)
+              .map((node) => node.key)
+              .filter((key): key is string => key !== undefined);
+            stackSpace = ORDINAL(topLevelKeys);
           }
 
           return {

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -317,7 +317,7 @@ export function spread<T>(
 
   const finalOptions = {
     ...opts,
-    label: opts?.label ?? true,
+    label: opts?.label ?? false,
     alignment: opts?.alignment ?? "start",
   };
 
@@ -347,9 +347,8 @@ export function spread<T>(
         For(grouped as any, async (groupData: T[], k) => {
           const currentKey = key != undefined ? `${key}-${k}` : k;
           const node = await mark(groupData, currentKey);
-          return finalOptions.label
-            ? node.setKey(currentKey?.toString() ?? "")
-            : node;
+          // Always set keys for ordinal axis mapping, regardless of label setting
+          return node.setKey(currentKey?.toString() ?? "");
         })
       );
     };

--- a/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
@@ -9,6 +9,7 @@ import {
   transformPath,
 } from "../../path";
 import { GoFishNode } from "../_node";
+import { GoFishAST } from "../_ast";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
 import { linear } from "../coordinateTransforms/linear";
 import {
@@ -52,8 +53,11 @@ export const ellipse = ({
       name,
       type: "ellipse",
       color: fill,
-      resolveUnderlyingSpace: () => {
-        let underlyingSpaceX = ORDINAL;
+      resolveUnderlyingSpace: (
+        _children: Size<UnderlyingSpace>[],
+        _childNodes: GoFishAST[]
+      ) => {
+        let underlyingSpaceX = ORDINAL([]);
         if (isValue(dims[0].min)) {
           // position. treat it like a position space w/ a single element
           underlyingSpaceX = POSITION;
@@ -62,7 +66,7 @@ export const ellipse = ({
           underlyingSpaceX = UNDEFINED;
         }
 
-        let underlyingSpaceY = ORDINAL;
+        let underlyingSpaceY = ORDINAL([]);
         if (isValue(dims[1].min)) {
           // position. treat it like a position space w/ a single element
           underlyingSpaceY = POSITION;

--- a/packages/gofish-graphics/src/ast/shapes/petal.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/petal.tsx
@@ -9,6 +9,7 @@ import {
   transformPath,
 } from "../../path";
 import { GoFishNode } from "../_node";
+import { GoFishAST } from "../_ast";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
 import { linear } from "../coordinateTransforms/linear";
 import {
@@ -71,8 +72,11 @@ export const petal = ({
       //       : undefined,
       //   ];
       // },
-      resolveUnderlyingSpace: () => {
-        let underlyingSpaceX = ORDINAL;
+      resolveUnderlyingSpace: (
+        _children: Size<UnderlyingSpace>[],
+        _childNodes: GoFishAST[]
+      ) => {
+        let underlyingSpaceX = ORDINAL([]);
         if (isValue(dims[0].min)) {
           // position. treat it like a position space w/ a single element
           underlyingSpaceX = POSITION;
@@ -81,7 +85,7 @@ export const petal = ({
           underlyingSpaceX = UNDEFINED;
         }
 
-        let underlyingSpaceY = ORDINAL;
+        let underlyingSpaceY = ORDINAL([]);
         if (isValue(dims[1].min)) {
           // position. treat it like a position space w/ a single element
           underlyingSpaceY = POSITION;

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -8,6 +8,7 @@ import {
   transformPath,
 } from "../../path";
 import { GoFishNode } from "../_node";
+import { GoFishAST } from "../_ast";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
 import { linear } from "../coordinateTransforms/linear";
 import {
@@ -88,7 +89,10 @@ export const rect = ({
         dims,
       },
       color: fill,
-      resolveUnderlyingSpace: () => {
+      resolveUnderlyingSpace: (
+        _children: Size<UnderlyingSpace>[],
+        _childNodes: GoFishAST[]
+      ) => {
         /* cases
         a: aesthetic
         v: value
@@ -126,7 +130,7 @@ export const rect = ({
         let underlyingSpaceX = UNDEFINED;
         if (!isValue(dims[0].min) && !isValue(dims[0].size)) {
           // nothing is data-driven
-          underlyingSpaceX = ORDINAL;
+          underlyingSpaceX = ORDINAL([]);
         } else if (isAesthetic(dims[0].min) && isValue(dims[0].size)) {
           // aesthetic position + data-driven size -> DIFFERENCE
           underlyingSpaceX = DIFFERENCE(getValue(dims[0].size)!);
@@ -144,7 +148,7 @@ export const rect = ({
         let underlyingSpaceY = UNDEFINED;
         if (!isValue(dims[1].min) && !isValue(dims[1].size)) {
           // nothing is data-driven
-          underlyingSpaceY = ORDINAL;
+          underlyingSpaceY = ORDINAL([]);
         } else if (isAesthetic(dims[1].min) && isValue(dims[1].size)) {
           // aesthetic position + data-driven size -> DIFFERENCE
           underlyingSpaceY = DIFFERENCE(getValue(dims[1].size)!);

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -37,6 +37,7 @@ export type ORDINAL_TYPE = {
   spacing?: number;
   ordinalGroupId?: string;
   source?: string;
+  domain?: string[]; // Top-level category keys for axis labels
 };
 
 export type UNDEFINED_TYPE = {
@@ -76,7 +77,10 @@ export const SIZE = (value: number): UnderlyingSpace => ({
 export const isSIZE = (space: UnderlyingSpace): space is SIZE_TYPE =>
   space.kind === "size";
 
-export const ORDINAL: UnderlyingSpace = { kind: "ordinal" };
+export const ORDINAL = (domain?: string[]): UnderlyingSpace => ({
+  kind: "ordinal",
+  domain,
+});
 export const isORDINAL = (space: UnderlyingSpace): space is ORDINAL_TYPE =>
   space.kind === "ordinal";
 


### PR DESCRIPTION
Removes overzealous chart labeling. Fixes #17. Fixes #91.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves discrete axis correctness and labeling by making ordinal spaces domain-aware and using those domains to drive axis labels.
> 
> - Make `ORDINAL` a constructor `ORDINAL(domain?: string[])`; thread domains through `resolveUnderlyingSpace(childSpaces, childNodes)` (updated signature) across operators (`layer`, `coord`, `stack`, `position`) and marks (`rect`, `ellipse`, `petal`, refs) by merging child ordinal domains or deriving from child keys
> - In `gofish` layout/render, build `ordinalScales` from `keyContext` and top-level node positions; render ordinal axes only when `axes` is enabled using `underlyingSpace{X,Y}.domain`, replacing per-node labeling
> - Tweak axis label placement; add centers where needed; change `spread()` default `label` to `false` to avoid unintended labels
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bb86f646d1d63390db6ee4c3638f7c8035aa86c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->