### PR TITLE
Add .facet() and .stack() fluent methods to ChartBuilder

### DIFF
--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -240,6 +240,23 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     );
   }
 
+  // facet is an alias for .flow(spread(...))
+  facet(
+    fieldOrOptions: Parameters<typeof spread>[0],
+    options?: Parameters<typeof spread>[1]
+  ): ChartBuilder<TInput, any> {
+    return this.flow(spread(fieldOrOptions as any, options));
+  }
+
+  // stack is an alias for .flow(stack(...))
+  // Note: 'stack' below refers to the module-level stack function, not this method
+  stack(
+    field: Parameters<typeof stack>[0],
+    options: Parameters<typeof stack>[1]
+  ): ChartBuilder<TInput, any> {
+    return this.flow(stack(field as any, options));
+  }
+
   // mark stores the mark and returns a new builder for chaining
   mark(mark: Mark<TOutput>): ChartBuilder<TInput, TOutput> {
     return new ChartBuilder(

--- a/packages/gofish-graphics/stories/forwardsyntax/Bar/BarStackedFluent.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Bar/BarStackedFluent.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../../helper";
+import { seafood } from "../../../src/data/catch";
+import { Chart, rect } from "../../../src/lib";
+
+const meta: Meta = {
+  title: "Forward Syntax V3/Bar/Stacked Fluent",
+  argTypes: {
+    w: {
+      control: { type: "number", min: 100, max: 1000, step: 10 },
+    },
+    h: {
+      control: { type: "number", min: 100, max: 1000, step: 10 },
+    },
+  },
+};
+export default meta;
+
+type Args = { w: number; h: number };
+
+// Uses new .facet() and .stack() methods instead of .flow(spread(...), stack(...))
+export const Default: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    Chart(seafood)
+      .facet("lake", { dir: "x" })
+      .stack("species", { dir: "y" })
+      .mark(rect({ h: "count", fill: "species" }))
+      .render(container, { w: args.w, h: args.h, axes: true });
+
+    return container;
+  },
+};


### PR DESCRIPTION
Closes #286.

## Summary

- Adds `.facet(field, options)` to `ChartBuilder` as ergonomic sugar for `.flow(spread(...))`
- Adds `.stack(field, options)` to `ChartBuilder` as ergonomic sugar for `.flow(stack(...))`
- Adds a Storybook story (`Forward Syntax V3/Bar/Stacked Fluent`) exercising the new API

Before:
```ts
Chart(seafood)
  .flow(
    spread("lake", { dir: "x" }),
    stack("species", { dir: "y" })
  )
  .mark(rect({ h: "count", fill: "species" }))
```

After:
```ts
Chart(seafood)
  .facet("lake", { dir: "x" })
  .stack("species", { dir: "y" })
  .mark(rect({ h: "count", fill: "species" }))
```

## Test plan

- [x] Open Storybook and verify "Forward Syntax V3/Bar/Stacked Fluent" renders a correct stacked bar chart
- [x] Confirm existing "Forward Syntax V3/Bar/Stacked" story is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)