### PR TITLE
Fix pie chart positioning by computing bounding box in screen space

### DIFF
--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coordUtils.ts
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coordUtils.ts
@@ -1,0 +1,100 @@
+import { CoordinateTransform } from "./coord";
+import { BoundingBox, union } from "../../util/bbox";
+
+export type TransformedBoundingBox = BoundingBox & {
+  width: number;
+  height: number;
+};
+
+/**
+ * Samples points from a bounding box in coordinate space for transformation.
+ * For polar/clock coordinates, includes additional samples to capture curved edges.
+ */
+function sampleBoundingBoxPoints(
+  minX: number,
+  maxX: number,
+  minY: number,
+  maxY: number,
+  coordTransform: CoordinateTransform
+): [number, number][] {
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const samples: [number, number][] = [];
+
+  // Sample corners
+  samples.push([minX, minY]);
+  samples.push([maxX, minY]);
+  samples.push([minX, maxY]);
+  samples.push([maxX, maxY]);
+
+  // Sample along edges - more samples for better accuracy with polar coordinates
+  const numSamples =
+    coordTransform.type === "clock" || coordTransform.type === "polar" ? 50 : 20;
+  for (let i = 0; i <= numSamples; i++) {
+    const t = i / numSamples;
+    // Bottom edge
+    samples.push([minX + width * t, minY]);
+    // Top edge - this is the outer arc for polar coordinates
+    samples.push([minX + width * t, maxY]);
+    // Left edge
+    samples.push([minX, minY + height * t]);
+    // Right edge
+    samples.push([maxX, minY + height * t]);
+  }
+
+  // For polar coordinates, also sample the center point (r=0) and midpoints
+  if (coordTransform.type === "clock" || coordTransform.type === "polar") {
+    // Center point
+    samples.push([(minX + maxX) / 2, 0]);
+    // Additional samples at intermediate radii for better coverage
+    for (let r = minY; r <= maxY; r += height / 10) {
+      for (let theta = minX; theta <= maxX; theta += width / 20) {
+        samples.push([theta, r]);
+      }
+    }
+  }
+
+  return samples;
+}
+
+/**
+ * Computes the transformed bounding box of a given bounding box using a coordinate transform.
+ * Samples points from the bounding box, transforms them to screen space, and computes
+ * the bounding box of the transformed points.
+ */
+export function computeTransformedBoundingBox(
+  minX: number,
+  maxX: number,
+  minY: number,
+  maxY: number,
+  coordTransform: CoordinateTransform
+): TransformedBoundingBox {
+  // Sample points from the bounding box
+  const samples = sampleBoundingBoxPoints(
+    minX,
+    maxX,
+    minY,
+    maxY,
+    coordTransform
+  );
+
+  // Transform all samples to screen space
+  const screenSamples = samples.map((coordPoint) =>
+    coordTransform.transform([coordPoint[0], coordPoint[1]])
+  );
+
+  // Compute bounding box in screen space
+  const screenBboxMinX = Math.min(...screenSamples.map((p) => p[0]));
+  const screenBboxMaxX = Math.max(...screenSamples.map((p) => p[0]));
+  const screenBboxMinY = Math.min(...screenSamples.map((p) => p[1]));
+  const screenBboxMaxY = Math.max(...screenSamples.map((p) => p[1]));
+
+  return {
+    minX: screenBboxMinX,
+    maxX: screenBboxMaxX,
+    minY: screenBboxMinY,
+    maxY: screenBboxMaxY,
+    width: screenBboxMaxX - screenBboxMinX,
+    height: screenBboxMaxY - screenBboxMinY,
+  };
+}

