### PR TITLE
ci(chromatic): inline project token to support fork PRs

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -15,8 +15,6 @@ on:
 jobs:
   chromatic:
     runs-on: ubuntu-latest
-    # Require approval for fork PRs to access secrets
-    environment: ${{ github.event.pull_request.head.repo.full_name != github.repository && 'chromatic-fork' || null }}
 
     steps:
       - name: Checkout code
@@ -44,7 +42,7 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@latest
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: chpt_b7e06495d0d4585
           workingDir: packages/gofish-graphics
           buildScriptName: build-storybook
           onlyChanged: true # Only test stories that changed


### PR DESCRIPTION
## Summary
- Removes the `chromatic-fork` environment gate and switches `projectToken` from a secret reference to the inlined plaintext token.
- GitHub Actions blocks secrets on `pull_request` events from forks regardless of environment-approval setup (verified via debug step: `secrets.CHROMATIC_PROJECT_TOKEN` evaluates to `null` even after env approval). This made all fork PRs fail with "Missing project token".
- Per [Chromatic's docs](https://www.chromatic.com/docs/github-actions/), the recommended fix for fork PRs is to inline the project token. The token is scoped to triggering builds only — it cannot accept baselines, access settings, or modify the project. Worst-case exposure is snapshot quota burn, mitigated by rotating the token.

Closes #382
Closes #180

## Test plan
- [ ] Open a fresh PR from a fork that touches `packages/gofish-graphics/**` and confirm the chromatic job runs to completion without an approval banner.
- [ ] After merge, delete the now-unused `chromatic-fork` environment (Settings → Environments) and the `CHROMATIC_PROJECT_TOKEN` repo secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)