### PR TITLE
fix(ci): visual diff review per-PR snapshot branch initialization

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       pull-requests: write
       contents: write # needed to push to snapshots/main on main push
+      statuses: write # needed to publish review-link commit status
 
     steps:
       - name: Checkout code
@@ -116,7 +117,11 @@ jobs:
         env:
           REVIEW_REPO: ${{ github.repository }}
           REVIEW_BRANCH: ${{ github.head_ref || github.ref_name }}
-          REVIEW_SHA: ${{ github.sha }}
+          # For pull_request events, github.sha is the *merge* commit, not the
+          # PR head. Statuses must be posted on the PR head SHA so they appear
+          # on the PR's checks list, so prefer pull_request.head.sha when set.
+          REVIEW_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          REVIEW_RUN_ID: ${{ github.run_id }}
 
       - name: Deploy review site to Cloudflare Pages
         if: failure() && github.event_name == 'pull_request'
@@ -134,17 +139,24 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NO_COLOR: "1"
 
-      - name: Comment PR with review URL
+      # Publish a commit status whose Details link jumps directly to the review
+      # app (no intermediate GitHub page, unlike check runs). Mirrors the UX of
+      # services like Chromatic.
+      - name: Publish review-link commit status
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v8
         with:
           script: |
             const url = '${{ steps.deploy-review.outputs.deployment-url }}';
-            await github.rest.issues.createComment({
+            if (!url) return;
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `## Visual Diff Review\n\nVisual tests failed. [**Open Review App**](${url})\n\nReview each diff, mark stories as accepted or rejected, then click **Commit Accepted** to push all accepted changes in a single commit.`
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              target_url: url,
+              description: 'Click Details to review and accept diffs',
+              context: 'Visual Diff Review',
             });
 
   python-parity:
@@ -152,6 +164,7 @@ jobs:
     needs: visual-test
     permissions:
       pull-requests: write
+      statuses: write # needed to publish parity-review-link commit status
 
     steps:
       - name: Checkout code
@@ -262,24 +275,19 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           NO_COLOR: "1"
 
-      - name: Comment PR with parity review link
+      - name: Publish parity-review-link commit status
         if: failure() && github.event_name == 'pull_request'
         uses: actions/github-script@v8
         with:
           script: |
             const url = '${{ steps.deploy-parity.outputs.deployment-url }}';
-            const urlLine = url
-              ? '[**Open Parity Review**](' + url + ')'
-              : '_Cloudflare deploy failed — download the `parity-review-site` artifact instead._';
-            await github.rest.issues.createComment({
+            if (!url) return;
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: [
-                '## Python Parity Review',
-                '',
-                'One or more Python parity checks failed. ' + urlLine,
-                '',
-                'This read-only site shows JS and Python source code side-by-side for each story pair, plus DOM diffs for parity failures.',
-              ].join('\n'),
+              sha: context.payload.pull_request.head.sha,
+              state: 'pending',
+              target_url: url,
+              description: 'Click Details to view JS/Python parity diffs',
+              context: 'Python Parity Review',
             });

--- a/tests/scripts/build-review-site.ts
+++ b/tests/scripts/build-review-site.ts
@@ -113,6 +113,10 @@ const meta = {
   sha: process.env.REVIEW_SHA ?? "unknown",
   /** The orphan branch that receives accepted snapshots. */
   snapshotBranch: `snapshots/${codeBranch}`,
+  /** Workflow run id, used by the commit endpoint to trigger rerun-failed-jobs
+   *  after Commit Accepted, so visual-test re-runs against the new baselines
+   *  and python-parity (blocked on visual-test) is allowed to run. */
+  runId: process.env.REVIEW_RUN_ID ?? "",
 };
 
 write(join(OUT_DIR, "data/meta.json"), JSON.stringify(meta, null, 2));
