### PR TITLE
feat(tooling): visual example iteration loop (capture-one + iterate-example skill)

### DIFF
--- a/.claude/skills/iterate-example/SKILL.md
+++ b/.claude/skills/iterate-example/SKILL.md
@@ -30,11 +30,22 @@ Storybook story headlessly and writes a PNG you can `Read`.
 
 ## The loop
 
-1. **Identify the target story and the intent.** Which `.stories.tsx` story are we
-   working on? What is the chart *supposed* to show? If the user named a story
-   (e.g. `bar/grouped`), use that. If unsure which stories exist, run
-   `pnpm --filter @gofish/tests capture-one` with no argument to list them, or
-   ask the user what the example should look like.
+1. **Identify the target story and the intent.** The user does **not** need to give
+   an exact story id — a freeform description is fine (e.g. `/iterate-example
+   implement a pulley diagram` or "fix the scatter example"). Resolve it to a story:
+   - **Existing story:** any substring works — `capture-one` matches case-insensitively
+     against `Title/StoryName`, so `"pulley"` or `"scatter"` is enough. If the
+     description is ambiguous, run `pnpm --filter @gofish/tests capture-one` with no
+     argument to list stories and pick the best match (confirm with the user if
+     genuinely unclear).
+   - **New example that doesn't exist yet** (e.g. "implement a pulley diagram"):
+     first **author the story** — add a `.stories.tsx` under
+     `packages/gofish-graphics/stories/` (follow a sibling story's structure: a
+     default `meta` with a `title`, and a named export with a `render`). Then iterate
+     on it with the loop below.
+
+   Either way, pin down what the chart is *supposed* to show before capturing — that
+   intent is what you critique the rendered image against.
 
 2. **Capture it.**
 

--- a/.claude/skills/iterate-example/SKILL.md
+++ b/.claude/skills/iterate-example/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: iterate-example
+description: Render a GoFish Storybook example to an image, look at it, and fix mistakes in a feedback loop. Use when authoring or debugging a chart example/story and you want to visually verify and refine the output (not just edit the code blind).
+user-invocable: true
+allowed-tools:
+  - Read
+  - Edit
+  - Write
+  - Bash
+---
+
+# Iterate on a GoFish example
+
+Author/refine a chart example by actually **looking** at the rendered output and
+fixing what's wrong — instead of editing the `.stories.tsx` blind and stopping.
+
+The enabling primitive is `tests/scripts/capture-one.ts`: it renders a single
+Storybook story headlessly and writes a PNG you can `Read`.
+
+## Prerequisites (check once per session)
+
+1. `node_modules` present — if pre-commit/dev tooling is broken, run `pnpm install`.
+2. `packages/gofish-graphics/dist/` exists — the render harness eagerly imports
+   every story, and one regression story imports the built `dist/`. If `dist/` is
+   missing the harness fails to initialize. If a capture errors with
+   "Stories runner failed to initialize", run `pnpm --filter gofish-graphics build`
+   once. You do **not** need to rebuild after editing `src/` — the harness aliases
+   `gofish-graphics` to live `src/lib.ts`, so source and story edits are picked up
+   on the next capture automatically.
+
+## The loop
+
+1. **Identify the target story and the intent.** Which `.stories.tsx` story are we
+   working on? What is the chart *supposed* to show? If the user named a story
+   (e.g. `bar/grouped`), use that. If unsure which stories exist, run
+   `pnpm --filter @gofish/tests capture-one` with no argument to list them, or
+   ask the user what the example should look like.
+
+2. **Capture it.**
+
+   ```bash
+   pnpm --filter @gofish/tests capture-one "<substring>"
+   ```
+
+   The substring is matched case-insensitively against `Title/StoryName`
+   (e.g. `"bar/grouped"`, `"scatter"`). It prints the PNG path(s) it wrote under
+   `tests/tmp/iterate/`. Watch the command output for `FAILED:` lines and
+   `[browser]` console errors — a render-time exception is itself a finding to fix.
+
+3. **Look at it.** `Read` the printed PNG path. Also `Read` the sibling `.html`
+   (normalized DOM/SVG) when you need exact coordinates, sizes, or to confirm an
+   element rendered at all.
+
+4. **Critique against intent + a chart-quality checklist:**
+   - Does it match what the example is meant to demonstrate?
+   - Marks overlapping, clipped, or escaping the frame; zero/negative sizes.
+   - Axes: correct domain/range, sensible ticks, no overlap, readable labels.
+   - Encodings: right channel for the data (size/pos/color/raw); legible color.
+   - Spacing, alignment, empty space, aspect ratio.
+   - Empty render or console errors (a blank PNG usually means a thrown error).
+
+5. **Fix.** Edit the story, or the library source under
+   `packages/gofish-graphics/src/` if the bug is in the engine. Keep changes
+   minimal and in the surrounding style.
+
+6. **Re-capture and re-look.** Repeat steps 2–5 until the chart matches intent or
+   you've made ~5 passes with no further improvement. If you stall, say what's
+   still off rather than declaring success.
+
+7. **Report.** Summarize what you changed and show the final image. Note any
+   issue you believe is a library bug rather than an example mistake.
+
+## Notes
+
+- This is **visual-judgment** review of a (possibly new) example — it does not
+  diff against a baseline. Pixel-diff regression testing is the separate
+  `pnpm test:visual` flow; do not run `update-baselines` here (baselines are
+  CI-Linux-specific and drift on Mac).
+- `capture-one` uses Vite port 3002, so it won't collide with a running
+  `pnpm storybook` (6006) or the full `capture-js` harness (3001).
+- If the user is also running `pnpm storybook`, they can watch the same story
+  live in the browser while you iterate; the capture is just how *you* see it.

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ __pycache__/
 *.egg-info/
 _static/
 .cursor/
