### PR TITLE
Give rect default sizing and add Vega-lite story

### DIFF
--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -44,6 +44,8 @@ const computeIntrinsicSize = (
     : Monotonic.linear(0, input ?? 0);
 };
 
+const DEFAULT_RECT_SIZE = 16;
+
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
 export const Rect = ({
     key,
@@ -182,7 +184,7 @@ export const Rect = ({
           const x = computeAesthetic(dims[0].min, posScales?.[0]!, undefined);
           const y = computeAesthetic(dims[1].min, posScales?.[1]!, undefined);
 
-          let w: number;
+          let w: number | undefined;
           if (isValue(dims[0].min) && isValue(dims[0].size)) {
             // If posScales for x exists, scale min and min+size, then subtract
             const min = x;
@@ -201,8 +203,13 @@ export const Rect = ({
           } else {
             w = computeSize(dims[0].size, scaleFactors?.[0]!, size[0]);
           }
+          // When parent constraints are unresolved and rect width is unspecified,
+          // keep a visible default instead of propagating undefined.
+          if (w === undefined || !Number.isFinite(w)) {
+            w = DEFAULT_RECT_SIZE;
+          }
 
-          let h: number;
+          let h: number | undefined;
           if (isValue(dims[1].min) && isValue(dims[1].size)) {
             // If posScales for y exists, scale min and min+size, then subtract
             const min = y;
@@ -220,6 +227,9 @@ export const Rect = ({
             h = maxPos - minPos;
           } else {
             h = computeSize(dims[1].size, scaleFactors?.[1]!, size[1]);
+          }
+          if (h === undefined || !Number.isFinite(h)) {
+            h = DEFAULT_RECT_SIZE;
           }
 
           const result = {

--- a/packages/gofish-graphics/stories/vega-lite/SimpleBarChart.stories.tsx
+++ b/packages/gofish-graphics/stories/vega-lite/SimpleBarChart.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import { Chart, spread, rect } from "../../src/lib";
+
+const values = [
+  { a: "A", b: 28 },
+  { a: "B", b: 55 },
+  { a: "C", b: 43 },
+  { a: "D", b: 91 },
+  { a: "E", b: 81 },
+  { a: "F", b: 53 },
+  { a: "G", b: 19 },
+  { a: "H", b: 87 },
+  { a: "I", b: 52 },
+];
+
+const meta: Meta = {
+  title: "Vega-Lite/Simple Bar Chart",
+  argTypes: {
+    h: {
+      control: { type: "number", min: 100, max: 1000, step: 10 },
+    },
+  },
+};
+
+export default meta;
+
+type Args = { h: number };
+
+export const Default: StoryObj<Args> = {
+  args: { h: 300 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    Chart(values)
+      .flow(spread("a", { dir: "x" }))
+      .mark(rect({ h: "b" }))
+      // Intentionally omit width to cover the rect default-width fallback path.
+      .render(container, { h: args.h, axes: true } as any);
+
+    return container;
+  },
+};


### PR DESCRIPTION
## Summary
- ensure `Rect` falls back to a default-visible size when width/height aren't defined by the rect or given by the parent
- add a Vega-Lite story directory and simple bar chart
- width is left undefined to be inferred
- height cannot be inferred b/c of #259