### PR TITLE
notes: labels & annotation system design

### DIFF
--- a/notes/labels-design.md
+++ b/notes/labels-design.md
@@ -1,0 +1,344 @@
+# Label & Annotation System — Research & Design Notes
+
+> **Status:** research / design-space doc, not a plan to execute. Surveys the references, maps GoFish's current state, and lays out the design axes with alternatives on each. Several axes are unsettled by intent — for iteration on syntax and approach.
+>
+> Companion to the brainstorm in [`label-syntax.md`](./label-syntax.md).
+
+---
+
+## 1. Goals
+
+A label/annotation system that:
+
+1. Adds **semi-automatic point label placement** (the immediate ask).
+2. Foundational for **point / line / area / ribbon** labels — same primitives, swapped strategies.
+3. **Generic in the placeable** — text, image, callout, custom shape — not text-only.
+4. **Composes with existing operators** (`connect`, `arrow`, `enclose`, `position`); doesn't introduce a parallel annotation runtime.
+5. **Path-aware collisions** — point labels in connected scatterplots avoid the lines, not just the points (vega-label parity).
+
+Two soft preferences set during this round:
+
+- **One operator** (probably `label()`), polymorphic over strategy. Not two parallel `label`/`annotate` operators (was confusing).
+- No back-compat shims — replace the existing `.label()` cleanly.
+
+---
+
+## 2. References
+
+### 2.1 Current GoFish state
+
+- v3 modifier: `.label(accessor, opts)` — `packages/gofish-graphics/src/ast/_node.ts:470-473`. Sets `_label?: LabelSpec` on the node (`_node.ts:140`).
+- Rendered post-layout via `_renderLabel()` (`_node.ts:403-407`) → `renderLabelJSX()` (`labels/renderLabel.tsx:68-124`); appended as JSX sibling.
+- Position inference is purely declarative: `labels/labelPlacement.ts:122-184` (`inferLabelPosition`), `:186-266` (`calculateLabelOffset`), `:269-293` (`getLabelTextAnchor`), `:295-334` (`shouldShowLabel`). Positions are an enum: `"center"`, `"outset"`, `"inset-top-end"`, etc.
+- **No collision avoidance** — `shouldShowLabel` only _hides_ labels that don't fit.
+- Label propagation parent → child if parent has no datum (`_node.ts:475-490`).
+- Coordinate transforms (`coordinateTransforms/coord.tsx:20-25`) bypassed by labels (rendered in screen space at the leaf's translate).
+- AST node lifecycle (`_node.ts:116-185`): construct → `resolveUnderlyingSpace` → `layout(size, scaleFactors, posScales)` → `render`. After layout: `intrinsicDims` and `transform` populated; `.dims` getter (`_node.ts:320-346`) gives final bbox per axis.
+- Three current passes: domain inference, layout, placement+render.
+- Operators that already read post-layout child bounds (the model for any new placement operator): `graphicalOperators/connect.tsx`, `arrow.tsx` (uses `perfect-arrows`'s `getBoxToBoxArrow`), `enclose.tsx`, `position.tsx`.
+- v3 marks via `createOperator` factory (`marks/createOperator.ts:325-349`); `by` for splits; `channels: {prop: "size"|"pos"|"color"}`.
+- `select(name)` / `.name()` for cross-layer references via `scopeContext.ts`.
+- Bounds utilities present but unused: `util/bbox.ts`, `util/interval.ts`.
+
+### 2.2 vega-label
+
+Source: `vega/packages/vega-label/src/`. (IEEE paper `arnumber=11298828` was unreachable — findings are from code + JSDoc.)
+
+- **Architecture:** single greedy first-fit pass. Sort labels by priority; rasterize-as-you-go onto an occupancy bitmap; first non-collision candidate wins.
+- **Bitmap:** packed `Uint32Array` (`util/Bitmap.js`); coord scaler coarsens to ~1M cells (`util/scaler.js`); two-layer (interior + outline) so "inside" labels collide vs the outline and "outside" labels collide vs interior + already-placed labels (`util/markBitmaps.js`).
+- **Mark labels:** 8-compass × user offsets; first non-collision wins (`util/placeMarkLabel.js`). Anchor codes are 8-bit; `dx/dy ∈ {−1, 0, 1}`; placed via `boundary[1+dx]`/`boundary[4+dy]` selecting min/mid/max from a 6-tuple.
+- **Area labels** — three algorithms (`util/placeAreaLabel/`):
+  - `naive`: pick the area sample with the widest slice; no collision check.
+  - `reduced-search`: sweep candidates around the slice midpoint outward, then **binary-search font size** (lo=textHeight, hi=viewportHeight) at each candidate.
+  - `floodfill`: 4-direction interior expansion through unvisited pixels; same binary-search-on-font.
+- **Limitations:** AABB only; text-only (no public hook for arbitrary shapes); no rotated text; no leader lines; greedy with no backtracking; lines get _one_ label at start or end (no along-the-path placement, no curvature awareness); **no ribbon support**; lossy bitmap above ~1M-cell viewports; tightly coupled to `vega-canvas`/`vega-scenegraph` for rasterization.
+
+### 2.3 AnnoGram
+
+Sources: arXiv:2507.04236 ("AnnoGram: An Annotative Grammar of Graphics Extension"); repo `rahatzamancse/vega-lite-annotation` (`packages/vega-lite-annotation-library/src/lib/`).
+
+- **Conceptual model:** annotations as first-class siblings of scales/geoms. The implementation collapses everything to one root type:
+  ```ts
+  RootAnnotation = { target: Markers, text?, enclosure?, connector? /* indicator declared but inactive */ }
+  ```
+  A `RootAnnotation` is a **bundle** — one shared target, up to four effect slots. Connectors auto-route between sibling effects in the bundle.
+- **Targeting (`Markers`):** `data-expr` (predicate over datum), `data-index` / `indices`, `data-space` / `pixel-space`. Resolution walks the rendered vega scenegraph (`enclosureAnnotation.ts`, `extract-sceneGraph.ts`). Other target kinds declared but commented out: `AnnotationMarker`, `ChartPartMarker`, `AxisMarker`.
+- **Effects:**
+  - `TextAnnotation` — full vega text styling.
+  - `EnclosureAnnotation` — schema declares Rect/Ellipse/CurlyBraces/ShapePath, **only Rect ships**.
+  - `ConnectorAnnotation` — 9 curve interpolations + arrowheads at either end; auto-routes if `connect_from/to` omitted.
+- **Position resolver:** bitmap is implemented (`positionResolver.ts`) but **not consumed** by the placement pipeline; `auto` falls back to defaults. Paper §6 admits this.
+- **Architecture:** external wrapper around vega-lite compiler, not a fork. `vlAnnotation.ts` orchestrates: normalize → strip → compile → re-add as vega marks.
+- **Headline claim:** annotations as grammar primitives bound to data (`data-expr`/`data-index` resolved against scenegraph), portable across chart types (Figure 4 demo: same annotation array applied to bar/line/scatter).
+- **Limitations:** one annotation per effect-slot per bundle; no facet/concat composition; no interactive annotations; placement is incomplete; many declared types unimplemented.
+
+### 2.4 d3-area-label (Curran Kelleher)
+
+- **Algorithm:** bisection method searching for the **largest rectangle** (matching the label's measured aspect ratio) that fits inside an area defined by `(x, y0, y1)` strips. For each candidate size, tests x-coordinates as left edges, checking that vertical clearance `(ceiling − floor)` exceeds the label height across the label's width span.
+- **API:** `areaLabel.area(d3Area)` accepts a d3.area generator instance; outputs an SVG transform string.
+- **Distinction from bitmap floodfill:** **resolution-independent** and **vector-exact**. No raster, no canvas. Cheaper than vega-label's reduced-search/floodfill for the common stacked-area / streamgraph case.
+- **Constraint:** assumes areas are defined by horizontal strips with single-valued ceiling/floor functions. Doesn't handle arbitrary polygons (treemap leaves with holes, choropleth regions). Vega-label's bitmap is more general but heavier.
+
+---
+
+## 3. Design space
+
+### 3.1 The anchor / generator / acceptor split
+
+Three independent questions a placer answers:
+
+- **Anchor — where on the target should the label go _near_?** Not a point; a _support set_. A bbox; a polyline; a polygon; a centerline.
+- **Generator — what candidate positions to try, in what order?** For a bbox: 8 compass positions with offset, in priority order. For a path: samples along the curve preferring endpoints / longest-straight / midpoint. For an area: largest inscribed rectangle, or interior search.
+- **Acceptor — can the label go there?** Does the candidate rect overlap any other mark? Any already-placed label? For inside-the-target labels, does it stay inside?
+
+Each axis varies independently. Same primitives compose for all label kinds; the obstacle list grows as we walk the post-layout tree.
+
+| Strategy                     | Anchor         | Generator                              | Acceptor                                       |
+| ---------------------------- | -------------- | -------------------------------------- | ---------------------------------------------- |
+| `"box"` (today's behavior)   | bbox           | priority-list compass                  | self only                                      |
+| `"point"` (vega-label-style) | bbox           | compass-N                              | tree-wide AABB list (incl. path-segment AABBs) |
+| `"line"`                     | polyline       | sample-along + endpoint                | tree-wide AABB list                            |
+| `"area"`                     | polygon strips | largest inscribed rect (d3-area-label) | polygon-interior + tree-wide AABB              |
+| `"ribbon"`                   | centerline     | walk-along + tangent-orient            | tree-wide AABB                                 |
+
+**Key consequence:** path-avoidance for point labels (vega-label parity for connected scatterplots) falls out of the _acceptor_ seeing path-typed marks during its tree walk and emitting per-segment AABBs. It's not a separate feature — it's inherent in "the acceptor sees everything."
+
+### 3.2 Operator surface — settled, but syntax open
+
+Soft consensus: one polymorphic `label()`, with strategy controlled by a `type` opt that **defaults from the target's mark kind**.
+
+What's still open: the exact spelling, slot composition, default ergonomics. A few sketches to chew on.
+
+**Sketch A — minimal, type defaults from target kind, place defaults to text**
+
+```ts
+bar.label("value"); // type: "box", place: text("value")
+scatter.label("name", { type: "point" }); // override strategy
+line.label("series"); // type: "line" inferred
+area.label("cat"); // type: "area" inferred
+
+bar
+  .label({ place: img("/star.svg", { w: 16, h: 16 }) }) // generic placeable
+
+  .add(
+    label({
+      // standalone for cross-mark
+      target: select("scatter").at({ name: "Norway" }),
+      place: text("highest GDP/cap"),
+      connect: arrow({ bow: 0.3 }),
+      enclose: enclose({ padding: 6 }),
+    })
+  );
+```
+
+**Sketch B — explicit type-named operators, `label` as polymorphic shorthand**
+
+```ts
+bar.boxLabel("value");
+scatter.pointLabel("name");
+line.lineLabel("series");
+area.areaLabel("cat");
+ribbon.ribbonLabel("flow");
+
+bar.label("value"); // polymorphic shorthand, dispatches by mark kind
+```
+
+Better discoverability per strategy; loses the unified-mental-model property.
+
+**Sketch C — strategy as a separate factory passed in**
+
+```ts
+bar.label("value", { strategy: pointStrategy({ priority: ["top", "right"] }) });
+area.label("cat", { strategy: areaStrategy() });
+```
+
+Most extensible (users can define new strategies); least ergonomic.
+
+**Open syntax questions:**
+
+- Is `place` a top-level key or wrapped (`{ place: text(...) }` vs `{ text: "..." }`)?
+- Where does the AnnoGram-style bundle live? (a) keys on the standalone `label({ connect, enclose })`; (b) separate top-level operators that take a `label()` as one arg; (c) chain on the per-mark form (`bar.label("v").enclose({ padding: 6 })`).
+- Should priority anchors be `positions: ["outset-top", "outset-right"]`, `position: ["outset-top", ...]` (same key, polymorphic), or a generator opt (`generator: compassN({ priority: ["top", "right"] })`)?
+- Should `.label()` accept a node directly when the placeable isn't text? `bar.label(img(...))` vs `bar.label({ place: img(...) })`.
+
+### 3.3 Generic-in-placeable
+
+Settled approach: the placer never inspects the placeable. It lays it out in isolation with `(size=[Inf,Inf], scaleFactors=[1,1])` against a throwaway parent, reads `placeable.dims` (`_node.ts:320-346`) for size, then commits a transform. Established pattern — `connect`/`arrow` already do this (`connect.tsx:62-65`, `arrow.tsx:69-72`). Means `text(...)`, `img(...)`, `vstack(text, text)`, or any custom GoFish node work with no special-casing.
+
+Open: whether the placeable is allowed to depend on the target (e.g., size proportional to target). Probably yes via accessor pattern: `place: (target) => text(target.datum.value)`.
+
+### 3.4 Selection / targeting
+
+Reuse `select(name)` and `.name()`. Extend `LayerSelector` (`marks/chartBuilder.ts:42`) with predicates — the v3 analogue of AnnoGram's `data-expr` / `data-index`:
+
+```ts
+select("bars").where((d) => d.value > 100);
+select("bars").at({ category: "A" });
+select("bars").indices([0, 3, 7]);
+```
+
+Open: should there be a semantic shorthand (`select("bars").max("value")`, `select("bars").top(3, "value")`)?
+
+### 3.5 Bundle composition (AnnoGram parallel)
+
+AnnoGram's bundle is one target + up to four effect slots sharing an anchor, with auto-routed connectors between sibling effects.
+
+In gofish: do we need a "bundle" concept at all, when we have `connect`, `arrow`, `enclose` as standalone operators?
+
+**Option A — slot keys on the `label()` call:**
+
+```ts
+.add(label({
+  target:  select("pts").at({ name: "Norway" }),
+  place:   text("highest GDP/cap"),
+  connect: arrow(...),
+  enclose: enclose(...),
+}))
+```
+
+Pro: AnnoGram-clean; auto-wiring. Con: a subset of `label`'s opts are wiring, not placement.
+
+**Option B — wire it yourself with refs:**
+
+```ts
+const callout = label({
+  target: select("pts").at({ name: "Norway" }),
+  place: text("highest GDP/cap"),
+}).name("callout");
+
+.add(callout)
+.add(arrow({ from: select("pts").at({ name: "Norway" }), to: select("callout") }))
+.add(enclose(select("callout"), { padding: 6 }))
+```
+
+Pro: small primitives, fully composable, no special slots. Con: verbose; manual wiring; user has to name the label.
+
+**Option C — operator that takes a label as one arg:**
+
+```ts
+.add(callout(
+  label({ target: ..., place: text("...") }),
+  { arrow: arrow(...), enclose: enclose(...) }
+))
+```
+
+Pro: explicit composite operator. Con: a new name for what's basically B.
+
+Open question worth iterating on. AnnoGram's slot model is ergonomic but hides the wiring; gofish has tended toward small composable primitives.
+
+### 3.6 Pipeline integration
+
+A new pass is needed because the acceptor must see _every_ placed mark before placing _any_ label (today's `shouldShowLabel` only sees one shape). Layout is bottom-up; placement needs global occupancy.
+
+**Option A — fourth pass** between `layout` and `INTERNAL_render`:
+
+```
+resolveColorScale → resolveNames → resolveKeys → resolveLabels
+  → resolveUnderlyingSpace → layout → placeLabels → INTERNAL_render
+```
+
+Recommended, but introduces a new traversal stage and a new context (the acceptor).
+
+**Option B — fold into the existing render pass** as a top-down sweep that defers label rendering until obstacles are gathered. Smaller architectural change but tangles render with placement.
+
+**Option C — annotations as marks** that participate in normal layout, with collision handled by a special parent operator (a "collision-aware layer"). Most gofish-y but requires placeable nodes to know they're labels.
+
+**Coordinate transforms.** Anchors should project through ambient `coordinateTransform`; the placer + placeable run in screen space. `bboxAnchor` reads `node.dims` (correct for cartesian); a future `polarBboxAnchor` reads through the parent `coord` without changing the placer.
+
+### 3.7 Acceptor implementation
+
+**Option A — AABB list with interval index.** Walk post-layout tree once; emit one bbox per shape, a chain of segment AABBs per path. Sufficient for points (incl. path avoidance), lines, ribbons. Not sufficient for "fit text inside an arbitrary polygon." Cheap, ships fast. Recommended for v1.
+
+**Option B — port vega-label's packed-Uint32 bitmap.** ~1M cells, 32-bit packed, two-layer (interior + outline). Required for arbitrary-polygon interior search. Heavier: needs per-mark rasterizer registry to handle coord-transformed shapes (gofish doesn't have vega's scenegraph rasterization — would need either a hidden-SVG measurement pass or duplicate the `coord.flattenLayout` logic).
+
+**Option C — d3-area-label-style analytic search for area interiors.** No bitmap. Works for areas defined by `(x, y0, y1)` strips. Doesn't help with arbitrary polygons but covers the common chart cases. Combine with Option A for the rest.
+
+For Phase-1 point labels, A is enough. The interesting choice is whether area-interior labels (later) go via B (general but heavy) or C (lighter, narrower applicability) or both.
+
+### 3.8 Re-layout feedback
+
+Today's bounds are frozen post-layout. A label that doesn't fit is hidden — there's no "re-layout to make room" loop.
+
+- **Stay frozen** (recommended start): hide-on-overflow, document the limit.
+- **One-shot iteration:** a label marked `critical` that fails to place triggers a re-layout with extra padding, capped at one iteration to keep layout monotonic.
+- **Constraint solver:** general fixed-point; expensive; probably never.
+
+---
+
+## 4. Algorithm catalog (per label kind)
+
+### 4.1 Point labels
+
+- **vega-label compass-8 + bitmap** — first-fit over priority anchors with offset; bitmap occupancy.
+- **vega-label compass-8 + AABB list** — same algorithm, AABB list instead of bitmap. (vega-label doesn't ship this; would be a gofish variant.)
+- **Force-directed** (D3 v4 era `d3-labeler`, simulated annealing) — label nodes repel each other and overlapping marks; iterative. More expensive, sometimes nicer-looking.
+- **ILP / global optimum** — academic, rarely used in interactive charts.
+
+### 4.2 Line labels
+
+- **Endpoint** (vega-label) — at start or end of the polyline.
+- **Sample-along-path with priority** — sample at intervals; prefer longest-straight / least-collision / midpoint of longest visible run.
+- **Curvature-aware along-path** — orient the label tangent to the curve; SVG `textPath`. Looks great for sparklines and small multiples.
+
+### 4.3 Area labels
+
+- **vega-label naive** — widest-slice midpoint, no collision check.
+- **vega-label reduced-search** — sweep candidates around slice midpoint, binary-search font size at each.
+- **vega-label floodfill** — flood-fill interior pixels, binary-search font size.
+- **d3-area-label** — analytic largest inscribed rectangle of the label's aspect ratio, on `(x, y0, y1)` strips. Resolution-independent.
+- **Polylabel** (Mapbox) — finds pole-of-inaccessibility (point inside polygon farthest from any edge) for arbitrary polygons. Doesn't directly choose a font size but gives a great starting point.
+
+### 4.4 Ribbon labels
+
+- **Centerline walk** — sample along centerline; orient text to local tangent; bound vertical extent by local ribbon width.
+- **Sankey-style midpoint** — single label at the centerline midpoint, oriented horizontally if local slope is shallow.
+- **Endpoint with leader** — at the wider end of the ribbon, with optional leader line into the narrow part.
+
+---
+
+## 5. Open questions
+
+Worth iterating on before committing:
+
+1. **Operator name and shape.** `label()` polymorphic, or strategy-named operators (`pointLabel`, `areaLabel`, …) with `label()` as shorthand? Where do AnnoGram-bundle slots live (slot keys, manual wiring, separate combinator)?
+2. **Default placeable.** Does `bar.label("value")` short-circuit to `text(...)`, or is everything expressed as `bar.label({ place: text("value") })` for consistency? The first is ergonomic; the second is uniform.
+3. **`positions: [...]` priority list.** Is this a `label()` opt, or a generator opt (`generator: compassN({ priority: [...] })`)? More general at the cost of more typing.
+4. **Targeting predicates.** What's the API for "the maximum-value bar" — `select("bars").max("value")` semantic shorthand, or always `select("bars").where(d => d.value === max(data.value))` and let the user write the reduce?
+5. **Pipeline pass shape.** New 4th pass with its own context (cleanest), or fold into render (smaller diff)?
+6. **Coord-transform projection.** Anchors project through `coordinateTransform` (recommended), or placer projects, or screen-space-only labels with explicit projection helpers?
+7. **Area algorithm.** d3-area-label as default + bitmap floodfill as fallback for arbitrary polygons, or pick one and live with it?
+8. **Re-layout feedback.** Hide-on-overflow forever, or one-shot critical-label iteration in Phase 4+?
+9. **Cross-pollination with `text()` mark.** Does the standalone `text` mark (`shapes/text.tsx`) participate in label placement when used as a top-level mark, or is "label" a strict superset (text mark = always at given position; label = collision-aware text placement)?
+10. **What about ordinal-axis labels and legend labels?** They're "text near a thing" too. Do they share the placer infrastructure (uniform but possibly over-engineered) or stay separate (current state)?
+
+---
+
+## 6. Files referenced (gofish)
+
+Current label code (would be touched/refactored):
+
+- `packages/gofish-graphics/src/ast/_node.ts:116-185, 320-346, 385-407, 470-490`
+- `packages/gofish-graphics/src/ast/labels/labelPlacement.ts`
+- `packages/gofish-graphics/src/ast/labels/renderLabel.tsx`
+- `packages/gofish-graphics/src/ast/gofish.tsx:178-181, 263-265`
+- `packages/gofish-graphics/src/ast/marks/chartBuilder.ts:42`
+- `packages/gofish-graphics/src/ast/marks/createOperator.ts:325-349`
+
+Reusable infrastructure:
+
+- `packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx`
+- `packages/gofish-graphics/src/ast/graphicalOperators/arrow.tsx`
+- `packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx`
+- `packages/gofish-graphics/src/ast/graphicalOperators/position.tsx`
+- `packages/gofish-graphics/src/ast/shapes/text.tsx:117-333`
+- `packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx`
+- `packages/gofish-graphics/src/util/bbox.ts`, `util/interval.ts`
+- `packages/gofish-graphics/src/ast/scopeContext.ts`
+
+External:
+
+- vega-label: https://github.com/vega/vega/tree/main/packages/vega-label
+- AnnoGram repo: https://github.com/rahatzamancse/vega-lite-annotation
+- AnnoGram paper: arXiv:2507.04236
+- d3-area-label: https://github.com/curran/d3-area-label
+- Vega-Lite legible-label paper: IEEE arnumber=11298828 (paywalled; couldn't fetch)

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -49,6 +49,7 @@ import {
   type LabelSpec,
 } from "./labels/labelPlacement";
 import { renderLabelJSX } from "./labels/renderLabel";
+import type { LabelKind } from "./labels/strategies/types";
 
 export type RenderSession = {
   scopeContext: ScopeContext;
@@ -138,6 +139,8 @@ export class GoFishNode {
   public constraints: ConstraintSpec[] = [];
   public colorConfig?: ColorConfig;
   public _label?: LabelSpec;
+  /** Default placement-strategy kind for this node's label. */
+  public _labelKind?: LabelKind;
   private _zOrder = 0;
   private renderSession?: RenderSession;
   constructor(
@@ -152,6 +155,7 @@ export class GoFishNode {
       render,
       shared = [false, false],
       color,
+      labelKind,
     }: {
       name?: string;
       key?: string;
@@ -163,6 +167,7 @@ export class GoFishNode {
       render: Render;
       shared?: Size<boolean>;
       color?: MaybeValue<string>;
+      labelKind?: LabelKind;
     },
     children: GoFishAST[]
   ) {
@@ -182,6 +187,7 @@ export class GoFishNode {
     this.args = args;
     this.shared = shared;
     this.color = color;
+    this._labelKind = labelKind;
   }
 
   private collectColorValues(out: any[]): void {
@@ -469,6 +475,11 @@ export class GoFishNode {
 
   public label(accessor: LabelAccessor, options?: LabelOptions): this {
     this._label = { accessor, ...options };
+    return this;
+  }
+
+  public labelKind(kind: LabelKind): this {
+    this._labelKind = kind;
     return this;
   }
 

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -20,6 +20,7 @@ import {
   isSIZE,
   type UnderlyingSpace,
 } from "./underlyingSpace";
+import { placeLabels } from "./labels/placeLabels";
 import { continuous } from "./domain";
 import { interval } from "../util/interval";
 import { path, pathToSVGPath, transformPath } from "../path";
@@ -263,6 +264,11 @@ export async function layout(
   child.layout([w, h], rootScaleFactors, posScales);
   child.place("x", x ?? transform?.x ?? 0, "baseline");
   child.place("y", y ?? transform?.y ?? 0, "baseline");
+
+  // Resolve label placements (post-layout, pre-render). Strategies look up
+  // `_labelKind` per node, gather obstacles globally, and write the resolved
+  // `Placement` into `_label.placement` for the renderer to consume.
+  placeLabels(child);
 
   if (debug) {
     console.log("🌳 Node Tree:");

--- a/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
@@ -39,6 +39,7 @@ export const connect = createNodeOperator(
     return new GoFishNode(
       {
         type: "connect",
+        labelKind: "path",
         shared: [false, false],
         color: fill,
         resolveUnderlyingSpace: (
@@ -296,6 +297,19 @@ export const connect = createNodeOperator(
           const bboxW = bboxPairs.length > 0 ? bboxMaxX - bboxMinX : 0;
           const bboxH = bboxPairs.length > 0 ? bboxMaxY - bboxMinY : 0;
 
+          // Derive label-placement geometry. `polygon` is the largest closed
+          // ring (sampled from beziers) for area-strategy polylabel; `strips`
+          // is a sorted-by-x array of (x, y0, y1) triples for ribbon-strategy
+          // d3-area-label. Both are derived from the same `paths` data and
+          // are populated only when meaningful (mode === "edge" closes each
+          // path; mode === "center" produces open polylines).
+          const labelPolygon =
+            mode === "edge" ? largestPolygon(paths) : undefined;
+          const labelStrips =
+            mode === "edge" && dir === 0
+              ? extractStripsXEdge(paths)
+              : undefined;
+
           return {
             intrinsicDims: [
               {
@@ -312,7 +326,12 @@ export const connect = createNodeOperator(
               },
             ],
             transform: { translate: [0, 0] },
-            renderData: { paths, defaultColor },
+            renderData: {
+              paths,
+              defaultColor,
+              polygon: labelPolygon,
+              strips: labelStrips,
+            },
           };
         },
         render: (
@@ -366,3 +385,112 @@ export const connect = createNodeOperator(
     );
   }
 );
+
+// ─── Label-placement geometry helpers ───────────────────────────────────────
+// Sample a cubic Bezier at parameter t ∈ [0, 1].
+const BEZIER_SAMPLES = 16;
+
+function bezierAt(
+  b: {
+    start: [number, number];
+    control1: [number, number];
+    control2: [number, number];
+    end: [number, number];
+  },
+  t: number
+): [number, number] {
+  const mt = 1 - t;
+  const x =
+    mt * mt * mt * b.start[0] +
+    3 * mt * mt * t * b.control1[0] +
+    3 * mt * t * t * b.control2[0] +
+    t * t * t * b.end[0];
+  const y =
+    mt * mt * mt * b.start[1] +
+    3 * mt * mt * t * b.control1[1] +
+    3 * mt * t * t * b.control2[1] +
+    t * t * t * b.end[1];
+  return [x, y];
+}
+
+function pathToPolygon(path: Path): [number, number][] {
+  const ring: [number, number][] = [];
+  for (const seg of path) {
+    if (seg.type === "line") {
+      if (ring.length === 0) ring.push(seg.points[0]);
+      ring.push(seg.points[1]);
+    } else {
+      if (ring.length === 0) ring.push(seg.start);
+      for (let i = 1; i <= BEZIER_SAMPLES; i++) {
+        ring.push(bezierAt(seg, i / BEZIER_SAMPLES));
+      }
+    }
+  }
+  return ring;
+}
+
+// Approximate signed area as a polygon-size proxy.
+function ringArea(ring: [number, number][]): number {
+  let a = 0;
+  for (let i = 0, n = ring.length; i < n; i++) {
+    const [x0, y0] = ring[i];
+    const [x1, y1] = ring[(i + 1) % n];
+    a += x0 * y1 - x1 * y0;
+  }
+  return Math.abs(a) / 2;
+}
+
+/** For multi-piece connect output, return the single largest closed ring. */
+function largestPolygon(paths: Path[]): [number, number][] | undefined {
+  let best: [number, number][] | undefined;
+  let bestArea = 0;
+  for (const p of paths) {
+    const ring = pathToPolygon(p);
+    if (ring.length < 3) continue;
+    const a = ringArea(ring);
+    if (a > bestArea) {
+      bestArea = a;
+      best = ring;
+    }
+  }
+  return best;
+}
+
+/**
+ * Extract strips for ribbon labeling. Assumes dir=x edge mode where each
+ * path is `[bottomBezier, line, topBezier, line]`. Walks bezier samples in
+ * lockstep so each sample yields a matched (x, y0, y1) triple.
+ */
+function extractStripsXEdge(
+  paths: Path[]
+): { x: number; y0: number; y1: number }[] | undefined {
+  const out: { x: number; y0: number; y1: number }[] = [];
+  for (const path of paths) {
+    if (path.length !== 4) continue;
+    const bottom = path[0];
+    const top = path[2];
+    if (bottom.type !== "bezier" && bottom.type !== "line") continue;
+    if (top.type !== "bezier" && top.type !== "line") continue;
+    for (let i = 0; i <= BEZIER_SAMPLES; i++) {
+      const t = i / BEZIER_SAMPLES;
+      const [bx, by] =
+        bottom.type === "bezier"
+          ? bezierAt(bottom, t)
+          : [
+              bottom.points[0][0] * (1 - t) + bottom.points[1][0] * t,
+              bottom.points[0][1] * (1 - t) + bottom.points[1][1] * t,
+            ];
+      // Top edge runs right→left; sample at (1 - t) so x's match approximately.
+      const [, ty] =
+        top.type === "bezier"
+          ? bezierAt(top, 1 - t)
+          : [
+              top.points[0][0] * t + top.points[1][0] * (1 - t),
+              top.points[0][1] * t + top.points[1][1] * (1 - t),
+            ];
+      out.push({ x: bx, y0: by, y1: ty });
+    }
+  }
+  out.sort((a, b) => a.x - b.x);
+  return out.length >= 2 ? out : undefined;
+}

--- a/packages/gofish-graphics/src/ast/labels/labelPlacement.ts
+++ b/packages/gofish-graphics/src/ast/labels/labelPlacement.ts
@@ -1,4 +1,5 @@
 import { Direction, Size } from "../dims";
+import type { LabelKind, Placement } from "./strategies/types";
 
 export type LabelAccessor<D = any> = string | ((d: D) => string);
 
@@ -9,10 +10,14 @@ export interface LabelOptions {
   offset?: number;
   minSpace?: number;
   rotate?: number;
+  /** Override the default placement-strategy kind for this label. */
+  kind?: LabelKind;
 }
 
 export interface LabelSpec<D = any> extends LabelOptions {
   accessor: LabelAccessor<D>;
+  /** Filled in by the `placeLabels` pipeline pass; consumed by `renderLabel`. */
+  placement?: Placement;
 }
 
 export function resolveLabelText(accessor: LabelAccessor, datum: any): string {

--- a/packages/gofish-graphics/src/ast/labels/obstacles.ts
+++ b/packages/gofish-graphics/src/ast/labels/obstacles.ts
@@ -1,0 +1,103 @@
+import type { GoFishNode } from "../_node";
+import type { Path, PathSegment } from "../../path";
+import type { BBox, Obstacle, ObstacleSet } from "./strategies/types";
+
+/** Walk the post-layout tree and collect screen-space obstacles. */
+export function gatherObstacles(root: GoFishNode): ObstacleSet {
+  const out: ObstacleSet = [];
+  walk(root, [0, 0], out);
+  return out;
+}
+
+function walk(
+  node: GoFishNode,
+  parentTranslate: [number, number],
+  out: ObstacleSet
+): void {
+  const tx = parentTranslate[0] + (node.transform?.translate?.[0] ?? 0);
+  const ty = parentTranslate[1] + (node.transform?.translate?.[1] ?? 0);
+
+  const isLeaf = node.children.length === 0;
+
+  if (isLeaf && node.intrinsicDims && node.type !== "text") {
+    const ix = node.intrinsicDims[0];
+    const iy = node.intrinsicDims[1];
+    if (ix && iy && ix.min !== undefined && iy.min !== undefined) {
+      out.push({
+        kind: "bbox",
+        bbox: {
+          minX: tx + (ix.min ?? 0),
+          minY: ty + (iy.min ?? 0),
+          maxX: tx + (ix.max ?? 0),
+          maxY: ty + (iy.max ?? 0),
+        },
+      });
+    }
+  }
+
+  // Connect nodes carry path data even when they have children (refs).
+  // Emit per-segment AABBs so point labels can avoid the lines.
+  if (node.type === "connect" && node.renderData?.paths) {
+    for (const path of node.renderData.paths as Path[]) {
+      for (const seg of path) {
+        const bb = segmentBBox(seg);
+        if (!bb) continue;
+        out.push({
+          kind: "bbox",
+          bbox: {
+            minX: tx + bb.minX,
+            minY: ty + bb.minY,
+            maxX: tx + bb.maxX,
+            maxY: ty + bb.maxY,
+          },
+        });
+      }
+    }
+  }
+
+  for (const child of node.children) {
+    if ("type" in child && "children" in child) {
+      walk(child as GoFishNode, [tx, ty], out);
+    }
+  }
+}
+
+function segmentBBox(seg: PathSegment): BBox | null {
+  if (seg.type === "line") {
+    const [[x1, y1], [x2, y2]] = seg.points;
+    return {
+      minX: Math.min(x1, x2),
+      minY: Math.min(y1, y2),
+      maxX: Math.max(x1, x2),
+      maxY: Math.max(y1, y2),
+    };
+  }
+  // Approximate bezier bbox via control hull (loose but correct as a superset).
+  const xs = [seg.start[0], seg.control1[0], seg.control2[0], seg.end[0]];
+  const ys = [seg.start[1], seg.control1[1], seg.control2[1], seg.end[1]];
+  return {
+    minX: Math.min(...xs),
+    minY: Math.min(...ys),
+    maxX: Math.max(...xs),
+    maxY: Math.max(...ys),
+  };
+}
+
+export function bboxesOverlap(a: BBox, b: BBox): boolean {
+  return !(
+    a.maxX < b.minX ||
+    b.maxX < a.minX ||
+    a.maxY < b.minY ||
+    b.maxY < a.minY
+  );
+}
+
+export function rectCollidesWithObstacles(
+  rect: BBox,
+  obstacles: ObstacleSet
+): boolean {
+  for (const o of obstacles) {
+    if (o.kind === "bbox" && bboxesOverlap(rect, o.bbox)) return true;
+  }
+  return false;
+}

--- a/packages/gofish-graphics/src/ast/labels/placeLabels.ts
+++ b/packages/gofish-graphics/src/ast/labels/placeLabels.ts
@@ -1,0 +1,88 @@
+import type { GoFishNode } from "../_node";
+import { gatherObstacles, bboxesOverlap } from "./obstacles";
+import { resolveLabelText } from "./labelPlacement";
+import { strategies } from "./strategies/registry";
+import { measureLabelDimensions } from "./strategies/measureText";
+import type { LabelKind, ObstacleSet, Placement } from "./strategies/types";
+
+/**
+ * Pipeline pass between layout and render. Walks the post-layout tree,
+ * resolves a `Placement` for every labeled node based on its `_labelKind`,
+ * and writes the result into `_label.placement` for the renderer to consume.
+ */
+export function placeLabels(root: GoFishNode): void {
+  const obstacles = gatherObstacles(root);
+  walk(root, [0, 0], obstacles);
+}
+
+function walk(
+  node: GoFishNode,
+  parentTranslate: [number, number],
+  obstacles: ObstacleSet
+): void {
+  const tx = parentTranslate[0] + (node.transform?.translate?.[0] ?? 0);
+  const ty = parentTranslate[1] + (node.transform?.translate?.[1] ?? 0);
+
+  for (const child of node.children) {
+    if ("type" in child && "children" in child) {
+      walk(child as GoFishNode, [tx, ty], obstacles);
+    }
+  }
+
+  if (!node._label || node.datum === undefined || !node.intrinsicDims) return;
+  // Per-call override (`label("...", { kind: "path" })`) wins over the node's
+  // default `_labelKind` (set per shape/mark constructor).
+  const kind = (node._label.kind ?? node._labelKind ?? "box") as LabelKind;
+  const labelText = resolveLabelText(node._label.accessor, node.datum);
+  if (!labelText) {
+    node._label.placement = { kind: "hidden" };
+    return;
+  }
+
+  const fontSize = node._label.fontSize ?? 11;
+  const { width: labelWidth, height: labelHeight } = measureLabelDimensions(
+    labelText,
+    fontSize
+  );
+
+  const strategy = strategies[kind];
+  const worldPlacement: Placement = strategy.place(
+    node,
+    obstacles,
+    node._label,
+    {
+      labelText,
+      labelWidth,
+      labelHeight,
+      parentTranslate,
+    }
+  );
+
+  // Strategies return world coords; convert to node-parent-local for the
+  // renderer (which uses `node.transform.translate`-relative coords).
+  let placement = worldPlacement;
+  if (worldPlacement.kind === "transform") {
+    placement = {
+      ...worldPlacement,
+      x: worldPlacement.x - parentTranslate[0],
+      y: worldPlacement.y - parentTranslate[1],
+    };
+  }
+  node._label.placement = placement;
+
+  // Greedy first-fit: append the resolved label rect (in WORLD coords) to the
+  // obstacle set so sibling labels (placed later) avoid this one.
+  if (worldPlacement.kind === "transform") {
+    const halfW = labelWidth / 2;
+    const halfH = labelHeight / 2;
+    obstacles.push({
+      kind: "bbox",
+      bbox: {
+        minX: worldPlacement.x - halfW,
+        minY: worldPlacement.y - halfH,
+        maxX: worldPlacement.x + halfW,
+        maxY: worldPlacement.y + halfH,
+      },
+    });
+  }
+}

--- a/packages/gofish-graphics/src/ast/labels/renderLabel.tsx
+++ b/packages/gofish-graphics/src/ast/labels/renderLabel.tsx
@@ -38,10 +38,8 @@ function resolveNodeFill(node: GoFishNode): string | null {
  * - Inside the shape: contrast against the fill.
  * - Outside the shape: darken the fill for a readable tint on white background.
  */
-function autoLabelColor(node: GoFishNode, position: LabelPosition): string {
+function autoLabelColor(node: GoFishNode, isInside: boolean): string {
   const fill = resolveNodeFill(node);
-  const isInside =
-    position === "center" || (position as string).startsWith("inset");
 
   if (isInside) {
     if (!fill) return "black";
@@ -73,6 +71,81 @@ export function renderLabelJSX(node: GoFishNode): JSX.Element | null {
   const labelText = resolveLabelText(node._label.accessor, datum);
   if (!labelText) return null;
 
+  const placement = node._label.placement;
+
+  // ─── Strategy-resolved placement ──────────────────────────────────────────
+  if (placement) {
+    if (placement.kind === "hidden") return null;
+
+    const fontSize = placement.fontSize ?? node._label.fontSize ?? 11;
+    const fontFamily = "source-sans-pro, sans-serif";
+
+    if (placement.kind === "textPath") {
+      const labelColor =
+        node._label.color ??
+        autoLabelColor(
+          node,
+          /* isInside= */ true /* path labels sit on the line */
+        );
+      // Render path into <defs> so the textPath flows along the same geometry
+      // the connect operator drew. The chart's outer <g> applies scale(1, -1);
+      // we counter-scale on the <text> so the glyphs remain upright.
+      return (
+        <>
+          <defs>
+            <path
+              id={placement.pathId}
+              d={placement.d}
+              fill="none"
+              stroke="none"
+            />
+          </defs>
+          <text
+            transform="scale(1, -1)"
+            fill={labelColor}
+            font-size={`${fontSize}px`}
+            font-family={fontFamily}
+            text-anchor="middle"
+            dominant-baseline="central"
+            pointer-events="none"
+          >
+            <textPath
+              href={`#${placement.pathId}`}
+              startOffset={placement.startOffset}
+            >
+              {labelText}
+            </textPath>
+          </text>
+        </>
+      );
+    }
+
+    // placement.kind === "transform"
+    const isInside = node._labelKind === "area" || node._labelKind === "ribbon";
+    const labelColor = node._label.color ?? autoLabelColor(node, isInside);
+    const rotate = node._label.rotate;
+    const transform = rotate
+      ? `rotate(${-rotate},${placement.x},${placement.y}) scale(1,-1)`
+      : "scale(1,-1)";
+
+    return (
+      <text
+        transform={transform}
+        x={placement.x}
+        y={-placement.y}
+        fill={labelColor}
+        font-size={`${fontSize}px`}
+        font-family={fontFamily}
+        text-anchor={placement.anchor}
+        dominant-baseline={placement.baseline}
+        pointer-events="none"
+      >
+        {labelText}
+      </text>
+    );
+  }
+
+  // ─── Legacy declarative fallback (no strategy resolved) ──────────────────
   const w = node.intrinsicDims[0].size ?? 0;
   const h = node.intrinsicDims[1].size ?? 0;
 
@@ -98,7 +171,9 @@ export function renderLabelJSX(node: GoFishNode): JSX.Element | null {
   const cx = (node.transform?.translate?.[0] ?? 0) + w / 2;
   const cy = (node.transform?.translate?.[1] ?? 0) + h / 2;
 
-  const labelColor = node._label.color ?? autoLabelColor(node, position);
+  const isInside =
+    position === "center" || (position as string).startsWith("inset");
+  const labelColor = node._label.color ?? autoLabelColor(node, isInside);
   const textAnchor = getLabelTextAnchor(position);
 
   const rotate = node._label.rotate;

--- a/packages/gofish-graphics/src/ast/labels/strategies/area.ts
+++ b/packages/gofish-graphics/src/ast/labels/strategies/area.ts
@@ -1,0 +1,209 @@
+import type { LabelStrategy } from "./types";
+
+/**
+ * Area-label placement via Mapbox's polylabel algorithm: find the polygon's
+ * pole of inaccessibility (interior point farthest from any edge).
+ *
+ * Reads `node.renderData.polygon` — a closed ring `[x, y][]` in node-parent-
+ * local coords (the connect operator populates this for area-mode marks).
+ */
+export const areaStrategy: LabelStrategy = {
+  place(node, _obstacles, _label, ctx) {
+    const polygon = node.renderData?.polygon as [number, number][] | undefined;
+    if (!polygon || polygon.length < 3) return { kind: "hidden" };
+
+    const result = polylabel([polygon], 1.0);
+    if (!result) return { kind: "hidden" };
+
+    const [localX, localY] = result;
+    const tx = ctx.parentTranslate[0] + (node.transform?.translate?.[0] ?? 0);
+    const ty = ctx.parentTranslate[1] + (node.transform?.translate?.[1] ?? 0);
+
+    return {
+      kind: "transform",
+      x: tx + localX,
+      y: ty + localY,
+      anchor: "middle",
+      baseline: "central",
+    };
+  },
+};
+
+// ─── polylabel port (Mapbox; ISC-licensed) ──────────────────────────────────
+// Adapted from https://github.com/mapbox/polylabel — pure-math reimplementation
+// without the `tinyqueue` dep (uses an inline max-heap).
+
+type Polygon = [number, number][][]; // outer ring + optional holes
+
+function polylabel(polygon: Polygon, precision = 1.0): [number, number] | null {
+  if (!polygon[0] || polygon[0].length < 3) return null;
+
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
+  for (const [x, y] of polygon[0]) {
+    if (x < minX) minX = x;
+    if (y < minY) minY = y;
+    if (x > maxX) maxX = x;
+    if (y > maxY) maxY = y;
+  }
+
+  const width = maxX - minX;
+  const height = maxY - minY;
+  const cellSize = Math.max(precision, Math.min(width, height));
+  if (cellSize === 0) return [minX, minY];
+  let h = cellSize / 2;
+
+  const heap = new MaxHeap();
+
+  // Initial cover.
+  for (let x = minX; x < maxX; x += cellSize) {
+    for (let y = minY; y < maxY; y += cellSize) {
+      heap.push(new Cell(x + h, y + h, h, polygon));
+    }
+  }
+
+  // First guesses.
+  let bestCell = getCentroidCell(polygon);
+  const bboxCell = new Cell(minX + width / 2, minY + height / 2, 0, polygon);
+  if (bboxCell.d > bestCell.d) bestCell = bboxCell;
+
+  while (heap.length) {
+    const cell = heap.pop()!;
+    if (cell.d > bestCell.d) bestCell = cell;
+    if (cell.max - bestCell.d <= precision) continue;
+    h = cell.h / 2;
+    heap.push(new Cell(cell.x - h, cell.y - h, h, polygon));
+    heap.push(new Cell(cell.x + h, cell.y - h, h, polygon));
+    heap.push(new Cell(cell.x - h, cell.y + h, h, polygon));
+    heap.push(new Cell(cell.x + h, cell.y + h, h, polygon));
+  }
+
+  return [bestCell.x, bestCell.y];
+}
+
+class Cell {
+  x: number;
+  y: number;
+  h: number;
+  d: number;
+  max: number;
+  constructor(x: number, y: number, h: number, polygon: Polygon) {
+    this.x = x;
+    this.y = y;
+    this.h = h;
+    this.d = pointToPolygonDist(x, y, polygon);
+    this.max = this.d + this.h * Math.SQRT2;
+  }
+}
+
+function getCentroidCell(polygon: Polygon): Cell {
+  let area = 0;
+  let cx = 0;
+  let cy = 0;
+  const points = polygon[0];
+  for (let i = 0, len = points.length, j = len - 1; i < len; j = i++) {
+    const a = points[i];
+    const b = points[j];
+    const f = a[0] * b[1] - b[0] * a[1];
+    cx += (a[0] + b[0]) * f;
+    cy += (a[1] + b[1]) * f;
+    area += f * 3;
+  }
+  if (area === 0) return new Cell(points[0][0], points[0][1], 0, polygon);
+  return new Cell(cx / area, cy / area, 0, polygon);
+}
+
+/** Signed distance: positive inside polygon, negative outside. */
+function pointToPolygonDist(x: number, y: number, polygon: Polygon): number {
+  let inside = false;
+  let minDistSq = Infinity;
+  for (const ring of polygon) {
+    for (let i = 0, len = ring.length, j = len - 1; i < len; j = i++) {
+      const a = ring[i];
+      const b = ring[j];
+      if (
+        a[1] > y !== b[1] > y &&
+        x < ((b[0] - a[0]) * (y - a[1])) / (b[1] - a[1]) + a[0]
+      ) {
+        inside = !inside;
+      }
+      minDistSq = Math.min(minDistSq, segDistSq(x, y, a, b));
+    }
+  }
+  const d = Math.sqrt(minDistSq);
+  return minDistSq === 0 ? 0 : (inside ? 1 : -1) * d;
+}
+
+function segDistSq(
+  px: number,
+  py: number,
+  a: [number, number],
+  b: [number, number]
+): number {
+  let x = a[0];
+  let y = a[1];
+  let dx = b[0] - x;
+  let dy = b[1] - y;
+  if (dx !== 0 || dy !== 0) {
+    const t = ((px - x) * dx + (py - y) * dy) / (dx * dx + dy * dy);
+    if (t > 1) {
+      x = b[0];
+      y = b[1];
+    } else if (t > 0) {
+      x += dx * t;
+      y += dy * t;
+    }
+  }
+  dx = px - x;
+  dy = py - y;
+  return dx * dx + dy * dy;
+}
+
+// ─── Inline max-heap on Cell.max ────────────────────────────────────────────
+class MaxHeap {
+  private data: Cell[] = [];
+  get length() {
+    return this.data.length;
+  }
+  push(c: Cell): void {
+    this.data.push(c);
+    this.siftUp(this.data.length - 1);
+  }
+  pop(): Cell | undefined {
+    if (this.data.length === 0) return undefined;
+    const top = this.data[0];
+    const last = this.data.pop()!;
+    if (this.data.length > 0) {
+      this.data[0] = last;
+      this.siftDown(0);
+    }
+    return top;
+  }
+  private siftUp(i: number): void {
+    const item = this.data[i];
+    while (i > 0) {
+      const parent = (i - 1) >> 1;
+      if (this.data[parent].max >= item.max) break;
+      this.data[i] = this.data[parent];
+      i = parent;
+    }
+    this.data[i] = item;
+  }
+  private siftDown(i: number): void {
+    const item = this.data[i];
+    const len = this.data.length;
+    while (true) {
+      const l = 2 * i + 1;
+      const r = 2 * i + 2;
+      let best = i;
+      if (l < len && this.data[l].max > this.data[best].max) best = l;
+      if (r < len && this.data[r].max > this.data[best].max) best = r;
+      if (best === i) break;
+      this.data[i] = this.data[best];
+      i = best;
+    }
+    this.data[i] = item;
+  }
+}

--- a/packages/gofish-graphics/src/ast/labels/strategies/box.ts
+++ b/packages/gofish-graphics/src/ast/labels/strategies/box.ts
@@ -1,0 +1,52 @@
+import {
+  inferLabelPosition,
+  calculateLabelOffset,
+  getLabelTextAnchor,
+  type ShapeInfo,
+} from "../labelPlacement";
+import type { LabelStrategy } from "./types";
+
+/**
+ * Default declarative behavior — preserves the existing `LabelOptions.position`
+ * enum. No collision avoidance.
+ */
+export const boxStrategy: LabelStrategy = {
+  place(node, _obstacles, label, ctx) {
+    const w = node.intrinsicDims![0].size ?? 0;
+    const h = node.intrinsicDims![1].size ?? 0;
+
+    const shapeType = (
+      ["rect", "ellipse", "petal", "line", "area"].includes(node.type)
+        ? node.type
+        : "rect"
+    ) as ShapeInfo["type"];
+
+    const position = inferLabelPosition(
+      { type: shapeType, dimensions: [w, h] },
+      {
+        chartBounds: { width: w, height: h },
+        availableSpace: { top: 20, right: 20, bottom: 20, left: 20 },
+      },
+      { position: label.position, offset: label.offset }
+    );
+
+    const offset = calculateLabelOffset(position, [w, h], {
+      offset: label.offset,
+    });
+    const anchor = getLabelTextAnchor(position);
+
+    // World coords: parentTranslate + nodeTranslate + intrinsic center + offset.
+    const localCenterX = (node.transform?.translate?.[0] ?? 0) + w / 2;
+    const localCenterY = (node.transform?.translate?.[1] ?? 0) + h / 2;
+    const worldX = ctx.parentTranslate[0] + localCenterX + offset.x;
+    const worldY = ctx.parentTranslate[1] + localCenterY + offset.y;
+
+    return {
+      kind: "transform",
+      x: worldX,
+      y: worldY,
+      anchor,
+      baseline: "central",
+    };
+  },
+};

--- a/packages/gofish-graphics/src/ast/labels/strategies/measureText.ts
+++ b/packages/gofish-graphics/src/ast/labels/strategies/measureText.ts
@@ -1,0 +1,40 @@
+/**
+ * Lightweight text measurement for the placer.
+ * Uses an offscreen canvas when available; falls back to a character-count
+ * approximation in non-DOM environments.
+ */
+
+let cachedCtx: CanvasRenderingContext2D | null | undefined;
+
+function getCtx(): CanvasRenderingContext2D | null {
+  if (cachedCtx !== undefined) return cachedCtx;
+  if (typeof document === "undefined") {
+    cachedCtx = null;
+    return null;
+  }
+  const canvas = document.createElement("canvas");
+  cachedCtx = canvas.getContext("2d");
+  return cachedCtx;
+}
+
+export function measureLabelDimensions(
+  text: string,
+  fontSize: number,
+  fontFamily = "source-sans-pro, sans-serif"
+): { width: number; height: number } {
+  const ctx = getCtx();
+  if (ctx) {
+    ctx.font = `${fontSize}px ${fontFamily.split(",")[0].trim()}`;
+    const metrics = ctx.measureText(text);
+    const ascent =
+      (metrics as any).fontBoundingBoxAscent ??
+      (metrics as any).actualBoundingBoxAscent ??
+      fontSize * 0.8;
+    const descent =
+      (metrics as any).fontBoundingBoxDescent ??
+      (metrics as any).actualBoundingBoxDescent ??
+      fontSize * 0.2;
+    return { width: metrics.width, height: ascent + descent };
+  }
+  return { width: text.length * fontSize * 0.6, height: fontSize };
+}

--- a/packages/gofish-graphics/src/ast/labels/strategies/path.ts
+++ b/packages/gofish-graphics/src/ast/labels/strategies/path.ts
@@ -1,0 +1,62 @@
+import type { Path } from "../../../path";
+import { pathToSVGPath } from "../../../path";
+import type { LabelStrategy } from "./types";
+
+let pathIdCounter = 0;
+
+/**
+ * Draws label text along an SVG `<textPath>`. Reads the first rendered path
+ * from `node.renderData.paths` (typically populated by the connect operator).
+ * Renders an inline `<defs><path id={pathId} d={d}/></defs>` so the textPath
+ * is self-contained and doesn't depend on a sibling element id.
+ */
+export const pathStrategy: LabelStrategy = {
+  place(node, _obstacles, label, _ctx) {
+    const paths = node.renderData?.paths as Path[] | undefined;
+    if (!paths || paths.length === 0) return { kind: "hidden" };
+
+    // For multi-pair connect (e.g. line marks with multiple segments), pick
+    // the longest path so the label has the most room.
+    let bestPath: Path | undefined;
+    let bestLen = -Infinity;
+    for (const p of paths) {
+      const len = approxPathLength(p);
+      if (len > bestLen) {
+        bestLen = len;
+        bestPath = p;
+      }
+    }
+    if (!bestPath) return { kind: "hidden" };
+
+    return {
+      kind: "textPath",
+      d: pathToSVGPath(bestPath),
+      pathId: `gofish-label-path-${++pathIdCounter}`,
+      startOffset: (label as any).startOffset ?? "50%",
+      fontSize: label.fontSize,
+    };
+  },
+};
+
+function approxPathLength(path: Path): number {
+  let len = 0;
+  for (const seg of path) {
+    if (seg.type === "line") {
+      const [a, b] = seg.points;
+      len += Math.hypot(b[0] - a[0], b[1] - a[1]);
+    } else {
+      // Cubic bezier: control hull length is a cheap upper bound.
+      len +=
+        Math.hypot(
+          seg.control1[0] - seg.start[0],
+          seg.control1[1] - seg.start[1]
+        ) +
+        Math.hypot(
+          seg.control2[0] - seg.control1[0],
+          seg.control2[1] - seg.control1[1]
+        ) +
+        Math.hypot(seg.end[0] - seg.control2[0], seg.end[1] - seg.control2[1]);
+    }
+  }
+  return len;
+}

--- a/packages/gofish-graphics/src/ast/labels/strategies/point.ts
+++ b/packages/gofish-graphics/src/ast/labels/strategies/point.ts
@@ -1,0 +1,96 @@
+import { rectCollidesWithObstacles } from "../obstacles";
+import type { BBox, LabelStrategy } from "./types";
+
+/**
+ * Vega-label-style compass-8 placement: try 8 anchor positions around the
+ * target's bbox in priority order, return the first that doesn't collide
+ * with the obstacle set.
+ *
+ * Anchors are encoded as (dx, dy) ∈ {-1, 0, 1}². Diagonal anchors get a
+ * `Math.SQRT1_2` factor on the offset to keep the visual distance constant.
+ */
+type Compass = "N" | "S" | "E" | "W" | "NE" | "NW" | "SE" | "SW";
+
+const ANCHOR_VECTORS: Record<Compass, { dx: -1 | 0 | 1; dy: -1 | 0 | 1 }> = {
+  N: { dx: 0, dy: 1 },
+  S: { dx: 0, dy: -1 },
+  E: { dx: 1, dy: 0 },
+  W: { dx: -1, dy: 0 },
+  NE: { dx: 1, dy: 1 },
+  NW: { dx: -1, dy: 1 },
+  SE: { dx: 1, dy: -1 },
+  SW: { dx: -1, dy: -1 },
+};
+
+const DEFAULT_PRIORITY: Compass[] = [
+  "N",
+  "S",
+  "E",
+  "W",
+  "NE",
+  "NW",
+  "SE",
+  "SW",
+];
+
+function dxToAnchor(dx: -1 | 0 | 1): "start" | "middle" | "end" {
+  if (dx < 0) return "end";
+  if (dx > 0) return "start";
+  return "middle";
+}
+
+export const pointStrategy: LabelStrategy = {
+  place(node, obstacles, label, ctx) {
+    const ix = node.intrinsicDims![0];
+    const iy = node.intrinsicDims![1];
+    const w = ix.size ?? 0;
+    const h = iy.size ?? 0;
+
+    // World-space target bbox.
+    const tx = ctx.parentTranslate[0] + (node.transform?.translate?.[0] ?? 0);
+    const ty = ctx.parentTranslate[1] + (node.transform?.translate?.[1] ?? 0);
+    const targetBBox: BBox = {
+      minX: tx + (ix.min ?? 0),
+      minY: ty + (iy.min ?? 0),
+      maxX: tx + (ix.max ?? 0),
+      maxY: ty + (iy.max ?? 0),
+    };
+    const targetCx = (targetBBox.minX + targetBBox.maxX) / 2;
+    const targetCy = (targetBBox.minY + targetBBox.maxY) / 2;
+    const halfW = (targetBBox.maxX - targetBBox.minX) / 2;
+    const halfH = (targetBBox.maxY - targetBBox.minY) / 2;
+
+    const baseOffset = label.offset ?? 6;
+    const priority = (label as any).anchorPriority as Compass[] | undefined;
+    const anchors = priority ?? DEFAULT_PRIORITY;
+
+    const labelHalfW = ctx.labelWidth / 2;
+    const labelHalfH = ctx.labelHeight / 2;
+
+    for (const compass of anchors) {
+      const { dx, dy } = ANCHOR_VECTORS[compass];
+      const isDiag = dx !== 0 && dy !== 0;
+      const offset = baseOffset * (isDiag ? Math.SQRT1_2 : 1);
+
+      const anchorX = targetCx + dx * (halfW + offset + labelHalfW);
+      const anchorY = targetCy + dy * (halfH + offset + labelHalfH);
+
+      const candidate: BBox = {
+        minX: anchorX - labelHalfW,
+        minY: anchorY - labelHalfH,
+        maxX: anchorX + labelHalfW,
+        maxY: anchorY + labelHalfH,
+      };
+      if (!rectCollidesWithObstacles(candidate, obstacles)) {
+        return {
+          kind: "transform",
+          x: anchorX,
+          y: anchorY,
+          anchor: dxToAnchor(dx),
+          baseline: "central",
+        };
+      }
+    }
+    return { kind: "hidden" };
+  },
+};

--- a/packages/gofish-graphics/src/ast/labels/strategies/registry.ts
+++ b/packages/gofish-graphics/src/ast/labels/strategies/registry.ts
@@ -1,0 +1,14 @@
+import type { LabelKind, LabelStrategy } from "./types";
+import { boxStrategy } from "./box";
+import { pointStrategy } from "./point";
+import { areaStrategy } from "./area";
+import { ribbonStrategy } from "./ribbon";
+import { pathStrategy } from "./path";
+
+export const strategies: Record<LabelKind, LabelStrategy> = {
+  box: boxStrategy,
+  point: pointStrategy,
+  area: areaStrategy,
+  ribbon: ribbonStrategy,
+  path: pathStrategy,
+};

--- a/packages/gofish-graphics/src/ast/labels/strategies/ribbon.ts
+++ b/packages/gofish-graphics/src/ast/labels/strategies/ribbon.ts
@@ -1,0 +1,128 @@
+import type { LabelStrategy } from "./types";
+
+export type Strip = { x: number; y0: number; y1: number };
+
+/**
+ * d3-area-label-style placement: bisection-find the largest rectangle of the
+ * label's aspect ratio that fits entirely inside the strip-defined area.
+ *
+ * Reads `node.renderData.strips` — sorted-by-x array of `{x, y0, y1}`
+ * populated by the connect operator for area-mode marks.
+ *
+ * Adapted from https://github.com/curran/d3-area-label (Apache 2.0). The d3
+ * dependencies (`d3-array.bisector` / `d3-scale.scaleLinear`) are replaced
+ * with vanilla equivalents. Returns world-space center plus a font-size
+ * scale relative to the input `labelHeight`.
+ */
+export const ribbonStrategy: LabelStrategy = {
+  place(node, _obstacles, label, ctx) {
+    const strips = node.renderData?.strips as Strip[] | undefined;
+    if (!strips || strips.length < 2) return { kind: "hidden" };
+    if (ctx.labelHeight <= 0 || ctx.labelWidth <= 0) return { kind: "hidden" };
+
+    const aspectRatio = ctx.labelWidth / ctx.labelHeight;
+
+    // Densify strips to a fixed resolution so sparse data still gets a smooth
+    // interior search. Linear interpolation between provided strips.
+    const dense = densifyStrips(strips, 400);
+
+    const xMin = dense[0].x;
+    const xMax = dense[dense.length - 1].x;
+    if (xMax <= xMin) return { kind: "hidden" };
+
+    // Clamp the scan range so the rect we want never exceeds the strip bounds.
+    let lo = 0;
+    let hi = Math.max(...dense.map((s) => s.y1 - s.y0));
+    if (hi <= 0) return { kind: "hidden" };
+
+    let best: { x: number; y: number; h: number } | null = null;
+    const epsilon = 0.5;
+    const maxIterations = 30;
+    for (let i = 0; i < maxIterations && hi - lo > epsilon; i++) {
+      const h = (lo + hi) / 2;
+      const fit = tryFit(dense, h, aspectRatio);
+      if (fit) {
+        best = fit;
+        lo = h;
+      } else {
+        hi = h;
+      }
+    }
+    if (!best) return { kind: "hidden" };
+
+    const tx = ctx.parentTranslate[0] + (node.transform?.translate?.[0] ?? 0);
+    const ty = ctx.parentTranslate[1] + (node.transform?.translate?.[1] ?? 0);
+
+    // Scale font size to the fitted height so the label fills the strip.
+    const labelFontSize = label.fontSize ?? 11;
+    const scale = best.h / ctx.labelHeight;
+
+    return {
+      kind: "transform",
+      x: tx + best.x,
+      y: ty + best.y,
+      anchor: "middle",
+      baseline: "central",
+      fontSize: labelFontSize * scale,
+    };
+  },
+};
+
+function densifyStrips(strips: Strip[], n: number): Strip[] {
+  const sorted = [...strips].sort((a, b) => a.x - b.x);
+  const xMin = sorted[0].x;
+  const xMax = sorted[sorted.length - 1].x;
+  if (xMax === xMin) return sorted;
+  const out: Strip[] = [];
+  for (let i = 0; i < n; i++) {
+    const x = xMin + ((xMax - xMin) * i) / (n - 1);
+    // Find the bracketing pair via linear scan (fine for ≤ a few hundred strips).
+    let j = 0;
+    while (j < sorted.length - 1 && sorted[j + 1].x < x) j++;
+    const a = sorted[j];
+    const b = sorted[Math.min(j + 1, sorted.length - 1)];
+    const t = b.x === a.x ? 0 : (x - a.x) / (b.x - a.x);
+    out.push({
+      x,
+      y0: a.y0 + (b.y0 - a.y0) * t,
+      y1: a.y1 + (b.y1 - a.y1) * t,
+    });
+  }
+  return out;
+}
+
+function tryFit(
+  dense: Strip[],
+  h: number,
+  aspectRatio: number
+): { x: number; y: number; h: number } | null {
+  const w = h * aspectRatio;
+  const xMin = dense[0].x;
+  const xMax = dense[dense.length - 1].x;
+  if (w > xMax - xMin) return null;
+
+  // For each x_left candidate (every dense sample), check that the rect
+  // [x_left, x_left + w] × [center_y - h/2, center_y + h/2] fits inside the
+  // strip envelope. We need min(y1) - max(y0) over [x_left, x_left + w] >= h.
+  for (let i = 0; i < dense.length; i++) {
+    const xLeft = dense[i].x;
+    const xRight = xLeft + w;
+    if (xRight > xMax) break;
+    let maxY0 = -Infinity;
+    let minY1 = Infinity;
+    for (let j = i; j < dense.length; j++) {
+      const s = dense[j];
+      if (s.x > xRight) break;
+      if (s.y0 > maxY0) maxY0 = s.y0;
+      if (s.y1 < minY1) minY1 = s.y1;
+    }
+    const clearance = minY1 - maxY0;
+    if (clearance >= h) {
+      // Center the rect vertically in the available clearance.
+      const centerY = (maxY0 + minY1) / 2;
+      const centerX = xLeft + w / 2;
+      return { x: centerX, y: centerY, h };
+    }
+  }
+  return null;
+}

--- a/packages/gofish-graphics/src/ast/labels/strategies/types.ts
+++ b/packages/gofish-graphics/src/ast/labels/strategies/types.ts
@@ -1,0 +1,64 @@
+import type { GoFishNode } from "../../_node";
+import type { LabelSpec } from "../labelPlacement";
+
+export type LabelKind = "box" | "point" | "area" | "ribbon" | "path";
+
+export type BBox = { minX: number; minY: number; maxX: number; maxY: number };
+
+/**
+ * A resolved label placement, written into `_label.placement` by the
+ * `placeLabels` pass and consumed by `renderLabelJSX`.
+ *
+ * - "transform": absolute screen-space (x, y) plus SVG anchor + baseline.
+ * - "textPath": text drawn along the SVG path with the given `d` attribute.
+ *   The renderer emits an inline `<defs><path id={pathId} d={d}/></defs>`.
+ * - "hidden": the strategy declined to place; renderer should emit nothing.
+ */
+export type Placement =
+  | {
+      kind: "transform";
+      x: number;
+      y: number;
+      anchor: "start" | "middle" | "end";
+      baseline: "auto" | "central" | "hanging" | "mathematical";
+      fontSize?: number;
+    }
+  | {
+      kind: "textPath";
+      d: string;
+      pathId: string;
+      startOffset: string;
+      fontSize?: number;
+    }
+  | { kind: "hidden" };
+
+export type Obstacle =
+  | { kind: "bbox"; bbox: BBox }
+  | { kind: "segment"; from: [number, number]; to: [number, number] };
+
+export type ObstacleSet = Obstacle[];
+
+export type LabelStrategyContext = {
+  /** The text to render. Pre-resolved from `_label.accessor` and `node.datum`. */
+  labelText: string;
+  /** Pre-measured label dimensions (in screen px). */
+  labelWidth: number;
+  labelHeight: number;
+  /**
+   * Accumulated translate from the root to this node's parent (world coords).
+   * Strategies work in world coords (obstacles are world-coord); the
+   * `placeLabels` walker subtracts this from the strategy's returned `x`/`y`
+   * before storing, so the renderer (which uses `node.transform.translate`,
+   * i.e. node-parent-local) consumes the placement directly.
+   */
+  parentTranslate: [number, number];
+};
+
+export interface LabelStrategy {
+  place(
+    node: GoFishNode,
+    obstacles: ObstacleSet,
+    label: LabelSpec,
+    ctx: LabelStrategyContext
+  ): Placement;
+}

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -128,6 +128,8 @@ export function circle<T extends Record<string, any>>({
       strokeWidth,
       label,
     }).name(key?.toString() ?? "");
+    // Circles are data points, so override the underlying Ellipse default ("box").
+    node._labelKind = "point";
     (node as any).datum = d;
     return node;
   };
@@ -146,8 +148,14 @@ export function line<T extends Record<string, any>>(options?: {
   strokeWidth?: number;
   opacity?: number;
   interpolation?: "linear" | "bezier";
-}): Mark<Array<T & { __ref?: GoFishNode }>> {
-  return async (
+}): Mark<Array<T & { __ref?: GoFishNode }>> & {
+  name(layerName: string): Mark<Array<T & { __ref?: GoFishNode }>>;
+  label(
+    accessor: LabelAccessor,
+    options?: LabelOptions
+  ): Mark<Array<T & { __ref?: GoFishNode }>>;
+} {
+  const base: Mark<Array<T & { __ref?: GoFishNode }>> = async (
     d: Array<T & { __ref?: GoFishNode }>,
     key?: string | number,
     _layerContext?: LayerContext
@@ -160,7 +168,7 @@ export function line<T extends Record<string, any>>(options?: {
       throw new Error("line mark expected __ref on items");
     });
 
-    return Connect(
+    const node = await Connect(
       {
         direction: 0, // x direction
         mode: "center",
@@ -171,7 +179,10 @@ export function line<T extends Record<string, any>>(options?: {
       },
       refs
     );
+    (node as any).datum = d;
+    return node;
   };
+  return nameableMark(base);
 }
 
 // area() mark connects data points using edge-to-edge mode
@@ -182,8 +193,14 @@ export function area<T extends Record<string, any>>(options?: {
   mixBlendMode?: "normal" | "multiply";
   dir?: "x" | "y";
   interpolation?: "linear" | "bezier";
-}): Mark<Array<T & { __ref?: GoFishNode }>> {
-  return async (
+}): Mark<Array<T & { __ref?: GoFishNode }>> & {
+  name(layerName: string): Mark<Array<T & { __ref?: GoFishNode }>>;
+  label(
+    accessor: LabelAccessor,
+    options?: LabelOptions
+  ): Mark<Array<T & { __ref?: GoFishNode }>>;
+} {
+  const base: Mark<Array<T & { __ref?: GoFishNode }>> = async (
     d: Array<T & { __ref?: GoFishNode }>,
     key?: string | number,
     _layerContext?: LayerContext
@@ -196,7 +213,7 @@ export function area<T extends Record<string, any>>(options?: {
       throw new Error("area mark expected __ref on items");
     });
 
-    return Connect(
+    const node = await Connect(
       {
         direction: options?.dir ?? "x",
         mode: "edge",
@@ -208,7 +225,12 @@ export function area<T extends Record<string, any>>(options?: {
       },
       refs
     );
+    // Override the connect node's default labelKind ("path") for area marks.
+    node._labelKind = "area";
+    (node as any).datum = d;
+    return node;
   };
+  return nameableMark(base);
 }
 
 // blank() mark creates invisible guides for positioning

--- a/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
@@ -61,6 +61,7 @@ export const Ellipse = ({
     {
       name,
       type: "ellipse",
+      labelKind: "box",
       color: fill,
       resolveUnderlyingSpace: (
         _children: Size<UnderlyingSpace>[],

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -234,6 +234,7 @@ export const Image = ({
       name,
       key,
       type: "image",
+      labelKind: "box",
       args: {
         key,
         name,

--- a/packages/gofish-graphics/src/ast/shapes/petal.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/petal.tsx
@@ -52,6 +52,7 @@ export const Petal = ({
     {
       name,
       type: "petal",
+      labelKind: "box",
       // inferDomains: () => {
       //   return [
       //     isValue(dims[0].size)

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -81,6 +81,7 @@ export const Rect = ({
       name,
       key,
       type: "rect",
+      labelKind: "box",
       args: {
         key,
         name,

--- a/packages/gofish-graphics/stories/forwardsyntax/LabelKinds.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/LabelKinds.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import { seafood, catchLocationsArray } from "../../src/data/catch";
+import { streamgraphData } from "../../src/data/streamgraphData";
+import {
+  Chart,
+  spread,
+  stack,
+  layer,
+  select,
+  rect,
+  circle,
+  line,
+  area,
+  blank,
+  group,
+  scatter,
+} from "../../src/lib";
+
+const meta: Meta = {
+  title: "Forward Syntax V3/Label Kinds (Prototype)",
+  argTypes: {
+    w: { control: { type: "number", min: 200, max: 1000, step: 10 } },
+    h: { control: { type: "number", min: 200, max: 1000, step: 10 } },
+  },
+};
+export default meta;
+
+type Args = { w: number; h: number };
+
+// ─── box ──────────────────────────────────────────────────────────────────────
+// Regression: bars with `.label("count")`. Falls through to the existing
+// declarative behavior — no obstacle-aware placement.
+
+export const Box: StoryObj<Args> = {
+  name: "box: bar chart (regression)",
+  args: { w: 500, h: 300 },
+  render: (args) => {
+    const container = initializeContainer();
+    Chart(seafood)
+      .flow(spread({ by: "lake", dir: "x" }))
+      .mark(rect({ h: "count" }).label("count"))
+      .render(container, { w: args.w, h: args.h, axes: true });
+    return container;
+  },
+};
+
+// ─── point ────────────────────────────────────────────────────────────────────
+// Connected scatterplot: circles labeled with lake name. Vega-label compass-8
+// placement should keep labels off both other points AND the connecting line
+// segments (path-avoidance falls out of the obstacle gatherer emitting per-
+// segment AABBs for the connect node).
+
+export const Point: StoryObj<Args> = {
+  name: "point: connected scatterplot with path avoidance",
+  args: { w: 600, h: 400 },
+  render: (args) => {
+    const container = initializeContainer();
+    layer([
+      Chart(catchLocationsArray)
+        .flow(scatter({ by: "lake", x: "x", y: "y" }))
+        .mark(circle({ r: 8 }).name("points").label("lake")),
+      Chart(select("points")).mark(line({ stroke: "#999", strokeWidth: 1 })),
+    ]).render(container, { w: args.w, h: args.h, axes: true });
+    return container;
+  },
+};
+
+// ─── path ─────────────────────────────────────────────────────────────────────
+// Line chart with text drawn along the curve via SVG <textPath>.
+
+export const Path: StoryObj<Args> = {
+  name: "path: text along the curve",
+  args: { w: 600, h: 400 },
+  render: (args) => {
+    const container = initializeContainer();
+    layer([
+      Chart(catchLocationsArray)
+        .flow(scatter({ by: "lake", x: "x", y: "y" }))
+        .mark(blank().name("points")),
+      Chart(select("points")).mark(
+        line({ stroke: "#4f46e5", strokeWidth: 2 }).label(
+          () => "the trip across all lakes",
+          { fontSize: 14 }
+        )
+      ),
+    ]).render(container, { w: args.w, h: args.h, axes: true });
+    return container;
+  },
+};
+
+// ─── area ─────────────────────────────────────────────────────────────────────
+// Single filled area, labeled at its polylabel (pole of inaccessibility).
+
+export const Area: StoryObj<Args> = {
+  name: "area: polylabel placement",
+  args: { w: 600, h: 400 },
+  render: (args) => {
+    const seriesZero = streamgraphData.filter((d) => d.c === 0);
+    const container = initializeContainer();
+    layer([
+      Chart(seriesZero)
+        .flow(spread({ by: "x", dir: "x", spacing: 50 }))
+        .mark(blank({ h: "y" }).name("pts")),
+      Chart(select("pts")).mark(
+        area({ opacity: 0.7 }).label(() => "series 0", { fontSize: 18 })
+      ),
+    ]).render(container, { w: args.w, h: args.h, axes: true });
+    return container;
+  },
+};
+
+// ─── ribbon ───────────────────────────────────────────────────────────────────
+// Stacked area, one label per ribbon via d3-area-label.
+
+export const Ribbon: StoryObj<Args> = {
+  name: "ribbon: d3-area-label per stack",
+  args: { w: 600, h: 400 },
+  render: (args) => {
+    const container = initializeContainer();
+    layer([
+      Chart(streamgraphData)
+        .flow(
+          group({ by: "c" }),
+          spread({ by: "x", dir: "x", spacing: 50 }),
+          stack({ by: "c", dir: "y" })
+        )
+        .mark(blank({ h: "y", fill: "c" }).name("bars")),
+      Chart(select("bars"))
+        .flow(group({ by: "c" }))
+        .mark(area({ opacity: 0.8 }).label("c", { kind: "ribbon" })),
+    ]).render(container, { w: args.w, h: args.h, axes: true });
+    return container;
+  },
+};
+
+// ─── override ─────────────────────────────────────────────────────────────────
+// Same data rendered three times with the same `area` mark, but the per-call
+// `.label("...", { kind })` overrides the default strategy. Demonstrates that
+// `kind` is data-independent — it's a placement choice.
+
+export const Override: StoryObj<Args> = {
+  name: "override: area / ribbon / path on the same shape",
+  args: { w: 900, h: 320 },
+  render: (args) => {
+    const container = initializeContainer();
+    const seriesZero = streamgraphData.filter((d) => d.c === 0);
+    const w = Math.floor(args.w / 3);
+    for (const kind of ["area", "ribbon", "path"] as const) {
+      const cell = document.createElement("div");
+      cell.style.display = "inline-block";
+      cell.style.verticalAlign = "top";
+      cell.style.padding = "4px";
+      const title = document.createElement("div");
+      title.textContent = `kind: "${kind}"`;
+      title.style.font = "12px monospace";
+      title.style.padding = "4px 0";
+      cell.appendChild(title);
+      const inner = document.createElement("div");
+      cell.appendChild(inner);
+      container.appendChild(cell);
+      layer([
+        Chart(seriesZero)
+          .flow(spread({ by: "x", dir: "x", spacing: 24 }))
+          .mark(blank({ h: "y" }).name("pts")),
+        Chart(select("pts")).mark(
+          area({ opacity: 0.7 }).label(() => "series 0", {
+            kind,
+            fontSize: 14,
+          })
+        ),
+      ]).render(inner, { w, h: args.h - 30, axes: false });
+    }
+    return container;
+  },
+};


### PR DESCRIPTION
## Summary

Adds `notes/labels-design.md` — a research / design-space writeup for a more expressive label library. Companion to the existing `notes/label-syntax.md` brainstorm.

- Surveys vega-label, AnnoGram (arXiv:2507.04236), and d3-area-label.
- Maps the current GoFish label surface (`_node.ts`, `labels/`, `gofish.tsx`) and where collision avoidance is missing.
- Lays out the design as three independent axes — **anchor / generator / acceptor** — with a strategy table for point / line / area / ribbon labels.
- Sketches three API alternatives (polymorphic `label()`, type-named operators, strategy factory) and three pipeline-integration options.
- Ends with 10 open questions for iteration before committing to a plan.

Draft because the doc is for design discussion, not an implementation commit.

## Update — prototype implementation (2d402f8d)

Now also lands a working first cut of the design as a follow-up commit, so the same PR carries the design and a runnable reference implementation to play with. Implementation lives behind a `kind` opt and per-shape default; existing label call-sites are unaffected.

- New pipeline pass `placeLabels` between layout/place and render. Walks the tree, gathers obstacles globally (incl. per-segment AABBs from connect for path-avoidance), then resolves a `Placement` per labeled node.
- Five strategies under `src/ast/labels/strategies/`:
  - `box` — wraps existing declarative behavior, no collision avoidance.
  - `point` — vega-label-style compass-8 first-fit AABB (greedy obstacle accumulation).
  - `area` — polylabel (Mapbox; ISC) port — pole of inaccessibility, inline binary heap, no `tinyqueue` dep.
  - `ribbon` — d3-area-label (Apache 2.0) port — bisection-find largest aspect-ratio rectangle in `(x, y0, y1)` strips; vanilla utilities replace d3-array/d3-scale.
  - `path` — SVG `<textPath>` with self-contained `<defs><path/></defs>`.
- AST: `_labelKind` on `GoFishNode` + chainable `.labelKind()` + `LabelOptions.kind` per-call override.
- Shape/mark defaults: Rect/Ellipse/Petal/Image → `box`; Connect → `path`; v3 `circle` → `point`, v3 `area` → `area`.
- Connect operator records `polygon` and `strips` on `renderData` so the area/ribbon strategies don't have to re-derive geometry.
- v3 `line` and `area` marks are now wrapped with `nameableMark` so `.label(...)` works uniformly with circle and rect.

Six new stories under `stories/forwardsyntax/LabelKinds.stories.tsx` exercise each strategy plus a side-by-side override comparison.

## Test plan

- [ ] Read `notes/labels-design.md` for clarity and accuracy of GoFish file:line citations
- [ ] Confirm/redirect on the open questions in §5
- [ ] `pnpm storybook` and look at the **Forward Syntax V3 / Label Kinds (Prototype)** stories — visually verify each strategy. The prototype is intentionally bounded; many open questions in §5 of the design doc remain open.
- [ ] Sanity-check the existing `Forward Syntax V3 / Labels` stories haven't regressed (legacy declarative path is preserved as a fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)