### PR TITLE
Unify mark API while keeping Rect/Image aliases

### DIFF
--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,71 @@
+# GoFish Graphics - Memory
+
+## Project Structure
+- Monorepo: `packages/gofish-graphics/` (main lib), `apps/docs/`, `packages/gofish-python/`
+- pnpm store: `/Users/jmp/Library/pnpm/store/v10`
+- Dev server: port 3000 (`pnpm dev`), Storybook: port 6006 (`pnpm storybook`)
+
+## Key Files
+- Main lib exports: `packages/gofish-graphics/src/lib.ts`
+- v3 chart API: `packages/gofish-graphics/src/ast/marks/chart.ts`
+- Rect shape: `packages/gofish-graphics/src/ast/shapes/rect.tsx`
+- Seafood sample data: `packages/gofish-graphics/src/data/catch.ts`
+- Stories: `packages/gofish-graphics/stories/`
+- Vega-Lite stories: `packages/gofish-graphics/stories/vega-lite/`
+
+## v3 Chart API Pattern
+```ts
+Chart(data)
+  .flow(spread("field", { dir: "x" | "y" }), stack("field", { dir: "x" | "y" }), derive(fn))
+  .mark(rect({ h: "field", fill: "field", rx: 3 }))
+  .render(container, { w, h, axes: true })
+```
+- `derive(fn)` transforms data before next operator (first in flow = runs before spread)
+- After `spread()`, `d` in derive is scoped to one x-group — use this to compute per-group totals (e.g. `sumBy(d, "field")`) without manual groupBy
+- Filter static subsets before `Chart()` rather than inside `derive()`
+- `rect()` passes unknown props through to `Rect()` (so `rx`/`ry` work)
+
+## Vega-Datasets
+- Added as devDependency to `packages/gofish-graphics`, along with `d3-dsv` and `@types/d3-dsv`
+- Do NOT use the fetch-based API (`import data from "vega-datasets"`) — causes Vite module resolution errors with d3-dsv
+- Import JSON directly (Vite handles natively): `import population from "vega-datasets/data/population.json"`
+- Import CSV as raw string + parse: `import raw from "vega-datasets/data/seattle-weather.csv?raw"` then `csvParse(raw, autoType)` from `d3-dsv`
+- d3-dsv `autoType` parses ISO date strings to Date objects, numeric strings to numbers
+- Available: population.json, barley.json, seattle-weather.csv, movies.json, etc.
+
+## Vega-Lite Bar Chart Stories Created
+All in `stories/vega-lite/`:
+- `SimpleBarChart.stories.tsx` - simple bar (existing)
+- `AggregateBarChart.stories.tsx` - population by age (horizontal), derive+groupBy+sumBy
+- `AggregateBarChartSorted.stories.tsx` - same, sorted desc by value
+- `GroupedBarChart.stories.tsx` - inline A/B/C data, spread+stack
+- `GroupedBarChartRepeat.stories.tsx` - movies.json, wide-to-long reshape in derive
+- `StackedBarChart.stories.tsx` - seattle-weather.csv, derive to month+count
+- `StackedBarChartRounded.stories.tsx` - same + rx/ry on rect
+- `HorizontalStackedBarChart.stories.tsx` - barley.json, spread(variety,y)+stack(site,x)
+- `NormalizedStackedBarChart.stories.tsx` - population.json yr2000, spread(age,x)+derive(proportion per row)+stack(sex,y)
+
+## place() API (post-refactor)
+- New signature: `place(axis: FancyDirection, value: number, anchor?: Anchor)`
+- Anchors: `"min"` (default), `"max"`, `"center"`, `"baseline"`
+- `"baseline"` anchor = places **local origin (0)** at value → `translate = value`. This replicates old `place({ x: value })` behavior.
+- `"min"` anchor = places min corner at value → `translate = value - intrinsicDims.min`. DIFFERENT from old for composite nodes where min≠0.
+- **Rule**: operators that co-locate children in a shared coordinate space (layer, enclose, porterDuff, coord, gofish root) MUST use `"baseline"` anchor, not `"min"`. Using `"min"` shifts composite nodes with non-zero min, breaking Ref-based layouts.
+- Spread's distribute/align passes correctly use `"min"`, `"center"`, `"max"`, `"baseline"` anchors per their alignment semantics.
+
+## Missing Features (catalogued in stories)
+1. **Custom color palettes/ranges** - Vega-Lite maps field values to specific colors; GoFish auto-assigns
+2. **Per-corner border radius** - Vega-Lite has cornerRadiusTopLeft/TopRight; GoFish `rx`/`ry` applies to all corners
+3. **Built-in repeat.layer / pivot** - Vega-Lite `repeat.layer` creates multi-measure charts declaratively; GoFish requires manual wide-to-long reshape with `derive()`
+4. **Declarative aggregation** - Vega-Lite has `aggregate: "sum"/"count"` in encodings; GoFish uses `derive()` + lodash groupBy/sumBy
+
+## Story Pattern for Async Data
+```ts
+render: (args) => {
+  const container = initializeContainer();
+  data['dataset.json']().then((rows: any[]) => {
+    Chart(rows).flow(...).mark(...).render(container, {...});
+  });
+  return container; // returned synchronously; chart fills in async
+}
+```

