### PR TITLE
feat: improve auto label coloring with HSLuv luminance

### DIFF
--- a/packages/gofish-graphics/src/ast/labels/renderLabel.tsx
+++ b/packages/gofish-graphics/src/ast/labels/renderLabel.tsx
@@ -1,5 +1,6 @@
 import type { JSX } from "solid-js";
 import chroma from "chroma-js";
+import { luv } from "culori";
 import type { GoFishNode } from "../_node";
 import { getValue } from "../data";
 import {
@@ -44,18 +45,21 @@ function autoLabelColor(node: GoFishNode, position: LabelPosition): string {
 
   if (isInside) {
     if (!fill) return "black";
-    try {
-      const luminance = chroma(fill).luminance();
-      const target = luminance < 0.4 ? "white" : "black";
-      return chroma.mix(fill, target, 0.6, "lab").hex();
-    } catch {
-      return "black";
+
+    const luvColor = luv(fill);
+    const lightness = luvColor?.l ?? 0;
+    const [, , hue] = chroma(fill).lch();
+    if (lightness < 60) {
+      return "white";
+    } else {
+      return chroma.lch(8, 18, hue).hex();
     }
   }
 
   if (!fill) return "#333333";
   try {
-    return chroma.mix(fill, "black", 0.5, "lab").hex();
+    const [, chr, hue] = chroma(fill).lch();
+    return chroma.lch(30, chr, hue).hex();
   } catch {
     return "#333333";
   }
@@ -109,6 +113,7 @@ export function renderLabelJSX(node: GoFishNode): JSX.Element | null {
       y={-(cy + offset.y)}
       fill={labelColor}
       font-size={`${node._label.fontSize ?? 11}px`}
+      font-family={"source-sans-pro, sans-serif"}
       text-anchor={textAnchor}
       dominant-baseline="central"
       pointer-events="none"


### PR DESCRIPTION
## Summary

Improves readability of labels provided by the recently added labeling abstractions cc @milintun @arvind

- Replace WCAG relative luminance with CIELUV lightness (the same L axis HSLuv uses) for perceptually accurate light/dark threshold detection
- Inside labels: pure white on dark fills; hue-tinted dark color on light fills (preserves hue, ignores full fill color)
- Outside labels: lock lightness at 30, keep fill's original chroma and hue
- Add `source-sans-pro` font-family to label text elements

## Test plan

- [ ] Verify labels on dark-filled shapes render white
- [ ] Verify labels on light-filled shapes render as a dark hue-tinted color matching the fill's hue
- [ ] Verify outside labels render as a dark tinted color at the fill's hue
- [ ] Check saturated colors (reds, blues, greens) and near-neutral colors look correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)