@@ -691,6 +695,8 @@ const html = `<!DOCTYPE html>
           screenshotContents,
           repo: meta.repo,
           branch: meta.snapshotBranch,
+          runId: meta.runId,
+          headSha: meta.sha,
         }),
       });
       const ct = res.headers.get('content-type') || '';
@@ -707,9 +713,11 @@ const html = `<!DOCTYPE html>
         setActionStatus('Error: ' + (data.error || 'Unknown error'), true);
       } else {
         hasUncommittedAccepts = false;
+        const warnings = (data.postCommitWarnings || []).join('; ');
         const msg = 'Committed ' + data.accepted + ' diff(s): ' + (data.commitSha || '').slice(0, 8) +
-          (data.errors && data.errors.length ? ' (' + data.errors.length + ' errors)' : '');
-        setActionStatus(msg, data.errors && data.errors.length > 0);
+          (data.errors && data.errors.length ? ' (' + data.errors.length + ' errors)' : '') +
+          (warnings ? ' — warnings: ' + warnings : '');
+        setActionStatus(msg, (data.errors && data.errors.length > 0) || Boolean(warnings));
         renderSidebar();
         updateCommitBtn();
       }

--- a/tests/scripts/cf-functions/api/commit.ts
+++ b/tests/scripts/cf-functions/api/commit.ts
@@ -28,6 +28,11 @@ interface CommitBody {
   repo: string;
   /** The snapshot branch to commit to (e.g. "snapshots/my-feature") */
   branch: string;
+  /** PR head SHA — used to update the Visual Diff Review commit status. */
+  headSha?: string;
+  /** Workflow run id — if provided, rerun-failed-jobs is triggered post-commit
+   *  so visual-test re-runs against the new baselines and python-parity gets to run. */
+  runId?: string;
 }
 
 type TreeItem = {
@@ -111,6 +116,8 @@ async function handleCommit(
     screenshotContents = {},
     repo,
     branch,
+    headSha: prHeadSha,
+    runId,
   } = body;
   const [owner, repoName] = repo.split("/");
 
@@ -191,11 +198,40 @@ async function handleCommit(
       `get commit ${headSha}`
     );
     baseTreeSha = commitData.tree.sha;
-  } else if (refRes.status !== 404) {
+  } else if (refRes.status === 404) {
+    // Per-PR snapshot branch doesn't exist yet — initialize from snapshots/main
+    // so the new orphan inherits all baselines, with accepted entries layered on top.
+    // Without this, the new branch would contain ONLY the accepted entries, and the
+    // next CI run (which prefers the per-PR branch over snapshots/main) would report
+    // every other story as "new".
+    const mainRefRes = await fetch(`${apiBase}/git/ref/heads/snapshots/main`, {
+      headers: githubHeaders,
+    });
+    if (mainRefRes.ok) {
+      const mainRefData = (await mainRefRes.json()) as {
+        object: { sha: string };
+      };
+      const mainCommit = await githubJson<{ tree: { sha: string } }>(
+        await fetch(`${apiBase}/git/commits/${mainRefData.object.sha}`, {
+          headers: githubHeaders,
+        }),
+        `get commit ${mainRefData.object.sha}`
+      );
+      baseTreeSha = mainCommit.tree.sha;
+      // headSha stays null so the new commit is parentless and the branch ref is
+      // created via POST /git/refs below.
+    } else if (mainRefRes.status !== 404) {
+      const text = await mainRefRes.text();
+      throw new Error(
+        `GitHub get snapshots/main ref failed (${mainRefRes.status}): ${text}`
+      );
+    }
+    // If snapshots/main also doesn't exist (truly fresh repo), baseTreeSha stays
+    // null and we fall back to creating an empty-base orphan.
+  } else {
     const text = await refRes.text();
     throw new Error(`GitHub get ref failed (${refRes.status}): ${text}`);
   }
-  // If 404, headSha/baseTreeSha remain null — we'll create an orphan branch below.
 
   // Create tree with all changes (base_tree omitted for orphan branch creation).
   const newTree = await githubJson<{ sha: string }>(
@@ -252,10 +288,56 @@ async function handleCommit(
     }
   }
 
