### PR TITLE
fix(tests): scope snapshot-branch staged check to the index

### DIFF
--- a/tests/scripts/snapshot-branch.ts
+++ b/tests/scripts/snapshot-branch.ts
@@ -255,9 +255,11 @@ export function commitAndPushSnapshots(
     // committed to the data-only snapshot branch.
     git("git add -A dom screenshots", { cwd: wtPath });
 
-    // Check if there's anything to commit.
-    const status = git("git status --porcelain", { cwd: wtPath });
-    if (!status) {
+    // Check if there's anything staged. Use --cached so untracked files
+    // like .husky/ (created by pnpm install) don't fool us into running
+    // `git commit` with an empty index.
+    const staged = git("git diff --cached --name-only", { cwd: wtPath });
+    if (!staged) {
       console.log("No changes to snapshot baselines.");
       return;
     }


### PR DESCRIPTION
## Summary

- `commitAndPushSnapshots` (`tests/scripts/snapshot-branch.ts`) used `git status --porcelain` to decide whether to commit, but that also reports untracked files. The `.husky/` directory created by `pnpm install` in the temporary worktree always shows up as untracked, so the early-return never fired when baselines were actually unchanged — and the subsequent `git commit` failed with "nothing added to commit but untracked files present".
- Replace the check with `git diff --cached --name-only`, which mirrors exactly what the preceding `git add -A dom screenshots` stages.

## Context

Surfaced today on `main` after squashing PR #411: the rewrite produced a tree identical to what was already on `snapshots/main`, so the `update-baselines` job generated zero baseline changes and hit this latent bug. Until now every push to `main` had real baseline diffs, masking it.

## Test plan

- [ ] `update-baselines` job on `main` succeeds after merge (next push that produces no baseline changes should now log "No changes to snapshot baselines." and exit cleanly).
- [ ] A push that *does* change baselines still commits and pushes them to the snapshot branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)