### PR TITLE
feat: axis title support with auto-inference from field encodings

### DIFF
--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -462,6 +462,7 @@ export class GoFishNode {
       debug = false,
       defs,
       axes = false,
+      axisFields,
       colorConfig,
     }: {
       w: number;
@@ -471,13 +472,14 @@ export class GoFishNode {
       transform?: { x?: number; y?: number };
       debug?: boolean;
       defs?: JSX.Element[];
-      axes?: boolean;
+      axes?: AxesOptions;
+      axisFields?: { x?: string; y?: string };
       colorConfig?: ColorConfig;
     }
   ) {
     return gofish(
       container,
-      { w, h, x, y, transform, debug, defs, axes, colorConfig },
+      { w, h, x, y, transform, debug, defs, axes, axisFields, colorConfig },
       this
     );
   }

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -32,11 +32,13 @@ export type KeyContext = { [key: string]: GoFishNode };
 export type AxesOptions = boolean | { x?: AxisOptions; y?: AxisOptions };
 export type AxisOptions = boolean | { title?: string | false };
 
+// string: custom title, false: no title, undefined: infer from encoding
 function resolveAxisTitle(
   axisOpt: AxisOptions | undefined
 ): string | false | undefined {
-  if (!axisOpt || axisOpt === true) return undefined;
-  return axisOpt.title;
+  if (!axisOpt) return false; // axis hidden, title irrelevant
+  if (axisOpt === true) return undefined; // axis shown, infer title from encoding
+  return axisOpt.title; // string: custom title, false: no title, undefined: infer title
 }
 
 function resolveAxes(axes: AxesOptions | undefined): {
@@ -49,7 +51,7 @@ function resolveAxes(axes: AxesOptions | undefined): {
     return { x: true, y: true, xTitle: undefined, yTitle: undefined };
   }
   if (!axes) {
-    return { x: false, y: false, xTitle: undefined, yTitle: undefined };
+    return { x: false, y: false, xTitle: false, yTitle: false };
   }
   return {
     x: !!axes.x,
@@ -489,6 +491,7 @@ export const render = (
   const hasAnyVisibleAxis = axisVisibility.x || axisVisibility.y;
   const axisPaddingX = axisVisibility.y ? 100 : 0;
   const axisPaddingY = axisVisibility.x ? 100 : 0;
+  const leftMargin = resolvedYTitle ? PADDING * 7 : PADDING * 4;
 
   let yTicks: number[] = [];
   let xTicks: number[] = [];
@@ -518,7 +521,7 @@ export const render = (
 
   const result = (
     <svg
-      width={width + PADDING * 6 + axisPaddingX}
+      width={width + leftMargin + PADDING * 2 + axisPaddingX}
       height={height + PADDING * 6 + axisPaddingY}
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -526,7 +529,7 @@ export const render = (
         <defs>{defs}</defs>
       </Show>
       <g
-        transform={`scale(1, -1) translate(${PADDING * 4}, ${-height - PADDING * 4})`}
+        transform={`scale(1, -1) translate(${leftMargin}, ${-height - PADDING * 4})`}
       >
         <Show when={transform} keyed fallback={child.INTERNAL_render()}>
           <g transform={transform ?? ""}>{child.INTERNAL_render()}</g>
@@ -1130,33 +1133,33 @@ export const render = (
                       );
                     })()}
                   </Show>
-                  {/* x axis title */}
-                  <Show when={axisVisibility.x && resolvedXTitle}>
-                    <text
-                      transform="scale(1, -1)"
-                      x={width / 2}
-                      y={PADDING * 3.5}
-                      text-anchor="middle"
-                      dominant-baseline="hanging"
-                      font-size="11px"
-                      fill="gray"
-                    >
-                      {resolvedXTitle}
-                    </text>
-                  </Show>
-                  {/* y axis title */}
-                  <Show when={axisVisibility.y && resolvedYTitle}>
-                    <text
-                      transform={`translate(${-PADDING * 3.5}, ${height / 2}) scale(1, -1) rotate(-90)`}
-                      text-anchor="middle"
-                      dominant-baseline="middle"
-                      font-size="11px"
-                      fill="gray"
-                    >
-                      {resolvedYTitle}
-                    </text>
-                  </Show>
                 </g>
+                {/* x axis title */}
+                <Show when={axisVisibility.x && resolvedXTitle}>
+                  <text
+                    transform="scale(1, -1)"
+                    x={width / 2}
+                    y={PADDING * 3.5}
+                    text-anchor="middle"
+                    dominant-baseline="hanging"
+                    font-size="11px"
+                    fill="gray"
+                  >
+                    {resolvedXTitle}
+                  </text>
+                </Show>
+                {/* y axis title */}
+                <Show when={axisVisibility.y && resolvedYTitle}>
+                  <text
+                    transform={`translate(${-PADDING * 3.5}, ${height / 2}) scale(1, -1) rotate(-90)`}
+                    text-anchor="middle"
+                    dominant-baseline="middle"
+                    font-size="11px"
+                    fill="gray"
+                  >
+                    {resolvedYTitle}
+                  </text>
+                </Show>
                 {/* legend (discrete color for now) */}
                 <g>
                   <For

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -286,6 +286,7 @@ export const gofish = (
     debug = false,
     defs,
     axes = false,
+    axisFields,
     colorConfig,
   }: {
     w: number;
@@ -295,7 +296,8 @@ export const gofish = (
     transform?: { x?: number; y?: number };
     debug?: boolean;
     defs?: JSX.Element[];
-    axes?: boolean;
+    axes?: AxesOptions;
+    axisFields?: { x?: string; y?: string };
     colorConfig?: ColorConfig;
   },
   child: GoFishNode | Promise<GoFishNode>
@@ -362,6 +364,7 @@ export const gofish = (
               height: h,
               defs,
               axes,
+              axisFields,
               scaleContext: data.scaleContext,
               keyContext: data.keyContext,
               sizeDomains: data.sizeDomains,
@@ -447,6 +450,7 @@ export const render = (
     transform,
     defs,
     axes,
+    axisFields,
     scaleContext: scaleContextParam,
     keyContext: keyContextParam,
     sizeDomains,
@@ -460,6 +464,7 @@ export const render = (
     transform?: string;
     defs?: JSX.Element[];
     axes?: AxesOptions;
+    axisFields?: { x?: string; y?: string };
     scaleContext: ScaleContext | null;
     keyContext: KeyContext | null;
     sizeDomains?: [any, any];
@@ -477,6 +482,10 @@ export const render = (
   const keyContext = keyContextParam;
   const { x: axisX, y: axisY, xTitle, yTitle } = resolveAxes(axes);
   const axisVisibility = { x: axisX, y: axisY };
+  const resolvedXTitle =
+    xTitle === false ? undefined : (xTitle ?? axisFields?.x);
+  const resolvedYTitle =
+    yTitle === false ? undefined : (yTitle ?? axisFields?.y);
   const hasAnyVisibleAxis = axisVisibility.x || axisVisibility.y;
   const axisPaddingX = axisVisibility.y ? 100 : 0;
   const axisPaddingY = axisVisibility.x ? 100 : 0;
@@ -1122,7 +1131,7 @@ export const render = (
                     })()}
                   </Show>
                   {/* x axis title */}
-                  <Show when={axisVisibility.x && xTitle !== false}>
+                  <Show when={axisVisibility.x && resolvedXTitle}>
                     <text
                       transform="scale(1, -1)"
                       x={width / 2}
@@ -1132,11 +1141,11 @@ export const render = (
                       font-size="11px"
                       fill="gray"
                     >
-                      {xTitle}
+                      {resolvedXTitle}
                     </text>
                   </Show>
                   {/* y axis title */}
-                  <Show when={axisVisibility.y && yTitle !== false}>
+                  <Show when={axisVisibility.y && resolvedYTitle}>
                     <text
                       transform={`translate(${-PADDING * 3.5}, ${height / 2}) scale(1, -1) rotate(-90)`}
                       text-anchor="middle"
@@ -1144,7 +1153,7 @@ export const render = (
                       font-size="11px"
                       fill="gray"
                     >
-                      {yTitle}
+                      {resolvedYTitle}
                     </text>
                   </Show>
                 </g>

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -29,21 +29,34 @@ export type ScaleContext = {
 };
 
 export type KeyContext = { [key: string]: GoFishNode };
-export type AxesOptions = boolean | { x: boolean; y: boolean };
+export type AxesOptions = boolean | { x?: AxisOptions; y?: AxisOptions };
+export type AxisOptions = boolean | { title?: string | false };
 
-function resolveAxesVisibility(axes: AxesOptions | undefined): {
+function resolveAxisTitle(
+  axisOpt: AxisOptions | undefined
+): string | false | undefined {
+  if (!axisOpt || axisOpt === true) return undefined;
+  return axisOpt.title;
+}
+
+function resolveAxes(axes: AxesOptions | undefined): {
   x: boolean;
   y: boolean;
+  xTitle: string | false | undefined;
+  yTitle: string | false | undefined;
 } {
   if (axes === true) {
-    return { x: true, y: true };
+    return { x: true, y: true, xTitle: undefined, yTitle: undefined };
   }
-  if (axes && typeof axes === "object") {
-    const x = axes.x === true;
-    const y = axes.y === true;
-    return { x, y };
+  if (!axes) {
+    return { x: false, y: false, xTitle: undefined, yTitle: undefined };
   }
-  return { x: false, y: false };
+  return {
+    x: !!axes.x,
+    y: !!axes.y,
+    xTitle: resolveAxisTitle(axes.x),
+    yTitle: resolveAxisTitle(axes.y),
+  };
 }
 
 type OrdinalScale = (key: string) => number | undefined;
@@ -462,7 +475,8 @@ export const render = (
 ): JSX.Element => {
   const scaleContext = scaleContextParam;
   const keyContext = keyContextParam;
-  const axisVisibility = resolveAxesVisibility(axes);
+  const { x: axisX, y: axisY, xTitle, yTitle } = resolveAxes(axes);
+  const axisVisibility = { x: axisX, y: axisY };
   const hasAnyVisibleAxis = axisVisibility.x || axisVisibility.y;
   const axisPaddingX = axisVisibility.y ? 100 : 0;
   const axisPaddingY = axisVisibility.x ? 100 : 0;
@@ -1106,6 +1120,32 @@ export const render = (
                         </g>
                       );
                     })()}
+                  </Show>
+                  {/* x axis title */}
+                  <Show when={axisVisibility.x && xTitle !== false}>
+                    <text
+                      transform="scale(1, -1)"
+                      x={width / 2}
+                      y={PADDING * 3.5}
+                      text-anchor="middle"
+                      dominant-baseline="hanging"
+                      font-size="11px"
+                      fill="gray"
+                    >
+                      {xTitle}
+                    </text>
+                  </Show>
+                  {/* y axis title */}
+                  <Show when={axisVisibility.y && yTitle !== false}>
+                    <text
+                      transform={`translate(${-PADDING * 3.5}, ${height / 2}) scale(1, -1) rotate(-90)`}
+                      text-anchor="middle"
+                      dominant-baseline="middle"
+                      font-size="11px"
+                      fill="gray"
+                    >
+                      {yTitle}
+                    </text>
                   </Show>
                 </g>
                 {/* legend (discrete color for now) */}

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -36,7 +36,7 @@ export type AxisOptions = boolean | { title?: string | false };
 function resolveAxisTitle(
   axisOpt: AxisOptions | undefined
 ): string | false | undefined {
-  if (!axisOpt) return false; // axis hidden, title irrelevant
+  if (axisOpt === undefined || axisOpt === false) return false; // axis hidden, title irrelevant
   if (axisOpt === true) return undefined; // axis shown, infer title from encoding
   return axisOpt.title; // string: custom title, false: no title, undefined: infer title
 }

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -390,10 +390,25 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     container: Parameters<GoFishNode["render"]>[0],
     options: Parameters<GoFishNode["render"]>[1]
   ): Promise<ReturnType<GoFishNode["render"]>> {
+    const inferredFields: { x?: string; y?: string } = {};
+    for (const op of this.operators) {
+      const meta = (op as any).__axisFields as
+        | { x?: string; y?: string }
+        | undefined;
+      if (meta?.x) inferredFields.x ??= meta.x;
+      if (meta?.y) inferredFields.y ??= meta.y;
+    }
+    const markMeta = (this.finalMark as any)?.__axisFields as
+      | { x?: string; y?: string }
+      | undefined;
+    if (markMeta?.x) inferredFields.x ??= markMeta.x;
+    if (markMeta?.y) inferredFields.y ??= markMeta.y;
+
     const node = await this.resolve();
     return node.render(container, {
       ...options,
       colorConfig: this.options?.color,
+      axisFields: inferredFields,
     });
   }
 }
@@ -486,7 +501,8 @@ export function spread<T>(
     alignment: opts?.alignment ?? "baseline",
   };
 
-  return async (mark: Mark<T[]>) => {
+  const spatialDir = (finalOptions.dir ?? "x").startsWith("x") ? "x" : "y";
+  const op = async (mark: Mark<T[]>) => {
     return async (
       d: T[],
       key?: string | number,
@@ -498,8 +514,6 @@ export function spread<T>(
           ? Map.groupBy(d, (row) => (row as any)[field])
           : Map.groupBy(d, field as any)
         : d;
-
-      const spatialDir = (finalOptions.dir ?? "x").startsWith("x") ? "x" : "y";
 
       return Spread(
         {
@@ -532,6 +546,11 @@ export function spread<T>(
       );
     };
   };
+  if (field !== undefined) {
+    (op as any).__axisFields =
+      spatialDir === "x" ? { x: String(field) } : { y: String(field) };
+  }
+  return op;
 }
 
 /** Mark combinator form: stack(opts, marks[]) → NameableMark */

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -391,6 +391,13 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     options: Parameters<GoFishNode["render"]>[1]
   ): Promise<ReturnType<GoFishNode["render"]>> {
     const inferredFields: { x?: string; y?: string } = {};
+    // Mark fields take priority: they encode measured values (e.g. w: "proportion").
+    // Operator fields fill remaining gaps: they encode grouping/layout (e.g. stack("sex")).
+    const markMeta = (this.finalMark as any)?.__axisFields as
+      | { x?: string; y?: string }
+      | undefined;
+    if (markMeta?.x) inferredFields.x ??= markMeta.x;
+    if (markMeta?.y) inferredFields.y ??= markMeta.y;
     for (const op of this.operators) {
       const meta = (op as any).__axisFields as
         | { x?: string; y?: string }
@@ -398,11 +405,6 @@ export class ChartBuilder<TInput, TOutput = TInput> {
       if (meta?.x) inferredFields.x ??= meta.x;
       if (meta?.y) inferredFields.y ??= meta.y;
     }
-    const markMeta = (this.finalMark as any)?.__axisFields as
-      | { x?: string; y?: string }
-      | undefined;
-    if (markMeta?.x) inferredFields.x ??= markMeta.x;
-    if (markMeta?.y) inferredFields.y ??= markMeta.y;
 
     const node = await this.resolve();
     return node.render(container, {

--- a/packages/gofish-graphics/src/ast/withGoFish.ts
+++ b/packages/gofish-graphics/src/ast/withGoFish.ts
@@ -482,6 +482,17 @@ export function createMark<
       return node;
     };
 
+    // Infer axis field names from string-valued size/pos channels
+    const axisFields: { x?: string; y?: string } = {};
+    const o = markOpts as any;
+    if (typeof o.w === "string") axisFields.x = o.w;
+    else if (typeof o.x === "string") axisFields.x = o.x;
+    if (typeof o.h === "string") axisFields.y = o.h;
+    else if (typeof o.y === "string") axisFields.y = o.y;
+    if (axisFields.x || axisFields.y) {
+      (baseMark as any).__axisFields = axisFields;
+    }
+
     const nameMethod = (
       layerName: string
     ): Mark<T | T[] | { item: T | T[]; key: number | string }> => {
@@ -503,6 +514,13 @@ export function createMark<
         return node;
       };
     };
+    const nameMethodWithFields = (layerName: string) => {
+      const fn = nameMethod(layerName);
+      if ((baseMark as any).__axisFields) {
+        (fn as any).__axisFields = (baseMark as any).__axisFields;
+      }
+      return fn;
+    };
     const labelMethod = (
       accessor: LabelAccessor,
       options?: LabelOptions
@@ -518,7 +536,7 @@ export function createMark<
       };
     };
     Object.defineProperty(baseMark, "name", {
-      value: nameMethod,
+      value: nameMethodWithFields,
       writable: true,
       configurable: true,
     });

--- a/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/html";
 import { initializeContainer } from "../../helper";
 import { seafood } from "../../../src/data/catch";
 import { Chart, spread, rect } from "../../../src/lib";
+import type { AxesOptions } from "../../../src/ast/gofish";
 
 const meta: Meta = {
   title: "Forward Syntax V3/Bar/Axes Permutations",
@@ -17,10 +18,9 @@ const meta: Meta = {
 
 export default meta;
 
-type AxesOption = boolean | { x: boolean; y: boolean };
 type Args = { w: number; h: number };
 
-function renderBar(args: Args, axes: AxesOption): HTMLElement {
+function renderBar(args: Args, axes: AxesOptions): HTMLElement {
   const container = initializeContainer();
 
   Chart(seafood)
@@ -63,4 +63,36 @@ export const AxesYOnly: StoryObj<Args> = {
 export const AxesXYFalse: StoryObj<Args> = {
   args: { w: 400, h: 400 },
   render: (args: Args) => renderBar(args, { x: false, y: false }),
+};
+
+// y is undefined, only x axis shown
+export const AxesXOnlyUndefinedY: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) => renderBar(args, { x: true }),
+};
+
+// x is undefined, only y axis shown
+export const AxesYOnlyUndefinedX: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) => renderBar(args, { y: true }),
+};
+
+// inferred titles from field encodings
+export const AxesInferredTitles: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) => renderBar(args, true),
+};
+
+// explicit title override on x, inferred on y
+export const AxesCustomXTitle: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) =>
+    renderBar(args, { x: { title: "Lake" }, y: true }),
+};
+
+// title: false suppresses the inferred title
+export const AxesSuppressedTitle: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) =>
+    renderBar(args, { x: { title: false }, y: true }),
 };

--- a/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
@@ -77,12 +77,6 @@ export const AxesYOnlyUndefinedX: StoryObj<Args> = {
   render: (args: Args) => renderBar(args, { y: true }),
 };
 
-// inferred titles from field encodings
-export const AxesInferredTitles: StoryObj<Args> = {
-  args: { w: 400, h: 400 },
-  render: (args: Args) => renderBar(args, true),
-};
-
 // explicit title override on x, inferred on y
 export const AxesCustomXTitle: StoryObj<Args> = {
   args: { w: 400, h: 400 },

--- a/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
@@ -81,7 +81,7 @@ export const AxesYOnlyUndefinedX: StoryObj<Args> = {
 export const AxesCustomXTitle: StoryObj<Args> = {
   args: { w: 400, h: 400 },
   render: (args: Args) =>
-    renderBar(args, { x: { title: "Lake" }, y: true }),
+    renderBar(args, { x: { title: "Custom X Title" }, y: true }),
 };
 
 // title: false suppresses the inferred title


### PR DESCRIPTION
## What

Adds axis title support to the v3 chart API (#263).

### Spec changes

`AxesOptions` now supports per-axis config objects:

    type AxesOptions = boolean | { x?: AxisOptions; y?: AxisOptions }
    type AxisOptions = boolean | { title?: string | false }

- `x`/`y` absent (`undefined`) → axis hidden
- `x`/`y: true` → axis shown, title inferred from encoding
- `x`/`y: { title: "Label" }` → axis shown with custom title
- `x`/`y: { title: false }` → axis shown, title suppressed

### Renderer changes

Titles render as SVG `<text>` elements — below the x-axis, rotated alongside the y-axis. They fall back to auto-inferred titles from field encodings when no explicit title is provided.

### Auto-inference

Field names are tagged onto mark/operator functions via `__axisFields` and collected at render time:
- `rect({ h: "count" })` → y-title inferred as `"count"`
- `spread("lake", { dir: "x" })` → x-title inferred as `"lake"`

## Usage

    // inferred titles from encodings
    Chart(data).flow(spread("lake", { dir: "x" })).mark(rect({ h: "count" }))
      .render(container, { w: 400, h: 400, axes: true });

    // custom x title, y inferred
    .render(container, { axes: { x: { title: "Lake" }, y: true } });

    // suppress inferred title on x
    .render(container, { axes: { x: { title: false }, y: true } });

    // only y axis shown (undefined = hidden)
    .render(container, { axes: { y: true } });

## Stories

`Forward Syntax V3 / Bar / Axes Permutations` covers all permutations including both axes, single axis, custom titles, suppressed titles, inferred titles, and undefined-as-hidden behavior.