### PR TITLE
chore: rename org from starfish-graphics to gofish-graphics

### DIFF
--- a/.github/scripts/summarize-with-claude.sh
+++ b/.github/scripts/summarize-with-claude.sh
@@ -77,7 +77,7 @@ Write a concise weekly summary using Slack mrkdwn format (NOT standard Markdown)
 - Use *Section Name* for section headers (Slack does NOT support # or ## headers)
 - Use • or - for bullet points
 - Use _underscores_ for italics if needed
-- When mentioning any PR in the summary, format it as a hyperlink using the URL from the data above: <PR_URL|PR #NUMBER> (e.g. <https://github.com/starfish-graphics/gofish-graphics/pull/123|PR #123>)
+- When mentioning any PR in the summary, format it as a hyperlink using the URL from the data above: <PR_URL|PR #NUMBER> (e.g. <https://github.com/gofish-graphics/gofish-graphics/pull/123|PR #123>)
 - Contributor coverage is REQUIRED: every contributor listed above must be called out by name with at least one specific contribution.
 - In *Highlights*, explicitly mention the number of PRs that landed this week using the PR count above.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,32 +3,41 @@
 Thanks for considering contributing to GoFish!
 
 ## Your First Contribution
+
 Here are some easy ways to help make the project better without having to understand the codebase first.
+
 - **Open an issue with a chart you want to make** in GoFish but can't/don't know how to. Attach an image of what you want to make and describe what you've tried already.
-- **Contribute to our documentation!** https://github.com/starfish-graphics/gofish-docs
+- **Contribute to our documentation!** https://github.com/gofish-graphics/gofish-docs
 - **Contribute to the project's infrastructure.** (Check for the "good first issue" tag for these.)
 
 ## Your First Codebase Contribution
+
 If you want to start contributing to the codebase itself, **try the "good first codebase issue" tag.**
 
 ### Installations
+
 [Ensure pnpm is installed](https://pnpm.io/installation), then build to setup the gofish-graphics package.
+
 ```bash
 pnpm build
 ```
 
 Use pnpm storybook to run the local storybook examples, and pnpm docs:dev to run local docs.
+
 ```bash
 pnpm storybook
 ```
+
 ```bash
 pnpm docs:dev
 ```
 
 ## Larger Contributions
+
 **Read our GitHub wiki** to learn more about the project's design philosophy. Major changes to the project (like adding a new intermediate representation or interaction/animation) will require a more back-and-forth conversation in the issues before we come to a consensus on what to do.
 
 ## Assessing Issues and Reviewing PRs
 
 ### Find a path to "yes"
+
 We strive to help everyone who opens an issue or PR on the repo. They have some pain they are trying to address! But the best way to address that pain isn't necessarily writing code or merging a PR. It may mean directing someone to a different project or an existing example. Sometimes it means saying no to the request. But we always strive to find the underlying pain point and solve it the best way we know how from first-principles.

--- a/apps/docs/docs/.vitepress/config.mts
+++ b/apps/docs/docs/.vitepress/config.mts
@@ -229,7 +229,7 @@ export default defineConfig({
     socialLinks: [
       {
         icon: "github",
-        link: "https://github.com/starfish-graphics/gofish-graphics",
+        link: "https://github.com/gofish-graphics/gofish-graphics",
       },
     ],
   },

--- a/packages/gofish-graphics/package.json
+++ b/packages/gofish-graphics/package.json
@@ -27,7 +27,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/starfish-graphics/gofish-graphics"
+    "url": "https://github.com/gofish-graphics/gofish-graphics"
   },
   "scripts": {
     "start": "vite",


### PR DESCRIPTION
## Summary

- Update hardcoded GitHub URLs in `package.json`, `config.mts`, `CONTRIBUTING.md`, and the Claude summarizer script to reflect the new org name (`gofish-graphics` instead of `starfish-graphics`)

## Test plan

- [ ] Verify links in docs nav point to correct repo
- [ ] Verify `package.json` repository URL is correct