### PR TITLE
fix(gofish-python): trait-based derive RPC for marimo + jupyter

### DIFF
--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -318,6 +318,17 @@ class ChartBuilder:
 
         return widget
 
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        """Auto-display in notebooks.
+
+        When a ChartBuilder is the last expression in a Jupyter / marimo
+        cell, the runtime calls this and inlines the widget's mimebundle.
+        Use ``.render(w=..., h=...)`` for explicit sizing.
+        """
+        if self._mark is None:
+            raise ValueError("Chart must have a mark before display")
+        return self.render()._repr_mimebundle_(include=include, exclude=exclude)
+
 
 # Operator factory functions
 
@@ -880,6 +891,10 @@ class LayerBuilder:
             debug=debug,
         )
         return widget
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        """Auto-display in notebooks (see ChartBuilder._repr_mimebundle_)."""
+        return self.render()._repr_mimebundle_(include=include, exclude=exclude)
 
 
 def Layer(

--- a/packages/gofish-python/gofish/widget.py
+++ b/packages/gofish-python/gofish/widget.py
@@ -1,9 +1,16 @@
-"""AnyWidget-based chart rendering for GoFish."""
+"""AnyWidget-based chart rendering for GoFish.
+
+Uses the Altair / Plotly trait protocol: synced traitlets + observer
+handlers, no `experimental.invoke` / `@command`. JS reads the chart spec
+and data on mount; for `derive` operators it round-trips through the
+`derive_request` / `derive_response` trait pair, which works identically
+in Jupyter and marimo.
+"""
 
 import base64
 import uuid
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import anywidget
 import traitlets
@@ -14,18 +21,26 @@ from .arrow_utils import arrow_to_dataframe, dataframe_to_arrow
 class GoFishChartWidget(anywidget.AnyWidget):
     """Widget for rendering GoFish charts from JSON specifications."""
 
-    # Traitlets for chart configuration
+    # Spec + data: set once in __init__, read by JS on mount.
     spec = traitlets.Dict().tag(sync=True)
-    arrow_data = traitlets.Unicode().tag(sync=True)  # Base64-encoded Arrow data
-    derive_functions = traitlets.Dict().tag(sync=False)  # Python-only registry
+    arrow_data = traitlets.Unicode().tag(sync=True)  # base64 Arrow IPC bytes
     width = traitlets.Int(800).tag(sync=True)
     height = traitlets.Int(600).tag(sync=True)
     axes = traitlets.Bool(False).tag(sync=True)
     debug = traitlets.Bool(False).tag(sync=True)
     container_id = traitlets.Unicode().tag(sync=True)
-    # Traitlet-based derive protocol (for marimo compatibility)
-    derive_request = traitlets.Dict({}).tag(sync=True)
-    derive_response = traitlets.Dict({}).tag(sync=True)
+
+    # Derive RPC: JS posts a request, Python's observer handles it and
+    # writes the response. Sequential — at most one in-flight per widget.
+    derive_request = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
+    derive_response = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
+
+    # Terminal status from the JS side: {value: True} on success or
+    # {error: str} on failure. Powers .result/.error/.done.
+    render_result = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
+
+    # Python-only registry: lambda_id -> callable. Never synced.
+    derive_functions = traitlets.Dict().tag(sync=False)
 
     def __init__(
         self,
@@ -38,45 +53,17 @@ class GoFishChartWidget(anywidget.AnyWidget):
         debug: bool = False,
         **kwargs,
     ):
-        """Initialize the GoFish chart widget.
-
-        Args:
-            spec: Chart specification (operators, mark, options)
-            arrow_data: Initial data as Arrow bytes
-            width: Chart width
-            height: Chart height
-            axes: Whether to show axes
-            debug: Whether to enable debug mode
-            derive_functions: Map of lambda_id -> Python callable for derive
-            **kwargs: Additional widget arguments
-        """
-        # Generate unique container ID
         container_id = f"gofish-chart-{uuid.uuid4().hex[:8]}"
 
-        # Store derive registry locally (not synced to the frontend)
-        self.derive_functions = derive_functions or {}
-
-        # Load the self-contained widget bundle
-        # The bundle includes all dependencies (gofish-graphics, solid-js, apache-arrow)
-        # and requires no network access or import maps
         bundle_path = Path(__file__).parent / "_static" / "widget.esm.js"
-
         if not bundle_path.exists():
             raise FileNotFoundError(
                 f"Widget bundle not found at {bundle_path}.\n"
-                f"This package requires the widget bundle to be built and included in the package.\n"
-                f"Please build the widget bundle:\n"
-                f"  cd packages/gofish-python-2 && pnpm build:widget\n"
-                f"Or ensure the bundle exists at: {bundle_path}\n"
-                f"If installing from PyPI, this should be included automatically. "
-                f"If installing from source, ensure the build step runs."
+                f"Build it with:  pnpm --filter gofish-python build:widget\n"
+                f"If installing from PyPI, this should be included automatically."
             )
+        esm_code = bundle_path.read_text(encoding="utf-8")
 
-        # Load the bundled ESM code
-        with open(bundle_path, "r", encoding="utf-8") as f:
-            esm_code = f.read()
-
-        # Encode Arrow data as base64 for transmission to JS
         arrow_data_b64 = base64.b64encode(arrow_data).decode("utf-8")
 
         super().__init__(
@@ -88,91 +75,67 @@ class GoFishChartWidget(anywidget.AnyWidget):
             axes=axes,
             debug=debug,
             container_id=container_id,
+            derive_functions=derive_functions or {},
             **kwargs,
         )
 
-    @anywidget.experimental.command
-    def _execute_derive(self, msg: dict, buffers: list):
-        """Execute a derive function and return Arrow data as base64.
-
-        Args:
-            msg: Message containing lambdaId and arrowB64
-            buffers: Optional buffers (not used for derive)
-
-        Returns:
-            Tuple of (response dict, buffers list)
-        """
-        lambda_id = msg.get("lambdaId")
-        arrow_b64 = msg.get("arrowB64")
-
-        if not lambda_id or not arrow_b64:
-            raise ValueError(f"Missing required fields: lambdaId and arrowB64")
-
-        # Locate Python function for this lambda_id
-        fn = self.derive_functions.get(lambda_id)
-        if fn is None:
-            raise ValueError(f"Derive function with ID {lambda_id} not found")
-
-        # Decode Arrow to list of row dicts
-        arrow_bytes = base64.b64decode(arrow_b64)
-        df = arrow_to_dataframe(arrow_bytes)
-
-        # Execute user function (receives list of dicts, matching JS convention)
-        result = fn(df.to_dict("records"))
-
-        # Normalize result to DataFrame
-        try:
-            import pandas as pd
-        except Exception as exc:  # pragma: no cover - import guard
-            raise RuntimeError("pandas is required for derive execution") from exc
-
-        if result is None:
-            result_df = pd.DataFrame()
-        elif isinstance(result, pd.DataFrame):
-            result_df = result
-        else:
-            result_df = pd.DataFrame(result)
-
-        # Encode result back to Arrow base64
-        result_arrow = dataframe_to_arrow(result_df)
-        result_b64 = base64.b64encode(result_arrow).decode("utf-8")
-
-        return {"resultB64": result_b64}, buffers
-
     @traitlets.observe("derive_request")
     def _on_derive_request(self, change):
-        """Handle derive requests via traitlet sync (for marimo compatibility)."""
+        """Run a Python derive callback and publish the result.
+
+        JS sets ``derive_request = {request_id, lambda_id, arrow_b64}``.
+        We look up the registered function, run it on the decoded data,
+        and publish ``derive_response = {request_id, result_b64}``.
+        Errors are surfaced via ``derive_response = {request_id, error}``
+        so the JS bridge can reject the awaiting promise.
+        """
         msg = change["new"]
         if not msg:
             return
-        request_id = msg.get("requestId")
-        lambda_id = msg.get("lambdaId")
-        arrow_b64 = msg.get("arrowB64")
-
+        request_id = msg.get("request_id")
+        lambda_id = msg.get("lambda_id")
+        arrow_b64 = msg.get("arrow_b64")
         if not request_id or not lambda_id or not arrow_b64:
             return
 
-        fn = self.derive_functions.get(lambda_id)
-        if fn is None:
-            return
-
-        arrow_bytes = base64.b64decode(arrow_b64)
-        df = arrow_to_dataframe(arrow_bytes)
-        result = fn(df.to_dict("records"))
-
         try:
-            import pandas as pd
-        except Exception as exc:  # pragma: no cover - import guard
-            raise RuntimeError("pandas is required for derive execution") from exc
+            fn = self.derive_functions.get(lambda_id)
+            if fn is None:
+                raise ValueError(f"Derive function with ID {lambda_id} not found")
 
-        if result is None:
-            result_df = pd.DataFrame()
-        elif isinstance(result, pd.DataFrame):
-            result_df = result
-        else:
-            result_df = pd.DataFrame(result)
+            df = arrow_to_dataframe(base64.b64decode(arrow_b64))
+            result = fn(df.to_dict("records"))
 
-        result_arrow = dataframe_to_arrow(result_df)
-        result_b64 = base64.b64encode(result_arrow).decode("utf-8")
+            try:
+                import pandas as pd
+            except Exception as exc:  # pragma: no cover
+                raise RuntimeError("pandas is required for derive execution") from exc
 
-        self.derive_response = {"requestId": request_id, "resultB64": result_b64}
+            if result is None:
+                result_df = pd.DataFrame()
+            elif isinstance(result, pd.DataFrame):
+                result_df = result
+            else:
+                result_df = pd.DataFrame(result)
+
+            result_b64 = base64.b64encode(dataframe_to_arrow(result_df)).decode("utf-8")
+            self.derive_response = {"request_id": request_id, "result_b64": result_b64}
+        except Exception as exc:
+            self.derive_response = {"request_id": request_id, "error": str(exc)}
+
+    @property
+    def result(self) -> bool:
+        """True once the JS side has reported a successful render."""
+        res = self.render_result
+        return bool(res and "value" in res)
+
+    @property
+    def error(self) -> Optional[str]:
+        """Error string from the JS side, or None if there was none."""
+        res = self.render_result
+        return res.get("error") if res else None
+
+    @property
+    def done(self) -> bool:
+        """True once the JS side has reported a terminal status."""
+        return self.render_result is not None

--- a/packages/gofish-python/notes/implementation.md
+++ b/packages/gofish-python/notes/implementation.md
@@ -25,10 +25,10 @@ graph TB
     IR -->|"Serialization:<br/>• JSON IR (spec)<br/>• Apache Arrow (data)<br/>• base64 encoding"| Widget
 
     subgraph AnyWidget["AnyWidget Bridge"]
-        Widget[GoFishChartWidget<br/>widget.py<br/><br/>• Traitlets for sync<br/>• Derive function registry<br/>• _execute_derive command]
+        Widget[GoFishChartWidget<br/>widget.py<br/><br/>• Traitlets for sync<br/>• Derive function registry<br/>• @observe(derive_request)]
     end
 
-    Widget -->|"Transport:<br/>• spec (JSON)<br/>• arrow_data (base64)<br/>• RPC via experimental.invoke()"| JS
+    Widget -->|"Transport:<br/>• spec (JSON)<br/>• arrow_data (base64)<br/>• Derive RPC via synced traits"| JS
 
     subgraph Browser["JavaScript Layer (Browser)"]
         JS[Widget Bundle<br/>widget.esm.js]
@@ -193,11 +193,25 @@ Inherits from `anywidget.AnyWidget` to provide seamless Jupyter integration.
 
 **Traitlets (State Management)**
 
-- `spec` (Dict, synced) - Chart specification JSON
-- `arrow_data` (Unicode, synced) - Base64-encoded Arrow IPC bytes
-- `derive_functions` (Dict, NOT synced) - Python-only registry mapping lambda_id -> callable
-- `width`, `height`, `axes`, `debug` (synced) - Render options
-- `container_id` (synced) - Unique DOM element ID
+Static (Python → JS, set once in `__init__`):
+
+- `spec` (Dict, synced) — Chart specification JSON
+- `arrow_data` (Unicode, synced) — Base64-encoded Arrow IPC bytes
+- `width`, `height`, `axes`, `debug` (synced) — Render options
+- `container_id` (synced) — Unique DOM element ID
+
+Derive RPC (bidirectional via observers):
+
+- `derive_request` (Dict, synced, JS → Python) — `{request_id, lambda_id, arrow_b64}`
+- `derive_response` (Dict, synced, Python → JS) — `{request_id, result_b64}` or `{request_id, error}`
+
+Status (JS → Python, terminal):
+
+- `render_result` (Dict, synced) — `{value: True}` on success or `{error: str}` on failure
+
+Python-only:
+
+- `derive_functions` (Dict, NOT synced) — `lambda_id -> callable` registry
 
 **Widget Initialization Flow**
 
@@ -209,28 +223,32 @@ Inherits from `anywidget.AnyWidget` to provide seamless Jupyter integration.
 
 **RPC Mechanism for Derive**
 
-The `_execute_derive` command enables JavaScript to call Python during rendering:
+We follow the Altair `JupyterChart` / Plotly `FigureWidget` pattern: synced
+traitlets + observer handlers, no `experimental.invoke` and no custom messages.
+This works identically in Jupyter and marimo because `experimental.invoke` is
+unsupported in marimo.
 
 ```python
-@anywidget.experimental.command
-def _execute_derive(self, msg: dict, buffers: list):
-    lambda_id = msg["lambdaId"]
-    arrow_b64 = msg["arrowB64"]
-
-    # Look up Python function
-    fn = self.derive_functions[lambda_id]
-
-    # Deserialize Arrow -> DataFrame
-    df = arrow_to_dataframe(base64.b64decode(arrow_b64))
-
-    # Execute user function
-    result_df = fn(df)
-
-    # Serialize result -> Arrow -> base64
-    result_b64 = base64.b64encode(dataframe_to_arrow(result_df))
-
-    return {"resultB64": result_b64}, buffers
+@traitlets.observe("derive_request")
+def _on_derive_request(self, change):
+    msg = change["new"]
+    if not msg:
+        return
+    request_id = msg["request_id"]
+    try:
+        fn = self.derive_functions[msg["lambda_id"]]
+        df = arrow_to_dataframe(base64.b64decode(msg["arrow_b64"]))
+        result_df = pd.DataFrame(fn(df.to_dict("records")))
+        result_b64 = base64.b64encode(dataframe_to_arrow(result_df)).decode()
+        self.derive_response = {"request_id": request_id, "result_b64": result_b64}
+    except Exception as exc:
+        self.derive_response = {"request_id": request_id, "error": str(exc)}
 ```
+
+The JS side correlates responses to requests via `request_id`. Derive ops are
+sequential (one in-flight per widget), so a single trait pair is enough. The
+fire-and-forget shape avoids the comm-during-cell-execution issue documented
+in [ipywidgets#1349](https://github.com/jupyter-widgets/ipywidgets/issues/1349).
 
 **Why AnyWidget?**
 
@@ -253,11 +271,16 @@ import * as Arrow from "apache-arrow";
 import { chart, spread, stack, ... } from "gofish-graphics";
 
 export default {
-  async render({ model, el, experimental }) {
-    // 1. Deserialize Arrow data
+  initialize({ model }) {
+    // Wire up the derive bridge: a per-widget pending map +
+    // model.on("change:derive_response") listener.
+    (model as any).__gofishBridge = makeDeriveBridge(model);
+  },
+  async render({ model, el }) {
+    // 1. Deserialize Arrow data from `arrow_data` trait
     // 2. Map IR operators to GoFish operators
     // 3. Map IR mark to GoFish mark
-    // 4. Render chart
+    // 4. Render chart, then set render_result for status
   }
 }
 ```
@@ -276,18 +299,19 @@ export default {
 - Used for serialize data for derive RPC
 - Tries multiple methods for Arrow API compatibility
 
-`mapOperator(opSpec, model, experimental)`
+`mapOperator(opSpec, bridge)`
 
 - Maps IR operator spec to GoFish operator function
 - Uses lookup table `OPERATOR_MAP` for extensibility
-- Special handling for `derive` (creates async RPC operator)
+- Special handling for `derive` (creates an async operator that calls
+  `bridge.request(lambdaId, arrowB64)`)
 
 `mapMark(markSpec)`
 
 - Maps IR mark spec to GoFish mark function
 - Simple lookup table `MARK_MAP`
 
-`renderChart(model, container, experimental)`
+`renderChart(model, container, bridge)`
 
 - Main rendering orchestrator
 - Deserializes data and spec
@@ -297,31 +321,24 @@ export default {
 
 **Derive RPC Implementation**
 
-The derive operator in JavaScript is async and calls back to Python:
+The derive operator in JavaScript is async and calls back to Python via the
+synced trait protocol:
 
 ```typescript
-derive: (opts, model, experimental) => {
+derive: (opts, bridge) => {
   const lambdaId = opts.lambdaId;
-
   return derive(async (d) => {
-    // Serialize current data to Arrow
-    const arrowBuffer = arrayToArrow(normalizeToArray(d));
-    const arrowB64 = btoa(String.fromCharCode(...arrowBuffer));
-
-    // Call Python via RPC
-    const [response] = await experimental.invoke("_execute_derive", {
-      lambdaId,
-      arrowB64,
-    });
-
-    // Deserialize result from Arrow
-    const resultBuffer = Uint8Array.from(atob(response.resultB64), (c) =>
+    const rows = normalizeToArray(d);
+    if (rows.length === 0) return Array.isArray(d) ? d : (d ?? null);
+    const arrowB64 = btoa(String.fromCharCode(...arrayToArrow(rows)));
+    // Bridge sets `derive_request` and resolves on `change:derive_response`
+    // with a matching request_id.
+    const resultB64 = await bridge.request(lambdaId, arrowB64);
+    const resultBuffer = Uint8Array.from(atob(resultB64), (c) =>
       c.charCodeAt(0)
     );
-    const resultTable = Arrow.tableFromIPC(resultBuffer);
-    const resultArray = arrowTableToArray(resultTable);
-
-    return Array.isArray(d) ? resultArray : resultArray[0];
+    const resultArray = arrowTableToArray(Arrow.tableFromIPC(resultBuffer));
+    return Array.isArray(d) ? resultArray : (resultArray[0] ?? null);
   });
 };
 ```
@@ -433,7 +450,8 @@ chart(data) \
 
 **4. Widget Render (JavaScript)**
 
-- AnyWidget calls `render({ model, el, experimental })`
+- AnyWidget calls `initialize({ model })` once to wire up the derive bridge,
+  then `render({ model, el })` to paint the chart
 - Decode base64 -> Arrow bytes -> `Arrow.tableFromIPC()`
 - Convert Arrow Table -> array of objects:
   ```js
@@ -488,33 +506,25 @@ const currentData = [...];  // After spread
 const arrowBuffer = arrayToArrow(currentData);
 const arrowB64 = btoa(String.fromCharCode(...arrowBuffer));
 
-// Call Python
-const [response] = await experimental.invoke(
-  "_execute_derive",
-  { lambdaId: "abc123", arrowB64 }
-);
+// Set the derive_request trait; resolve when derive_response arrives
+// with a matching request_id.
+const resultB64 = await bridge.request("abc123", arrowB64);
 
 // Deserialize result
-const resultBuffer = Uint8Array.from(atob(response.resultB64), ...);
+const resultBuffer = Uint8Array.from(atob(resultB64), c => c.charCodeAt(0));
 const resultTable = Arrow.tableFromIPC(resultBuffer);
 const sortedData = arrowTableToArray(resultTable);
 ```
 
-Python side (`_execute_derive`):
+Python side (`@traitlets.observe("derive_request")`):
 
 ```python
-# Receive Arrow bytes
-arrow_bytes = base64.b64decode(arrow_b64)
-df = arrow_to_dataframe(arrow_bytes)
-
-# Execute user function
-fn = self.derive_functions["abc123"]  # lambda df: df.sort_values("count")
-result_df = fn(df)
-
-# Return Arrow bytes
-result_arrow = dataframe_to_arrow(result_df)
-result_b64 = base64.b64encode(result_arrow)
-return {"resultB64": result_b64}
+# change.new == {"request_id": "r-0", "lambda_id": "abc123", "arrow_b64": ...}
+df = arrow_to_dataframe(base64.b64decode(msg["arrow_b64"]))
+fn = self.derive_functions["abc123"]  # lambda rows: sorted(rows, key=...)
+result_df = pd.DataFrame(fn(df.to_dict("records")))
+result_b64 = base64.b64encode(dataframe_to_arrow(result_df)).decode()
+self.derive_response = {"request_id": "r-0", "result_b64": result_b64}
 ```
 
 **8. Final Render (JavaScript)**

--- a/packages/gofish-python/pyproject.toml
+++ b/packages/gofish-python/pyproject.toml
@@ -12,7 +12,6 @@ dependencies = [
     "anywidget>=0.9.0",
     "pyarrow>=10.0.0",
     "pandas>=1.5.0",
-    "marimo>=0.8.22",
 ]
 # Note: The widget bundle (gofish/_static/widget.esm.js) is self-contained
 # and includes all dependencies (gofish-graphics, solid-js, apache-arrow).

--- a/packages/gofish-python/tests/test_widget_protocol.py
+++ b/packages/gofish-python/tests/test_widget_protocol.py
@@ -1,0 +1,162 @@
+"""In-process tests for the widget's trait protocol.
+
+These exercise the Python observer side of the JS↔Python derive bridge
+without spinning up a browser. We construct a real ``GoFishChartWidget``
+and drive its ``derive_request`` trait the way the JS bundle would.
+"""
+
+import base64
+from typing import Any, Dict
+
+import pandas as pd
+import pyarrow as pa
+import pyarrow.ipc as pa_ipc
+import pytest
+
+from gofish.arrow_utils import dataframe_to_arrow
+from gofish.widget import GoFishChartWidget
+
+
+def _arrow_b64(rows: list) -> str:
+    return base64.b64encode(dataframe_to_arrow(pd.DataFrame(rows))).decode("utf-8")
+
+
+def _decode_arrow_b64(b64: str) -> list:
+    buf = base64.b64decode(b64)
+    reader = pa_ipc.open_stream(pa.BufferReader(buf))
+    table = reader.read_all()
+    return table.to_pylist()
+
+
+def _make_widget(derive_functions: Dict[str, Any]) -> GoFishChartWidget:
+    spec = {
+        "data": None,
+        "operators": [{"type": "derive", "lambdaId": next(iter(derive_functions), "x")}],
+        "mark": {"type": "rect"},
+        "options": {},
+        "zOrder": None,
+    }
+    return GoFishChartWidget(
+        spec=spec,
+        arrow_data=dataframe_to_arrow(pd.DataFrame([{"x": 1}])),
+        derive_functions=derive_functions,
+        width=400,
+        height=300,
+    )
+
+
+class TestDeriveProtocol:
+    def test_derive_request_round_trip(self):
+        """derive_request -> observer runs callback -> derive_response set."""
+        seen = {}
+
+        def fn(rows):
+            seen["rows"] = rows
+            return [{**r, "doubled": r["x"] * 2} for r in rows]
+
+        widget = _make_widget({"abc": fn})
+
+        widget.derive_request = {
+            "request_id": "r-0",
+            "lambda_id": "abc",
+            "arrow_b64": _arrow_b64([{"x": 1}, {"x": 2}, {"x": 3}]),
+        }
+
+        assert widget.derive_response is not None
+        assert widget.derive_response["request_id"] == "r-0"
+        assert "result_b64" in widget.derive_response
+        assert seen["rows"] == [{"x": 1}, {"x": 2}, {"x": 3}]
+
+        result_rows = _decode_arrow_b64(widget.derive_response["result_b64"])
+        assert result_rows == [
+            {"x": 1, "doubled": 2},
+            {"x": 2, "doubled": 4},
+            {"x": 3, "doubled": 6},
+        ]
+
+    def test_request_id_preserved_across_calls(self):
+        """Each request_id is echoed back unchanged."""
+        widget = _make_widget({"abc": lambda rows: rows})
+
+        for rid in ("r-1", "r-7", "r-99"):
+            widget.derive_request = {
+                "request_id": rid,
+                "lambda_id": "abc",
+                "arrow_b64": _arrow_b64([{"x": 0}]),
+            }
+            assert widget.derive_response["request_id"] == rid
+
+    def test_unknown_lambda_id_yields_error(self):
+        """Missing lambda_id surfaces as derive_response.error, not an exception."""
+        widget = _make_widget({"abc": lambda rows: rows})
+
+        widget.derive_request = {
+            "request_id": "r-0",
+            "lambda_id": "does-not-exist",
+            "arrow_b64": _arrow_b64([{"x": 1}]),
+        }
+
+        assert widget.derive_response is not None
+        assert widget.derive_response["request_id"] == "r-0"
+        assert "error" in widget.derive_response
+        assert "does-not-exist" in widget.derive_response["error"]
+
+    def test_callback_exception_yields_error_response(self):
+        """A raising user callback becomes a derive_response.error."""
+        def boom(rows):
+            raise RuntimeError("kaboom")
+
+        widget = _make_widget({"abc": boom})
+        widget.derive_request = {
+            "request_id": "r-0",
+            "lambda_id": "abc",
+            "arrow_b64": _arrow_b64([{"x": 1}]),
+        }
+
+        assert widget.derive_response["request_id"] == "r-0"
+        assert "kaboom" in widget.derive_response["error"]
+
+    def test_empty_request_is_ignored(self):
+        """A None or {} derive_request must not produce a response."""
+        widget = _make_widget({"abc": lambda rows: rows})
+        # Default value is None — set to {} explicitly. The observer
+        # should bail before producing a response.
+        widget.derive_request = {}
+        assert widget.derive_response is None
+
+    def test_callback_receives_list_of_dicts(self):
+        """The callback contract is: receive list[dict], return list[dict]."""
+        def assert_shape(rows):
+            assert isinstance(rows, list)
+            assert all(isinstance(r, dict) for r in rows)
+            return rows
+
+        widget = _make_widget({"abc": assert_shape})
+        widget.derive_request = {
+            "request_id": "r-0",
+            "lambda_id": "abc",
+            "arrow_b64": _arrow_b64([{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]),
+        }
+        assert "result_b64" in widget.derive_response
+
+
+class TestRenderResultStatus:
+    def test_done_starts_false(self):
+        widget = _make_widget({"abc": lambda rows: rows})
+        assert widget.done is False
+        assert widget.result is False
+        assert widget.error is None
+
+    def test_done_true_on_success(self):
+        widget = _make_widget({"abc": lambda rows: rows})
+        widget.render_result = {"value": True}
+        assert widget.done is True
+        assert widget.result is True
+        assert widget.error is None
+
+    def test_error_string_on_failure(self):
+        widget = _make_widget({"abc": lambda rows: rows})
+        widget.render_result = {"error": "boom"}
+        assert widget.done is True
+        assert widget.result is False
+        assert widget.error == "boom"

--- a/packages/gofish-python/widget-src/index.ts
+++ b/packages/gofish-python/widget-src/index.ts
@@ -1,8 +1,13 @@
 /**
- * GoFish Python Widget - Self-contained ESM bundle entry point
+ * GoFish Python Widget — self-contained ESM bundle entry point.
  *
- * This module is the single source of widget logic. It will be bundled
- * with dependencies (gofish-graphics, solid-js, apache-arrow) at build time.
+ * Trait-based protocol (Altair / Plotly pattern):
+ *   - JS reads `spec`, `arrow_data`, render options on mount and renders.
+ *   - For `derive` operators, JS sets `derive_request` and awaits a
+ *     `derive_response` change. Python's `@traitlets.observe` runs the
+ *     callback. Sequential — at most one in-flight derive per widget.
+ *   - On success/failure, JS sets `render_result` so Python can read
+ *     `widget.result` / `widget.error` / `widget.done`.
  */
 
 import * as Arrow from "apache-arrow";
@@ -34,27 +39,24 @@ import {
   type Mark,
 } from "gofish-graphics";
 
-// Type definitions for widget model and IR
 interface WidgetModel {
   get(key: "spec"): ChartSpec | LayerSpec;
-  get(key: "arrow_data"): string; // base64-encoded Arrow IPC bytes (or JSON dict for layer)
+  get(key: "arrow_data"): string;
   get(key: "width"): number;
   get(key: "height"): number;
   get(key: "axes"): boolean;
   get(key: "debug"): boolean;
   get(key: "container_id"): string;
-  get(key: "derive_response"): { requestId: string; resultB64: string } | null;
-  set(key: string, value: any): void;
+  get(
+    key: "derive_response"
+  ): { request_id: string; result_b64?: string; error?: string } | null;
+  set(key: string, value: unknown): void;
   save_changes(): void;
   on(event: string, callback: () => void): void;
 }
 
-interface ExperimentalAPI {
-  invoke<T = any>(
-    name: string,
-    msg?: any,
-    buffers?: DataView[]
-  ): Promise<[T, DataView[]]>;
+interface DeriveBridge {
+  request(lambdaId: string, arrowB64: string): Promise<string>;
 }
 
 interface SelectSpec {
@@ -116,20 +118,12 @@ interface RenderOptions {
   debug: boolean;
 }
 
-// Arrow conversion helper
-/**
- * Converts Arrow IPC bytes to an array of plain objects.
- */
 function arrowTableToArray(table: Arrow.Table): Record<string, any>[] {
   const numRows = table.numRows;
   const columns = table.schema.fields.map((field, i) => {
     const column = table.getChildAt(i);
     const values = column.toArray();
-    return {
-      name: field.name,
-      type: field.type,
-      values: values,
-    };
+    return { name: field.name, type: field.type, values };
   });
 
   const data: Record<string, any>[] = [];
@@ -137,7 +131,6 @@ function arrowTableToArray(table: Arrow.Table): Record<string, any>[] {
     const row: Record<string, any> = {};
     columns.forEach((col) => {
       let value = col.values[i];
-      // Convert BigInt to Number if needed
       if (typeof value === "bigint") {
         value = Number(value);
       } else if (value !== null && value !== undefined) {
@@ -158,289 +151,98 @@ function arrowTableToArray(table: Arrow.Table): Record<string, any>[] {
   return data;
 }
 
-/**
- * Normalizes a value to an array for Arrow conversion.
- */
 function normalizeToArray(value: any): any[] {
-  if (Array.isArray(value)) {
-    return value;
-  }
-  if (value === null || value === undefined) {
-    return [];
-  }
+  if (Array.isArray(value)) return value;
+  if (value === null || value === undefined) return [];
   return [value];
 }
 
-/**
- * Converts an array of objects to Arrow IPC (Uint8Array).
- * Requires at least one row; callers should guard empty arrays.
- *
- * This matches the implementation of Arrow's tableToIPC function:
- * RecordBatchStreamWriter.writeAll(table).toUint8Array(true)
- */
 function arrayToArrow(rows: Record<string, any>[]): Uint8Array {
   if (!rows || rows.length === 0) {
     throw new Error("Cannot serialize empty data to Arrow");
   }
-
   const table = Arrow.tableFromJSON(rows);
-  let buffer: Uint8Array | ArrayBuffer | null = null;
 
-  try {
-    // Try tableToIPC if available (simplest method)
-    if (
-      (Arrow as any).tableToIPC &&
-      typeof (Arrow as any).tableToIPC === "function"
-    ) {
-      buffer = (Arrow as any).tableToIPC(table);
-      if (buffer && buffer.byteLength > 0) {
-        return buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
-      }
+  if (
+    (Arrow as any).tableToIPC &&
+    typeof (Arrow as any).tableToIPC === "function"
+  ) {
+    const buffer = (Arrow as any).tableToIPC(table);
+    if (buffer && buffer.byteLength > 0) {
+      return buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
     }
-  } catch (error) {
-    // Fall through to direct approach
-    console.warn("tableToIPC failed, trying direct approach:", error);
   }
 
-  // Direct approach: RecordBatchStreamWriter.writeAll(table).toUint8Array(true)
-  // This is what tableToIPC does internally
-  try {
-    const writer = (Arrow as any).RecordBatchStreamWriter;
-    if (!writer || typeof writer.writeAll !== "function") {
-      throw new Error("RecordBatchStreamWriter.writeAll is not available");
-    }
-
-    // writeAll accepts the table directly and returns a stream
-    const stream = writer.writeAll(table);
-    if (!stream) {
-      throw new Error("writeAll returned null/undefined");
-    }
-
-    // The stream has a toUint8Array method that finishes the stream when passed true
-    if (typeof stream.toUint8Array === "function") {
-      buffer = stream.toUint8Array(true);
-    } else if (typeof stream.finish === "function") {
-      buffer = stream.finish();
-    } else {
-      throw new Error(
-        "Stream from writeAll has neither toUint8Array nor finish method"
-      );
-    }
-
-    if (!buffer || buffer.byteLength === 0) {
-      throw new Error("Serialized Arrow buffer is empty");
-    }
-
-    return buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
-  } catch (error) {
-    throw new Error(
-      `Failed to serialize Arrow table: ${error instanceof Error ? error.message : String(error)}`
-    );
+  const writer = (Arrow as any).RecordBatchStreamWriter;
+  if (!writer || typeof writer.writeAll !== "function") {
+    throw new Error("RecordBatchStreamWriter.writeAll is not available");
   }
+  const stream = writer.writeAll(table);
+  const buffer =
+    typeof stream.toUint8Array === "function"
+      ? stream.toUint8Array(true)
+      : stream.finish();
+  if (!buffer || buffer.byteLength === 0) {
+    throw new Error("Serialized Arrow buffer is empty");
+  }
+  return buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
 }
 
-// Module-level state for traitlet-based derive fallback
-// null = untested, true = invoke works, false = use traitlet fallback
-let useInvoke: boolean | null = null;
-const pendingDerivesByModel = new WeakMap<
-  object,
-  Map<string, { resolve: (v: string) => void; reject: (e: Error) => void }>
->();
-const listenerSetupByModel = new WeakSet<object>();
-
-function setupDeriveResponseListener(model: WidgetModel): void {
-  const key = model as object;
-  if (listenerSetupByModel.has(key)) return;
-  listenerSetupByModel.add(key);
-  if (!pendingDerivesByModel.has(key)) {
-    pendingDerivesByModel.set(key, new Map());
-  }
-  // Guard: marimo may not support model.on()
-  if (typeof (model as any).on !== "function") return;
-  model.on("change:derive_response", () => {
-    const response = model.get("derive_response");
-    if (!response?.requestId) return;
-    const pending = pendingDerivesByModel.get(key);
-    const handlers = pending?.get(response.requestId);
-    if (handlers) {
-      pending!.delete(response.requestId);
-      handlers.resolve(response.resultB64);
-    }
-  });
-}
-
-// Operator mapping: IR operator specs -> GoFish API operators
-/**
- * Lookup table mapping operator type to factory function.
- */
 const OPERATOR_MAP: Record<
   string,
-  (
-    opts: Record<string, any>,
-    model: WidgetModel,
-    experimental: ExperimentalAPI
-  ) => Operator<any, any> | null
+  (opts: Record<string, any>, bridge: DeriveBridge) => Operator<any, any> | null
 > = {
-  derive: (
-    opts: Record<string, any>,
-    model: WidgetModel,
-    experimental: ExperimentalAPI
-  ) => {
+  derive: (opts, bridge) => {
     const lambdaId = opts.lambdaId;
-
     if (!lambdaId) {
       throw new Error("derive operator missing lambdaId");
     }
-
-    // Ensure traitlet response listener is set up for this model
-    setupDeriveResponseListener(model);
-
     return derive(async (d: any) => {
       const rows = normalizeToArray(d);
       if (rows.length === 0) {
         return Array.isArray(d) ? d : (d ?? null);
       }
-
       const arrowBuffer = arrayToArrow(rows);
       const arrowB64 = btoa(String.fromCharCode(...arrowBuffer));
-
-      let resultB64: string | undefined;
-
-      // Fast path: try experimental.invoke (works in Jupyter, not in marimo)
-      if (useInvoke !== false) {
-        try {
-          // Wrap in Promise.resolve to ensure synchronous throws become rejections
-          const [response] = await Promise.resolve().then(() =>
-            experimental.invoke<{ resultB64: string }>("_execute_derive", {
-              lambdaId,
-              arrowB64,
-            })
-          );
-          useInvoke = true;
-          const rb64 = response?.resultB64;
-          if (typeof rb64 !== "string") {
-            throw new Error("Invalid executeDerive response from Python");
-          }
-          resultB64 = rb64;
-        } catch (err: any) {
-          if (useInvoke === null) {
-            // First attempt failed — invoke not supported, fall back to traitlets
-            useInvoke = false;
-          } else {
-            throw err;
-          }
-        }
-      }
-
-      // Traitlet fallback: used when invoke is not supported (e.g. marimo)
-      if (useInvoke === false) {
-        if (
-          typeof (model as any).set !== "function" ||
-          typeof (model as any).save_changes !== "function"
-        ) {
-          throw new Error(
-            "GoFish derive: neither experimental.invoke nor traitlet sync (model.set/save_changes) is available in this environment"
-          );
-        }
-        const requestId = `r-${Math.random().toString(36).slice(2)}`;
-        resultB64 = await new Promise<string>((resolve, reject) => {
-          const pending = pendingDerivesByModel.get(model as object);
-          if (!pending) {
-            reject(
-              new Error(
-                "GoFish derive: pendingDerives map not initialized for this model"
-              )
-            );
-            return;
-          }
-          pending.set(requestId, { resolve, reject });
-          model.set("derive_request", { requestId, lambdaId, arrowB64 });
-          model.save_changes();
-        });
-      }
-
-      const resultBuffer = Uint8Array.from(atob(resultB64!), (c) =>
+      const resultB64 = await bridge.request(lambdaId, arrowB64);
+      const resultBuffer = Uint8Array.from(atob(resultB64), (c) =>
         c.charCodeAt(0)
       );
       const resultTable = Arrow.tableFromIPC(resultBuffer);
       const resultArray = arrowTableToArray(resultTable);
-
-      if (Array.isArray(d)) {
-        return resultArray;
-      }
-
-      return resultArray[0] ?? null;
+      return Array.isArray(d) ? resultArray : (resultArray[0] ?? null);
     });
   },
-  spread: (
-    opts: Record<string, any>,
-    _model: WidgetModel,
-    _experimental: ExperimentalAPI
-  ) => spread(opts as any),
-  stack: (
-    opts: Record<string, any>,
-    _model: WidgetModel,
-    _experimental: ExperimentalAPI
-  ) => stack(opts as any),
-  group: (
-    opts: Record<string, any>,
-    _model: WidgetModel,
-    _experimental: ExperimentalAPI
-  ) => group(opts as any),
-  scatter: (
-    opts: Record<string, any>,
-    _model: WidgetModel,
-    _experimental: ExperimentalAPI
-  ) => scatter(opts as any),
-  table: (
-    opts: Record<string, any>,
-    _model: WidgetModel,
-    _experimental: ExperimentalAPI
-  ) => table(opts as any),
-  log: (
-    opts: Record<string, any>,
-    _model: WidgetModel,
-    _experimental: ExperimentalAPI
-  ) => {
-    return log(opts.label);
-  },
+  spread: (opts) => spread(opts as any),
+  stack: (opts) => stack(opts as any),
+  group: (opts) => group(opts as any),
+  scatter: (opts) => scatter(opts as any),
+  table: (opts) => table(opts as any),
+  log: (opts) => log(opts.label),
 };
 
-/**
- * Maps an IR operator spec to a GoFish operator function.
- */
 function mapOperator(
   op: OperatorSpec,
-  model: WidgetModel,
-  experimental: ExperimentalAPI
+  bridge: DeriveBridge
 ): Operator<any, any> | null {
   const { type, ...opts } = op;
   const factory = OPERATOR_MAP[type];
-  if (!factory) {
-    return null;
-  }
-  return factory(opts, model, experimental);
+  if (!factory) return null;
+  return factory(opts, bridge);
 }
 
-// Mark mapping: IR mark spec -> GoFish API mark
-/**
- * Lookup table mapping mark type to factory function.
- */
 const MARK_MAP: Record<string, (opts: Record<string, any>) => Mark<any>> = {
-  rect: (opts: Record<string, any>) => rect(opts),
-  circle: (opts: Record<string, any>) => circle(opts),
-  line: (opts: Record<string, any>) => line(opts),
-  area: (opts: Record<string, any>) => area(opts),
-  blank: (opts: Record<string, any>) => blank(opts),
-  ellipse: (opts: Record<string, any>) => ellipse(opts),
-  petal: (opts: Record<string, any>) => petal(opts),
-  text: (opts: Record<string, any>) => text(opts),
-  image: (opts: Record<string, any>) => image(opts),
+  rect: (opts) => rect(opts),
+  circle: (opts) => circle(opts),
+  line: (opts) => line(opts),
+  area: (opts) => area(opts),
+  blank: (opts) => blank(opts),
+  ellipse: (opts) => ellipse(opts),
+  petal: (opts) => petal(opts),
+  text: (opts) => text(opts),
+  image: (opts) => image(opts),
 };
 
-/**
- * Maps an IR mark spec to a GoFish mark function, applying .name() and .label() if present.
- */
 function mapMark(markSpec: MarkSpec): Mark<any> {
   const { type, name: layerName, label: labelSpec, ...opts } = markSpec;
   const factory = MARK_MAP[type];
@@ -461,31 +263,17 @@ function mapMark(markSpec: MarkSpec): Mark<any> {
   return mark;
 }
 
-/**
- * Resolves a color config dict (with _tag) to a real palette() or gradient() call.
- */
 function resolveColorConfig(colorSpec: Record<string, any>): any {
-  if (colorSpec._tag === "palette") {
-    return palette(colorSpec.values);
-  } else if (colorSpec._tag === "gradient") {
-    return gradient(colorSpec.stops);
-  }
+  if (colorSpec._tag === "palette") return palette(colorSpec.values);
+  if (colorSpec._tag === "gradient") return gradient(colorSpec.stops);
   return colorSpec;
 }
 
-/**
- * Resolves a coord config dict (with type) to a real coordinate transform.
- */
 function resolveCoordConfig(coordSpec: Record<string, any>): any {
-  if (coordSpec.type === "clock") {
-    return clock();
-  }
+  if (coordSpec.type === "clock") return clock();
   return coordSpec;
 }
 
-/**
- * Resolves all known special values in an options dict (color, coord).
- */
 function resolveOptions(raw: Record<string, any>): Record<string, any> {
   const resolved: Record<string, any> = { ...raw };
   if (
@@ -505,10 +293,6 @@ function resolveOptions(raw: Record<string, any>): Record<string, any> {
   return resolved;
 }
 
-// Error rendering helper
-/**
- * Renders an error message to the container element.
- */
 function renderError(
   container: HTMLElement,
   error: Error,
@@ -516,7 +300,6 @@ function renderError(
 ): void {
   const message = error.message || String(error);
   const stack = debug && error.stack ? error.stack : "";
-
   container.innerHTML = `
     <div style="color: red; padding: 20px; border: 2px solid red; background: #ffe0e0;">
       <h2 style="margin-top: 0;">GoFish Widget Error</h2>
@@ -526,9 +309,6 @@ function renderError(
   `;
 }
 
-/**
- * Decodes a base64 Arrow IPC buffer to an array of data objects.
- */
 function decodeArrowB64(b64: string): Record<string, any>[] {
   if (!b64) return [];
   const arrowBuffer = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
@@ -536,26 +316,18 @@ function decodeArrowB64(b64: string): Record<string, any>[] {
   return arrowTableToArray(table);
 }
 
-/**
- * Builds a ChartBuilder from a ChartSpec + resolved data array.
- */
 function buildChart(
   chartSpec: ChartSpec,
   data: Record<string, any>[],
-  model: WidgetModel,
-  experimental: ExperimentalAPI
+  bridge: DeriveBridge
 ): ChartBuilder {
   const operators: Operator<any, any>[] = [];
   for (const opSpec of chartSpec.operators || []) {
-    const op = mapOperator(opSpec, model, experimental);
-    if (op) {
-      operators.push(op);
-    }
+    const op = mapOperator(opSpec, bridge);
+    if (op) operators.push(op);
   }
-
   const markSpec = chartSpec.mark || { type: "rect" };
   const mark = mapMark(markSpec);
-
   const resolvedOptions = resolveOptions(chartSpec.options || {});
 
   let chartData: any = data;
@@ -576,13 +348,10 @@ function buildChart(
   return builder;
 }
 
-/**
- * Renders a Layer (multi-chart composition) from widget model state.
- */
 function renderLayer(
   model: WidgetModel,
   container: HTMLElement,
-  experimental: ExperimentalAPI
+  bridge: DeriveBridge
 ): void {
   const debug = model.get("debug");
   const log = debug
@@ -594,7 +363,6 @@ function renderLayer(
   const spec = model.get("spec") as LayerSpec;
   const arrowDataRaw = model.get("arrow_data");
 
-  // Parse per-chart arrow data dict
   let arrowDict: Record<string, string> = {};
   try {
     arrowDict = JSON.parse(arrowDataRaw);
@@ -602,27 +370,23 @@ function renderLayer(
     throw new Error(`Failed to parse layer arrow_data JSON: ${e}`);
   }
 
-  // Build each child chart
   const childCharts: ChartBuilder[] = spec.charts.map(
     (chartSpec: ChartSpec, i: number) => {
       const b64 = arrowDict[String(i)] || "";
       const data = decodeArrowB64(b64);
       log(`Building chart ${i}: ${data.length} rows`);
-      return buildChart(chartSpec, data, model, experimental);
+      return buildChart(chartSpec, data, bridge);
     }
   );
 
-  // Resolve layer-level options
-  const rawOptions = spec.options || {};
-  const resolvedLayerOptions = resolveOptions(rawOptions);
+  const resolvedLayerOptions = resolveOptions(spec.options || {});
   const renderOptions: RenderOptions = {
     w: model.get("width"),
     h: model.get("height"),
     axes: model.get("axes"),
-    debug: debug,
+    debug,
   };
 
-  log("Calling Layer([...]).render()...");
   if (Object.keys(resolvedLayerOptions).length > 0) {
     Layer(resolvedLayerOptions, childCharts).render(container, renderOptions);
   } else {
@@ -631,124 +395,182 @@ function renderLayer(
   log("Layer rendered successfully!");
 }
 
-// Main chart rendering function
-/**
- * Renders a GoFish chart from widget model state.
- */
 function renderChart(
   model: WidgetModel,
   container: HTMLElement,
-  experimental: ExperimentalAPI
+  bridge: DeriveBridge
 ): void {
   const spec = model.get("spec");
-
-  // Dispatch to layer renderer if spec.type === "layer"
   if ((spec as any).type === "layer") {
-    renderLayer(model, container, experimental);
+    renderLayer(model, container, bridge);
     return;
   }
 
   const chartSpec = spec as ChartSpec;
   const debug = model.get("debug");
-
-  // Log only if debug mode is enabled
   const log = debug
     ? (...args: any[]) => console.log("[GoFish Widget]", ...args)
     : () => {};
 
-  log("Rendering chart...");
-
-  // 1. Deserialize Arrow data
   let data: Record<string, any>[] = [];
   const arrowDataB64 = model.get("arrow_data");
   if (arrowDataB64) {
-    try {
-      log("Decoding Arrow data...");
-      data = decodeArrowB64(arrowDataB64);
-      log(`Converted to ${data.length} data objects`);
-    } catch (error) {
-      const err =
-        error instanceof Error
-          ? error
-          : new Error(`Failed to deserialize Arrow data: ${error}`);
-      log("Error deserializing Arrow data:", err);
-      throw err;
-    }
+    log("Decoding Arrow data...");
+    data = decodeArrowB64(arrowDataB64);
+    log(`Converted to ${data.length} data objects`);
   }
 
-  log("Processing spec:", chartSpec);
-  // 2. Build and render chart
-  try {
-    log("Building chart...");
-    let node = buildChart(chartSpec, data, model, experimental);
+  log("Building chart...");
+  const node = buildChart(chartSpec, data, bridge);
 
-    const renderOptions: RenderOptions = {
-      w: model.get("width"),
-      h: model.get("height"),
-      axes: model.get("axes"),
-      debug: debug,
-    };
-    log("Render options:", renderOptions);
-    log("Calling node.render()...");
-    node.render(container, renderOptions);
-    log("Chart rendered successfully!");
-  } catch (error) {
-    const err =
-      error instanceof Error
-        ? error
-        : new Error(`Failed to render chart: ${error}`);
-    log("Error rendering chart:", err);
-    throw err;
-  }
+  const renderOptions: RenderOptions = {
+    w: model.get("width"),
+    h: model.get("height"),
+    axes: model.get("axes"),
+    debug,
+  };
+  log("Rendering with options:", renderOptions);
+  node.render(container, renderOptions);
+  log("Chart rendered successfully!");
 }
 
-// AnyWidget entry point
 /**
- * Main render function for AnyWidget.
- * Accepts { model, el, experimental } from AnyWidget and renders the chart.
+ * Per-widget derive bridge: assigns request_ids, sets `derive_request`,
+ * resolves the matching promise when `derive_response` arrives.
+ */
+function makeDeriveBridge(model: WidgetModel): DeriveBridge {
+  let nextId = 0;
+  const pending = new Map<
+    string,
+    { resolve: (v: string) => void; reject: (e: Error) => void }
+  >();
+
+  if (typeof (model as any).on === "function") {
+    model.on("change:derive_response", () => {
+      const response = model.get("derive_response");
+      if (!response || !response.request_id) return;
+      const entry = pending.get(response.request_id);
+      if (!entry) return;
+      pending.delete(response.request_id);
+      if (typeof response.error === "string") {
+        entry.reject(new Error(response.error));
+      } else if (typeof response.result_b64 === "string") {
+        entry.resolve(response.result_b64);
+      } else {
+        entry.reject(new Error("Invalid derive_response payload"));
+      }
+    });
+  }
+
+  // Serialize requests onto a single in-flight queue. Writing the
+  // `derive_request` trait many times in a tick gets coalesced by the
+  // ipykernel / marimo comm — only the latest value reaches Python. By
+  // chaining each request after the previous response resolves, every
+  // `derive_request` write happens in its own comm tick.
+  let chain: Promise<unknown> = Promise.resolve();
+
+  function sendOne(lambdaId: string, arrowB64: string): Promise<string> {
+    if (
+      typeof (model as any).set !== "function" ||
+      typeof (model as any).save_changes !== "function"
+    ) {
+      return Promise.reject(
+        new Error(
+          "GoFish derive: model.set/save_changes is not available; " +
+            "trait sync is not supported in this environment"
+        )
+      );
+    }
+    const requestId = `r-${nextId++}`;
+    return new Promise<string>((resolve, reject) => {
+      pending.set(requestId, { resolve, reject });
+      model.set("derive_request", {
+        request_id: requestId,
+        lambda_id: lambdaId,
+        arrow_b64: arrowB64,
+      });
+      model.save_changes();
+    });
+  }
+
+  return {
+    request(lambdaId: string, arrowB64: string): Promise<string> {
+      // Recover from a previous failure so one bad derive doesn't block
+      // the queue.
+      const next = chain.then(
+        () => sendOne(lambdaId, arrowB64),
+        () => sendOne(lambdaId, arrowB64)
+      );
+      chain = next.catch(() => undefined);
+      return next;
+    },
+  };
+}
+
+/**
+ * AnyWidget entry point.
+ *
+ * `initialize` runs once per widget on mount: that's where we wire up
+ * the derive bridge so its listener and pending map are scoped to this
+ * widget instance. `render` paints the chart into the cell DOM.
  */
 export default {
-  async render({
-    model,
-    el,
-    experimental,
-  }: {
-    model: WidgetModel;
-    el: HTMLElement;
-    experimental: ExperimentalAPI;
-  }) {
+  initialize({ model }: { model: WidgetModel }) {
+    // Stash the bridge on the model so render() can reuse it without
+    // re-wiring listeners on each re-render.
+    (model as any).__gofishBridge = makeDeriveBridge(model);
+  },
+
+  async render({ model, el }: { model: WidgetModel; el: HTMLElement }) {
     const debug = model.get("debug");
     const log = debug
       ? (...args: any[]) => console.log("[GoFish Widget]", ...args)
       : () => {};
-
     log("render() called");
 
-    // Get container ID
     const containerId = model.get("container_id");
-    log(`Container ID: ${containerId}`);
-
-    // Create container div
     el.innerHTML = `<div id="${containerId}"></div>`;
-    // Query the container directly from el to avoid timing issues
     const container = el.querySelector(`#${containerId}`) as HTMLElement;
     if (!container) {
       const error = new Error(
         `Container with id "${containerId}" not found after creation`
       );
       renderError(el, error, debug);
+      try {
+        model.set("render_result", { error: error.message });
+        model.save_changes();
+      } catch {
+        /* ignore */
+      }
       return;
     }
 
-    // Render the chart with error handling
+    let bridge = (model as any).__gofishBridge as DeriveBridge | undefined;
+    if (!bridge) {
+      // Fallback if initialize() didn't run for some reason (e.g. older
+      // anywidget environment that only calls render).
+      bridge = makeDeriveBridge(model);
+      (model as any).__gofishBridge = bridge;
+    }
+
     try {
-      renderChart(model, container, experimental);
+      renderChart(model, container, bridge);
+      try {
+        model.set("render_result", { value: true });
+        model.save_changes();
+      } catch {
+        /* ignore */
+      }
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       log("Error in render():", err);
       renderError(container, err, debug);
+      try {
+        model.set("render_result", { error: err.message });
+        model.save_changes();
+      } catch {
+        /* ignore */
+      }
     }
-
-    log("render() completed");
   },
 };


### PR DESCRIPTION
## Summary

- Replaces the unsupported `@anywidget.experimental.command` / `experimental.invoke` derive RPC with the Altair / Plotly synced-traits + observer pattern. Works identically in Jupyter and marimo.
- Serializes concurrent derive requests in the JS bridge: spread + derive fires N parallel requests per partition, and rapid in-tick `model.set("derive_request", ...)` writes get coalesced by the comm — the queue keeps every write in its own comm tick so every observer fire reaches Python.
- Adds auto-display via `_repr_mimebundle_` on `ChartBuilder` / `LayerBuilder`; `.render(w, h, axes, debug)` still exists for explicit sizing.
- Adds `render_result` trait + `.result` / `.error` / `.done` properties for status surfacing.
- Drops `marimo` from runtime deps (it's a consumer, not a dependency).
- New `tests/test_widget_protocol.py` with FakeWidget-style in-process tests.

## Test plan

- [x] `pytest tests/` — 86 passed, 2 pre-existing xfail
- [x] `pnpm build:widget` — bundle builds clean
- [x] Smoke-tested in **marimo**: `bar_sorted_stacked` (uses `derive`) renders correctly across all 6 partitions
- [x] Smoke-tested in **Jupyter**: same story renders correctly
- [ ] Visual parity suite (run separately with the existing parity workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)