### PR TITLE
Add weekly summary GitHub Action with dry-run support

### DIFF
--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -1,0 +1,191 @@
+name: Weekly GoFish Summary
+on:
+  schedule:
+    - cron: "0 14 * * 5" # Fridays at 2pm UTC (adjust to your timezone)
+  workflow_dispatch: # Allow manual triggers
+    inputs:
+      dry_run:
+        description: "Dry run mode (skip Slack posting, output to logs)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Full history for git log
+
+      - name: Get date range
+        id: dates
+        run: |
+          echo "week_ago=$(date -d '7 days ago' +%Y-%m-%d)" >> $GITHUB_OUTPUT
+          echo "today=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Get commits from last week
+        id: commits
+        run: |
+          COMMITS=$(git log --since="7 days ago" --pretty=format:"- **%s** (%an, %as)" | head -100)
+          if [ -z "$COMMITS" ]; then
+            COMMITS="No commits this week."
+          fi
+          # Escape for JSON
+          COMMITS_ESCAPED=$(echo "$COMMITS" | jq -Rs .)
+          echo "commits=$COMMITS_ESCAPED" >> $GITHUB_OUTPUT
+
+      - name: Get merged PRs from last week
+        id: prs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PRS=$(gh pr list \
+            --state merged \
+            --search "merged:>=${{ steps.dates.outputs.week_ago }}" \
+            --json number,title,body,author,mergedAt,url \
+            --jq '.[] | "### PR #\(.number): \(.title)\n- **Author:** \(.author.login)\n- **Merged:** \(.mergedAt[:10])\n- **URL:** \(.url)\n- **Description:** \(.body // "No description" | split("\n")[0:3] | join(" ") | .[0:300])\n"')
+          if [ -z "$PRS" ]; then
+            PRS="No PRs merged this week."
+          fi
+          # Escape for JSON
+          PRS_ESCAPED=$(echo "$PRS" | jq -Rs .)
+          echo "prs=$PRS_ESCAPED" >> $GITHUB_OUTPUT
+
+      - name: Summarize with Claude
+        id: summary
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Build the prompt
+          read -r -d '' PROMPT << 'ENDPROMPT'
+          You're summarizing a week of development on GoFish, a charting library for data visualization. Create a Slack-friendly weekly update.
+
+          ## Commits from the last 7 days:
+          COMMITS_PLACEHOLDER
+
+          ## Merged PRs from the last 7 days:
+          PRS_PLACEHOLDER
+
+          Write a concise weekly summary with:
+          1. **Highlights** - 2-3 sentence overview of the main thrust of work this week
+          2. **What changed** - Group related changes by theme (e.g., "API improvements", "Bug fixes", "Documentation"). Use bullet points, keep each brief.
+          3. **PRs of note** - Call out any significant PRs with a one-liner each
+
+          Keep the tone casual and informative. Use emoji sparingly. Total length should be readable in ~30 seconds.
+          ENDPROMPT
+
+          # Substitute the actual data
+          COMMITS_DATA=$(echo ${{ steps.commits.outputs.commits }} | jq -r .)
+          PRS_DATA=$(echo ${{ steps.prs.outputs.prs }} | jq -r .)
+
+          PROMPT="${PROMPT//COMMITS_PLACEHOLDER/$COMMITS_DATA}"
+          PROMPT="${PROMPT//PRS_PLACEHOLDER/$PRS_DATA}"
+
+          # Escape for JSON payload
+          PROMPT_JSON=$(echo "$PROMPT" | jq -Rs .)
+
+          # Call Claude API
+          RESPONSE=$(curl -s https://api.anthropic.com/v1/messages \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: $ANTHROPIC_API_KEY" \
+            -H "anthropic-version: 2024-06-01" \
+            -d "{
+              \"model\": \"claude-3-5-sonnet-20241022\",
+              \"max_tokens\": 1024,
+              \"messages\": [{\"role\": \"user\", \"content\": $PROMPT_JSON}]
+            }")
+
+          # Check for errors
+          if echo "$RESPONSE" | jq -e '.error' > /dev/null 2>&1; then
+            echo "Error from Claude API:"
+            echo "$RESPONSE" | jq -r '.error'
+            exit 1
+          fi
+
+          SUMMARY=$(echo "$RESPONSE" | jq -r '.content[0].text // "Failed to generate summary"')
+
+          if [ -z "$SUMMARY" ] || [ "$SUMMARY" = "Failed to generate summary" ]; then
+            echo "Failed to extract summary from API response"
+            echo "Response: $RESPONSE"
+            exit 1
+          fi
+
+          # Save to file to avoid escaping issues
+          echo "$SUMMARY" > summary.txt
+
+      - name: Display summary (always shown)
+        run: |
+          echo "## 📋 Generated Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          cat summary.txt >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "---" >> $GITHUB_STEP_SUMMARY
+
+          # Also output to console for easy viewing
+          echo "=========================================="
+          echo "GENERATED SUMMARY:"
+          echo "=========================================="
+          cat summary.txt
+          echo "=========================================="
+
+      - name: Post to Slack
+        if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.dry_run != 'true') }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.GOFISH_SLACK_CHANNEL_WEBHOOK_URL }}
+        run: |
+          SUMMARY=$(cat summary.txt)
+
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "⚠️  SLACK_WEBHOOK_URL secret not set. Skipping Slack post."
+            exit 0
+          fi
+
+          # Build Slack payload with proper escaping
+          jq -n \
+            --arg text "🐟 *GoFish Weekly Update* (${{ steps.dates.outputs.week_ago }} → ${{ steps.dates.outputs.today }})" \
+            --arg summary "$SUMMARY" \
+            '{
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "🐟 GoFish Weekly Update",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": $text | split("*") | join("")
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": $summary
+                  }
+                }
+              ]
+            }' > payload.json
+
+          curl -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d @payload.json
+
+      - name: Dry run notice
+        if: ${{ inputs.dry_run == 'true' }}
+        run: |
+          echo "✅ DRY RUN MODE: Summary generated but NOT posted to Slack"
+          echo "To post to Slack, run the workflow with dry_run set to 'false'"


### PR DESCRIPTION
- Collects commits and merged PRs from last 7 days
- Generates summary using Claude API
- Posts to Slack (with dry-run option for testing)
- Includes error handling and proper API version