### PR TITLE
Use render sessions for node contexts

### DIFF
--- a/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
@@ -6,7 +6,6 @@ import { elaborateDirection, FancyDirection, Size } from "../dims";
 import { pairs } from "../../util";
 import { linear } from "../coordinateTransforms/linear";
 import { getValue, isValue, MaybeValue } from "../data";
-import { scaleContext } from "../gofish";
 import { Domain } from "../domain";
 import * as Monotonic from "../../util/monotonic";
 import { UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
@@ -325,8 +324,10 @@ export const connect = createOperator(
         },
         render: (
           { intrinsicDims, transform, renderData, coordinateTransform },
-          children
+          children,
+          node
         ) => {
+          const scaleContext = node.getRenderSession().scaleContext;
           fill = fill ?? renderData.defaultColor;
           fill = isValue(fill)
             ? scaleContext?.unit?.color

--- a/packages/gofish-graphics/src/ast/graphicalOperators/frame.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/frame.tsx
@@ -1,35 +1,9 @@
-import { GoFishNode } from "../_node";
 import { FancyDims } from "../dims";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
 import { coord } from "../coordinateTransforms/coord";
 import { layer } from "./layer";
 import { createOperator } from "../withGoFish";
 import { GoFishAST } from "../_ast";
-
-/* layer context */
-type LayerContext = {
-  [name: string]: {
-    data: any[];
-    nodes: GoFishNode[];
-  };
-};
-
-let layerContext: LayerContext | null = null;
-
-export const getLayerContext = (): LayerContext => {
-  if (!layerContext) {
-    layerContext = {};
-  }
-  return layerContext;
-};
-
-export const initLayerContext = (): void => {
-  layerContext = {};
-};
-
-export const resetLayerContext = (): void => {
-  layerContext = null;
-};
 export const frame = createOperator(
   (
     options: {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -12,12 +12,8 @@ import * as Interval from "../../util/interval";
 import { computeSize } from "../../util";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
 import { coord } from "../coordinateTransforms/coord";
-import { getLayerContext, resetLayerContext } from "./frame";
 import { createOperatorSequential } from "../withGoFish";
 import { GoFishAST } from "../_ast";
-
-// Re-export layer context functions for backward compatibility
-export { getLayerContext, resetLayerContext };
 
 export const layer = createOperatorSequential(
   async (

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -13,7 +13,6 @@ import {
 import _, { Collection, size } from "lodash";
 import { computeAesthetic, computeSize, findTargetMonotonic } from "../../util";
 import { GoFishAST } from "../_ast";
-import { getScaleContext } from "../gofish";
 import { createOperator } from "../withGoFish";
 import * as Monotonic from "../../util/monotonic";
 import {
@@ -246,7 +245,8 @@ export const spread = createOperator(
           scaleFactors,
           children,
           measurement,
-          posScales
+          posScales,
+          node
         ) => {
           if (dir === "ttb" || reverse) {
             children = children.reverse();
@@ -292,7 +292,7 @@ export const spread = createOperator(
           }
 
           // console.log(size, scaleFactors, posScales);
-          const scaleContext = getScaleContext();
+          const scaleContext = node.getRenderSession().scaleContext;
           scaleContext.x = {
             domain: [0, size[0] / scaleFactors[0]],
             scaleFactor: scaleFactors[0],

--- a/packages/gofish-graphics/src/ast/index.tsx
+++ b/packages/gofish-graphics/src/ast/index.tsx
@@ -1,5 +1,5 @@
 // Core gofish API
-export { gofish, render, getScopeContext, getScaleContext } from "./gofish";
+export { gofish, render } from "./gofish";
 
 // SolidJS wrappers
 export { GoFishSolid } from "./GoFishSolid";

--- a/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
@@ -29,7 +29,6 @@ import {
   Transform,
 } from "../dims";
 import { aesthetic, continuous } from "../domain";
-import { scaleContext } from "../gofish";
 import { ORDINAL, POSITION, UNDEFINED } from "../underlyingSpace";
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
 export const ellipse = ({
@@ -158,7 +157,7 @@ export const ellipse = ({
           intrinsicDims?: Dimensions;
           transform?: Transform;
           coordinateTransform?: CoordinateTransform;
-        }) => {
+        }, _children, node) => {
           const space = coordinateTransform ?? linear();
 
           // const isDataX = isValue(dims[0].size);
@@ -194,6 +193,7 @@ export const ellipse = ({
             },
           ];
 
+          const scaleContext = node.getRenderSession().scaleContext;
           fill = isValue(fill)
             ? scaleContext?.unit?.color
               ? scaleContext.unit.color.get(getValue(fill))

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -23,7 +23,6 @@ import {
   Transform,
 } from "../dims";
 import { aesthetic, continuous, Domain } from "../domain";
-import { scaleContext } from "../gofish";
 import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic, computeSize } from "../../util";
 import {
@@ -254,7 +253,7 @@ export const Rect = ({
           intrinsicDims?: Dimensions;
           transform?: Transform;
           coordinateTransform?: CoordinateTransform;
-        }) => {
+        }, _children, node: GoFishNode) => {
           const space = coordinateTransform ?? linear();
 
           // const isDataX = isValue(dims[0].size);
@@ -290,6 +289,7 @@ export const Rect = ({
             },
           ];
 
+          const scaleContext = node.getRenderSession().scaleContext;
           const originalFill = fill;
           fill = isValue(fill)
             ? scaleContext?.unit?.color

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -10,7 +10,6 @@ import {
   MaybeValue,
 } from "../data";
 import { Dimensions, elaborateDims, FancyDims, Transform } from "../dims";
-import { scaleContext } from "../gofish";
 import {
   DIFFERENCE,
   ORDINAL,
@@ -279,7 +278,7 @@ export const text = ({
           intrinsicDims?: Dimensions;
           transform?: Transform;
           renderData?: { layout?: TextLayout };
-        }) => {
+        }, _children, node) => {
           const finalText = isValue(textContent)
             ? getValue(textContent)
             : textContent;
@@ -287,7 +286,7 @@ export const text = ({
           const anchorX = transform?.translate?.[0] ?? 0;
           const anchorY = transform?.translate?.[1] ?? 0;
 
-          const unit = scaleContext?.unit;
+          const unit = node.getRenderSession().scaleContext?.unit;
           const unitColorScale =
             unit && "color" in unit ? unit.color : undefined;
           const resolvedFill = isValue(fill)

--- a/packages/gofish-graphics/src/lib.ts
+++ b/packages/gofish-graphics/src/lib.ts
@@ -19,10 +19,6 @@ export { text } from "./ast/shapes/text";
 export { stackX } from "./ast/graphicalOperators/stackX";
 export { stackY } from "./ast/graphicalOperators/stackY";
 export { layer } from "./ast/graphicalOperators/layer";
-export {
-  getLayerContext,
-  resetLayerContext,
-} from "./ast/graphicalOperators/frame";
 export { wrap } from "./ast/graphicalOperators/wrap";
 export { connect } from "./ast/graphicalOperators/connect";
 export { connectX } from "./ast/graphicalOperators/connectX";

--- a/packages/gofish-graphics/stories/DocsContextRegression.stories.tsx
+++ b/packages/gofish-graphics/stories/DocsContextRegression.stories.tsx
@@ -1,0 +1,198 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { chart, spread, stack, rect } from "../src/lib";
+import { seafood } from "../src/data/catch";
+import * as publicApi from "../dist/index.js";
+
+const meta: Meta = {
+  title: "Regressions/Docs Context Parity",
+  parameters: {
+    layout: "fullscreen",
+  },
+};
+
+export default meta;
+
+type Args = { w: number; h: number };
+
+const DOCS_GROUPED_BAR_CODE = `
+chart(seafood)
+  .flow(
+    spread("lake", { dir: "x" }),
+    stack("species", { dir: "x", label: false })
+  )
+  .mark(rect({ h: "count", fill: "species" }))
+  .render(root, {
+    w,
+    h,
+    axes: true,
+  });
+`;
+
+type ChartApi = {
+  chart: typeof chart;
+  spread: typeof spread;
+  stack: typeof stack;
+  rect: typeof rect;
+};
+
+const runDocsLikeSnippet = (
+  container: HTMLElement,
+  api: ChartApi,
+  w: number,
+  h: number
+) => {
+  const root = document.createElement("div");
+  root.style.margin = "8px";
+  container.appendChild(root);
+
+  const fn = new Function(
+    "root",
+    "w",
+    "h",
+    "chart",
+    "spread",
+    "stack",
+    "rect",
+    "seafood",
+    DOCS_GROUPED_BAR_CODE
+  ) as (
+    root: HTMLElement,
+    w: number,
+    h: number,
+    chartFn: typeof chart,
+    spreadFn: typeof spread,
+    stackFn: typeof stack,
+    rectFn: typeof rect,
+    seafoodData: typeof seafood
+  ) => void;
+
+  fn(root, w, h, api.chart, api.spread, api.stack, api.rect, seafood);
+  return root;
+};
+
+const runDirectStorybookVersion = (container: HTMLElement, w: number, h: number) => {
+  const root = document.createElement("div");
+  root.style.margin = "8px";
+  container.appendChild(root);
+
+  chart(seafood)
+    .flow(
+      spread("lake", { dir: "x" }),
+      stack("species", { dir: "x" })
+    )
+    .mark(rect({ h: "count", fill: "species" }))
+    .render(root, {
+      w,
+      h,
+      axes: true,
+    });
+
+  return root;
+};
+
+const inspectHealth = (container: HTMLElement) => {
+  const hasLoading = (container.textContent ?? "").includes("Loading");
+  const fills = Array.from(container.querySelectorAll("rect"))
+    .map((el) => el.getAttribute("fill"))
+    .filter((v): v is string => !!v && v !== "none");
+  const uniqueFills = new Set(fills);
+  return {
+    hasLoading,
+    uniqueFillCount: uniqueFills.size,
+    isHealthy: !hasLoading && uniqueFills.size >= 3,
+  };
+};
+
+const renderPanel = (title: string, mount: HTMLElement) => {
+  const panel = document.createElement("section");
+  panel.style.border = "1px solid #d8d8d8";
+  panel.style.borderRadius = "8px";
+  panel.style.padding = "10px";
+  panel.style.background = "#fff";
+
+  const heading = document.createElement("h4");
+  heading.textContent = title;
+  heading.style.margin = "0 0 8px 0";
+  heading.style.fontFamily = "Space Grotesk, sans-serif";
+  heading.style.fontWeight = "500";
+  panel.appendChild(heading);
+
+  panel.appendChild(mount);
+  return panel;
+};
+
+export const GroupedBarDocsParity: StoryObj<Args> = {
+  args: { w: 400, h: 300 },
+  render: (args: Args) => {
+    const host = document.createElement("div");
+    host.style.padding = "20px";
+
+    const grid = document.createElement("div");
+    grid.style.display = "grid";
+    grid.style.gridTemplateColumns = "repeat(auto-fit, minmax(420px, 1fr))";
+    grid.style.gap = "12px";
+    host.appendChild(grid);
+
+    const directMount = document.createElement("div");
+    const docsLikeSourceMount = document.createElement("div");
+    const docsLikePublicMount = document.createElement("div");
+
+    runDirectStorybookVersion(directMount, args.w, args.h);
+    runDocsLikeSnippet(
+      docsLikeSourceMount,
+      { chart, spread, stack, rect },
+      args.w,
+      args.h
+    );
+    runDocsLikeSnippet(
+      docsLikePublicMount,
+      {
+        chart: publicApi.chart as typeof chart,
+        spread: publicApi.spread as typeof spread,
+        stack: publicApi.stack as typeof stack,
+        rect: publicApi.rect as typeof rect,
+      },
+      args.w,
+      args.h
+    );
+
+    const directPanel = renderPanel("Storybook source API", directMount);
+    const docsSourcePanel = renderPanel(
+      "Docs-style runtime (new Function) + source API",
+      docsLikeSourceMount
+    );
+    const docsPublicPanel = renderPanel(
+      "Docs-style runtime (new Function) + public dist API",
+      docsLikePublicMount
+    );
+
+    const status = document.createElement("pre");
+    status.style.margin = "8px 0 0 0";
+    status.style.padding = "8px";
+    status.style.borderRadius = "6px";
+    status.style.background = "#f7f7f7";
+    status.style.fontSize = "12px";
+    status.style.lineHeight = "1.4";
+    status.textContent = "Running parity checks...";
+    host.appendChild(status);
+
+    grid.appendChild(directPanel);
+    grid.appendChild(docsSourcePanel);
+    grid.appendChild(docsPublicPanel);
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const a = inspectHealth(directMount);
+        const b = inspectHealth(docsLikeSourceMount);
+        const c = inspectHealth(docsLikePublicMount);
+
+        status.textContent =
+          `source: healthy=${a.isHealthy}, loading=${a.hasLoading}, uniqueFills=${a.uniqueFillCount}\n` +
+          `docs+source: healthy=${b.isHealthy}, loading=${b.hasLoading}, uniqueFills=${b.uniqueFillCount}\n` +
+          `docs+public: healthy=${c.isHealthy}, loading=${c.hasLoading}, uniqueFills=${c.uniqueFillCount}`;
+      });
+    });
+
+    return host;
+  },
+};


### PR DESCRIPTION
Closes #132. Closes #134.

Summary
- store scope/scale/key contexts in a shared `RenderSession` that's injected into each node/ref during layout
- stop relying on module globals for contexts and layer tracking, instead thread a shared layer context through chart builders and operators
- fix downstream operators/shapes to consume the session context and add a regression story covering docs parity

Testing
- Added a new regression test for context race condition.