-.claude/
+.claude/*
+# Share project skills with the team; keep everything else under .claude/ local.
+!.claude/skills/
 tests/tmp/
 __snapshots__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,12 @@ Key coordinate systems available:
 - **Update docs on user-facing API changes**: When you change a public API surface (signatures, option shapes, exported names, default behaviors) in `packages/gofish-graphics/src/`, update the corresponding page under `apps/docs/docs/js/` in the same change — signature, examples, and any equivalences tables. For Python API changes (`packages/gofish-python/`), update the mirror page under `apps/docs/docs/python/`. The docs site has one folder per language (`js/`, `python/`) with a top-level language toggle. Do not defer this to a follow-up.
 - **Monorepo Management**: Uses pnpm workspaces
 - **Visual Development**: Use Storybook (`pnpm storybook`) for interactive development and testing
+- **Iterating on examples with Claude**: `pnpm capture-one "<title/story>"` renders a single
+  Storybook story headlessly to `tests/tmp/iterate/<path>.png` (+ normalized DOM) so Claude can
+  look at the output and fix mistakes in a feedback loop instead of editing blind. Run with no
+  argument to list stories. The `/iterate-example` skill (`.claude/skills/iterate-example/`) drives
+  this render → review → fix loop. Requires `dist/` to exist once (`pnpm --filter gofish-graphics
+build`); source edits are picked up live without rebuilding.
 - **Documentation**: VitePress site in `apps/docs/` with live chart examples
 - **Testing**: The `src/tests/` directory contains visual chart examples for development, not automated unit tests
 - **Development Server**: `pnpm dev` runs Vite dev server on port 3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,8 @@ Key coordinate systems available:
   Storybook story headlessly to `tests/tmp/iterate/<path>.png` (+ normalized DOM) so Claude can
   look at the output and fix mistakes in a feedback loop instead of editing blind. Run with no
   argument to list stories. The `/iterate-example` skill (`.claude/skills/iterate-example/`) drives
-  this render → review → fix loop. Requires `dist/` to exist once (`pnpm --filter gofish-graphics
-build`); source edits are picked up live without rebuilding.
+  this render → review → fix loop. Requires `dist/` to exist once
+  (`pnpm --filter gofish-graphics build`); source edits are picked up live without rebuilding.
 - **Documentation**: VitePress site in `apps/docs/` with live chart examples
 - **Testing**: The `src/tests/` directory contains visual chart examples for development, not automated unit tests
 - **Development Server**: `pnpm dev` runs Vite dev server on port 3000

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:visual": "pnpm --filter @gofish/tests test",
     "test:visual:update": "pnpm --filter @gofish/tests update",
     "test:visual:js": "pnpm --filter @gofish/tests test:js",
+    "capture-one": "pnpm --filter @gofish/tests capture-one",
     "test:visual:review": "pnpm --filter @gofish/tests review",
     "test:visual:check-sync": "pnpm --filter @gofish/tests check-sync",
     "test:visual:python": "pnpm --filter @gofish/tests test:python",

--- a/tests/package.json
+++ b/tests/package.json
@@ -8,6 +8,7 @@
     "test:js": "tsx scripts/capture-js-dom.ts && tsx scripts/compare.ts --js-only",
     "update": "tsx scripts/capture-js-dom.ts && tsx scripts/update-baselines.ts",
     "capture-js": "tsx scripts/capture-js-dom.ts",
+    "capture-one": "tsx scripts/capture-one.ts",
     "update-baselines": "tsx scripts/update-baselines.ts",
     "check-sync": "tsx scripts/check-python-sync.ts",
     "check-python-sync": "tsx scripts/check-python-sync.ts",

--- a/tests/scripts/capture-js-dom.ts
+++ b/tests/scripts/capture-js-dom.ts
@@ -16,6 +16,7 @@ import { spawn, type ChildProcess } from "child_process";
 import { writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { normalizeDom } from "./normalize-dom.js";
+import { storyToPath } from "./path-mapping.js";
 
 // ---------------------------------------------------------------------------
 // Config
@@ -25,28 +26,6 @@ const TESTS_DIR = join(import.meta.dirname, "..");
 const HARNESS_DIR = join(TESTS_DIR, "harness");
 const TMP_DIR = join(TESTS_DIR, "tmp/js");
 const VITE_PORT = 3001;
-
-// ---------------------------------------------------------------------------
-// Story ID → file path mapping
-// ---------------------------------------------------------------------------
-
-/** Convert a story title + name into a file-system path for snapshots. */
-function storyToPath(title: string, name: string): string {
-  // "Forward Syntax V3/Bar/Basic" + "Default" → "forward-syntax/bar/basic--default"
-  const segments = title.split("/").map((s) =>
-    s
-      .replace(/([a-z])([A-Z])/g, "$1-$2")
-      .replace(/\s+/g, "-")
-      .toLowerCase()
-  );
-
-  const storyName = name
-    .replace(/([a-z])([A-Z])/g, "$1-$2")
-    .replace(/\s+/g, "-")
-    .toLowerCase();
-
-  return `${segments.join("/")}--${storyName}`;
-}
 
 // ---------------------------------------------------------------------------
 // Start Vite dev server

