### PR TITLE
auto accept storybook changes on 'main'

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0  # Required for Chromatic to track git history
+          fetch-depth: 0 # Required for Chromatic to track git history
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
@@ -39,4 +39,5 @@ jobs:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/gofish-graphics
           buildScriptName: build-storybook
-          onlyChanged: true  # Only test stories that changed
+          onlyChanged: true # Only test stories that changed
+          autoAcceptChanges: "main"


### PR DESCRIPTION
This is so we don't forget to accept the changes on main. We currently block on pulls so having to reverify on main doesn't really make sense to do.