### PR TITLE
fix: Update Node.js version to 24 in nightly release workflow

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Setup pnpm


### PR DESCRIPTION
Updates the Node.js version from 20 to 24 in the nightly release workflow.