### PR TITLE
feat: add isoScale option for equal pixels-per-data-unit on both axes

### DIFF
--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -448,6 +448,7 @@ export class GoFishNode {
       defs,
       axes = false,
       colorConfig,
+      isoScale = false,
     }: {
       w: number;
       h: number;
@@ -458,11 +459,13 @@ export class GoFishNode {
       defs?: JSX.Element[];
       axes?: boolean;
       colorConfig?: ColorConfig;
+      /** When true, both position axes share the same pixels-per-data-unit. */
+      isoScale?: boolean;
     }
   ) {
     return gofish(
       container,
-      { w, h, x, y, transform, debug, defs, axes, colorConfig },
+      { w, h, x, y, transform, debug, defs, axes, colorConfig, isoScale },
       this
     );
   }

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -114,6 +114,7 @@ export async function layout(
     debug = false,
     defs,
     axes = false,
+    isoScale = false,
   }: {
     w: number;
     h: number;
@@ -123,6 +124,9 @@ export async function layout(
     debug?: boolean;
     defs?: JSX.Element[];
     axes?: AxesOptions;
+    /** When true, both position axes share the same pixels-per-data-unit,
+     *  equal to min(w/xRange, h/yRange). Excess space is left empty. */
+    isoScale?: boolean;
   },
   child: GoFishNode | Promise<GoFishNode>,
   contexts?: {
@@ -228,6 +232,26 @@ export async function layout(
       : undefined,
   ];
 
+  if (
+    isoScale &&
+    isPOSITION(niceUnderlyingSpaceX) &&
+    niceUnderlyingSpaceX.domain &&
+    isPOSITION(niceUnderlyingSpaceY) &&
+    niceUnderlyingSpaceY.domain
+  ) {
+    const xRange =
+      niceUnderlyingSpaceX.domain.max - niceUnderlyingSpaceX.domain.min;
+    const yRange =
+      niceUnderlyingSpaceY.domain.max - niceUnderlyingSpaceY.domain.min;
+    if (xRange > 0 && yRange > 0) {
+      const sharedPxPerUnit = Math.min(w / xRange, h / yRange);
+      const xMin = niceUnderlyingSpaceX.domain.min;
+      const yMin = niceUnderlyingSpaceY.domain.min;
+      posScales[0] = (pos: number) => (pos - xMin) * sharedPxPerUnit;
+      posScales[1] = (pos: number) => (pos - yMin) * sharedPxPerUnit;
+    }
+  }
+
   if (debug) {
     console.log("width and height constraints:", w, h);
   }
@@ -273,6 +297,7 @@ export const gofish = (
     defs,
     axes = false,
     colorConfig,
+    isoScale = false,
   }: {
     w: number;
     h: number;
@@ -283,6 +308,8 @@ export const gofish = (
     defs?: JSX.Element[];
     axes?: boolean;
     colorConfig?: ColorConfig;
+    /** When true, both position axes share the same pixels-per-data-unit. */
+    isoScale?: boolean;
   },
   child: GoFishNode | Promise<GoFishNode>
 ) => {
@@ -312,7 +339,7 @@ export const gofish = (
       };
 
       const layoutResult = await layout(
-        { w, h, x, y, transform, debug, defs, axes },
+        { w, h, x, y, transform, debug, defs, axes, isoScale },
         child,
         contexts
       );


### PR DESCRIPTION
## Summary

Adds `isoScale?: boolean` to `GoFishNode.render()`, `gofish()`, and `layout()`. When enabled, both POSITION axes share the same pixels-per-data-unit — `min(w/xRange, h/yRange)` — so that a distance of 1 in x looks the same as a distance of 1 in y. Excess container space is left empty rather than stretching the scale.

The option is a no-op unless both axes resolve to `POSITION` with defined domains (e.g., scatter plots with explicit x/y fields). Bar charts, ordinal axes, etc. are unaffected.

`ChartBuilder.render()` inherits `isoScale` automatically via `Parameters<GoFishNode["render"]>[1]`, so the v3 fluent API already supports it without any additional changes.

## Usage

```ts
chart(data)
  .flow(scatter("x", "y"))
  .mark(circle({ r: 4 }))
  .render(container, { w: 400, h: 300, isoScale: true });
```

## Test plan

- [ ] Scatter plot with `x: [0,10]` and `y: [0,5]` in a 400×300 container with `isoScale: true` — verify the y axis spans 0–5 at the same pixel density as x, with remaining space unused
- [ ] Same chart without `isoScale` — both axes should still stretch to fill the container (existing behavior unchanged)
- [ ] Charts without POSITION axes (bar charts, etc.) should be completely unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)