+  // Best-effort post-commit actions: flip the Visual Diff Review status to
+  // success (so the PR's checks reflect the action immediately) and rerun the
+  // failed workflow jobs (so visual-test re-runs against the new baselines
+  // and python-parity, blocked on visual-test, finally executes). Failures
+  // here are non-fatal — the snapshot commit already succeeded.
+  const postCommitWarnings: string[] = [];
+
+  if (prHeadSha) {
+    try {
+      const statusRes = await fetch(`${apiBase}/statuses/${prHeadSha}`, {
+        method: "POST",
+        headers: githubHeaders,
+        body: JSON.stringify({
+          state: "success",
+          target_url: `https://github.com/${repo}/tree/${branch}`,
+          description: `Accepted ${accepted} diff(s); re-running tests`,
+          context: "Visual Diff Review",
+        }),
+      });
+      if (!statusRes.ok) {
+        postCommitWarnings.push(
+          `status update failed (${statusRes.status}) — token may be missing 'statuses: write'`
+        );
+      }
+    } catch (e) {
+      postCommitWarnings.push(`status update threw: ${String(e)}`);
+    }
+  }
+
+  if (runId) {
+    try {
+      const rerunRes = await fetch(
+        `${apiBase}/actions/runs/${runId}/rerun-failed-jobs`,
+        { method: "POST", headers: githubHeaders }
+      );
+      if (!rerunRes.ok) {
+        postCommitWarnings.push(
+          `rerun failed (${rerunRes.status}) — token may be missing 'actions: write'`
+        );
+      }
+    } catch (e) {
+      postCommitWarnings.push(`rerun threw: ${String(e)}`);
+    }
+  }
+
   return json({
     ok: errors.length === 0,
     accepted,
     errors,
     commitSha: newCommit.sha,
+    postCommitWarnings,
   });
 }


### PR DESCRIPTION
## Summary

Primary fix:
- "Commit Accepted" in the visual diff review used to create the per-PR snapshot branch (`snapshots/<branch>`) as a fresh orphan whose tree contained **only** the accepted entries. The next CI run on the PR preferred that incomplete branch over `snapshots/main` and reported every other story as "new". When the per-PR ref returns 404, we now fall back to fetching `snapshots/main` and use its commit's tree SHA as `base_tree`, so the new orphan inherits all baselines with accepted entries layered on top.

Bundled UX improvements:
- Replace bot-comment review URLs with **commit statuses** (`Visual Diff Review` and `Python Parity Review`) whose `target_url` jumps directly to the deployed review app (mirrors Chromatic's UX, no intermediate GitHub page). Adds `statuses: write` to both jobs.
- After successful **Commit Accepted**, the CF function (a) flips the Visual Diff Review status to `success` on the PR head SHA and (b) triggers `rerun-failed-jobs` on the original workflow run — so visual-test re-runs against the new baselines and python-parity (blocked on `needs: visual-test`) finally executes. Both actions are best-effort; failures surface as warnings in the SPA's success message.
- `REVIEW_SHA` is now `pull_request.head.sha` (falling back to `github.sha`) so the status update lands on the SHA the PR's checks list actually displays, not the merge commit.

## Token requirements

The `GITHUB_TOKEN` Cloudflare Pages secret on the `gofish-visual-review` project must have:
- `actions: write` (rerun-failed-jobs)
- `commit statuses: write` (status update)
- `contents: write` (existing — branch creation)

If those scopes aren't granted, snapshot commit still succeeds but post-commit actions fail loudly in the SPA.

## Follow-up

- Existing per-PR snapshot branches created with the broken (only-accepted-entries) state need manual reset (delete on GitHub; next accept recreates correctly). Tracked: `snapshots/createOperator-factory` for #389.

## Test plan

- [x] Verified end-to-end on this PR by tweaking BarBasic's fill repeatedly: accept → snapshot tree includes full main baseline + accepted entry; status flips green; workflow auto-reruns; visual-test passes; python-parity runs.
- [x] Verified status posts on PR head SHA (single entry, flips in place — no orphan on merge commit).
- [x] Verified post-commit warnings surface when token lacks required scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)