--- a/tests/scripts/capture-one.ts
+++ b/tests/scripts/capture-one.ts
@@ -1,0 +1,221 @@
+/**
+ * Capture a screenshot (+ normalized DOM) for ONE story (or a small subset),
+ * on demand, for an interactive review loop.
+ *
+ * This is the fast primitive behind the `iterate-example` skill: render the
+ * single story you're working on to a PNG that Claude (or you) can look at,
+ * critique, and fix — without re-rendering the entire story corpus the way
+ * `capture-js-dom.ts` does.
+ *
+ * It reuses the same headless harness as `capture-js-dom.ts`:
+ *   1. Start a Vite dev server serving the stories-runner page
+ *   2. Navigate Playwright to that page ONCE
+ *   3. List stories, filter by the CLI substring, render + screenshot matches
+ *
+ * Usage:
+ *   tsx scripts/capture-one.ts                 # list all available stories
+ *   tsx scripts/capture-one.ts bar/grouped     # capture stories matching "bar/grouped"
+ *   tsx scripts/capture-one.ts "Scatter"       # case-insensitive substring on title/name/id
+ *
+ * Output: tests/tmp/iterate/<path>.png  (and .html for the normalized DOM)
+ * The matched output paths are printed at the end so a caller knows what to read.
+ */
+
+import { chromium, type Browser } from "playwright";
+import { spawn, type ChildProcess } from "child_process";
+import { writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { normalizeDom } from "./normalize-dom.js";
+
+const TESTS_DIR = join(import.meta.dirname, "..");
+const HARNESS_DIR = join(TESTS_DIR, "harness");
+const OUT_DIR = join(TESTS_DIR, "tmp/iterate");
+const VITE_PORT = 3002; // distinct from capture-js-dom (3001) so both can run
+
+/** Convert a story title + name into a file-system path for snapshots. */
+function storyToPath(title: string, name: string): string {
+  const segments = title.split("/").map((s) =>
+    s
+      .replace(/([a-z])([A-Z])/g, "$1-$2")
+      .replace(/\s+/g, "-")
+      .toLowerCase()
+  );
+  const storyName = name
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+  return `${segments.join("/")}--${storyName}`;
+}
+
+function startViteServer(): ChildProcess {
+  return spawn(
+    "npx",
+    [
+      "vite",
+      "--config",
+      join(HARNESS_DIR, "vite.config.ts"),
+      "--port",
+      String(VITE_PORT),
+    ],
+    {
+      cwd: HARNESS_DIR,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, NODE_ENV: "development" },
+    }
+  );
+}
+
+async function waitForVite(port: number, timeoutMs = 30_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const resp = await fetch(`http://localhost:${port}/stories-runner.html`);
+      if (resp.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Vite server did not start within ${timeoutMs}ms`);
+}
+
+async function main() {
+  const filter = process.argv[2]?.toLowerCase().trim();
+
+  const viteProc = startViteServer();
+  viteProc.stdout?.on("data", (d) => {
+    if (process.env.DEBUG) process.stdout.write(d.toString());
+  });
+  viteProc.stderr?.on("data", (d) => process.stderr.write(d.toString()));
+
+  let browser: Browser | undefined;
+
+  try {
+    await waitForVite(VITE_PORT);
+
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 720 },
+    });
+    const page = await context.newPage();
+
+    // Surface render-time errors — these are exactly what the review loop wants to see.
+    page.on("console", (msg) => {
+      if (msg.type() === "error") console.error(`[browser] ${msg.text()}`);
+      else if (process.env.DEBUG)
+        console.log(`[browser:${msg.type()}] ${msg.text()}`);
+    });
+    page.on("pageerror", (err) =>
+      console.error(`[browser pageerror] ${err.message}`)
+    );
+
+    await page.goto(`http://localhost:${VITE_PORT}/stories-runner.html`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForFunction(
+      () => (window as any).__STORIES_RUNNER_READY__ === true,
+      { timeout: 30_000 }
+    );
+    const runnerError = await page.evaluate(
+      () => (window as any).__STORIES_RUNNER_ERROR__
+    );
+    if (runnerError)
+      throw new Error(`Stories runner failed to initialize: ${runnerError}`);
+
+    const stories = await page.evaluate(() => window.__listStories__());
+
+    // No filter → list what's available and exit. Helps when you don't know the id.
+    if (!filter) {
+      console.log(
+        `\n${stories.length} stories available. Pass a substring to capture one:\n`
+      );
+      for (const s of stories) console.log(`  ${s.title}/${s.name}`);
+      console.log(
+        `\ne.g.  tsx scripts/capture-one.ts "${stories[0]?.title}/${stories[0]?.name}"`
+      );
+      return;
+    }
+
+    const matches = stories.filter((s) => {
+      const hay = `${s.title}/${s.name}`.toLowerCase();
+      return hay.includes(filter) || s.id.includes(filter);
+    });
+
+    if (matches.length === 0) {
+      console.error(
+        `\nNo stories match "${filter}". Run without an argument to list all stories.`
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    // Clean only this iterate output dir (never touches capture-js-dom's tmp/js).
+    if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true });
+    mkdirSync(OUT_DIR, { recursive: true });
+
+    console.log(
+      `\nCapturing ${matches.length} story(ies) matching "${filter}":\n`
+    );
+    const written: string[] = [];
+
+    for (const story of matches) {
+      const path = storyToPath(story.title, story.name);
+      process.stdout.write(`  ${story.title}/${story.name} ... `);
+
+      const success = await page.evaluate(
+        async (id) => window.__renderStory__(id),
+        story.id
+      );
+      if (!success) {
+        const err = await page.evaluate(() => window.__STORY_RENDER_ERROR__);
+        console.log(`FAILED: ${err}`);
+        continue;
+      }
+      await page.waitForFunction(() => window.__STORY_RENDER_DONE__ === true, {
+        timeout: 15_000,
+      });
+
+      const rawDom = await page.evaluate(() => {
+        const root = document.getElementById("stories-root");
+        return root ? root.innerHTML : "";
+      });
+      if (!rawDom.trim()) {
+        console.log("SKIP (empty)");
+        continue;
+      }
+
+      const domPath = join(OUT_DIR, `${path}.html`);
+      mkdirSync(dirname(domPath), { recursive: true });
+      writeFileSync(domPath, normalizeDom(rawDom), "utf-8");
+
+      const rootHandle = await page.$("#stories-root");
+      if (rootHandle) {
+        const screenshotPath = join(OUT_DIR, `${path}.png`);
+        mkdirSync(dirname(screenshotPath), { recursive: true });
+        writeFileSync(
+          screenshotPath,
+          await rootHandle.screenshot({ type: "png" })
+        );
+        written.push(screenshotPath);
+      }
+      console.log("OK");
+    }
+
+    if (written.length) {
+      console.log(`\nScreenshots written — open/read these:`);
+      for (const p of written) console.log(`  ${p}`);
+    }
+
+    await context.close();
+  } finally {
+    await browser?.close();
+    viteProc.kill();
+  }
+}
+
+main()
+  .then(() => process.exit(process.exitCode ?? 0))
+  .catch((err) => {
+    console.error("Fatal error:", err);
+    process.exit(1);
+  });

