### PR TITLE
chore(ci): bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,20 +29,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Not needed if lastUpdated is not enabled
-      - uses: pnpm/action-setup@v3 # Uncomment this block if you're using pnpm
+      - uses: pnpm/action-setup@v4 # Uncomment this block if you're using pnpm
         with:
           version: 9 # Not needed if you've set "packageManager" in package.json
       # - uses: oven-sh/setup-bun@v1 # Uncomment this if you're using Bun
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm # or pnpm / yarn
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - name: Install dependencies
         run: pnpm install # or pnpm install / yarn install / bun install
       - name: Build gofish-graphics library
@@ -50,7 +50,7 @@ jobs:
       - name: Build with VitePress
         run: pnpm --filter docs docs:build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: apps/docs/docs/.vitepress/dist
 
@@ -65,4 +65,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Need full history to check for recent commits
 
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.check_commits.outputs.has_recent_commits == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -6,11 +6,11 @@ on:
     branches:
       - main
     paths:
-      - 'packages/gofish-graphics/**'
+      - "packages/gofish-graphics/**"
 
   pull_request:
     paths:
-      - 'packages/gofish-graphics/**'
+      - "packages/gofish-graphics/**"
 
 jobs:
   chromatic:
@@ -20,17 +20,17 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Required for Chromatic to track git history
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -55,18 +55,18 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -104,7 +104,7 @@ jobs:
 
       - name: Upload diff report
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: visual-diff-report
           path: tests/tmp/diff-report.html
@@ -135,7 +135,7 @@ jobs:
 
       - name: Comment PR with review URL
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const url = '${{ steps.deploy-review.outputs.deployment-url }}';
@@ -154,7 +154,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -185,18 +185,18 @@ jobs:
           fi
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -239,7 +239,7 @@ jobs:
 
       - name: Upload parity report artifact
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: parity-review-site
           path: tests/tmp/parity-review-site/
@@ -262,7 +262,7 @@ jobs:
 
       - name: Comment PR with parity review link
         if: failure() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const url = '${{ steps.deploy-parity.outputs.deployment-url }}';

--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -17,7 +17,7 @@ jobs:
   summarize:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Full history for git log
 

--- a/packages/gofish-graphics/tsconfig.build.json
+++ b/packages/gofish-graphics/tsconfig.build.json
@@ -5,7 +5,9 @@
     "emitDeclarationOnly": true,
     "declaration": true,
     "declarationMap": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "rootDir": "./src",
+    "ignoreDeprecations": "6.0"
   },
   "include": ["src/lib.ts", "src/color.ts", "src/path.ts", "src/util.ts"],
   "exclude": [


### PR DESCRIPTION
## Summary

- Bump each GitHub Action in `.github/workflows/` to the minimum major version that runs on Node.js 24. GitHub is deprecating Node 20 action runtimes — warning surfaced on recent runs.
- Fix two `tsc` errors in the nightly release's declaration build (`rootDir` and `moduleResolution` deprecation) so `pnpm exec tsc --project packages/gofish-graphics/tsconfig.build.json` no longer fails (it was being swallowed by `|| true`).

### Action bumps

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v5 |
| `actions/setup-python` | v5 | v6 |
| `actions/configure-pages` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |
| `actions/upload-artifact` | v4 | v5 |
| `actions/github-script` | v7 | v8 |
| `pnpm/action-setup` | v3 | v4 |

Each version is the first major that ships the Node 24 runtime — chose minimum-viable bumps rather than latest-majors to avoid pulling in unrelated breaking changes (e.g. `upload-artifact@v7`'s ESM/direct-upload overhaul).

### tsconfig.build.json

- Added `"rootDir": "./src"` — was being inferred; TS now requires it to be explicit.
- Added `"ignoreDeprecations": "6.0"` — silences `moduleResolution=node10` deprecation. Proper migration to `"bundler"` is a follow-up; this just unblocks TS 6.x.

## Test plan

- [ ] Nightly release workflow runs cleanly on next schedule (or `workflow_dispatch`) — no Node 20 warnings, `tsc` step no longer errors.
- [ ] Visual-tests, Storybook CI, lint-format, deploy-docs, weekly-summary all pass on this PR.
- [ ] `setup-node@v5` auto-caching breaking change is inert — repo has no `packageManager` field in root `package.json` and `cache: pnpm` remains explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)