### PR TITLE
docs: add pulley example page and docs-build CI check

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: docs-build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,37 @@
+name: Docs Build
+
+# Verifies the VitePress docs site builds cleanly on every PR — catches broken
+# links, missing example registrations, and TypeDoc failures before they land.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build gofish-graphics library
+        run: pnpm --filter gofish-graphics build
+
+      - name: Build docs site
+        run: pnpm --filter docs docs:build

--- a/apps/docs/docs/.vitepress/data/examples.data.js
+++ b/apps/docs/docs/.vitepress/data/examples.data.js
@@ -162,6 +162,12 @@ export default {
         description: "A layered area chart",
       },
       {
+        id: "pulley",
+        title: "Pulley Diagram",
+        description:
+          "A constraint-based physics diagram ported from Bluefish — pulleys, ropes, and weights laid out in nested layer tiers",
+      },
+      {
         id: "HIDDEN-bar-chart-get-started",
       },
       {

--- a/apps/docs/docs/.vitepress/examples/pulley.ts
+++ b/apps/docs/docs/.vitepress/examples/pulley.ts
@@ -1,0 +1,222 @@
+// Ported from Bluefish's example-gallery pulley.tsx. A constraint-based physics
+// diagram: a ceiling bar, three pulley wheels (A/B/C), two hanging weights
+// (W1/W2), brown rope segments, and single-letter dimension labels.
+//
+// Structured as nested layer tiers: tier 1 places the shapes, tier 2 lays
+// down the ropes (which read those placed shapes), and tier 3 places the
+// dimension labels beside the ropes.
+
+const r = 25;
+const w2jut = 10;
+// Connect's default mix-blend-mode is "multiply" — that turns the brown stroke
+// translucent over the gray pulleys. Override to "normal" so the ropes are
+// solid/opaque, matching the Bluefish reference.
+const rope = {
+  stroke: "#774e32",
+  strokeWidth: 3,
+  mixBlendMode: "normal",
+};
+
+const PulleyCircle = gf.createMark(({ r = 25 } = {}) =>
+  gf
+    .Layer([
+      gf
+        .circle({ r, stroke: "#828282", strokeWidth: 3, fill: "#C1C1C1" })
+        .name("wheel"),
+      gf.circle({ r: 5, fill: "#555555" }).name("hub"),
+    ])
+    .constrain(({ wheel, hub }) => [
+      gf.Constraint.align({ x: "middle", y: "middle" }, [wheel, hub]),
+    ])
+);
+
+const Weight = gf.createMark(({ width, height, label }) =>
+  gf
+    .Layer([
+      gf
+        .polygon({
+          // GoFish y-up: full-width bottom edge at y=0, inset top edge at y=height.
+          points: [
+            [0, 0],
+            [width, 0],
+            [width - 10, height],
+            [10, height],
+          ],
+          fill: "#545454",
+          stroke: "#545454",
+        })
+        .name("body"),
+      gf.text({ text: label, fontSize: 10, fill: "white" }).name("label"),
+    ])
+    .constrain(({ body, label }) => [
+      gf.Constraint.align({ x: "middle", y: "middle" }, [body, label]),
+    ])
+);
+
+// Cross-tier names: the ropes (outer layer) reference the shapes (inner
+// layer). String names are layer-scoped; `createName` tokens register
+// globally, so `ref(token)` resolves across the layer boundary.
+const ceiling = gf.createName("ceiling");
+const A = gf.createName("A");
+const B = gf.createName("B");
+const C = gf.createName("C");
+const w1 = gf.createName("w1");
+const w2 = gf.createName("w2");
+
+// x/y shift the resolved bounding box to start at (20, 20) — the constraint
+// layout produces negative coordinates and the root render does not auto-fit.
+gf.Layer({ x: 20, y: 20 }, [
+  // ── tier 1: shapes + letter labels — a finished, fully-placed unit ──
+  gf
+    .Layer([
+      gf
+        .rect({
+          h: 20,
+          w: 9 * r,
+          fill: "#C9C9C9",
+          stroke: "#000",
+          strokeWidth: 2,
+        })
+        .name(ceiling),
+      PulleyCircle({ r }).name(A),
+      PulleyCircle({ r }).name(B),
+      PulleyCircle({ r }).name(C),
+      Weight({ width: 30, height: 30, label: "W1" }).name(w1),
+      Weight({ width: 3 * r + w2jut, height: 30, label: "W2" }).name(w2),
+      gf.text({ text: "A", fontSize: 12 }).name("Alabel"),
+      gf.text({ text: "B", fontSize: 12 }).name("Blabel"),
+      gf.text({ text: "C", fontSize: 12 }).name("Clabel"),
+    ])
+    .constrain((c) => [
+      // horizontal pulley cluster — each adjacent pair shares an edge:
+      // B.start sits on A.middle (overlap by half a wheel), C.start on B.end.
+      gf.Constraint.align({ x: ["middle", "start"] }, [c.A, c.B]),
+      gf.Constraint.align({ x: ["end", "start"] }, [c.B, c.C]),
+
+      // vertical placement (GoFish is y-up; pair order flipped vs Bluefish)
+      gf.Constraint.distribute({ dir: "y", spacing: 40, mode: "edge" }, [
+        c.B,
+        c.ceiling,
+      ]),
+      gf.Constraint.distribute({ dir: "y", spacing: 30, mode: "edge" }, [
+        c.A,
+        c.B,
+      ]),
+      gf.Constraint.distribute({ dir: "y", spacing: 50, mode: "edge" }, [
+        c.C,
+        c.B,
+      ]),
+
+      // ceiling centered over the cluster
+      gf.Constraint.align({ x: "middle" }, [c.B, c.ceiling]),
+
+      // weights (negative spacing offsets each weight so its inset trapezoid
+      // top sits under the rope source points)
+      gf.Constraint.distribute({ dir: "y", spacing: 50, mode: "edge" }, [
+        c.w2,
+        c.C,
+      ]),
+      gf.Constraint.distribute({ dir: "x", spacing: -20, mode: "edge" }, [
+        c.A,
+        c.w2,
+      ]),
+      gf.Constraint.distribute({ dir: "x", spacing: -15, mode: "edge" }, [
+        c.w1,
+        c.A,
+      ]),
+      gf.Constraint.align({ y: "middle" }, [c.w2, c.w1]),
+
+      // pulley letter labels — 1px gap from the wheel; the label sits on
+      // one side and y-anchors to one corner of the wheel.
+      ...[
+        { pulley: c.A, label: c.Alabel, side: "left", y: "end" },
+        { pulley: c.B, label: c.Blabel, side: "right", y: "end" },
+        { pulley: c.C, label: c.Clabel, side: "right", y: "start" },
+      ].flatMap(({ pulley, label, side, y }) => [
+        gf.Constraint.distribute(
+          { dir: "x", spacing: 1, mode: "edge" },
+          side === "right" ? [pulley, label] : [label, pulley]
+        ),
+        gf.Constraint.align({ y }, [pulley, label]),
+      ]),
+    ]),
+
+  // ── tier 2: rope segments — read the placed shapes ──────────────────
+  // Declared after tier 1 so their ref()s resolve against placed shapes.
+  // zOrder(-1): painted behind tier 1, so the wheels draw over rope ends.
+  // `ropeSupport` is the unlabeled support rope from the ceiling to B; the
+  // rest are named after the dimension letter (x/y/z/p/q/s) they carry.
+  gf
+    .Connect({ ...rope, target: "middle" }, [gf.ref(ceiling), gf.ref(B)])
+    .name("ropeSupport")
+    .zOrder(-1),
+  gf
+    .Connect({ ...rope, source: ["start", "middle"], target: "middle" }, [
+      gf.ref(B),
+      gf.ref(A),
+    ])
+    .name("ropeX")
+    .zOrder(-1),
+  gf
+    .Connect(
+      { ...rope, source: ["end", "middle"], target: ["start", "middle"] },
+      [gf.ref(B), gf.ref(C)]
+    )
+    .name("ropeY")
+    .zOrder(-1),
+  gf
+    .Connect({ ...rope, target: ["end", "middle"] }, [
+      gf.ref(ceiling),
+      gf.ref(C),
+    ])
+    .name("ropeZ")
+    .zOrder(-1),
+  gf
+    .Connect({ ...rope, source: ["start", "middle"] }, [gf.ref(A), gf.ref(w1)])
+    .name("ropeP")
+    .zOrder(-1),
+  gf
+    .Connect({ ...rope, source: ["end", "middle"] }, [gf.ref(A), gf.ref(w2)])
+    .name("ropeQ")
+    .zOrder(-1),
+  gf
+    .Connect({ ...rope, source: "middle" }, [gf.ref(C), gf.ref(w2)])
+    .name("ropeS")
+    .zOrder(-1),
+
+  // ── tier 3: dimension labels ────────────────────────────────────────
+  gf.text({ text: "x" }).name("labelX"),
+  gf.text({ text: "y" }).name("labelY"),
+  gf.text({ text: "z" }).name("labelZ"),
+  gf.text({ text: "p" }).name("labelP"),
+  gf.text({ text: "q" }).name("labelQ"),
+  gf.text({ text: "s" }).name("labelS"),
+])
+  .constrain((c) => [
+    // Each dimension label sits 5px right of its rope on x. On y, the upper
+    // trio (x/y/z) shares ropeX's centerY; the lower trio (p/q/s) shares
+    // ropeS's.
+    ...[
+      { rope: c.ropeX, label: c.labelX, yAnchorTo: c.ropeX },
+      { rope: c.ropeY, label: c.labelY, yAnchorTo: c.labelX },
+      { rope: c.ropeZ, label: c.labelZ, yAnchorTo: c.labelX },
+      { rope: c.ropeS, label: c.labelS, yAnchorTo: c.ropeS },
+      { rope: c.ropeQ, label: c.labelQ, yAnchorTo: c.labelS },
+      { rope: c.ropeP, label: c.labelP, yAnchorTo: c.labelS },
+    ].flatMap(({ rope, label, yAnchorTo }) => [
+      gf.Constraint.distribute({ dir: "x", spacing: 5, mode: "edge" }, [
+        rope,
+        label,
+      ]),
+      gf.Constraint.align({ y: "middle" }, [yAnchorTo, label]),
+    ]),
+
+    // ── granular paint order: relative z-order constraints ────────────
+    // The ropes' default .zOrder(-1) keeps the unmentioned ropes (Y/Z/P/Q)
+    // behind their circles; these constraints carve out the four exceptions.
+    gf.Constraint.zAbove(c.ropeX, c.A), // x over A
+    gf.Constraint.zBelow(c.ropeX, c.B), // x under B
+    gf.Constraint.zAbove(c.ropeSupport, c.B), // ceiling→B over B
+    gf.Constraint.zAbove(c.ropeS, c.C), // s over C
+  ])
+  .render(root, { w: 360, h: 440 });

--- a/apps/docs/docs/js/api/operators/connect.md
+++ b/apps/docs/docs/js/api/operators/connect.md
@@ -158,4 +158,4 @@ Connect({ source: "middle" }, [ref("A"), ref("B"), ref("C")]);
 - Pair the operator with z-order constraints
   ([`Constraint.zAbove` / `zBelow`](/js/api/constraints/constrain#constraint-zabove-constraint-zbelow))
   when a connector needs to sit _between_ two elements in paint order — see
-  the [pulley story](/js/examples/pulley) for the canonical use case.
+  the [pulley diagram](/js/examples/pulley) for the canonical use case.

--- a/apps/docs/docs/js/examples/pulley.md
+++ b/apps/docs/docs/js/examples/pulley.md
@@ -23,3 +23,4 @@ The diagram demonstrates several mid-level features in concert:
   "rope passes _between_ two pulley wheels" effect.
 
 ::: starfish example:pulley
+:::

--- a/apps/docs/docs/js/examples/pulley.md
+++ b/apps/docs/docs/js/examples/pulley.md
@@ -1,0 +1,25 @@
+# Pulley Diagram
+
+A constraint-based physics diagram ported from
+[Bluefish's example gallery](https://github.com/bluefish-vis/bluefish). Three
+pulley wheels, two hanging weights, brown rope segments threading between them,
+and single-letter dimension labels — all positioned by declarative constraints
+rather than absolute coordinates.
+
+The diagram demonstrates several mid-level features in concert:
+
+- **Nested layer tiers** — tier 1 places the shapes, tier 2 lays down the
+  ropes that read those placed shapes, tier 3 places the dimension labels
+  beside the ropes.
+- **`createName` tokens** — global names that let cross-tier
+  [`ref`](/js/api/marks/ref) lookups (the ropes in the outer layer) resolve
+  shapes declared inside an inner layer.
+- **[`Connect`](/js/api/operators/connect) anchor sugar** — `source` /
+  `target` accept `start | middle | end` per axis (and per-axis tuples) to
+  pick where each rope attaches.
+- **Relative z-order constraints** — `Constraint.zAbove` / `zBelow` declare
+  partial-order paint relations between named children; the engine
+  topologically sorts them into a total order. This is what carves out the
+  "rope passes _between_ two pulley wheels" effect.
+
+::: starfish example:pulley


### PR DESCRIPTION
## Summary

- **Fixes a broken link from the most recent commit.** `apps/docs/docs/js/api/operators/connect.md` linked to `/js/examples/pulley`, but no such page existed — `pnpm --filter docs docs:build` failed with a dead-link error.
- **Adds a real pulley example page.** Ports the `Bluefish/Pulley` Storybook story into a gallery entry (`apps/docs/docs/js/examples/pulley.md` + registered `pulley.ts` example). The example demonstrates exactly the use case the connect-operator docs cite for it: nested layer tiers, `createName` for cross-tier `ref`s, `Connect`'s anchor sugar, and `Constraint.zAbove` / `zBelow` for granular paint order.
- **Adds a PR-gated docs-build CI workflow.** `.github/workflows/docs-build.yml` runs on every PR (and pushes to `main`), building `gofish-graphics` and then the VitePress site — so future broken links, missing example registrations, and TypeDoc failures are caught pre-merge instead of after `deploy-docs.yml` fails on main.

## Test plan

- [x] `pnpm --filter docs docs:build` succeeds locally (was failing before this change with `Found dead link /js/examples/pulley in file js/api/operators/connect.md`)
- [ ] New `docs-build` CI job runs green on this PR
- [ ] Visit `/js/examples/pulley` on the preview — pulley figure renders identically to the Storybook story
- [ ] Click through from the connect-operator docs to confirm the link now resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)