--- a/tests/scripts/capture-one.ts
+++ b/tests/scripts/capture-one.ts
@@ -148,44 +148,51 @@ async function main() {
       const path = storyToPath(story.title, story.name);
       process.stdout.write(`  ${story.title}/${story.name} ... `);
 
-      const success = await page.evaluate(
-        async (id) => window.__renderStory__(id),
-        story.id
-      );
-      if (!success) {
-        const err = await page.evaluate(() => window.__STORY_RENDER_ERROR__);
-        console.log(`FAILED: ${err}`);
-        continue;
-      }
-      await page.waitForFunction(() => window.__STORY_RENDER_DONE__ === true, {
-        timeout: 15_000,
-      });
-
-      const rawDom = await page.evaluate(() => {
-        const root = document.getElementById("stories-root");
-        return root ? root.innerHTML : "";
-      });
-      if (!rawDom.trim()) {
-        console.log("SKIP (empty)");
-        continue;
-      }
-
-      const domPath = join(OUT_DIR, `${path}.html`);
-      mkdirSync(dirname(domPath), { recursive: true });
-      writeFileSync(domPath, normalizeDom(rawDom), "utf-8");
-
-      const rootHandle = await page.$("#stories-root");
-      if (rootHandle) {
-        const screenshotPath = join(OUT_DIR, `${path}.png`);
-        mkdirSync(dirname(screenshotPath), { recursive: true });
-        writeFileSync(
-          screenshotPath,
-          await rootHandle.screenshot({ type: "png" })
+      // Guard each story (like capture-js-dom.ts) so one render/timeout failure
+      // doesn't abort the remaining matches when a filter hits several stories.
+      try {
+        const success = await page.evaluate(
+          async (id) => window.__renderStory__(id),
+          story.id
         );
-        // PNG first (read this), then the DOM (read for exact coords/sizes).
-        written.push(screenshotPath, domPath);
+        if (!success) {
+          const err = await page.evaluate(() => window.__STORY_RENDER_ERROR__);
+          console.log(`FAILED: ${err}`);
+          continue;
+        }
+        await page.waitForFunction(
+          () => window.__STORY_RENDER_DONE__ === true,
+          { timeout: 15_000 }
+        );
+
+        const rawDom = await page.evaluate(() => {
+          const root = document.getElementById("stories-root");
+          return root ? root.innerHTML : "";
+        });
+        if (!rawDom.trim()) {
+          console.log("SKIP (empty)");
+          continue;
+        }
+
+        const domPath = join(OUT_DIR, `${path}.html`);
+        mkdirSync(dirname(domPath), { recursive: true });
+        writeFileSync(domPath, normalizeDom(rawDom), "utf-8");
+
+        const rootHandle = await page.$("#stories-root");
+        if (rootHandle) {
+          const screenshotPath = join(OUT_DIR, `${path}.png`);
+          mkdirSync(dirname(screenshotPath), { recursive: true });
+          writeFileSync(
+            screenshotPath,
+            await rootHandle.screenshot({ type: "png" })
+          );
+          // PNG first (read this), then the DOM (read for exact coords/sizes).
+          written.push(screenshotPath, domPath);
+        }
+        console.log("OK");
+      } catch (err) {
+        console.log(`FAILED: ${err instanceof Error ? err.message : err}`);
       }
-      console.log("OK");
     }
 
     if (written.length) {

--- a/tests/scripts/capture-one.ts
+++ b/tests/scripts/capture-one.ts
@@ -23,29 +23,15 @@
 
 import { chromium, type Browser } from "playwright";
 import { spawn, type ChildProcess } from "child_process";
-import { writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { writeFileSync, mkdirSync } from "fs";
 import { join, dirname } from "path";
 import { normalizeDom } from "./normalize-dom.js";
+import { storyToPath } from "./path-mapping.js";
 
 const TESTS_DIR = join(import.meta.dirname, "..");
 const HARNESS_DIR = join(TESTS_DIR, "harness");
 const OUT_DIR = join(TESTS_DIR, "tmp/iterate");
 const VITE_PORT = 3002; // distinct from capture-js-dom (3001) so both can run
-
-/** Convert a story title + name into a file-system path for snapshots. */
-function storyToPath(title: string, name: string): string {
-  const segments = title.split("/").map((s) =>
-    s
-      .replace(/([a-z])([A-Z])/g, "$1-$2")
-      .replace(/\s+/g, "-")
-      .toLowerCase()
-  );
-  const storyName = name
-    .replace(/([a-z])([A-Z])/g, "$1-$2")
-    .replace(/\s+/g, "-")
-    .toLowerCase();
-  return `${segments.join("/")}--${storyName}`;
-}
 
 function startViteServer(): ChildProcess {
   return spawn(
@@ -149,8 +135,8 @@ async function main() {
       return;
     }
 
-    // Clean only this iterate output dir (never touches capture-js-dom's tmp/js).
-    if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true });
+    // Overwrite per-story below (never wipe the whole dir): captures from a
+    // previous filter survive, so you can compare two stories across runs.
     mkdirSync(OUT_DIR, { recursive: true });
 
     console.log(
@@ -196,13 +182,16 @@ async function main() {
           screenshotPath,
           await rootHandle.screenshot({ type: "png" })
         );
-        written.push(screenshotPath);
+        // PNG first (read this), then the DOM (read for exact coords/sizes).
+        written.push(screenshotPath, domPath);
       }
       console.log("OK");
     }
 
     if (written.length) {
-      console.log(`\nScreenshots written — open/read these:`);
+      console.log(
+        `\nWritten — read the .png (and .html for exact coords/sizes):`
+      );
       for (const p of written) console.log(`  ${p}`);
     }
 

--- a/tests/scripts/path-mapping.ts
+++ b/tests/scripts/path-mapping.ts
@@ -1,9 +1,9 @@
 /**
  * path-mapping.ts
  *
- * Pure utility: maps JS story file paths to Python test file paths.
- * Extracted from check-python-sync.ts so it can be imported without
- * triggering that script's top-level imperative code.
+ * Pure utilities for mapping between story identities and file paths.
+ * Extracted so they can be imported without triggering a script's top-level
+ * imperative code.
  */
 
 import { readFileSync } from "fs";
@@ -12,6 +12,25 @@ import { join, dirname } from "path";
 const SCRIPTS_DIR = import.meta.dirname;
 const TESTS_DIR = dirname(SCRIPTS_DIR);
 const ROOT_DIR = dirname(TESTS_DIR);
+
+/**
+ * Convert a Storybook story title + export name into a stable file-system path
+ * used for snapshots/screenshots.
+ *
+ * e.g. ("Forward Syntax V3/Bar/Basic", "Default") → "forward-syntax-v3/bar/basic--default"
+ *
+ * Shared by capture-js-dom.ts (full corpus) and capture-one.ts (single story) so
+ * the two stay in lockstep if the kebab-casing rule ever changes.
+ */
+export function storyToPath(title: string, name: string): string {
+  const toKebab = (s: string) =>
+    s
+      .replace(/([a-z])([A-Z])/g, "$1-$2")
+      .replace(/\s+/g, "-")
+      .toLowerCase();
+  const segments = title.split("/").map(toKebab);
+  return `${segments.join("/")}--${toKebab(name)}`;
+}
 
 /**
  * Maps a JS story file path to the expected Python test file path.

--- a/tests/scripts/path-mapping.ts
+++ b/tests/scripts/path-mapping.ts
@@ -13,6 +13,13 @@ const SCRIPTS_DIR = import.meta.dirname;
 const TESTS_DIR = dirname(SCRIPTS_DIR);
 const ROOT_DIR = dirname(TESTS_DIR);
 
+/** CamelCase / spaced → kebab-case (one source of truth for path generation). */
+const toKebab = (s: string) =>
+  s
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/\s+/g, "-")
+    .toLowerCase();
+
 /**
  * Convert a Storybook story title + export name into a stable file-system path
  * used for snapshots/screenshots.
@@ -23,11 +30,6 @@ const ROOT_DIR = dirname(TESTS_DIR);
  * the two stay in lockstep if the kebab-casing rule ever changes.
  */
 export function storyToPath(title: string, name: string): string {
-  const toKebab = (s: string) =>
-    s
-      .replace(/([a-z])([A-Z])/g, "$1-$2")
-      .replace(/\s+/g, "-")
-      .toLowerCase();
   const segments = title.split("/").map(toKebab);
   return `${segments.join("/")}--${toKebab(name)}`;
 }
@@ -52,11 +54,6 @@ export function mapJsToPython(jsFile: string): string {
   }
 
   if (title) {
-    const toKebab = (s: string) =>
-      s
-        .replace(/([a-z])([A-Z])/g, "$1-$2")
-        .replace(/\s+/g, "-")
-        .toLowerCase();
     const segments = title.split("/").map(toKebab);
     const dirPath = segments.slice(0, -1).join("/");
     const basePart = segments[segments.length - 1].replace(/-/g, "_");


### PR DESCRIPTION
## What

Adds tooling so Claude (and people) can iterate on chart examples by **looking at the rendered output** and fixing mistakes — instead of editing a `.stories.tsx` blind and stopping.

## Why

We add examples as Storybook stories, but Claude Code can't see the rendered chart, so it never enters a review→fix feedback loop after adding one. This closes that gap.

## What's in it

- **`tests/scripts/capture-one.ts`** (`pnpm capture-one "<title/story>"`) — renders a *single* story headlessly to `tests/tmp/iterate/<path>.png` (+ normalized DOM), reusing the existing `stories-runner` harness. Substring-matches title/name; no-arg lists all stories. Watches for render errors and browser console errors. Uses Vite port 3002 so it won't collide with `pnpm storybook` (6006) or the full `capture-js` harness (3001).
- **`.claude/skills/iterate-example/`** — a `user-invocable` skill that encodes the loop: identify story + intent → capture → look at the PNG → critique against a chart-quality checklist → fix → re-capture → repeat.
- **`.gitignore`** — un-ignores `.claude/skills/` so project skills ship with the repo; local `.claude` settings stay private.
- **`pnpm capture-one`** script (root + `@gofish/tests`) and a CLAUDE.md dev note.

## Notes

- Requires `dist/` to exist once (`pnpm --filter gofish-graphics build`) because the harness eagerly imports a regression story that pulls from the build; `src`/story edits are then picked up live without rebuilding.
- This is visual-judgment review of (often new) examples — it does **not** diff against baselines. Pixel-diff regression testing remains the separate `pnpm test:visual` flow.

## Try it

```bash
pnpm --filter gofish-graphics build   # once
pnpm capture-one "bar/basic"          # → tests/tmp/iterate/.../basic--default.png
```

Or run `/iterate-example bar/grouped` and let Claude drive the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)