### PR TITLE
Update docs for lowercase GoFish marks

### DIFF
--- a/apps/docs/docs/.vitepress/examples/balloon-chart.ts
+++ b/apps/docs/docs/.vitepress/examples/balloon-chart.ts
@@ -31,21 +31,21 @@ const Balloon = (options) =>
       },
     },
     [
-      gf.Ellipse({
+      gf.ellipse({
         cx: 15,
         cy: 15,
         w: 24,
         h: 30,
         fill: (options?.color ?? gf.color.red)[4],
       }),
-      gf.Ellipse({
+      gf.ellipse({
         cx: 12,
         cy: 11,
         w: 7,
         h: 11,
         fill: (options?.color ?? gf.color.red)[3],
       }),
-      gf.Rect({
+      gf.rect({
         cx: 15,
         cy: 32,
         w: 8,
@@ -54,7 +54,7 @@ const Balloon = (options) =>
         rx: 3,
         ry: 2,
       }),
-      gf.Rect({
+      gf.rect({
         cx: 15,
         cy: 32,
         w: 5,
@@ -70,7 +70,7 @@ gf.Frame(
   { coord: gf.wavy(), x: 0, y: 0 },
   scatterData.map((data, i) =>
     gf.Frame({ x: data.x }, [
-      gf.Rect({
+      gf.rect({
         x: 0,
         y: 0,
         // x: data.x,

--- a/apps/docs/docs/.vitepress/examples/box-plot.ts
+++ b/apps/docs/docs/.vitepress/examples/box-plot.ts
@@ -2,14 +2,14 @@ const boxAndWhisker = ({ median, min, max, q1, q3, fill }) => {
   const minName = `min-${Math.random().toString(36).substring(2, 9)}`;
   const maxName = `max-${Math.random().toString(36).substring(2, 9)}`;
   return gf.Frame({}, [
-    gf.Rect({ w: 8, h: 1, y: gf.v(min), fill: "gray" }).name(minName),
-    gf.Rect({ w: 8, h: 1, y: gf.v(max), fill: "gray" }).name(maxName),
+    gf.rect({ w: 8, h: 1, y: gf.v(min), fill: "gray" }).name(minName),
+    gf.rect({ w: 8, h: 1, y: gf.v(max), fill: "gray" }).name(maxName),
     gf.ConnectY({ mode: "center-to-center", strokeWidth: 1 }, [
-      gf.Ref(minName),
-      gf.Ref(maxName),
+      gf.ref(minName),
+      gf.ref(maxName),
     ]),
-    gf.Rect({ w: 8, y: gf.v(q1), h: gf.v(q3 - q1), fill }),
-    gf.Rect({ w: 8, h: 1, y: gf.v(median), fill: "white" }),
+    gf.rect({ w: 8, y: gf.v(q1), h: gf.v(q3 - q1), fill }),
+    gf.rect({ w: 8, h: 1, y: gf.v(median), fill: "white" }),
   ]);
 };
 

--- a/apps/docs/docs/.vitepress/examples/bump-chart.ts
+++ b/apps/docs/docs/.vitepress/examples/bump-chart.ts
@@ -8,14 +8,14 @@ gf.Frame({}, [
         alignment: "start",
       },
       gf.For(_.sortBy(d, "Rank"), (d) =>
-        gf.Ellipse({ w: 8, h: 8, fill: gf.v(d.Color) }).name(`${d.Color}-${d.Year}`)
+        gf.ellipse({ w: 8, h: 8, fill: gf.v(d.Color) }).name(`${d.Color}-${d.Year}`)
       )
     )
   ),
   gf.For(_.groupBy(newCarColors, "Color"), (d) =>
     gf.ConnectY(
       { strokeWidth: 2, mode: "center-to-center" },
-      gf.For(d, (d) => gf.Ref(`${d.Color}-${d.Year}`))
+      gf.For(d, (d) => gf.ref(`${d.Color}-${d.Year}`))
     )
   ),
 ]).render(root, { w: 500, h: 300 });

--- a/apps/docs/docs/.vitepress/examples/flower-chart.ts
+++ b/apps/docs/docs/.vitepress/examples/flower-chart.ts
@@ -14,7 +14,7 @@ const scatterData = _(seafood)
 gf.Frame(
   gf.For(scatterData, (sample) =>
     gf.Frame({ x: sample.x, y: sample.y }, [
-      gf.Rect({
+      gf.rect({
         w: 2,
         h: 300 - sample.y,
         fill: gf.color.green[5],
@@ -32,7 +32,7 @@ gf.Frame(
               sharedScale: true,
             },
             gf.For(sample.collection, (d, i) =>
-              gf.Petal({
+              gf.petal({
                 w: gf.v(d.count),
                 fill: mix(gf.color6[i % 6], gf.white, 0.5),
               })

--- a/apps/docs/docs/.vitepress/examples/icicle-chart.ts
+++ b/apps/docs/docs/.vitepress/examples/icicle-chart.ts
@@ -6,7 +6,7 @@ const classColor = {
 };
 
 gf.StackX({ spacing: 0, alignment: "middle" }, [
-  gf.Rect({
+  gf.rect({
     w: 40,
     h: _(titanic).sumBy("count") / 10,
     fill: gf.neutral,
@@ -23,14 +23,14 @@ gf.StackX({ spacing: 0, alignment: "middle" }, [
             alignment: "start",
           },
           [
-            gf.Rect({ w: 40, fill: classColor[cls] }),
+            gf.rect({ w: 40, fill: classColor[cls] }),
             gf.StackY(
               { dir: "ttb", spacing: 0, alignment: "middle" },
               _(items)
                 .groupBy("sex")
                 .map((items, sex) =>
                   gf.StackX({ spacing: 0, alignment: "middle" }, [
-                    gf.Rect({
+                    gf.rect({
                       w: 0,
                       h: _(items).sumBy("count") / 10,
                       fill: sex === "Female" ? gf.color6[4] : gf.color6[5],
@@ -45,7 +45,7 @@ gf.StackX({ spacing: 0, alignment: "middle" }, [
                       _(items)
                         .groupBy("survived")
                         .map((survivedItems, survived) => {
-                          return gf.Rect({
+                          return gf.rect({
                             h: _(survivedItems).sumBy("count") / 10,
                             fill:
                               sex === "Female"

--- a/apps/docs/docs/.vitepress/examples/nested-mosaic-plot.ts
+++ b/apps/docs/docs/.vitepress/examples/nested-mosaic-plot.ts
@@ -19,7 +19,7 @@ gf.StackY(
             sharedScale: true,
           },
           gf.For(_.groupBy(sItems, "survived"), (items, survived) =>
-            gf.Rect({
+            gf.rect({
               h: gf.v(_(items).sumBy("count")),
               fill: survived === "No" ? gf.gray : classColor[cls],
             })

--- a/apps/docs/docs/.vitepress/examples/nested-waffle-chart.ts
+++ b/apps/docs/docs/.vitepress/examples/nested-waffle-chart.ts
@@ -31,7 +31,7 @@ gf.StackY(
                     gf.StackX(
                       { spacing: 0.5, alignment: "end" },
                       d.map((d) =>
-                        gf.Ellipse({
+                        gf.ellipse({
                           w: 4,
                           h: 4,
                           fill:

--- a/apps/docs/docs/.vitepress/examples/sankey-tree.ts
+++ b/apps/docs/docs/.vitepress/examples/sankey-tree.ts
@@ -13,7 +13,7 @@ gf.Frame([
     gf.StackY(
       { spacing: 0, alignment: "middle" },
       gf.For(_.groupBy(titanic, "class"), (items, cls) =>
-        gf.Rect({
+        gf.rect({
           w: 40,
           h: _(items).sumBy("count") / 10,
           fill: gf.neutral,
@@ -27,7 +27,7 @@ gf.Frame([
           gf.StackY(
             { spacing: 0, alignment: "middle" },
             gf.For(_.groupBy(items, "sex"), (items, sex) =>
-              gf.Rect({
+              gf.rect({
                 w: 40,
                 h: _(items).sumBy("count") / 10,
                 fill: classColor[cls],
@@ -48,7 +48,7 @@ gf.Frame([
                     alignment: "middle",
                   },
                   gf.For(_.groupBy(items, "survived"), (survivedItems, survived) =>
-                    gf.Rect({
+                    gf.rect({
                       w: 40,
                       h: _(survivedItems).sumBy("count") / 10,
                       fill: sex === "Female" ? gf.color6[4] : gf.color6[5],
@@ -62,7 +62,7 @@ gf.Frame([
                     alignment: "middle",
                   },
                   gf.For(_.groupBy(items, "survived"), (survivedItems, survived) => {
-                    return gf.Rect({
+                    return gf.rect({
                       h: _(survivedItems).sumBy("count") / 10,
                       fill:
                         sex === "Female"
@@ -89,7 +89,7 @@ gf.Frame([
         interpolation: "bezier",
         opacity: 0.7,
       },
-      [gf.Ref(`${cls}-src`), gf.Ref(`${cls}-tgt`)]
+      [gf.ref(`${cls}-src`), gf.ref(`${cls}-tgt`)]
     ),
     gf.For(_.groupBy(items, "sex"), (sexItems, sex) => [
       gf.ConnectX(
@@ -98,7 +98,7 @@ gf.Frame([
           interpolation: "bezier",
           opacity: 0.7,
         },
-        [gf.Ref(`${cls}-${sex}-src`), gf.Ref(`${cls}-${sex}-tgt`)]
+        [gf.ref(`${cls}-${sex}-src`), gf.ref(`${cls}-${sex}-tgt`)]
       ),
       gf.For(_.groupBy(sexItems, "survived"), (survivedItems, survived) =>
         gf.ConnectX(
@@ -115,8 +115,8 @@ gf.Frame([
             opacity: 0.7,
           },
           [
-            gf.Ref(`${cls}-${sex}-${survived}-src`),
-            gf.Ref(`${cls}-${sex}-${survived}-tgt`),
+            gf.ref(`${cls}-${sex}-${survived}-src`),
+            gf.ref(`${cls}-${sex}-${survived}-tgt`),
           ]
         )
       ),

--- a/apps/docs/docs/.vitepress/examples/stringline-chart.ts
+++ b/apps/docs/docs/.vitepress/examples/stringline-chart.ts
@@ -17,9 +17,9 @@ gf.Frame({}, [
       ),
       (d, key) =>
         gf.Frame({ key }, [
-          gf.Rect({ w: 0, h: 0 }),
+          gf.rect({ w: 0, h: 0 }),
           gf.For(d, (d) =>
-            gf.Ellipse({ x: d.Time / 3, w: 4, h: 4, fill: gf.v(d.Direction) }).name(
+            gf.ellipse({ x: d.Time / 3, w: 4, h: 4, fill: gf.v(d.Direction) }).name(
               `${d.Train}-${d.Station}-${d.Time}`
             )
           ),
@@ -29,7 +29,7 @@ gf.Frame({}, [
   gf.For(_.groupBy(caltrainProcessed, "Train"), (d) =>
     gf.ConnectY(
       { strokeWidth: 1, mode: "center-to-center" },
-      gf.For(d, (d) => gf.Ref(`${d.Train}-${d.Station}-${d.Time}`))
+      gf.For(d, (d) => gf.ref(`${d.Train}-${d.Station}-${d.Time}`))
     )
   ),
 ]).render(root, { w: 500, h: 400 });

--- a/apps/docs/docs/.vitepress/examples/violin-plot.ts
+++ b/apps/docs/docs/.vitepress/examples/violin-plot.ts
@@ -10,14 +10,14 @@ gf.StackX(
       gf.StackY(
         { spacing: 0, alignment: "middle" },
         gf.For(density, (d) =>
-          gf.Rect({ y: d.x / 40, w: d.y * 100000, h: 0, fill: gf.v(species) }).name(
+          gf.rect({ y: d.x / 40, w: d.y * 100000, h: 0, fill: gf.v(species) }).name(
             `${species}-${d.x}`
           )
         )
       ),
       gf.ConnectY(
         { opacity: 1, mixBlendMode: "normal" },
-        gf.For(density, (d) => gf.Ref(`${species}-${d.x}`))
+        gf.For(density, (d) => gf.ref(`${species}-${d.x}`))
       ),
     ]);
   })

--- a/apps/docs/docs/api/howto/create-glyph.md
+++ b/apps/docs/docs/api/howto/create-glyph.md
@@ -24,8 +24,8 @@ Here's a simple "badge" glyph with a rounded rectangle and a dot:
 
 ```js
 gf.Layer([
-  gf.Rect({ cx: 0, cy: 0, w: 50, h: 30, rx: 8, fill: "steelblue" }),
-  gf.Ellipse({ cx: -15, cy: 0, w: 10, h: 10, fill: "white" }),
+  gf.rect({ cx: 0, cy: 0, w: 50, h: 30, rx: 8, fill: "steelblue" }),
+  gf.ellipse({ cx: -15, cy: 0, w: 10, h: 10, fill: "white" }),
 ]).render(root, { w: 100, h: 100 });
 ```
 
@@ -40,8 +40,8 @@ Wrap your glyph in a function to make it reusable with different parameters:
 ```ts
 const Badge = ({ w = 50, h = 30, fill = "steelblue" }) =>
   Layer([
-    Rect({ cx: 0, cy: 0, w, h, rx: 8, fill }),
-    Ellipse({ cx: -w / 2 + 10, cy: 0, w: 10, h: 10, fill: "white" }),
+    rect({ cx: 0, cy: 0, w, h, rx: 8, fill }),
+    ellipse({ cx: -w / 2 + 10, cy: 0, w: 10, h: 10, fill: "white" }),
   ]);
 ```
 
@@ -52,8 +52,8 @@ Now you can create badges of different sizes and colors:
 ```js
 const Badge = ({ w = 50, h = 30, fill = "steelblue" }) =>
   gf.Layer([
-    gf.Rect({ cx: 0, cy: 0, w, h, rx: 8, fill }),
-    gf.Ellipse({ cx: -w / 2 + 10, cy: 0, w: 10, h: 10, fill: "white" }),
+    gf.rect({ cx: 0, cy: 0, w, h, rx: 8, fill }),
+    gf.ellipse({ cx: -w / 2 + 10, cy: 0, w: 10, h: 10, fill: "white" }),
   ]);
 
 gf.Spread({ direction: "x", spacing: 20 }, [
@@ -74,9 +74,9 @@ Pass a function to `.mark()` that returns your glyph. The function receives the 
 ```js
 const Pin = ({ fill = "tomato" }) =>
   gf.Layer([
-    gf.Ellipse({ cx: 0, cy: -8, w: 16, h: 16, fill }),
-    gf.Ellipse({ cx: 0, cy: -10, w: 6, h: 6, fill: "white" }),
-    gf.Rect({ cx: 0, cy: 0, w: 3, h: 10, fill }),
+    gf.ellipse({ cx: 0, cy: -8, w: 16, h: 16, fill }),
+    gf.ellipse({ cx: 0, cy: -10, w: 6, h: 6, fill: "white" }),
+    gf.rect({ cx: 0, cy: 0, w: 3, h: 10, fill }),
   ]);
 
 const locations = [
@@ -104,8 +104,8 @@ You can combine any shapes: rectangles, ellipses, text, and more. Here's a label
 ```js
 const DataPoint = ({ value, fill = "steelblue" }) =>
   gf.Spread({ direction: "y", spacing: 4, alignment: "middle" }, [
-    gf.Ellipse({ cx: 0, cy: 0, w: 12, h: 12, fill }),
-    gf.Text({ text: String(value), fontSize: 10 }),
+    gf.ellipse({ cx: 0, cy: 0, w: 12, h: 12, fill }),
+    gf.text({ text: String(value), fontSize: 10 }),
   ]);
 
 const points = [

--- a/apps/docs/docs/api/howto/selection.md
+++ b/apps/docs/docs/api/howto/selection.md
@@ -37,8 +37,8 @@ gf.Layer([
     .flow(gf.group("lake"))
     .mark((d) =>
       gf.Spread({ direction: "y", alignment: "middle", spacing: 10 }, [
-        gf.Ref(d[0]),
-        gf.Text({ text: d[0].count }),
+        gf.ref(d[0]),
+        gf.text({ text: d[0].count }),
       ])
     ),
 ]).render(root, { w: 400, h: 250, axes: true });
@@ -46,7 +46,7 @@ gf.Layer([
 
 :::
 
-Here, `select("bars")` returns the bar nodes with their original data attached. The mark function receives each node and creates a vertical spread containing a reference to the bar (`Ref`) and a text label.
+Here, `select("bars")` returns the bar nodes with their original data attached. The mark function receives each node and creates a vertical spread containing a reference to the bar (`ref`) and a text label.
 
 ## Example: Connected scatterplot
 
@@ -104,7 +104,7 @@ This allows overlay marks to position themselves relative to the original marks 
 
 | Goal | Pattern |
 |------|---------|
-| Labels on bars | `rect().name("bars")` → `select("bars")` + `Text` |
+| Labels on bars | `rect().name("bars")` → `select("bars")` + `text` |
 | Line through points | `circle().name("points")` → `select("points")` + `line()` |
 | Area under line | `scaffold().name("points")` → `select("points")` + `area()` |
 | Annotations | Name any mark → select and add custom overlay |

--- a/apps/docs/docs/api/marks/ellipse.md
+++ b/apps/docs/docs/api/marks/ellipse.md
@@ -5,7 +5,7 @@ Draws an ellipse. Unlike `circle`, allows independent control of width and heigh
 ::: starfish
 
 ```js
-gf.Ellipse({ w: 100, h: 60, fill: "mediumseagreen" })
+gf.ellipse({ w: 100, h: 60, fill: "mediumseagreen" })
   .render(root, { w: 150, h: 100 });
 ```
 
@@ -14,7 +14,7 @@ gf.Ellipse({ w: 100, h: 60, fill: "mediumseagreen" })
 ## Signature
 
 ```ts
-Ellipse({ w?, h?, fill?, stroke?, strokeWidth? })
+ellipse({ w?, h?, fill?, stroke?, strokeWidth? })
 ```
 
 ## Parameters
@@ -31,13 +31,13 @@ Ellipse({ w?, h?, fill?, stroke?, strokeWidth? })
 
 ```ts
 // Fixed size ellipse
-Ellipse({ w: 80, h: 40, fill: "coral" })
+ellipse({ w: 80, h: 40, fill: "coral" })
 
 // Ellipse with stroke
-Ellipse({ w: 60, h: 30, fill: "white", stroke: "black", strokeWidth: 2 })
+ellipse({ w: 60, h: 30, fill: "white", stroke: "black", strokeWidth: 2 })
 
 // Data-driven dimensions
-Ellipse({ w: "width", h: "height", fill: "category" })
+ellipse({ w: "width", h: "height", fill: "category" })
 ```
 
 ## See Also

--- a/apps/docs/docs/api/operators/layer.md
+++ b/apps/docs/docs/api/operators/layer.md
@@ -6,8 +6,8 @@ Overlays multiple children in the same coordinate space without any layout offse
 
 ```js
 gf.Layer([
-  gf.Rect({ w: 100, h: 80, fill: gf.color.blue[3] }),
-  gf.Ellipse({ w: 60, h: 60, fill: gf.color.red[3] }),
+  gf.rect({ w: 100, h: 80, fill: gf.color.blue[3] }),
+  gf.ellipse({ w: 60, h: 60, fill: gf.color.red[3] }),
 ]).render(root, { w: 200, h: 150 });
 ```
 

--- a/apps/docs/docs/examples/layered-area-chart.md
+++ b/apps/docs/docs/examples/layered-area-chart.md
@@ -90,7 +90,7 @@ export const streamgraphData = [
 ```
 
 ```ts v1syntax.ts
-import { Frame, StackX, Rect, ConnectX, Ref, v } from "gofish-graphics";
+import { Frame, StackX, rect, ConnectX, ref, v } from "gofish-graphics";
 import _ from "lodash";
 import { streamgraphData } from "./dataset";
 
@@ -103,7 +103,7 @@ Frame([
       StackX(
         { spacing: 0, sharedScale: true },
         items.map((d) =>
-          Rect({
+          rect({
             name: `${c}-${d.x}`,
             x: v(d.x),
             h: v(d.y),
@@ -122,7 +122,7 @@ Frame([
           interpolation: "linear",
           opacity: 0.7,
         },
-        items.map((d) => Ref(`${c}-${d.x}`))
+        items.map((d) => ref(`${c}-${d.x}`))
       )
     )
     .value(),

--- a/apps/docs/docs/tutorial.md
+++ b/apps/docs/docs/tutorial.md
@@ -10,12 +10,12 @@ To start, duplicate this tab to follow along in the live editor!
 
 <!-- ```ts index.ts
 // prettier-ignore
-import { StackX, StackY, ConnectX, Rect, Ref, For, v, color, Frame, polar, groupBy, sumBy, orderBy } from "gofish-graphics";
+import { StackX, StackY, ConnectX, rect, ref, For, v, color, Frame, polar, groupBy, sumBy, orderBy } from "gofish-graphics";
 import { seafood } from "./dataset";
 
 const root = document.getElementById("app");
 
-Rect({ x: 0, y: 0, w: 32, h: 300, fill: gf.color.green[5] }).render(root, {
+rect({ x: 0, y: 0, w: 32, h: 300, fill: gf.color.green[5] }).render(root, {
   w: 500,
   h: 300,
 });
@@ -361,7 +361,7 @@ not tied to an argument like `h`, we'll need to pass a `key` field to the object
 StackX(
   { spacing: 8, sharedScale: true },
   For(_.groupBy(seafood, "lake"), (lake, key) =>
-    Rect({ key, w: 32, h: v(_.sumBy(lake, "count")), fill: gf.color.green[5] })
+    rect({ key, w: 32, h: v(_.sumBy(lake, "count")), fill: gf.color.green[5] })
   )
 ).render(root, { w: 500, h: 300, axes: true });
 ```
@@ -370,7 +370,7 @@ StackX(
 
 Voila! Now we have a y-axis and labels for each of the bars.
 
-<!-- Notice also that we've added a `key` field to the `Rect`. This let's GoFish know the identity of -->
+<!-- Notice also that we've added a `key` field to `rect`. This let's GoFish know the identity of -->
 <!-- each -->
 
 ## Stacked Bar Chart
@@ -527,7 +527,7 @@ Frame([
       StackY(
         { key, spacing: 1 },
         For(_.orderBy(lake, "count", "desc"), (d) =>
-          Rect({ w: 16, h: v(d.count), fill: v(d.species) }).name(
+          rect({ w: 16, h: v(d.count), fill: v(d.species) }).name(
             `${d.lake}-${d.species}`
           )
         )
@@ -537,7 +537,7 @@ Frame([
   For(_.groupBy(seafood, "species"), (items) =>
     ConnectX(
       { opacity: 0.8 },
-      For(items, (d) => Ref(`${d.lake}-${d.species}`))
+      For(items, (d) => ref(`${d.lake}-${d.species}`))
     )
   ),
 ]).render(root, { w: 500, h: 300, axes: true });


### PR DESCRIPTION
## Summary
- refresh docs/examples to use the new lowercase GoFish mark exports (rect/ellipse/petal/etc.) and references consistent with updated API
- adjust tutorial and howto content so code samples stay accurate with the latest lib.ts behavior

## Testing
- Not run (not requested)