### PR TITLE
Refine weekly summary script to highlight contributors

### DIFF
--- a/.github/scripts/summarize-with-claude.sh
+++ b/.github/scripts/summarize-with-claude.sh
@@ -12,12 +12,65 @@ if [ ! -f prs.txt ]; then
   exit 1
 fi
 
-# Build the prompt
-PROMPT=$(cat <<'ENDPROMPT'
+# Build contributor callout guidance from PR data
+# Expected PR blocks look like:
+# - "### PR #123: Title"
+# - "- **Author:** username"
+# - "- **URL:** https://..."
+CONTRIBUTOR_CALLOUTS=$(
+  awk '
+    /^### PR #[0-9]+:/ {
+      line = $0
+      sub(/^### PR #/, "", line)
+      split(line, parts, ": ")
+      pr = parts[1]
+      title = substr(line, length(pr) + 3)
+    }
+    /^- \*\*Author:\*\* / {
+      author = $0
+      sub(/^- \*\*Author:\*\* /, "", author)
+    }
+    /^- \*\*URL:\*\* / {
+      url = $0
+      sub(/^- \*\*URL:\*\* /, "", url)
+      if (author != "" && !(author in seen)) {
+        seen[author] = 1
+        firstPr[author] = pr
+        firstTitle[author] = title
+        firstUrl[author] = url
+      }
+      author = ""
+      pr = ""
+      title = ""
+      url = ""
+    }
+    END {
+      for (a in seen) {
+        printf("- %s: <%s|PR #%s> - %s\n", a, firstUrl[a], firstPr[a], firstTitle[a])
+      }
+    }
+  ' prs.txt | sort
+)
+
+if [ -z "$CONTRIBUTOR_CALLOUTS" ]; then
+  CONTRIBUTOR_CALLOUTS="(No named contributors detected.)"
+fi
+
+# Count merged PRs to include in Highlights.
+PR_COUNT=$(grep -c '^### PR #' prs.txt || true)
+
+# Build the prompt template
+read -r -d '' PROMPT_TEMPLATE <<'ENDPROMPT' || true
 You are summarizing a week of development on GoFish, a charting library for data visualization. Create a Slack-friendly weekly update.
 
 ## Merged PRs from the last 7 days:
 PRS_PLACEHOLDER
+
+## Weekly PR count:
+PR_COUNT_PLACEHOLDER
+
+## Contributor coverage requirements (MUST follow):
+CONTRIBUTOR_CALLOUTS_PLACEHOLDER
 
 Write a concise weekly summary using Slack mrkdwn format (NOT standard Markdown):
 - Use *single asterisks* for bold (Slack does NOT support **double asterisks**)
@@ -25,20 +78,23 @@ Write a concise weekly summary using Slack mrkdwn format (NOT standard Markdown)
 - Use • or - for bullet points
 - Use _underscores_ for italics if needed
 - When mentioning any PR in the summary, format it as a hyperlink using the URL from the data above: <PR_URL|PR #NUMBER> (e.g. <https://github.com/starfish-graphics/gofish-graphics/pull/123|PR #123>)
+- Contributor coverage is REQUIRED: every contributor listed above must be called out by name with at least one specific contribution.
+- In *Highlights*, explicitly mention the number of PRs that landed this week using the PR count above.
 
 Structure your response as:
 1. *Highlights* - 2-3 sentence overview of the main thrust of work this week
 2. *What changed* - Group related changes by theme (e.g., "API improvements", "Bug fixes", "Documentation"). Use bullet points, keep each brief.
-3. *PRs of note* - Call out any significant PRs with a one-liner each
+3. *Contributor shout-outs* - One bullet per contributor, each explicitly naming the person and one concrete contribution (preferably linked PR).
 
 Keep the tone casual and informative. Use emoji sparingly. Total length should be readable in ~30 seconds.
 ENDPROMPT
-)
 
 # Read data from file (avoids escaping issues with GitHub Actions outputs)
 PRS_DATA=$(cat prs.txt)
 