--- a/packages/gofish-graphics/src/util/bbox.ts
+++ b/packages/gofish-graphics/src/util/bbox.ts
@@ -1,0 +1,117 @@
+export type BoundingBox = {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+};
+
+/**
+ * Creates a bounding box from min/max values.
+ * Ensures minX <= maxX and minY <= maxY.
+ */
+export function bbox(
+  minX: number,
+  maxX: number,
+  minY: number,
+  maxY: number
+): BoundingBox {
+  return {
+    minX: Math.min(minX, maxX),
+    maxX: Math.max(minX, maxX),
+    minY: Math.min(minY, maxY),
+    maxY: Math.max(minY, maxY),
+  };
+}
+
+/**
+ * Gets the width of a bounding box
+ */
+export const width = (bbox: BoundingBox): number => {
+  return bbox.maxX - bbox.minX;
+};
+
+/**
+ * Gets the height of a bounding box
+ */
+export const height = (bbox: BoundingBox): number => {
+  return bbox.maxY - bbox.minY;
+};
+
+/**
+ * Checks if a bounding box is valid (minX <= maxX and minY <= maxY)
+ */
+export const isValid = (bbox: BoundingBox): boolean => {
+  return bbox.minX <= bbox.maxX && bbox.minY <= bbox.maxY;
+};
+
+/**
+ * Checks if a bounding box is empty
+ */
+export const isEmpty = (bbox: BoundingBox): boolean => {
+  return bbox.minX > bbox.maxX || bbox.minY > bbox.maxY;
+};
+
+/**
+ * Checks if a point is contained within a bounding box
+ */
+export const contains = (bbox: BoundingBox, x: number, y: number): boolean => {
+  return x >= bbox.minX && x <= bbox.maxX && y >= bbox.minY && y <= bbox.maxY;
+};
+
+/**
+ * Checks if two bounding boxes overlap
+ */
+export const overlaps = (a: BoundingBox, b: BoundingBox): boolean => {
+  return (
+    a.minX <= b.maxX && b.minX <= a.maxX && a.minY <= b.maxY && b.minY <= a.maxY
+  );
+};
+
+/**
+ * Computes the union of two bounding boxes
+ */
+export const union = (a: BoundingBox, b: BoundingBox): BoundingBox => {
+  return bbox(
+    Math.min(a.minX, b.minX),
+    Math.max(a.maxX, b.maxX),
+    Math.min(a.minY, b.minY),
+    Math.max(a.maxY, b.maxY)
+  );
+};
+
+/**
+ * Computes the union of multiple bounding boxes
+ */
+export const unionAll = (...bboxes: BoundingBox[]): BoundingBox => {
+  if (bboxes.length === 0) {
+    return bbox(0, 0, 0, 0);
+  }
+
+  return bboxes.reduce((acc, bbox) => union(acc, bbox));
+};
+
+/**
+ * Creates an empty bounding box that can be used as a starting point for unioning.
+ * All dimensions are set to Infinity/-Infinity so that the first union will
+ * replace them with actual values.
+ */
+export const empty = (): BoundingBox => {
+  return {
+    minX: Infinity,
+    maxX: -Infinity,
+    minY: Infinity,
+    maxY: -Infinity,
+  };
+};
+
+/**
+ * Checks if a bounding box is empty (has Infinity values from empty())
+ */
+export const isEmptyInfinity = (bbox: BoundingBox): boolean => {
+  return (
+    bbox.minX === Infinity ||
+    bbox.maxX === -Infinity ||
+    bbox.minY === Infinity ||
+    bbox.maxY === -Infinity
+  );
+};

--- a/packages/gofish-graphics/stories/ForwardSyntaxV3.stories.tsx
+++ b/packages/gofish-graphics/stories/ForwardSyntaxV3.stories.tsx
@@ -256,7 +256,6 @@ export const PolarRibbonChart: StoryObj<Args> = {
     ]).render(container, {
       w: args.w,
       h: args.h,
-      transform: { x: 200, y: 200 },
       axes: true,
     });
 
@@ -316,12 +315,11 @@ export const PieChart: StoryObj<Args> = {
 
     chart(seafood, { coord: clock() })
       .flow(stack("species", { dir: "x" }))
-      .mark(rect({ w: "count", fill: "species" }))
+      .mark(rect({ w: "count", fill: "species", emY: true }))
       .render(container, {
         w: args.w,
         h: args.h,
         axes: true,
-        transform: { x: 200, y: 200 },
       });
 
     return container;
@@ -340,7 +338,6 @@ export const DonutChart: StoryObj<Args> = {
         w: args.w,
         h: args.h,
         axes: true,
-        transform: { x: 200, y: 200 },
       });
 
     return container;
@@ -367,7 +364,6 @@ export const RoseChart: StoryObj<Args> = {
         w: args.w,
         h: args.h,
         axes: true,
-        transform: { x: 200, y: 200 },
       });
 
     return container;


### PR DESCRIPTION
- Refactor bounding box calculation in coord.tsx to transform coordinate-space sample points to screen space before computing bounding box
- Extract coordinate transform utilities to coordUtils.ts with computeTransformedBoundingBox function
- Extract bounding box utilities to util/bbox.ts with union operations
- Fix layout call to include required posScales parameter

This fixes the issue where pie charts required manual translation to appear in the correct position. The bounding box is now correctly computed by transforming sample points from coordinate space (theta, r) to screen space (x, y) before computing the bounding box.

Closes #110