### PR TITLE
docs: axis title support for render options

### DIFF
--- a/apps/docs/docs/api/core/render.md
+++ b/apps/docs/docs/api/core/render.md
@@ -10,25 +10,78 @@ Renders the chart into a DOM element.
 
 ## Parameters
 
-| Parameter      | Type                                    | Description                                                                             |
-| -------------- | --------------------------------------- | --------------------------------------------------------------------------------------- |
-| `container`    | `HTMLElement`                           | The DOM element to render into                                                          |
-| `options.w`    | `number`                                | Width in pixels                                                                         |
-| `options.h`    | `number`                                | Height in pixels                                                                        |
-| `options.axes` | `boolean \| { x: boolean; y: boolean }` | Auto-generate axes, labels, and legends. Use an object to toggle x/y axes individually. |
+| Parameter      | Type          | Description                                                       |
+| -------------- | ------------- | ----------------------------------------------------------------- |
+| `container`    | `HTMLElement` | The DOM element to render into                                    |
+| `options.w`    | `number`      | Width in pixels                                                   |
+| `options.h`    | `number`      | Height in pixels                                                  |
+| `options.axes` | `AxesOptions` | Auto-generate axes, labels, and legends. See [Axes](#axes) below. |
 
-## Example
+## Axes
+
+The `axes` option controls per-axis visibility and titles:
+
+```ts
+type AxesOptions = boolean | { x?: AxisOptions; y?: AxisOptions };
+type AxisOptions = boolean | { title?: string | false };
+```
+
+**`AxesOptions` (top level)**
+
+- `true` — both axes visible with inferred titles
+- `false` — both axes hidden
+- `{ x: AxisOptions }` — configure x-axis; y absent means y hidden
+- `{ x: AxisOptions, y: AxisOptions }` — configure both axes
+
+**`AxisOptions` (per axis)**
+
+- `true` — axis visible, title inferred from the field encoding (e.g. `rect({ h: "count" })` infers `"count"`)
+- `false` — axis hidden, title irrelevant
+- `{ title: "Custom" }` — axis visible with title "Custom"
+- `{ title: false }` — axis visible, title suppressed
+
+## Examples
+
+Inferred titles from encodings:
 
 ```ts
 chart(data)
-  .flow(spread({ by: "category", dir: "x" }))
+  .flow(spread("category", { dir: "x" }))
   .mark(rect({ h: "value" }))
   .render(container, { w: 500, h: 300, axes: true });
 ```
 
+Only x-axis visible:
+
 ```ts
 chart(data)
-  .flow(spread({ by: "category", dir: "x" }))
+  .flow(spread("category", { dir: "x" }))
   .mark(rect({ h: "value" }))
-  .render(container, { w: 500, h: 300, axes: { x: true, y: false } });
+  .render(container, { w: 500, h: 300, axes: { x: true } });
+```
+
+Custom x-axis title, inferred y-axis title:
+
+```ts
+chart(data)
+  .flow(spread("category", { dir: "x" }))
+  .mark(rect({ h: "value" }))
+  .render(container, {
+    w: 500,
+    h: 300,
+    axes: { x: { title: "Product Category" }, y: true },
+  });
+```
+
+Suppress the inferred title on the x-axis:
+
+```ts
+chart(data)
+  .flow(spread("category", { dir: "x" }))
+  .mark(rect({ h: "value" }))
+  .render(container, {
+    w: 500,
+    h: 300,
+    axes: { x: { title: false }, y: true },
+  });
 ```

--- a/apps/docs/docs/api/core/render.md
+++ b/apps/docs/docs/api/core/render.md
@@ -42,46 +42,62 @@ type AxisOptions = boolean | { title?: string | false };
 
 ## Examples
 
-Inferred titles from encodings:
+### Inferred titles from encodings
 
-```ts
-chart(data)
-  .flow(spread("category", { dir: "x" }))
-  .mark(rect({ h: "value" }))
-  .render(container, { w: 500, h: 300, axes: true });
+::: starfish
+
+```js
+gf.Chart(seafood)
+  .flow(gf.spread({ by: "lake", dir: "x" }))
+  .mark(gf.rect({ h: "count" }))
+  .render(root, { w: 400, h: 250, axes: true });
 ```
 
-Only x-axis visible:
+:::
 
-```ts
-chart(data)
-  .flow(spread("category", { dir: "x" }))
-  .mark(rect({ h: "value" }))
-  .render(container, { w: 500, h: 300, axes: { x: true } });
+### Only x-axis visible
+
+::: starfish
+
+```js
+gf.Chart(seafood)
+  .flow(gf.spread({ by: "lake", dir: "x" }))
+  .mark(gf.rect({ h: "count" }))
+  .render(root, { w: 400, h: 250, axes: { x: true } });
 ```
 
-Custom x-axis title, inferred y-axis title:
+:::
 
-```ts
-chart(data)
-  .flow(spread("category", { dir: "x" }))
-  .mark(rect({ h: "value" }))
-  .render(container, {
-    w: 500,
-    h: 300,
-    axes: { x: { title: "Product Category" }, y: true },
+### Custom x-axis title, inferred y-axis title
+
+::: starfish
+
+```js
+gf.Chart(seafood)
+  .flow(gf.spread({ by: "lake", dir: "x" }))
+  .mark(gf.rect({ h: "count" }))
+  .render(root, {
+    w: 400,
+    h: 250,
+    axes: { x: { title: "Sampling Location" }, y: true },
   });
 ```
 
-Suppress the inferred title on the x-axis:
+:::
 
-```ts
-chart(data)
-  .flow(spread("category", { dir: "x" }))
-  .mark(rect({ h: "value" }))
-  .render(container, {
-    w: 500,
-    h: 300,
+### Suppress the inferred title on the x-axis
+
+::: starfish
+
+```js
+gf.Chart(seafood)
+  .flow(gf.spread({ by: "lake", dir: "x" }))
+  .mark(gf.rect({ h: "count" }))
+  .render(root, {
+    w: 400,
+    h: 250,
     axes: { x: { title: false }, y: true },
   });
 ```
+
+:::


### PR DESCRIPTION
## What

Documents the axis title support added in #<previous-pr-number>.

Updates `apps/docs/docs/api/core/render.md` with:

- Updated `axes` option type signature (`AxesOptions` and `AxisOptions`)
- New "Axes" section describing top-level vs per-axis behavior
- Examples covering inferred titles, single axis, custom title, and suppressed title

## Sample

    chart(data)
      .flow(spread("category", { dir: "x" }))
      .mark(rect({ h: "value" }))
      .render(container, {
        w: 500,
        h: 300,
        axes: { x: { title: "Product Category" }, y: true },
      });