### PR TITLE
feat: auto-update snapshots/main on every main push

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      contents: write # needed to push to snapshots/main on main push
 
     steps:
       - name: Checkout code
@@ -81,18 +82,35 @@ jobs:
       - name: Install Playwright browsers
         run: pnpm --filter @gofish/tests exec playwright install --with-deps chromium
 
-      - name: Run visual tests (JS only)
-        run: pnpm test:visual:js
+      - name: Capture JS DOM snapshots
+        run: pnpm --filter @gofish/tests capture-js
+
+      # On PRs: compare against baselines and fail if regressions are detected.
+      - name: Compare snapshots (PR only)
+        if: github.event_name == 'pull_request'
+        run: pnpm --filter @gofish/tests exec tsx scripts/compare.ts --js-only
+
+      # On main push: auto-accept all captures as the new baselines and push
+      # to snapshots/main. This keeps snapshots/main in sync after every merge.
+      - name: Configure git for snapshot commit (main push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Auto-update snapshots/main (main push only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: pnpm --filter @gofish/tests update-baselines
 
       - name: Upload diff report
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: visual-diff-report
           path: tests/tmp/diff-report.html
 
       - name: Build review site
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         run: pnpm --filter @gofish/tests build:review-site
         env:
           REVIEW_REPO: ${{ github.repository }}
@@ -100,7 +118,7 @@ jobs:
           REVIEW_SHA: ${{ github.sha }}
 
       - name: Deploy review site to Cloudflare Pages
-        if: failure()
+        if: failure() && github.event_name == 'pull_request'
         id: deploy-review
         run: |
           output=$(npx wrangler@latest --cwd tests/tmp/review-site pages deploy . \

--- a/tests/package.json
+++ b/tests/package.json
@@ -7,6 +7,8 @@
     "test": "tsx scripts/capture-js-dom.ts && tsx scripts/capture-python-dom.ts && tsx scripts/compare.ts",
     "test:js": "tsx scripts/capture-js-dom.ts && tsx scripts/compare.ts --js-only",
     "update": "tsx scripts/capture-js-dom.ts && tsx scripts/update-baselines.ts",
+    "capture-js": "tsx scripts/capture-js-dom.ts",
+    "update-baselines": "tsx scripts/update-baselines.ts",
     "check-sync": "tsx scripts/check-python-sync.ts",
     "check-python-sync": "tsx scripts/check-python-sync.ts",
     "capture-python": "tsx scripts/capture-python-dom.ts",


### PR DESCRIPTION
## Summary

- After each merge to `main`, CI now re-captures all JS DOM snapshots and pushes them to `snapshots/main` automatically — no manual review-site click needed
- PRs are unchanged: compare against baselines, fail + open review site on regression
- Adds `capture-js` and `update-baselines` scripts to `tests/package.json` to support the split steps

## How it works

The `visual-test` job now has two separate paths depending on the trigger:

**Pull request** (unchanged behavior):
1. Fetch baselines from `snapshots/<branch>` (or fall back to `snapshots/main`)
2. Capture JS DOM snapshots
3. Compare — fail if regressions detected, open review site

**Push to main** (new):
1. Fetch baselines from `snapshots/main`
2. Capture JS DOM snapshots
3. Auto-accept all captures → push to `snapshots/main` (no compare, no failure)

This closes the gap where merging a PR would leave `snapshots/main` stale until someone manually accepted diffs through the review site.

## Test plan

- [ ] Push a change to `main` — CI `visual-test` job should succeed and `snapshots/main` should have a new commit from `github-actions[bot]`
- [ ] Open a PR with a visual change — CI should still fail with a review site link as before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)