### PR TITLE
double token limit for claude summary

### DIFF
--- a/.github/scripts/summarize-with-claude.sh
+++ b/.github/scripts/summarize-with-claude.sh
@@ -107,7 +107,7 @@ PAYLOAD=$(jq -n \
   --arg prompt "$PROMPT" \
   '{
     "model": "claude-opus-4-6",
-    "max_tokens": 1024,
+    "max_tokens": 2048,
     "messages": [{"role": "user", "content": $prompt}]
   }'
 )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-parameter change to a GitHub workflow script; primary impact is slightly higher API usage/cost and longer summaries.
> 
> **Overview**
> Increases the Claude API request `max_tokens` limit in `.github/scripts/summarize-with-claude.sh` from 1024 to 2048 to allow longer generated weekly summaries.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42bc206c5d14d4ee1b6a2f577cc1bf96d611be9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->