### PR TITLE
Fix nightly release bug: Add repository field to package.json

### DIFF
--- a/packages/gofish-graphics/package.json
+++ b/packages/gofish-graphics/package.json
@@ -25,6 +25,10 @@
   ],
   "author": "Your Name",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/starfish-graphics/gofish-graphics"
+  },
   "scripts": {
     "start": "vite",
     "dev": "vite",


### PR DESCRIPTION
Fixes npm publish error E422 by adding the repository field to package.json to match the provenance repository URL.