--- a/packages/gofish-graphics/src/ast/channels.ts
+++ b/packages/gofish-graphics/src/ast/channels.ts
@@ -1,5 +1,5 @@
 import { sumBy } from "lodash";
-import { MaybeValue, value } from "./data";
+import { isValue, MaybeValue, value } from "./data";
 
 export type ChannelType = "size" | "color";
 
@@ -7,12 +7,19 @@ export type ChannelAnnotations<T> = {
   [K in keyof T]?: ChannelType;
 };
 
+export type AccessorFn<T extends Record<string, any>, V> = (d: T[]) => V;
+
+export type ResolvableProp<T extends Record<string, any>, V> =
+  | V
+  | (keyof T & string)
+  | AccessorFn<T, V | (keyof T & string)>;
+
 /**
  * Derive mark prop types from shape prop types + channel annotations.
  *
- * - "size" channels: mark accepts `number | keyof T` instead of `MaybeValue<number>`
- * - "color" channels: mark accepts `string | keyof T` instead of `MaybeValue<string>`
- * - unannotated props: passed through with the same type
+ * - "size" channels: mark accepts shape value, string field shorthand, or accessor fn
+ * - "color" channels: mark accepts shape value, string field shorthand, or accessor fn
+ * - unannotated props: passed through or accessor fn
  */
 export type DeriveMarkProps<
   ShapeProps,
