### PR TITLE
change weekly summary to tuesdays

### DIFF
--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -1,7 +1,7 @@
 name: Weekly GoFish Summary
 on:
   schedule:
-    - cron: "0 14 * * 5" # Fridays at 2pm UTC (adjust to your timezone)
+    - cron: "0 14 * * 2" # Tuesdays at 2pm UTC
   workflow_dispatch: # Allow manual triggers
     inputs:
       dry_run:


### PR DESCRIPTION
Change the day the summaries go to slack to align with our project meeting schedule (which is Tuesday afternoons)