### PR TITLE
feat: Add label support for rect marks

### DIFF
--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -433,6 +433,7 @@ export function rect<T extends Record<string, any>>({
   debug,
   stroke,
   strokeWidth,
+  label,
 }: {
   emX?: boolean;
   emY?: boolean;
@@ -446,6 +447,7 @@ export function rect<T extends Record<string, any>>({
   stroke?: string;
   strokeWidth?: number;
   debug?: boolean;
+  label?: boolean;
 }): Mark<T | T[] | { item: T | T[]; key: number | string }> {
   return async (input: T | T[] | { item: T | T[]; key: number | string }) => {
     let d: T | T[], key: number | string | undefined;
@@ -482,6 +484,7 @@ export function rect<T extends Record<string, any>>({
           : fill,
       stroke,
       strokeWidth,
+      label,
     }).name(key?.toString() ?? "");
     (node as any).datum = d;
     return node;

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -60,6 +60,7 @@ export const rect = ({
   rx = 0,
   ry = 0,
   filter,
+  label,
   ...fancyDims
 }: {
   key?: string;
@@ -70,6 +71,7 @@ export const rect = ({
   rx?: number;
   ry?: number;
   filter?: string;
+  label?: boolean;
 } & FancyDims<MaybeValue<number>>) => {
   const dims = elaborateDims(fancyDims).map(inferEmbedded);
   return new GoFishNode(
@@ -86,6 +88,7 @@ export const rect = ({
         rx,
         ry,
         filter,
+        label,
         dims,
       },
       color: fill,
@@ -288,11 +291,21 @@ export const rect = ({
           },
         ];
 
+        const originalFill = fill;
         fill = isValue(fill)
           ? scaleContext?.unit?.color
             ? scaleContext.unit.color.get(getValue(fill))
             : getValue(fill)
           : fill;
+
+        const resolvedFill = fill as string | undefined;
+        const resolvedStroke =
+          (stroke as string | undefined) ?? resolvedFill ?? "black";
+
+        const labelText =
+          label && originalFill && isValue(originalFill)
+            ? String(getValue(originalFill) ?? "")
+            : undefined;
 
         // Both dimensions are aesthetic - render as transformed point
         if (!isXEmbedded && !isYEmbedded) {
@@ -305,19 +318,34 @@ export const rect = ({
           const height = displayDims[1].size ?? 0;
 
           return (
-            <rect
-              transform={`scale(1, -1)`}
-              x={transformedX - width / 2}
-              y={-(transformedY - height / 2) - height}
-              rx={rx}
-              ry={ry}
-              width={width}
-              height={height}
-              fill={fill}
-              stroke={stroke ?? fill ?? "black"}
-              stroke-width={strokeWidth ?? 0}
-              filter={filter}
-            />
+            <>
+              <rect
+                transform={`scale(1, -1)`}
+                x={transformedX - width / 2}
+                y={-(transformedY - height / 2) - height}
+                rx={rx}
+                ry={ry}
+                width={width}
+                height={height}
+                fill={resolvedFill}
+                stroke={resolvedStroke}
+                stroke-width={strokeWidth ?? 0}
+                filter={filter}
+              />
+              {labelText && (
+                <text
+                  transform="scale(1, -1)"
+                  x={transformedX}
+                  y={-transformedY}
+                  fill="white"
+                  font-size="12px"
+                  text-anchor="middle"
+                  dominant-baseline="central"
+                >
+                  {labelText}
+                </text>
+              )}
+            </>
           );
         }
 
@@ -353,18 +381,39 @@ export const rect = ({
             const x = rawWidth < 0 ? baseX + rawWidth : baseX;
             const y = rawHeight < 0 ? baseY + rawHeight : baseY;
 
+            const center: [number, number] = [
+              x + width / 2,
+              y + height / 2,
+            ];
+            const [transformedX, transformedY] = space.transform(center);
+
             return (
-              <rect
-                transform={`scale(1, -1)`}
-                x={x}
-                y={-y - height}
-                width={width}
-                height={height}
-                fill={fill}
-                stroke={stroke ?? fill ?? "black"}
-                stroke-width={strokeWidth ?? 0}
-                filter={filter}
-              />
+              <>
+                <rect
+                  transform={`scale(1, -1)`}
+                  x={x}
+                  y={-y - height}
+                  width={width}
+                  height={height}
+                  fill={resolvedFill}
+                  stroke={resolvedStroke}
+                  stroke-width={strokeWidth ?? 0}
+                  filter={filter}
+                />
+                {labelText && (
+                  <text
+                    transform="scale(1, -1)"
+                    x={transformedX}
+                    y={-transformedY}
+                    fill="white"
+                    font-size="12px"
+                    text-anchor="middle"
+                    dominant-baseline="central"
+                  >
+                    {labelText}
+                  </text>
+                )}
+              </>
             );
           }
 
@@ -390,7 +439,7 @@ export const rect = ({
           return (
             <path
               d={pathToSVGPath(transformed)}
-              stroke={fill}
+              stroke={resolvedFill}
               stroke-width={thickness + 0.5}
               fill="none"
               filter={filter}
@@ -413,15 +462,36 @@ export const rect = ({
           const x = rawWidth < 0 ? baseX + rawWidth : baseX;
           const y = rawHeight < 0 ? baseY + rawHeight : baseY;
 
+          const center: [number, number] = [
+            x + width / 2,
+            y + height / 2,
+          ];
+          const [transformedX, transformedY] = space.transform(center);
+
           return (
-            <rect
-              transform={`scale(1, -1)`}
-              x={x}
-              y={-y - height}
-              width={width}
-              height={height}
-              fill={fill}
-            />
+            <>
+              <rect
+                transform={`scale(1, -1)`}
+                x={x}
+                y={-y - height}
+                width={width}
+                height={height}
+                fill={resolvedFill}
+              />
+              {labelText && (
+                <text
+                  transform="scale(1, -1)"
+                  x={transformedX}
+                  y={-transformedY}
+                  fill="white"
+                  font-size="12px"
+                  text-anchor="middle"
+                  dominant-baseline="central"
+                >
+                  {labelText}
+                </text>
+              )}
+            </>
           );
         }
 
@@ -440,8 +510,8 @@ export const rect = ({
         return (
           <path
             d={pathToSVGPath(transformed)}
-            fill={fill}
-            stroke={stroke ?? fill ?? "black"}
+            fill={resolvedFill}
+            stroke={resolvedStroke}
             stroke-width={strokeWidth ?? 0}
             filter={filter}
           />

--- a/packages/gofish-graphics/stories/ForwardSyntaxV3.stories.tsx
+++ b/packages/gofish-graphics/stories/ForwardSyntaxV3.stories.tsx
@@ -115,10 +115,31 @@ export const StackedBarChart: StoryObj<Args> = {
 
     chart(seafood)
       .flow(
-        spread("lake", { dir: "x" }), //
-        stack("species", { dir: "y" })
+        spread("lake", { dir: "x"}), //
+        stack("species", { dir: "y", })
       )
       .mark(rect({ h: "count", fill: "species" }))
+      .render(container, {
+        w: args.w,
+        h: args.h,
+        axes: true,
+      });
+
+    return container;
+  },
+};
+
+export const StackedBarChartStoryWithLabels: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    chart(seafood)
+      .flow(
+        spread("lake", { dir: "x"}), //
+        stack("species", { dir: "y",  })
+      )
+      .mark(rect({ h: "count", fill: "species", label: true }))
       .render(container, {
         w: args.w,
         h: args.h,


### PR DESCRIPTION
## Summary

This PR implements the `label: true` feature for rectangle marks, allowing labels to be displayed inside each rendered rectangle.

## Changes

- **Added `label` parameter** to `rect()` mark function in `packages/gofish-graphics/src/ast/marks/chart.ts`
- **Implemented label rendering** in `packages/gofish-graphics/src/ast/shapes/rect.tsx`:
  - Labels display the value of the `fill` field when `fill` is a data column (e.g., species name)
  - Labels are centered within each rectangle
  - Works for all linear coordinate space rendering cases:
    - Both dimensions aesthetic (point-like)
    - One dimension data-driven (bar-like)
    - Both dimensions data-driven (area-like)
- **Added example story** `StackedBarChartStoryWithLabels` demonstrating the feature

## Usage

```typescript
chart(data)
  .flow(
    spread("lake", { dir: "x" }),
    stack("species", { dir: "y" })
  )
  .mark(rect({ h: "count", fill: "species", label: true }))
```

When `label: true` is specified, each rectangle will display a white, centered label showing the value of the `fill` field (in this case, the species name).

## Implementation Details

- Labels are rendered as SVG `<text>` elements positioned at the center of each rectangle
- The label text is extracted from the original `fill` value before it's converted to a color
- Labels use white fill color with 12px font size for visibility
- Coordinate transforms are properly applied to ensure labels are correctly positioned

## Testing

The feature has been tested with the example story in `ForwardSyntaxV3.stories.tsx`.