@@ -21,11 +28,11 @@ export type DeriveMarkProps<
 > = {
   [K in keyof ShapeProps]: K extends keyof Channels
     ? Channels[K] extends "size"
-      ? number | (keyof T & string) | undefined
+      ? ResolvableProp<T, ShapeProps[K]>
       : Channels[K] extends "color"
-        ? string | (keyof T & string) | undefined
-        : ShapeProps[K]
-    : ShapeProps[K];
+        ? ResolvableProp<T, ShapeProps[K]>
+        : ShapeProps[K] | AccessorFn<T, ShapeProps[K]>
+    : ShapeProps[K] | AccessorFn<T, ShapeProps[K]>;
 } & { debug?: boolean };
 
 /**
@@ -34,9 +41,12 @@ export type DeriveMarkProps<
  * If accessor is a number, passes it through as a literal.
  */
 export const inferSize = <T>(
-  accessor: string | number | undefined,
+  accessor: string | number | MaybeValue<number> | undefined,
   d: T | T[],
 ): MaybeValue<number> | undefined => {
+  if (isValue(accessor as MaybeValue<number>)) {
+    return accessor as MaybeValue<number>;
+  }
   return typeof accessor === "number"
     ? accessor
     : accessor !== undefined
@@ -50,9 +60,10 @@ export const inferSize = <T>(
  * Otherwise passes through as a literal color string.
  */
 export const inferColor = <T extends Record<string, any>>(
-  accessor: string | undefined,
+  accessor: string | MaybeValue<string> | undefined,
   data: T[],
 ): MaybeValue<string> | undefined => {
+  if (isValue(accessor)) return accessor;
   if (accessor === undefined) return undefined;
   if (data.length > 0 && accessor in data[0]) {
     return value(data[0][accessor]);

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -41,7 +41,11 @@ function nameableMark<T>(
   base: Mark<T>
 ): Mark<T> & { name(layerName: string): Mark<T> } {
   const withName = (layerName: string): Mark<T> => {
-    return async (d: T, key?: string | number, layerContext?: LayerContext) => {
+    return async (
+      d: T | undefined,
+      key?: string | number,
+      layerContext?: LayerContext
+    ) => {
       const node = await resolveMarkResult(
         base(d, key, layerContext),
         layerContext
@@ -113,10 +117,13 @@ export class LayerSelector<T = any> {
 export function derive<T, U>(fn: (d: T) => U | Promise<U>): Operator<T, U> {
   return async (mark: Mark<U>) => {
     return (async (
-      d: T,
+      d: T | undefined,
       key?: string | number,
       layerContext?: LayerContext
     ) => {
+      if (d === undefined) {
+        return mark(undefined, key, layerContext);
+      }
       return mark(await fn(d), key, layerContext);
     }) as Mark<T>;
   };
@@ -146,7 +153,7 @@ export const normalize = <T, K extends keyof T>(
 export function log<T>(label?: string): Operator<T, T> {
   return async (mark: Mark<T>) => {
     return (async (
-      d: T,
+      d: T | undefined,
       key?: string | number,
       layerContext?: LayerContext
     ) => {
@@ -354,10 +361,13 @@ export function spread<T>(
 
   return async (mark: Mark<T[]>) => {
     return async (
-      d: T[],
+      d: T[] | undefined,
       key?: string | number,
       layerContext?: LayerContext
     ) => {
+      if (d === undefined) {
+        throw new Error("spread operator requires data but received undefined.");
+      }
       // Group by the field if provided, otherwise iterate over raw data
       const grouped = field
         ? typeof field === "string"
@@ -423,15 +433,21 @@ export function scatter<T>(
 ): Operator<T[], T[]> {
   return async (mark: Mark<T[]>) => {
     return async (
-      d: T[],
+      d: T[] | undefined,
       key?: string | number,
       layerContext?: LayerContext
     ) => {
+      if (d === undefined) {
+        throw new Error("scatter operator requires data but received undefined.");
+      }
       // Group by the field
-      const groups = groupBy(d, field as ValueIteratee<T>);
+      const groups = groupBy(d, field as ValueIteratee<T>) as Record<
+        string,
+        T[]
+      >;
       if (options?.debug) console.log("scatter groups", groups);
       return Frame(
-        For(groups, async (items, groupKey) => {
+        For(groups, async (items: T[], groupKey) => {
           // Calculate average x and y values for this group
           const avgX = meanBy(items, options.x as string);
           const avgY = meanBy(items, options.y as string);
@@ -452,16 +468,22 @@ export function scatter<T>(
 export function group<T>(field: keyof T): Operator<T[], T[]> {
   return async (mark: Mark<T[]>) => {
     return async (
-      d: T[],
+      d: T[] | undefined,
       key?: string | number,
       layerContext?: LayerContext
     ) => {
+      if (d === undefined) {
+        throw new Error("group operator requires data but received undefined.");
+      }
       // Group by the field
-      const groups = groupBy(d, field as ValueIteratee<T>);
+      const groups = groupBy(d, field as ValueIteratee<T>) as Record<
+        string,
+        T[]
+      >;
 
       return Frame(
         {},
-        For(groups, (items, groupKey) => {
+        For(groups, (items: T[], groupKey) => {
           // Apply mark to each group
           const currentKey = key != undefined ? `${key}-${groupKey}` : groupKey;
           return mark(items, currentKey, layerContext) as any;
@@ -483,12 +505,16 @@ export function circle<T extends Record<string, any>>({
   stroke?: string;
   strokeWidth?: number;
   debug?: boolean;
-}): Mark<T> & { name(layerName: string): Mark<T> } {
-  const base: Mark<T> = async (
-    d: T,
+}): Mark<T[]> & { name(layerName: string): Mark<T[]> } {
+  const base: Mark<T[]> = async (
+    d: T[] | undefined,
     key?: string | number,
     _layerContext?: LayerContext
   ) => {
+    if (!d || d.length === 0) {
+      throw new Error("circle mark requires non-empty grouped data.");
+    }
+    const first = d[0];
     if (debug) console.log("circle", key, d);
     const node = Rect({
       w: typeof r === "number" ? r * 2 : inferSize(r, d),
@@ -496,7 +522,9 @@ export function circle<T extends Record<string, any>>({
       rx: typeof r === "number" ? r : 5,
       ry: typeof r === "number" ? r : 5,
       fill:
-        typeof fill === "string" && fill in d ? v(d[fill as keyof T]) : fill,
+        typeof fill === "string" && fill in first
+          ? v(first[fill as keyof T])
+          : fill,
       stroke,
       strokeWidth,
     }).name(key?.toString() ?? "");
@@ -520,10 +548,11 @@ export function line<T extends Record<string, any>>(options?: {
   interpolation?: "linear" | "bezier";
 }): Mark<Array<T & { __ref?: GoFishNode }>> {
   return async (
-    d: Array<T & { __ref?: GoFishNode }>,
+    d: Array<T & { __ref?: GoFishNode }> | undefined,
     key?: string | number,
     _layerContext?: LayerContext
   ) => {
+    if (!d) throw new Error("line mark requires data but received undefined.");
     // Use refs from enriched data (lazy resolution via __ref)
     const refs = d.map((item) => {
       if ("__ref" in item && item.__ref) {
@@ -556,10 +585,11 @@ export function area<T extends Record<string, any>>(options?: {
   interpolation?: "linear" | "bezier";
 }): Mark<Array<T & { __ref?: GoFishNode }>> {
   return async (
-    d: Array<T & { __ref?: GoFishNode }>,
+    d: Array<T & { __ref?: GoFishNode }> | undefined,
     key?: string | number,
     _layerContext?: LayerContext
   ) => {
+    if (!d) throw new Error("area mark requires data but received undefined.");
     // Use refs from enriched data (lazy resolution via __ref)
     const refs = d.map((item) => {
       if ("__ref" in item && item.__ref) {
@@ -606,7 +636,7 @@ export function scaffold<T extends Record<string, any>>({
   stroke?: string;
   strokeWidth?: number;
   debug?: boolean;
-} = {}): Mark<T | T[] | { item: T | T[]; key: number | string }> {
+} = {}): Mark<T[]> {
   // scaffold is essentially a transparent/zero-size rect
   return generatedRect({
     emX,

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -168,7 +168,16 @@ const resolveRenderedDimensions = (
   return { width: 0, height: 0 };
 };
 
-export const Image = ({
+export type ImageProps = {
+  key?: string;
+  name?: string;
+  href: string;
+  filter?: string;
+  opacity?: number;
+  preserveAspectRatio?: string;
+} & FancyDims<number>;
+
+const ImageShape = ({
   key,
   name,
   href,
@@ -176,14 +185,7 @@ export const Image = ({
   opacity,
   preserveAspectRatio = "xMidYMid meet",
   ...fancyDims
-}: {
-  key?: string;
-  name?: string;
-  href: string;
-  filter?: string;
-  opacity?: number;
-  preserveAspectRatio?: string;
-} & FancyDims<number>) => {
+}: ImageProps) => {
   const dims = elaborateDims(fancyDims).map(inferEmbedded);
 
   return new GoFishNode(
@@ -336,4 +338,11 @@ export const Image = ({
   );
 };
 
-export const image = createMark(Image, {});
+export const image = createMark(ImageShape, {});
+
+/**
+ * @deprecated Use `image(opts)(undefined)` for low-level/no-data usage.
+ */
+export const Image = (opts: ImageProps): GoFishNode => {
+  return image(opts)(undefined) as GoFishNode;
+};

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -46,8 +46,20 @@ const computeIntrinsicSize = (
 
 const DEFAULT_RECT_SIZE = 16;
 
+export type RectProps = {
+  key?: string;
+  name?: string;
+  fill?: MaybeValue<string>;
+  stroke?: MaybeValue<string>;
+  strokeWidth?: number;
+  rx?: number;
+  ry?: number;
+  filter?: string;
+  label?: boolean;
+} & FancyDims<MaybeValue<number>>;
+
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
-export const Rect = ({
+const RectShape = ({
     key,
     name,
     fill = color6[0],
@@ -58,17 +70,7 @@ export const Rect = ({
     filter,
     label,
     ...fancyDims
-  }: {
-    key?: string;
-    name?: string;
-    fill?: MaybeValue<string>;
-    stroke?: MaybeValue<string>;
-    strokeWidth?: number;
-    rx?: number;
-    ry?: number;
-    filter?: string;
-    label?: boolean;
-  } & FancyDims<MaybeValue<number>>) => {
+  }: RectProps) => {
     const dims = elaborateDims(fancyDims).map(inferEmbedded);
     return new GoFishNode(
       {
@@ -535,8 +537,15 @@ export const Rect = ({
     );
   };
 
-export const rect = createMark(Rect, {
+export const rect = createMark(RectShape, {
   w: "size",
   h: "size",
   fill: "color",
 });
+
+/**
+ * @deprecated Use `rect(opts)(undefined)` for low-level/no-data usage.
+ */
+export const Rect = (opts: RectProps): GoFishNode => {
+  return rect(opts)(undefined) as GoFishNode;
+};

--- a/packages/gofish-graphics/src/ast/types.ts
+++ b/packages/gofish-graphics/src/ast/types.ts
@@ -4,7 +4,7 @@ import { GoFishNode } from "./_node";
 
 /** Optional third argument: when provided by ChartBuilder.resolve(), named marks register each produced node/datum here. */
 export type Mark<T> = (
-  d: T,
+  d: T | undefined,
   key?: string | number,
   layerContext?: { [name: string]: { data: any[]; nodes: GoFishNode[] } }
 ) => GoFishAST | Promise<GoFishAST>

--- a/packages/gofish-graphics/src/ast/withGoFish.ts
+++ b/packages/gofish-graphics/src/ast/withGoFish.ts
@@ -340,14 +340,20 @@ export type NameableMark<T> = Mark<T> & {
   name(layerName: string): Mark<T>;
 };
 
+const isAccessorFunction = <T extends Record<string, any>, V>(
+  value: V | ((d: T[]) => V)
+): value is (d: T[]) => V => {
+  return typeof value === "function";
+};
+
 /**
  * Creates a high-level mark function from a low-level shape function
  * and channel annotations.
  *
  * Channel annotations describe how each prop encodes data:
- * - "size": mark accepts `number | keyof T`, uses inferSize to convert
- * - "color": mark accepts `string | keyof T`, uses inferColor to convert
- * - unannotated props are passed through unchanged
+ * - "size": mark accepts literal, string field shorthand, or accessor function
+ * - "color": mark accepts literal, string field shorthand, or accessor function
+ * - unannotated props are passed through as-is (or resolved from accessor functions)
  *
  * The returned mark supports .name("layerName") so that when used in a chart,
  * each produced node is registered for select("layerName").
@@ -360,39 +366,39 @@ export function createMark<
   channels: C
 ): <T extends Record<string, any>>(
   opts: DeriveMarkProps<ShapeProps, C, T>
-) => NameableMark<T | T[] | { item: T | T[]; key: number | string }> {
+) => NameableMark<T[]> {
   return <T extends Record<string, any>>(
     markOpts: DeriveMarkProps<ShapeProps, C, T>
-  ): NameableMark<T | T[] | { item: T | T[]; key: number | string }> => {
-    const baseMark: Mark<
-      T | T[] | { item: T | T[]; key: number | string }
-    > = async (
-      input: T | T[] | { item: T | T[]; key: number | string },
-      keyParam?: string | number,
-      layerContext?: LayerContext
+  ): NameableMark<T[]> => {
+    const baseMark: Mark<T[]> = (
+      data: T[] | undefined,
+      key?: string | number
     ) => {
-      // Unwrap input: handles T, T[], or { item, key } patterns
-      let d: T | T[], key: number | string | undefined;
-      if (typeof input === "object" && input !== null && "item" in input) {
-        d = (input as { item: T | T[]; key: number | string }).item;
-        key = (input as { item: T | T[]; key: number | string }).key;
-      } else {
-        d = input as T | T[];
-        key = keyParam;
-      }
-
       if ((markOpts as any).debug) {
-        console.log("mark", key, d);
+        console.log("mark", key, data);
       }
-
-      const data = Array.isArray(d) ? d : [d];
 
       // Build shape props by encoding each channel
       const shapeProps: Record<string, any> = {};
       for (const propName of Object.keys(markOpts as any)) {
         if (propName === "debug") continue;
         const channelType = channels[propName as keyof C];
-        const markValue = (markOpts as any)[propName];
+        const unresolvedMarkValue = (markOpts as any)[propName];
+        const markValue = isAccessorFunction(unresolvedMarkValue)
+          ? (() => {
+              if (data === undefined) {
+                throw new Error(
+                  `Mark option "${propName}" requires data, but this mark was called without data.`
+                );
+              }
+              return unresolvedMarkValue(data);
+            })()
+          : unresolvedMarkValue;
+
+        if (data === undefined) {
+          shapeProps[propName] = markValue;
+          continue;
+        }
 
         if (channelType === "size") {
           shapeProps[propName] = inferSize(markValue, data);
@@ -405,19 +411,17 @@ export function createMark<
 
       const node = shapeFn(shapeProps as ShapeProps);
       node.name(key?.toString() ?? "");
-      (node as any).datum = d;
+      (node as any).datum = data;
       return node;
     };
 
-    const nameMethod = (
-      layerName: string
-    ): Mark<T | T[] | { item: T | T[]; key: number | string }> => {
+    const nameMethod = (layerName: string): Mark<T[]> => {
       return async (
-        input: T | T[] | { item: T | T[]; key: number | string },
+        data: T[] | undefined,
         keyParam?: string | number,
         layerContext?: LayerContext
       ) => {
-        const node = await baseMark(input, keyParam, layerContext);
+        const node = await baseMark(data, keyParam, layerContext);
         if (layerContext && layerName) {
           if (!layerContext[layerName]) {
             layerContext[layerName] = { data: [], nodes: [] };
@@ -434,8 +438,6 @@ export function createMark<
       configurable: true,
     });
 
-    return baseMark as NameableMark<
-      T | T[] | { item: T | T[]; key: number | string }
-    >;
+    return baseMark as NameableMark<T[]>;
   };
 }

--- a/packages/gofish-graphics/src/charts/bar.ts
+++ b/packages/gofish-graphics/src/charts/bar.ts
@@ -69,7 +69,7 @@ export const barChart = <T extends Record<string, any>>(
       w?: string | number | keyof T;
       fill?: string | keyof T;
       [key: string]: any;
-    }) => Mark<T | T[] | { item: T | T[]; key: number | string }>;
+    }) => Mark<T[]>;
   }
 ) => {
   // Both x and y are required

--- a/packages/gofish-graphics/src/lib.ts
+++ b/packages/gofish-graphics/src/lib.ts
@@ -30,6 +30,8 @@ export { For } from "./ast/iterators/for";
 export { groupBy, sumBy, orderBy, meanBy } from "lodash";
 
 // Shapes
+// Deprecated low-level aliases retained for compatibility:
+// prefer `rect(opts)(undefined)` / `image(opts)(undefined)` from chart marks.
 export { Rect } from "./ast/shapes/rect";
 export { ellipse as Ellipse } from "./ast/shapes/ellipse";
 export { Image } from "./ast/shapes/image";


### PR DESCRIPTION
## Summary
- Consolidate the mark contract/types so `Mark<D>` accepts optional data and createMark resolves literal values, string shorthand, or accessor functions while guarding against accessor use with no data.
- Refactor chart operators and the unified mark generator (`packages/gofish-graphics/src/ast/withGoFish.ts`) so every mark flow consumes a single callable, async-safe factory and resolves props consistently via the new accessor utilities.
- Keep `rect`/`image` factories as the primary entry points while exposing deprecated `Rect`/`Image` wrappers that route through the same prop-resolution path, preserving legacy low-level usage.

## Testing
- Not run (not requested)