### PR TITLE
feat(parity): low-level combinator marks + raw-mark render

### DIFF
--- a/packages/gofish-python/gofish/__init__.py
+++ b/packages/gofish-python/gofish/__init__.py
@@ -29,6 +29,7 @@ from .ast import (
     petal,
     text,
     image,
+    v,
 )
 
 __all__ = [
@@ -58,6 +59,7 @@ __all__ = [
     "petal",
     "text",
     "image",
+    "v",
 ]
 
 __version__ = "0.1.0"

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -34,11 +34,27 @@ class DeriveOperator(Operator):
 class Mark:
     """Base class for chart marks."""
 
-    def __init__(self, mark_type: str, **kwargs):
+    def __init__(
+        self,
+        mark_type: str,
+        _children: Optional[List["Mark"]] = None,
+        **kwargs,
+    ):
         self.mark_type = mark_type
         self.kwargs = kwargs
         self._name: Optional[str] = None
         self._label: Optional[dict] = None
+        # When set, this Mark is the combinator form of a layout operator
+        # (e.g. `spread([rect, rect], dir="x")`) and `to_dict()` will emit a
+        # `__combinator: true` payload the harness/widget reconstructs by
+        # calling the JS-side combinator overload.
+        self._children: Optional[List["Mark"]] = _children
+
+    def _copy_meta(self, target: "Mark") -> "Mark":
+        target._name = self._name
+        target._label = self._label
+        target._children = self._children
+        return target
 
     def name(self, layer_name: str) -> "Mark":
         """
@@ -51,8 +67,8 @@ class Mark:
             New Mark with name set
         """
         new_mark = Mark(self.mark_type, **self.kwargs)
+        self._copy_meta(new_mark)
         new_mark._name = layer_name
-        new_mark._label = self._label
         return new_mark
 
     def label(
@@ -81,7 +97,7 @@ class Mark:
             New Mark with label set
         """
         new_mark = Mark(self.mark_type, **self.kwargs)
-        new_mark._name = self._name
+        self._copy_meta(new_mark)
         label_spec: Dict[str, Any] = {"accessor": accessor}
         if position is not None:
             label_spec["position"] = position
@@ -100,12 +116,74 @@ class Mark:
 
     def to_dict(self) -> dict:
         """Convert mark to dictionary for JSON IR."""
-        d: dict = {"type": self.mark_type, **self.kwargs}
+        if self._children is not None:
+            # Combinator form: emit a nested payload the JS side reconstructs
+            # via the operator's `(opts, marks)` overload.
+            d: dict = {
+                "type": self.mark_type,
+                "__combinator": True,
+                "options": self.kwargs,
+                "children": [child.to_dict() for child in self._children],
+            }
+        else:
+            d = {"type": self.mark_type, **self.kwargs}
         if self._name is not None:
             d["name"] = self._name
         if self._label is not None:
             d["label"] = self._label
         return d
+
+    def to_ir(self) -> dict:
+        """
+        Top-level IR shape when this Mark is rendered directly (no Chart).
+
+        Mirrors JS storybook spelling `spread(opts, [marks]).render(...)`:
+        no data, no operators, no chart-level color/coord config. The harness
+        calls the NameableMark's own `.render(container, opts)` and skips the
+        Chart/Frame wrapper, which is what gives byte-identical output to a
+        JS storybook export that renders a mark directly.
+        """
+        return {"type": "raw-mark", "mark": self.to_dict()}
+
+    def render(
+        self,
+        w: int = 800,
+        h: int = 600,
+        axes: bool = False,
+        debug: bool = False,
+    ):
+        """
+        Render this Mark directly (no Chart wrapper) — mirrors the JS storybook
+        pattern `spread({...}, [marks]).render(container, {w, h})`.
+
+        Returns a GoFishChartWidget; in a notebook this auto-displays.
+        """
+        import base64
+        import json
+        from .widget import GoFishChartWidget
+        import pyarrow as pa
+
+        schema = pa.schema([pa.field("_placeholder", pa.int32())])
+        table = pa.Table.from_arrays([], schema=schema)
+        sink = pa.BufferOutputStream()
+        with pa.ipc.new_stream(sink, schema) as writer:
+            writer.write_table(table)
+        arrow_data = sink.getvalue().to_pybytes()
+
+        widget = GoFishChartWidget(
+            spec=self.to_ir(),
+            arrow_data=arrow_data,
+            derive_functions={},
+            width=w,
+            height=h,
+            axes=axes,
+            debug=debug,
+        )
+        return widget
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        """Auto-display in notebooks (see ChartBuilder._repr_mimebundle_)."""
+        return self.render()._repr_mimebundle_(include=include, exclude=exclude)
 
 
 class LayerSelector:
@@ -334,25 +412,48 @@ class ChartBuilder:
 
 
 def spread(
+    children: Optional[List["Mark"]] = None,
     *,
     by: Optional[str] = None,
     **options: Any,
-) -> Operator:
+) -> Union[Operator, "Mark"]:
     """
-    Spread operator — partitions data by `by` (or iterates per-item when
-    omitted) and lays out children with spacing along an axis.
+    Spread — polymorphic.
+
+    Operator form (no positional arg): partitions data by `by` (or iterates
+    per-item when omitted) and lays children out along an axis. Used inside
+    `.flow(...)`.
+
+        spread(by="category", dir="x", spacing=24)
+
+    Combinator form (positional list of marks): returns a low-level Mark
+    that lays the given child marks out along an axis. Used inside `.mark()`
+    when you want explicit nested marks instead of repeating a single mark
+    across data.
+
+        spread([rect(h="A"), rect(h="B")], dir="x", spacing=0)
 
     Args:
-        by: Field name to partition by. Omit for per-item spread.
+        children: When provided, switches to combinator form. List of child
+            Marks to lay out side-by-side.
+        by: Field name to partition by (operator form only). Omit for
+            per-item spread.
         **options: dir ("x"|"y"), spacing, alignment, sharedScale, mode, etc.
 
     Returns:
-        Operator object
+        Operator (no children) or Mark (with children).
     """
-    if by is not None:
-        options["by"] = by
     if "dir" not in options:
         raise ValueError("spread() requires 'dir' option ('x' or 'y')")
+    if children is not None:
+        if by is not None:
+            raise ValueError(
+                "spread() combinator form (with children) does not accept "
+                "`by` — the layout is over the explicit child list, not data."
+            )
+        return Mark("spread", _children=list(children), **options)
+    if by is not None:
+        options["by"] = by
     return Operator("spread", **options)
 
 
@@ -526,6 +627,28 @@ def select(layer_name: str) -> LayerSelector:
         LayerSelector sentinel for use as chart() data argument
     """
     return LayerSelector(layer_name)
+
+
+# Literal-value wrapper
+
+
+def v(field_name: str) -> dict:
+    """
+    Wrap a field name so a mark prop reads it as a per-row literal value
+    instead of as an aesthetic-channel field accessor.
+
+    Mirrors JS `v(field)` (`packages/gofish-graphics/src/ast/data.ts:10`):
+    `rect(fill=v("Worldwide Gross"))` uses the row's `Worldwide Gross` value
+    as the literal fill color, instead of treating it as a categorical
+    encoding to map through the chart's color scale.
+
+    Args:
+        field_name: Field name whose per-row value should be used literally.
+
+    Returns:
+        Sentinel dict the harness/widget unwraps into a JS `v()` call.
+    """
+    return {"__gofish_v": field_name}
 
 
 # Data utilities (for use inside derive() callbacks)

--- a/packages/gofish-python/widget-src/index.ts
+++ b/packages/gofish-python/widget-src/index.ts
@@ -34,13 +34,14 @@ import {
   petal,
   text,
   image,
+  v,
   type ChartBuilder,
   type Operator,
   type Mark,
 } from "gofish-graphics";
 
 interface WidgetModel {
-  get(key: "spec"): ChartSpec | LayerSpec;
+  get(key: "spec"): ChartSpec | LayerSpec | RawMarkSpec;
   get(key: "arrow_data"): string;
   get(key: "width"): number;
   get(key: "height"): number;
@@ -79,6 +80,12 @@ interface LayerSpec {
   options?: Record<string, any>;
 }
 
+interface RawMarkSpec {
+  type: "raw-mark";
+  mark: MarkSpec;
+  options?: Record<string, any>;
+}
+
 interface OperatorSpec {
   type: "derive" | "spread" | "stack" | "group" | "scatter" | "table" | "log";
   lambdaId?: string;
@@ -96,6 +103,8 @@ interface LabelSpec {
 }
 
 interface MarkSpec {
+  // Mark types include the leaf shapes plus combinator-form layout
+  // operators ("spread") used as marks via the `__combinator` flag.
   type:
     | "rect"
     | "circle"
@@ -105,10 +114,31 @@ interface MarkSpec {
     | "ellipse"
     | "petal"
     | "text"
-    | "image";
+    | "image"
+    | "spread";
   name?: string;
   label?: LabelSpec;
+  __combinator?: boolean;
+  options?: Record<string, any>;
+  children?: MarkSpec[];
   [key: string]: any;
+}
+
+/**
+ * Walk an arbitrary value and replace `{__gofish_v: field}` sentinels with
+ * a real JS `v(field)` call. Python uses the sentinel because dict-only IR
+ * has no way to author a function call; this rebuilds the call before
+ * handing the prop to the JS mark factory.
+ */
+function unwrapValues(value: any): any {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(unwrapValues);
+  if (typeof value.__gofish_v === "string") return v(value.__gofish_v);
+  const out: Record<string, any> = {};
+  for (const [k, val] of Object.entries(value)) {
+    out[k] = unwrapValues(val);
+  }
+  return out;
 }
 
 interface RenderOptions {
@@ -244,12 +274,31 @@ const MARK_MAP: Record<string, (opts: Record<string, any>) => Mark<any>> = {
 };
 
 function mapMark(markSpec: MarkSpec): Mark<any> {
+  // Combinator-form marks: a layout operator (currently just `spread`) used
+  // as a mark, with explicit nested children. Python emits `{type,
+  // __combinator: true, options, children, name?, label?}`; rebuild it by
+  // calling the JS operator's `(opts, marks)` overload.
+  if (markSpec.__combinator) {
+    const childMarks = (markSpec.children ?? []).map(mapMark);
+    const opts = unwrapValues(markSpec.options ?? {});
+    let mark: Mark<any>;
+    if (markSpec.type === "spread") {
+      mark = spread(opts, childMarks) as unknown as Mark<any>;
+    } else {
+      throw new Error(`Unknown combinator mark type: ${markSpec.type}`);
+    }
+    if (markSpec.name && typeof (mark as any).name === "function") {
+      mark = (mark as any).name(markSpec.name);
+    }
+    return mark;
+  }
+
   const { type, name: layerName, label: labelSpec, ...opts } = markSpec;
-  const factory = MARK_MAP[type];
+  const factory = MARK_MAP[type as Exclude<MarkSpec["type"], "spread">];
   if (!factory) {
     throw new Error(`Unknown mark type: ${type}`);
   }
-  let mark = factory(opts);
+  let mark = factory(unwrapValues(opts));
   if (layerName && typeof (mark as any).name === "function") {
     mark = (mark as any).name(layerName);
   }
@@ -395,6 +444,26 @@ function renderLayer(
   log("Layer rendered successfully!");
 }
 
+function renderRawMark(model: WidgetModel, container: HTMLElement): void {
+  const spec = model.get("spec") as unknown as RawMarkSpec;
+  const debug = model.get("debug");
+  const log = debug
+    ? (...args: any[]) => console.log("[GoFish Widget]", ...args)
+    : () => {};
+
+  log("Building raw mark...");
+  const mark = mapMark(spec.mark) as any;
+  const renderOptions: RenderOptions = {
+    w: model.get("width"),
+    h: model.get("height"),
+    axes: model.get("axes"),
+    debug,
+  };
+  log("Rendering raw mark with options:", renderOptions);
+  mark.render(container, renderOptions);
+  log("Raw mark rendered successfully!");
+}
+
 function renderChart(
   model: WidgetModel,
   container: HTMLElement,
@@ -403,6 +472,10 @@ function renderChart(
   const spec = model.get("spec");
   if ((spec as any).type === "layer") {
     renderLayer(model, container, bridge);
+    return;
+  }
+  if ((spec as any).type === "raw-mark") {
+    renderRawMark(model, container);
     return;
   }
 

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -16,8 +16,14 @@ packages/gofish-graphics/stories/lowlevel/StringlineChart.stories.tsx
 packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx
 packages/gofish-graphics/stories/lowlevel/Whisker.stories.tsx
 
-# Bluefish examples
-packages/gofish-graphics/stories/bluefish/Planets.stories.tsx
+# Bluefish examples — Planets.stories.tsx::PlanetsOnly is ported; the other
+# exports use additional low-level primitives (`layer`, `text`, `ref`,
+# `arrow`) that the Python wrapper doesn't expose yet.
+packages/gofish-graphics/stories/bluefish/Planets.stories.tsx::PlanetsWithLabelAbove
+packages/gofish-graphics/stories/bluefish/Planets.stories.tsx::PlanetsWithLabelBelow
+packages/gofish-graphics/stories/bluefish/Planets.stories.tsx::PlanetsWithLabelAboveNoSpacing
+packages/gofish-graphics/stories/bluefish/Planets.stories.tsx::PlanetsWithLabelBelowNoSpacing
+packages/gofish-graphics/stories/bluefish/Planets.stories.tsx::PlanetsWithArrow
 
 # Shape primitives
 packages/gofish-graphics/stories/shapes/TextMarks.stories.tsx
@@ -39,8 +45,6 @@ packages/gofish-graphics/stories/forwardsyntax/FacetedChart.stories.tsx
 # (Vega-Lite ports were brought over from exempt to real parity tests;
 # see tests/python-stories/vega-lite/.)
 
-# Needs low-level v1/v2 API (v() literal fills + mark-as-spread-with-nested-rects).
-packages/gofish-graphics/stories/vega-lite/Bar/GroupedBarChartRepeat.stories.tsx
 
 # Per-export exemption — uses `assignGradientColor` to precompute per-row
 # fills from two distinct gradients in a single chart. The Python wrapper

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -32,6 +32,7 @@ import {
   palette,
   gradient,
   clock,
+  v,
   type ChartBuilder,
   type Operator,
   type Mark,
@@ -66,7 +67,17 @@ interface LayerHarnessSpec {
   deriveServerUrl?: string;
 }
 
-type HarnessSpec = SingleChartHarnessSpec | LayerHarnessSpec;
+interface RawMarkHarnessSpec {
+  type: "raw-mark";
+  mark: MarkSpec;
+  options: Record<string, any>;
+  deriveServerUrl?: string;
+}
+
+type HarnessSpec =
+  | SingleChartHarnessSpec
+  | LayerHarnessSpec
+  | RawMarkHarnessSpec;
 
 interface OperatorSpec {
   type: string;
@@ -77,7 +88,27 @@ interface OperatorSpec {
 interface MarkSpec {
   type: string;
   name?: string;
+  __combinator?: boolean;
+  options?: Record<string, any>;
+  children?: MarkSpec[];
   [key: string]: any;
+}
+
+/**
+ * Walk an arbitrary value and replace `{__gofish_v: field}` sentinels with
+ * a real JS `v(field)` call. Python uses the sentinel because dict-only IR
+ * has no way to author a function call; the harness rebuilds the call
+ * before handing the prop to the JS mark factory.
+ */
+function unwrapValues(value: any): any {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(unwrapValues);
+  if (typeof value.__gofish_v === "string") return v(value.__gofish_v);
+  const out: Record<string, any> = {};
+  for (const [k, val] of Object.entries(value)) {
+    out[k] = unwrapValues(val);
+  }
+  return out;
 }
 
 declare global {
@@ -160,6 +191,26 @@ const MARK_MAP: Record<string, (opts: Record<string, any>) => Mark<any>> = {
 };
 
 function mapMark(spec: MarkSpec): Mark<any> {
+  // Combinator-form marks: a layout operator (currently just `spread`) used
+  // as a mark, with explicit nested children instead of repeating a single
+  // mark across data. Python emits `{type, __combinator: true, options,
+  // children, name?, label?}`; rebuild it by calling the JS operator's
+  // `(opts, marks)` overload.
+  if (spec.__combinator) {
+    const childMarks = (spec.children ?? []).map(mapMark);
+    const opts = unwrapValues(spec.options ?? {});
+    let mark: Mark<any>;
+    if (spec.type === "spread") {
+      mark = spread(opts, childMarks) as unknown as Mark<any>;
+    } else {
+      throw new Error(`Unknown combinator mark type: ${spec.type}`);
+    }
+    if (spec.name && typeof (mark as any).name === "function") {
+      mark = (mark as any).name(spec.name);
+    }
+    return mark;
+  }
+
   const { type, name: layerName, label, ...opts } = spec;
   const factory = MARK_MAP[type];
   if (!factory) throw new Error(`Unknown mark type: ${type}`);
@@ -171,9 +222,11 @@ function mapMark(spec: MarkSpec): Mark<any> {
   // uses (e.g. `rect({h: "count"}).label("count", {position: "outset"})`).
   const isStructuredLabel =
     label && typeof label === "object" && !Array.isArray(label);
-  const factoryOpts: Record<string, any> = isStructuredLabel
-    ? opts
-    : { ...opts, ...(label !== undefined ? { label } : {}) };
+  const factoryOpts: Record<string, any> = unwrapValues(
+    isStructuredLabel
+      ? opts
+      : { ...opts, ...(label !== undefined ? { label } : {}) }
+  );
 
   let mark = factory(factoryOpts);
   if (isStructuredLabel && typeof (mark as any).label === "function") {
@@ -270,7 +323,22 @@ function renderChart(spec: HarnessSpec) {
   }
 
   try {
-    if (spec.type === "layer") {
+    if (spec.type === "raw-mark") {
+      // Bypass the Chart wrapper entirely: the mark renders itself directly.
+      // Mirrors JS storybook spelling `spread(opts, [marks]).render(...)`,
+      // which produces a noticeably different DOM shape than going through
+      // Chart (Chart adds an identity-transform Frame wrapper that JS-side
+      // direct renders skip).
+      const allOpts = spec.options || {};
+      const { w, h, axes, debug } = allOpts;
+      const mark = mapMark(spec.mark) as any;
+      mark.render(container, {
+        w,
+        h,
+        axes: axes ?? false,
+        debug: debug ?? false,
+      });
+    } else if (spec.type === "layer") {
       // Layer-level options: w/h/axes/debug are render options; the rest
       // (coord, color) become Layer's chart-level options.
       const layerAll = spec.options || {};

--- a/tests/python-stories/bluefish/test_planets.py
+++ b/tests/python-stories/bluefish/test_planets.py
@@ -1,0 +1,41 @@
+"""Equivalent of bluefish/Planets.stories.tsx::PlanetsOnly — Bluefish/Planets.
+
+PlanetsOnly is the simplest export in the file: pure low-level composition
+of a `spread` combinator over per-planet `ellipse` children, rendered
+directly (no Chart wrapper). The other Planets exports (labels, arrows)
+need additional low-level primitives (`layer`, `text`, `ref`, `arrow`)
+that the Python wrapper doesn't yet expose — those stay per-export exempt.
+
+JS uses `For(planets, planet => ellipse({...}))` to produce the children;
+Python uses a list comprehension to the same effect.
+"""
+
+from gofish import ellipse, spread
+
+PLANETS = [
+    {"name": "Mercury", "radius": 15, "color": "#EBE3CF"},
+    {"name": "Venus", "radius": 36, "color": "#DC933C"},
+    {"name": "Earth", "radius": 38, "color": "#179DD7"},
+    {"name": "Mars", "radius": 21, "color": "#F1CF8E"},
+]
+
+
+def story_planets_only():
+    return (
+        spread(
+            [
+                ellipse(
+                    w=p["radius"] * 2,
+                    h=p["radius"] * 2,
+                    fill=p["color"],
+                    stroke="#333",
+                    strokeWidth=3,
+                )
+                for p in PLANETS
+            ],
+            dir="x",
+            spacing=50,
+            alignment="middle",
+        ),
+        {"w": 800, "h": 200},
+    )

--- a/tests/python-stories/vega-lite/test_grouped_bar_chart_(multiple_measure_with_repeat).py
+++ b/tests/python-stories/vega-lite/test_grouped_bar_chart_(multiple_measure_with_repeat).py
@@ -1,0 +1,30 @@
+"""Equivalent of GroupedBarChartRepeat.stories.tsx —
+Vega-Lite/Grouped Bar Chart (Multiple Measure with Repeat).
+
+Demonstrates the low-level combinator form of `spread` used as a mark with
+two explicit child rects, plus the `v()` literal-value wrapper so the fill
+reads the per-row value directly instead of going through a categorical
+color encoding.
+"""
+
+from gofish import chart, rect, spread, v
+from python_stories.vega_data_urls import read_json
+
+
+def story_default():
+    movies = read_json("movies.json").to_dict("records")
+    return (
+        chart(movies)
+        .flow(spread(by="Major Genre", dir="x"))
+        .mark(
+            spread(
+                [
+                    rect(h="Worldwide Gross", fill=v("Worldwide Gross")),
+                    rect(h="US Gross", fill=v("US Gross")),
+                ],
+                dir="x",
+                spacing=0,
+            )
+        ),
+        {"w": 600, "h": 300, "axes": True},
+    )

--- a/tests/scripts/capture-python-dom.ts
+++ b/tests/scripts/capture-python-dom.ts
@@ -116,6 +116,12 @@ type IRResult =
       options: any;
       deriveIds: string[];
     }
+  | {
+      kind: "raw-mark";
+      mark: any;
+      options: any;
+      deriveIds: string[];
+    }
   | { kind: "layer-unsupported"; reason: string }
   | { kind: "error"; reason: string };
 
@@ -160,6 +166,14 @@ async function loadStory(story: PythonStory): Promise<IRResult> {
     return {
       kind: "layer",
       charts: json.charts,
+      options: json.options ?? {},
+      deriveIds: json.deriveIds ?? [],
+    };
+  }
+  if (json && json._kind === "raw-mark") {
+    return {
+      kind: "raw-mark",
+      mark: json.mark,
       options: json.options ?? {},
       deriveIds: json.deriveIds ?? [],
     };
@@ -253,7 +267,7 @@ async function captureStory(
   page: Page,
   harnessUrl: string,
   story: PythonStory,
-  ir: IRResult & { kind: "chart" | "layer" }
+  ir: IRResult & { kind: "chart" | "layer" | "raw-mark" }
 ): Promise<{ dom: string; screenshot: Buffer }> {
   await page.goto(harnessUrl, { waitUntil: "networkidle" });
 
@@ -262,23 +276,33 @@ async function captureStory(
       ? `http://localhost:${DERIVE_SERVER_PORT}`
       : undefined;
 
-  // Inject spec and trigger render. Layer specs use a different shape
-  // that the harness dispatches on via `spec.type === "layer"`.
-  const spec =
-    ir.kind === "layer"
-      ? {
-          type: "layer",
-          charts: ir.charts,
-          options: ir.options,
-          deriveServerUrl,
-        }
-      : {
-          data: ir.data,
-          operators: ir.operators,
-          mark: ir.mark,
-          options: ir.options,
-          deriveServerUrl,
-        };
+  // Inject spec and trigger render. The harness dispatches on `spec.type`:
+  // `"layer"` for a multi-chart layer, `"raw-mark"` for a bare Mark
+  // rendered without a Chart wrapper, undefined for the single-chart path.
+  let spec: any;
+  if (ir.kind === "layer") {
+    spec = {
+      type: "layer",
+      charts: ir.charts,
+      options: ir.options,
+      deriveServerUrl,
+    };
+  } else if (ir.kind === "raw-mark") {
+    spec = {
+      type: "raw-mark",
+      mark: ir.mark,
+      options: ir.options,
+      deriveServerUrl,
+    };
+  } else {
+    spec = {
+      data: ir.data,
+      operators: ir.operators,
+      mark: ir.mark,
+      options: ir.options,
+      deriveServerUrl,
+    };
+  }
 
   await page.evaluate((s) => {
     window.__GOFISH_RENDER_COMPLETE__ = false;

--- a/tests/scripts/derive-server.py
+++ b/tests/scripts/derive-server.py
@@ -138,7 +138,7 @@ class DeriveHandler(BaseHTTPRequestHandler):
             builder = result[0]
             options = result[1] if len(result) > 1 else {}
 
-            from gofish.ast import ChartBuilder, DeriveOperator, LayerBuilder, LayerSelector
+            from gofish.ast import ChartBuilder, DeriveOperator, LayerBuilder, LayerSelector, Mark
 
             def serialize_chart(child: ChartBuilder) -> tuple:
                 """Return (child_payload, derive_ids) for one chart builder.
@@ -175,6 +175,18 @@ class DeriveHandler(BaseHTTPRequestHandler):
                     },
                     child_derive_ids,
                 )
+
+            if isinstance(builder, Mark):
+                # Raw-mark render path: a Mark returned directly from a
+                # story (no Chart, no Layer). Mirrors JS storybook spelling
+                # `spread(opts, [marks]).render(container, {w, h})`.
+                self._json_response(200, {
+                    "_kind": "raw-mark",
+                    "mark": builder.to_dict(),
+                    "options": options,
+                    "deriveIds": [],
+                })
+                return
 
             if isinstance(builder, LayerBuilder):
                 child_payloads = []


### PR DESCRIPTION
## Summary

Adds the minimum wrapper surface to port two long-exempt low-level storybook stories — `GroupedBarChartRepeat` and `Planets::PlanetsOnly` — without porting any layout logic into Python. JS already has the polymorphism; the new pieces just marshal the calls.

**Stacked on #426** (Labels parity port). Diff against this PR's base is just the low-level-marks additions.

## What's new

### Python wrapper (`packages/gofish-python/gofish/ast.py`)

- **`spread()` is now polymorphic.** Pass a positional list of child marks to get a combinator-form Mark; the existing kw-only form keeps operator semantics. **Kwargs stay consistent across both forms** — no dict-of-options drift between operator and combinator callsites.
  ```python
  # Operator form (unchanged)
  spread(by="genre", dir="x", spacing=24)

  # Combinator form (new)
  spread([rect(h="A"), rect(h="B")], dir="x", spacing=0)
  ```
- **`Mark._children`** + nested `to_dict()`. Emits a `__combinator: true` payload the harness reconstructs by calling the JS operator's `(opts, marks)` overload.
- **`v(field)` literal-value wrapper.** Mirrors JS `v()` from `lib.ts`. Emits a `__gofish_v` sentinel that the harness unwraps to a real `v()` call before handing the prop to the JS mark factory.
- **Raw-mark render path on `Mark`.** `mark.render(w=, h=)` skips the Chart/Frame wrapper entirely, matching JS storybook spelling like `spread(opts, [marks]).render(container, {w, h})`. Without this, the Python-rendered Planets had an extra identity-transform `<g>` from the Chart's Frame and byte-diffed against JS.

### Harness + widget translation (`tests/harness/main.ts`, `packages/gofish-python/widget-src/index.ts`)

- `mapMark` branches on `__combinator: true` and rebuilds via `spread(opts, mappedChildren)`.
- New `unwrapValues` helper walks mark opts and replaces `__gofish_v` sentinels with `v(field)` calls.
- New `raw-mark` spec variant in `renderChart` / widget renderer: maps the mark and calls `.render(container, opts)` directly, bypassing Chart.

### Capture plumbing (`tests/scripts/capture-python-dom.ts`, `tests/scripts/derive-server.py`)

- Derive-server now dispatches on `Mark` builder type and emits a `_kind: "raw-mark"` payload alongside the existing `_kind: "layer"` and single-chart shapes.
- Capture script's `IRResult` gains a `raw-mark` variant that maps to the harness's `type: "raw-mark"` spec.

### Coverage

| | Story | Status |
|---|---|---|
| New | `tests/python-stories/vega-lite/test_grouped_bar_chart_(multiple_measure_with_repeat).py` | byte-matches |
| New | `tests/python-stories/bluefish/test_planets.py::story_planets_only` | byte-matches |
| Exempt → ported | `vega-lite/Bar/GroupedBarChartRepeat.stories.tsx` | removed whole-file exempt |
| Exempt → split | `bluefish/Planets.stories.tsx` | whole-file exempt → 5 per-export exempts (Labeled/Arrow variants need `layer`/`text`/`ref`/`arrow`, separate surface work) |

Sync delta: `OK: 66 → 68`, `Exempt: 52 → 50`, `Missing: 24` (unchanged).

## Test plan

- [x] `pnpm --filter=@gofish/tests capture-js` — 140 stories captured, 0 failures
- [x] `pnpm --filter=@gofish/tests capture-python` — 68 stories captured (66 baseline + 2 new), 0 failures
- [x] All 68 Python outputs byte-match the JS capture
- [x] Existing v3 stories (e.g. labels, ribbon, stacked-bars, normalized-stacked) still byte-match — no regression in the single-mark dispatch
- [x] `pnpm --filter=@gofish/tests check-python-sync-all` — `GroupedBarChartRepeat` covered; `Planets` shows 5 per-export exempts and 1 covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)