-PROMPT="${PROMPT//PRS_PLACEHOLDER/$PRS_DATA}"
+PROMPT="${PROMPT_TEMPLATE//PRS_PLACEHOLDER/$PRS_DATA}"
+PROMPT="${PROMPT//PR_COUNT_PLACEHOLDER/$PR_COUNT}"
+PROMPT="${PROMPT//CONTRIBUTOR_CALLOUTS_PLACEHOLDER/$CONTRIBUTOR_CALLOUTS}"
 
 # Check if API key is set
 if [ -z "$ANTHROPIC_API_KEY" ]; then
@@ -75,6 +131,53 @@ if [ -z "$SUMMARY" ] || [ "$SUMMARY" = "Failed to generate summary" ]; then
   echo "Failed to extract summary from API response"
   echo "Response: $RESPONSE"
   exit 1
+fi
+
+# Guarantee each contributor appears by name at least once.
+MISSING_CALLOUTS=$(
+  awk '
+    /^### PR #[0-9]+:/ {
+      line = $0
+      sub(/^### PR #/, "", line)
+      split(line, parts, ": ")
+      pr = parts[1]
+      title = substr(line, length(pr) + 3)
+    }
+    /^- \*\*Author:\*\* / {
+      author = $0
+      sub(/^- \*\*Author:\*\* /, "", author)
+    }
+    /^- \*\*URL:\*\* / {
+      url = $0
+      sub(/^- \*\*URL:\*\* /, "", url)
+      if (author != "" && !(author in seen)) {
+        seen[author] = 1
+        firstPr[author] = pr
+        firstTitle[author] = title
+        firstUrl[author] = url
+      }
+      author = ""
+      pr = ""
+      title = ""
+      url = ""
+    }
+    END {
+      for (a in seen) {
+        print a "\t" firstPr[a] "\t" firstUrl[a] "\t" firstTitle[a]
+      }
+    }
+  ' prs.txt | sort | while IFS=$'\t' read -r author pr url title; do
+    if ! grep -iqE "(^|[^[:alnum:]_])${author}([^[:alnum:]_]|$)" <<< "$SUMMARY"; then
+      printf -- "- %s: Shipped %s (%s).\n" "$author" "<${url}|PR #${pr}>" "$title"
+    fi
+  done
+)
+
+if [ -n "$MISSING_CALLOUTS" ]; then
+  SUMMARY="${SUMMARY}
+
+*Contributor shout-outs (added for full coverage)*
+${MISSING_CALLOUTS}"
 fi
 
 # Save to file to avoid escaping issues


### PR DESCRIPTION
Summary:
- Update `.github/scripts/summarize-with-claude.sh` so the prompt includes merged PR count and enforces contributor callouts that link to each contributor’s PR.
- Drop the old “PRs of note” section in favor of contributor shout-outs and append any missing calls if the generated summary doesn’t already mention someone.
- Capture merged PR count from `prs.txt` and build the contributor guidance dynamically so each person is called out by name with their first PR title and link.

Testing:
- Not run (not requested).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes that adjust prompt construction and add deterministic post-processing; main risk is occasional false positives/negatives in name matching or `prs.txt` parsing leading to awkward shout-outs.
> 
> **Overview**
> Updates `.github/scripts/summarize-with-claude.sh` to dynamically derive a unique contributor list from `prs.txt` (linking each author to their first PR) and inject it into the Claude prompt as a **required** “Contributor shout-outs” section.
> 
> The prompt now includes the weekly merged PR count and replaces the previous “PRs of note” structure with contributor-focused coverage requirements.
> 
> After generation, the script validates that every contributor name appears in the returned summary and, if not, appends an extra shout-outs block with linked PR references to guarantee coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 012ccf2228d758332df7fbd894283d40bff69142. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->