### PR TITLE
ci(storybook): publish-only Chromatic, drop UI Tests step

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -39,11 +39,13 @@ jobs:
       - name: Build gofish-graphics library
         run: pnpm --filter gofish-graphics build
 
-      - name: Run Chromatic
+      - name: Publish Storybook to Chromatic
         uses: chromaui/action@latest
         with:
           projectToken: chpt_b7e06495d0d4585
           workingDir: packages/gofish-graphics
           buildScriptName: build-storybook
-          onlyChanged: true # Only test stories that changed
-          autoAcceptChanges: "main"
+          # Publish-only mode: visual regressions are caught by our custom
+          # diff viewer (see visual-tests.yml), so exit as soon as Storybook
+          # is uploaded instead of waiting for Chromatic's UI Tests.
+          exitOnceUploaded: true

--- a/packages/gofish-graphics/index.html
+++ b/packages/gofish-graphics/index.html
@@ -1,5 +1,4 @@
-<!doctype html>
-<!-- trigger storybook workflow to verify publish-only mode -->
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/packages/gofish-graphics/index.html
+++ b/packages/gofish-graphics/index.html
@@ -1,4 +1,5 @@
-<!DOCTYPE html>
+<!doctype html>
+<!-- trigger storybook workflow to verify publish-only mode -->
 <html lang="en">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
## Summary
- Sets `exitOnceUploaded: true` on the Chromatic action so the CI step finishes as soon as Storybook is uploaded, instead of waiting on Chromatic's UI Tests.
- Drops `onlyChanged` and `autoAcceptChanges` (both only relevant when UI Tests run).
- Visual regressions are caught by our custom diff viewer in `visual-tests.yml`; UI Tests have also been disabled in the Chromatic project settings.

## Test plan
- [ ] On this PR, confirm the "Storybook Publish" check still appears and passes.
- [ ] Confirm no "UI Tests" commit status is posted on the PR.
- [ ] After merge, confirm the published Storybook URL still updates on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)