### PR TITLE
Ref handles objects with __ref properties

### DIFF
--- a/packages/gofish-graphics/src/ast/shapes/ref.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ref.tsx
@@ -1,9 +1,13 @@
 import { GoFishRef } from "../_ref";
 import { GoFishNode } from "../_node";
 
-export const ref = (selectionOrNode: string | GoFishNode) => {
+export const ref = (
+  selectionOrNode: string | GoFishNode | { __ref: GoFishNode }
+) => {
   if (typeof selectionOrNode === "string") {
     return new GoFishRef({ selection: selectionOrNode });
+  } else if ("__ref" in selectionOrNode) {
+    return new GoFishRef({ node: selectionOrNode.__ref });
   } else {
     return new GoFishRef({ node: selectionOrNode });
   }

--- a/packages/gofish-graphics/stories/forwardsyntax/Bar/BarWithLabels.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Bar/BarWithLabels.stories.tsx
@@ -32,9 +32,8 @@ export const Default: StoryObj<Args> = {
       chart(select("bars"))
         .flow(group("lake"))
         .mark((d) => {
-          console.log(d);
           return Spread({ direction: "y", alignment: "middle", spacing: 10 }, [
-            Ref(d[0].__ref!),
+            Ref(d[0]),
             Text({ text: d[0].count }),
           ]);
         }),


### PR DESCRIPTION
Closes #142!
Added case in Ref() to accept objects with __ref: GoFishNode properties. Returns new GoFishRef with node extracted from __ref.