### PR TITLE
fix(ci): visual diff viewer reporting all stories as new

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -40,18 +40,19 @@ jobs:
           elif git ls-remote --exit-code origin "snapshots/main" 2>/dev/null; then
             FOUND="snapshots/main"
           fi
+          mkdir -p __snapshots__/dom __snapshots__/screenshots
           if [ -n "$FOUND" ]; then
             git fetch origin "$FOUND"
             FETCH_SHA=$(git rev-parse FETCH_HEAD)
             git worktree add --detach /tmp/snap-baselines "$FETCH_SHA"
             cd /tmp/snap-baselines && git lfs pull && cd -
-            mkdir -p __snapshots__
-            [ -d /tmp/snap-baselines/dom ] && cp -r /tmp/snap-baselines/dom __snapshots__/dom
-            [ -d /tmp/snap-baselines/screenshots ] && cp -r /tmp/snap-baselines/screenshots __snapshots__/screenshots
+            # Copy SRC contents (SRC/.) into existing DEST so a pre-existing
+            # __snapshots__/dom doesn't end up nested as __snapshots__/dom/dom.
+            [ -d /tmp/snap-baselines/dom ] && cp -r /tmp/snap-baselines/dom/. __snapshots__/dom/
+            [ -d /tmp/snap-baselines/screenshots ] && cp -r /tmp/snap-baselines/screenshots/. __snapshots__/screenshots/
             git worktree remove --force /tmp/snap-baselines
           else
             echo "No snapshot branch found; starting with empty baselines."
-            mkdir -p __snapshots__/dom __snapshots__/screenshots
           fi
 
       - name: Setup pnpm
@@ -170,18 +171,19 @@ jobs:
           elif git ls-remote --exit-code origin "snapshots/main" 2>/dev/null; then
             FOUND="snapshots/main"
           fi
+          mkdir -p __snapshots__/dom __snapshots__/screenshots
           if [ -n "$FOUND" ]; then
             git fetch origin "$FOUND"
             FETCH_SHA=$(git rev-parse FETCH_HEAD)
             git worktree add --detach /tmp/snap-baselines "$FETCH_SHA"
             cd /tmp/snap-baselines && git lfs pull && cd -
-            mkdir -p __snapshots__
-            [ -d /tmp/snap-baselines/dom ] && cp -r /tmp/snap-baselines/dom __snapshots__/dom
-            [ -d /tmp/snap-baselines/screenshots ] && cp -r /tmp/snap-baselines/screenshots __snapshots__/screenshots
+            # Copy SRC contents (SRC/.) into existing DEST so a pre-existing
+            # __snapshots__/dom doesn't end up nested as __snapshots__/dom/dom.
+            [ -d /tmp/snap-baselines/dom ] && cp -r /tmp/snap-baselines/dom/. __snapshots__/dom/
+            [ -d /tmp/snap-baselines/screenshots ] && cp -r /tmp/snap-baselines/screenshots/. __snapshots__/screenshots/
             git worktree remove --force /tmp/snap-baselines
           else
             echo "No snapshot branch found; starting with empty baselines."
-            mkdir -p __snapshots__/dom __snapshots__/screenshots
           fi
 
       - name: Setup pnpm

--- a/tests/scripts/snapshot-branch.ts
+++ b/tests/scripts/snapshot-branch.ts
@@ -250,8 +250,10 @@ export function commitAndPushSnapshots(
     syncDir(join(sourceDir, "dom"), join(wtPath, "dom"));
     syncDir(join(sourceDir, "screenshots"), join(wtPath, "screenshots"));
 
-    // Stage all changes. LFS hooks auto-handle PNGs via .gitattributes.
-    git("git add -A", { cwd: wtPath });
+    // Stage only the data dirs. Avoid `git add -A` so husky/lfs-installed
+    // hook files in .husky/_/ (created during pnpm install) don't get
+    // committed to the data-only snapshot branch.
+    git("git add -A dom screenshots", { cwd: wtPath });
 
     // Check if there's anything to commit.
     const status = git("git status --porcelain", { cwd: wtPath });


### PR DESCRIPTION
Closes #362.

## Summary

The Visual Tests workflow was reporting every story as a "new story without baseline" on PR runs (e.g. 100 stories flagged as missing in run 25021644129) because the snapshot baseline directory on the runner ended up nested as `__snapshots__/dom/dom/...`, while `compare.ts` looks at flat paths.

## Root causes

1. **`cp -r SRC DEST` in `Fetch snapshot baselines`** puts SRC inside DEST when DEST already exists. Switched to `cp -r SRC/. DEST/` with explicit `mkdir -p` of DEST — this idiom always merges contents into DEST regardless of state.
2. **`git add -A` in `commitAndPushSnapshots`** was capturing `.husky/_/post-checkout` etc. that husky/git-lfs install during `pnpm install`. The snapshot orphan branch is data-only and shouldn't carry hooks. Replaced with `git add -A dom screenshots`.

These two bugs together caused `snapshots/main` to accumulate 7 levels of `dom/dom/dom/.../` nesting on every auto-update commit. Branch was reset to a clean depth-0 state in a separate fast-forward commit (`51372b91..7e735599`) before this PR was opened.

## Test plan

Includes a throwaway commit (`9baf3541`) that bumps BarBasic's width from 400 to 500. Expected CI behavior with the fix:

- [x] `Compare snapshots (PR only)` reports exactly **1 regression** (`forward-syntax-v3/bar/basic--default.html`)
- [x] **0 missing baselines** (vs. ~135 before this fix)
- [x] Review site URL posted as PR comment

If CI passes the test, drop commit `9baf3541` (`git reset --hard HEAD~1 && git push --force-with-lease`) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)