### PR TITLE
Underlying space as a serialized per-node type annotation

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -5,8 +5,11 @@ order: 10
 status: draft
 covers:
   - packages/gofish-graphics/src/ast/underlyingSpace.ts
+  - packages/gofish-graphics/src/ast/underlyingSpaceRules.ts
   - packages/gofish-graphics/src/ast/_node.ts
   - packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+  - packages/gofish-graphics/src/serialize/inferUnderlyingSpace.ts
+  - packages/gofish-graphics/src/serialize/typecheckChannels.ts
 ---
 
 # The underlying space tree
@@ -410,6 +413,70 @@ If your operator is layout-time-only (no contribution to the kind tree),
 return `[UNDEFINED, UNDEFINED]` and rely on the children to drive
 inference upward through your wrapper (e.g. via `unionChildSpaces` from
 a parent layer).
+
+## Underlying space as a type, and as a serialized annotation
+
+Underlying space is, in effect, GoFish's **type system**: each node's per-axis
+kind is its "type", and the resolution traversal is type _inference_. Two
+practical consequences follow, both implemented in
+`src/ast/underlyingSpace.ts` and `src/ast/underlyingSpaceRules.ts`.
+
+**The annotation travels into the frontend IR.** `underlyingSpaceToAnnotation`
+projects a node's runtime `Size<UnderlyingSpace>` onto the serializable
+`UnderlyingSpaceAnnotation` carried in the IR's per-node `meta.space` slot (see
+[The Frontend IR](/internals/frontend/serialization)). The annotation is the
+_data-domain view_ of the runtime space — `POSITION`/`SIZE` carry a numeric
+`[min, max]`, `DIFFERENCE` a `width`, `ORDINAL` its category keys. A runtime
+`SIZE` holds a layout-time `Monotonic` rather than a data extent; for the linear
+case `computeIntrinsicSize` produces, the extent is recoverable as
+`[intercept, intercept + slope]` (the image of the unit interval), so the two
+representations agree. Non-linear Monotonics have no closed-form extent and
+raise `UnderlyingSpaceInferenceError`.
+
+**Two stages, one type system.** This mirrors GHC (the surface `HsSyn` is
+typechecked _before_ desugaring to Core, and **Core Lint** re-checks the typed
+Core after each optimization pass) and Lean (surface syntax elaborates to a
+fully-typed `Expr`, with types carried as inline metadata that survive
+lowering). GoFish has the analogous split:
+
+- **Cheap kind inference on the chart-builder AST** —
+  `serialize/inferUnderlyingSpace.ts` classifies a leaf mark's per-axis _kind_
+  from its channel annotations alone (`underlyingSpaceRules.ts`), with no data
+  and no node construction. This is the early typecheck: runnable on the small
+  surface AST before it is resolved.
+- **Full resolution on the scenegraph** — `resolveUnderlyingSpace()` (above)
+  computes kinds _and_ domains, and composes them through operators. This is the
+  authoritative stage; it is what `meta.space` is read off, and what axes,
+  legends, and scales consume.
+
+Today the two stages overlap only at the leaves: domains and operator
+composition (a `spread` turning child `SIZE` into a stacked `POSITION`, say)
+require the data pipeline, which is still coupled to node construction. Once
+elaboration is split into its own pass (issue #457), the cheap stage can
+compose and carry domains too, and the parity check below extends to the whole
+tree. The cross-stage parity test ("Core Lint") asserts the cheap leaf kinds
+agree with every resolved leaf node's kind.
+
+### Channel typechecking against the inline-data schema
+
+When data is inline, the column types read off the **first row** give the
+cheap stage a typing context (`serialize/typecheckChannels.ts`). Each channel
+argument is _elaborated_ — a string that names a column becomes a field access,
+otherwise a literal (the same rule the runtime `inferSize`/`inferColor`/… use)
+— and then _typechecked_ against the type its channel expects: `size`/`pos`
+want numbers, a literal `color` wants a CSS string, `raw` takes anything.
+`rect({ h: "species" })` over `{species: string, count: number}` is a type
+error (a size channel bound to a string column); `rect({ h: "count" })` checks.
+
+The schema is **opaque past a `derive`**: an arbitrary transform can rename or
+retype columns, so once a `derive` (or any operator the emitter can't tag) sits
+between the data and the mark, no schema is known, strings stay unresolved, and
+only schema-free errors (a literal in the wrong slot) are reported. This is the
+elaboration seam #457 will formalize.
+
+A spec may freely **mix chart-builder (v3) code with low-level (`GoFishNode`)
+code**; the cheap pass classifies the marks it understands and otherwise leaves
+classification to resolution, so both stages stay sound on mixed trees.
 
 ## Prior art
 

--- a/apps/docs/docs/internals/frontend/mark-factory.md
+++ b/apps/docs/docs/internals/frontend/mark-factory.md
@@ -208,5 +208,8 @@ to layout operators (split + per-partition application).
 - The factory's optional `serialize` config (third argument) tags the
   produced mark with `__serialize` metadata that the frontend-IR emitter
   reads — see [Frontend IR (Serialization)](/internals/frontend/serialization).
+  The tag also carries the mark's `channels` map (not emitted to the wire) so
+  the cheap underlying-space _kind_ inference can classify each axis without
+  resolving — see [Underlying Space](/internals/core/underlying-space).
 - Encodable: paper [arxiv:2009.00722](https://arxiv.org/abs/2009.00722),
   source [github.com/kristw/encodable](https://github.com/kristw/encodable).

--- a/apps/docs/docs/internals/frontend/serialization.md
+++ b/apps/docs/docs/internals/frontend/serialization.md
@@ -289,6 +289,43 @@ User-defined custom marks via the no-channels `createMark((data, props) => …)`
 overload are an open question (deferred to v0.1+ — Olli treats them as
 opaque semantic boundaries via the `name` field).
 
+## Underlying-space annotations (`meta.space`)
+
+Every IR node has an optional `meta` slot for later-pass info. The first
+field populated is `meta.space` — the node's **underlying-space type**, the
+classification the layout pipeline uses to drive scales, axes, and legends
+(see [Underlying Space](/internals/core/underlying-space)). It is per-axis and,
+when present, complete:
+
+```jsonc
+"meta": {
+  "space": {
+    "x": { "kind": "ORDINAL", "domain": ["A", "B"] },
+    "y": { "kind": "POSITION", "domain": [0, 20] }
+  }
+}
+```
+
+Two rules govern it:
+
+- **Derived, never authoritative.** `meta.space` is _read off the in-memory
+  model_, not inferred from the JSON. The emitter (`toJSON`) resolves the chart
+  and projects the resolved root's `_underlyingSpace` via
+  `underlyingSpaceToAnnotation`; the deserializer ignores `meta` entirely. A
+  `toJSON → fromJSON → toJSON` round-trip therefore re-derives an identical
+  annotation. Domains require the data pipeline (today coupled to node
+  construction, #457), which is why they come from resolution rather than a
+  pre-resolve pass; _kinds_ alone can be checked cheaply on the chart-builder
+  AST (`serialize/inferUnderlyingSpace.ts`), the early typecheck of #452.
+- **Optional per node, but complete when emitted.** Its fields are required, so
+  if resolution can't determine them — unbound/external data, a mark the
+  resolver can't build standalone, a non-linear `SIZE` — `meta.space` is simply
+  omitted for that node. Serialization never throws on a missing annotation.
+
+The Python wrapper does not compute underlying space, so its `to_ir()` output
+omits `meta.space`; since the slot is optional this round-trips cleanly, and
+visual parity is unaffected (the annotation doesn't drive rendering).
+
 ## Future evolution
 
 v0 publishes the existing widget wire shape so consumers can ship
@@ -310,9 +347,10 @@ in the design improvements:
   `Syntax` → `Expr`. Reserved as namespace; nothing ships under
   `Core` or `Rendered` yet.
 - **Inline `meta?` annotations** — per-node optional slot for
-  later-pass info (underlying-space classification, source positions,
-  scale resolution). Open-typed; the slot is reserved in v0,
-  unset by emitters.
+  later-pass info (source positions, scale resolution, …). Open-typed.
+  The first populated field, `meta.space`, ships in v0 (see
+  [§ Underlying-space annotations](#underlying-space-annotations-meta-space));
+  the remaining fields stay reserved until their passes land.
 
 ## Bridge extensions (Python widget)
 

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -6,6 +6,8 @@
 import { interval, Interval } from "../util/interval";
 import { CoordinateTransform } from "./coordinateTransforms/coord";
 import * as Monotonic from "../util/monotonic";
+import type { Size } from "./dims";
+import type { Frontend } from "gofish-ir";
 
 export type UnderlyingSpaceKind =
   | "position"
@@ -98,3 +100,68 @@ export const isORDINAL = (space: UnderlyingSpace): space is ORDINAL_TYPE =>
 export const UNDEFINED: UnderlyingSpace = { kind: "undefined" };
 export const isUNDEFINED = (space: UnderlyingSpace): space is UNDEFINED_TYPE =>
   space.kind === "undefined";
+
+// ---------------------------------------------------------------------------
+// Serializable annotation view
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when a required underlying-space field can't be determined — e.g. a
+ * `SIZE` whose Monotonic isn't linear (no closed-form data extent). Callers
+ * doing a strict typecheck surface this; serialization catches it and omits
+ * `meta.space` for that node (the annotation is derived, not authoritative).
+ */
+export class UnderlyingSpaceInferenceError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "UnderlyingSpaceInferenceError";
+  }
+}
+
+/**
+ * Project a single runtime {@link UnderlyingSpace} onto the serializable IR
+ * {@link Frontend.AxisSpace}, the data-domain view that the frontend IR
+ * carries in `meta.space`.
+ *
+ * The runtime `SIZE` carries a layout-time `Monotonic` rather than a data
+ * extent; for the linear case (the only one `computeIntrinsicSize` produces)
+ * the data extent is `[intercept, intercept + slope]` — i.e. the image of the
+ * unit interval, which equals `[0, value]` for a data-driven size. Non-linear
+ * Monotonics have no closed-form extent and raise.
+ */
+export const axisSpaceToAnnotation = (
+  space: UnderlyingSpace
+): Frontend.AxisSpace => {
+  if (isPOSITION(space)) {
+    return { kind: "POSITION", domain: [space.domain.min, space.domain.max] };
+  }
+  if (isDIFFERENCE(space)) {
+    return { kind: "DIFFERENCE", width: space.width };
+  }
+  if (isSIZE(space)) {
+    if (!Monotonic.isLinear(space.domain)) {
+      throw new UnderlyingSpaceInferenceError(
+        "cannot infer SIZE domain: underlying Monotonic is non-linear; explicit annotation required"
+      );
+    }
+    const { slope, intercept } = space.domain;
+    return { kind: "SIZE", domain: [intercept, intercept + slope] };
+  }
+  if (isORDINAL(space)) {
+    return { kind: "ORDINAL", domain: space.domain ?? [] };
+  }
+  return { kind: "UNDEFINED" };
+};
+
+/**
+ * Project a node's per-axis runtime underlying space onto the serializable
+ * {@link Frontend.UnderlyingSpaceAnnotation}. Single source of truth for the
+ * runtime → IR mapping; used both by the chart-builder inference pass (for
+ * embedded low-level subtrees) and by the cross-stage parity test.
+ */
+export const underlyingSpaceToAnnotation = (
+  space: Size<UnderlyingSpace>
+): Frontend.UnderlyingSpaceAnnotation => ({
+  x: axisSpaceToAnnotation(space[0]),
+  y: axisSpaceToAnnotation(space[1]),
+});

--- a/packages/gofish-graphics/src/ast/underlyingSpaceRules.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpaceRules.ts
@@ -1,0 +1,101 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
+/**
+ * Data-independent underlying-space *kind* rules.
+ *
+ * This is the shared classifier the cheap, pre-resolution typecheck consults
+ * to assign each axis of a leaf mark an underlying-space kind from its channel
+ * structure alone — no data, no layout. It mirrors the per-axis branches of
+ * the runtime resolver in `shapes/rect.tsx` (`resolveAxis`), lifted to the v3
+ * channel level so the two stages classify the same way (see the parity test).
+ *
+ * Domains are *not* computed here — they require the data pipeline, which today
+ * also builds the node tree (#457). The full annotation's domain fields are
+ * read off the resolved scenegraph; this module produces only the kind, which
+ * is the part that's checkable early on the small chart-builder AST (#452).
+ *
+ * Operator-level composition (spread turning child SIZE into a stacked
+ * POSITION, etc.) is intentionally out of scope here — that logic lives in the
+ * operators' own `resolveUnderlyingSpace` and is faithfully reproducible at the
+ * chart-builder level only once elaboration is split out (#457). Callers that
+ * need a composed kind should resolve.
+ */
+
+import type { Frontend } from "gofish-ir";
+
+export type AxisSpaceKind = Frontend.AxisSpaceKind;
+
+/** Per-axis channel-name groups, keyed by role. Mirrors `rect`'s annotations. */
+const X_POS_CHANNELS = ["x", "cx", "l", "r", "xMin", "xMax", "center"] as const;
+const Y_POS_CHANNELS = ["y", "cy", "t", "b", "yMin", "yMax"] as const;
+const X_SIZE_CHANNEL = "w";
+const Y_SIZE_CHANNEL = "h";
+
+/** A serialize-tag channel-annotation map, e.g. `{ w: "size", x: "pos", … }`. */
+export type ChannelAnnotationMap = Record<string, string | { type?: string }>;
+
+const channelRole = (
+  channels: ChannelAnnotationMap | undefined,
+  name: string
+): string | undefined => {
+  const spec = channels?.[name];
+  if (spec === undefined) return undefined;
+  return typeof spec === "string" ? spec : spec.type;
+};
+
+const isBound = (opts: Record<string, unknown>, name: string): boolean =>
+  opts[name] !== undefined;
+
+/**
+ * Classify one axis of a leaf mark into an underlying-space kind, given the
+ * mark's channel annotations and its raw options. Mirrors `rect.resolveAxis`:
+ *
+ *  - a bound positional channel → POSITION (data-driven position)
+ *  - else a bound size channel:
+ *      - literal number size → DIFFERENCE (fixed pixel extent)
+ *      - field / Value / accessor size → SIZE (data-driven magnitude)
+ *  - else → UNDEFINED
+ */
+export function classifyLeafAxis(
+  axis: 0 | 1,
+  channels: ChannelAnnotationMap | undefined,
+  opts: Record<string, unknown>
+): AxisSpaceKind {
+  const posChannels = axis === 0 ? X_POS_CHANNELS : Y_POS_CHANNELS;
+  const sizeChannel = axis === 0 ? X_SIZE_CHANNEL : Y_SIZE_CHANNEL;
+
+  const posBound = posChannels.some(
+    (name) => channelRole(channels, name) === "pos" && isBound(opts, name)
+  );
+  if (posBound) return "POSITION";
+
+  if (
+    channelRole(channels, sizeChannel) === "size" &&
+    isBound(opts, sizeChannel)
+  ) {
+    const sizeVal = opts[sizeChannel];
+    // A literal pixel number is a fixed difference; a field name, accessor, or
+    // `v(...)`-wrapped Value is a data-driven magnitude.
+    if (typeof sizeVal === "number") return "DIFFERENCE";
+    return "SIZE";
+  }
+
+  return "UNDEFINED";
+}
+
+// (literal-vs-Value is decided structurally above: a plain `number` is a fixed
+// DIFFERENCE; a field name, accessor, or `v(...)`-wrapped Value is data-driven
+// SIZE — no need to import the runtime `isValue` guard.)
+
+/** Classify both axes of a leaf mark. */
+export function classifyLeafMark(
+  channels: ChannelAnnotationMap | undefined,
+  opts: Record<string, unknown>
+): { x: AxisSpaceKind; y: AxisSpaceKind } {
+  return {
+    x: classifyLeafAxis(0, channels, opts),
+    y: classifyLeafAxis(1, channels, opts),
+  };
+}

--- a/packages/gofish-graphics/src/ast/withGoFish.ts
+++ b/packages/gofish-graphics/src/ast/withGoFish.ts
@@ -697,6 +697,12 @@ export function createMark(
       (baseMark as any).__serialize = {
         type: serializeConfig.type,
         opts: payload,
+        // Per-channel annotations (`{w:"size", h:"size", x:"pos", …}`), so the
+        // underlying-space *kind* inference (gofish-graphics/serialize/
+        // inferUnderlyingSpace) can classify each axis structurally without
+        // resolving the node. Not emitted to the wire — the emitter only reads
+        // type/opts/name/label/children off the tag.
+        channels,
       };
     }
 

--- a/packages/gofish-graphics/src/serialize/index.ts
+++ b/packages/gofish-graphics/src/serialize/index.ts
@@ -37,3 +37,26 @@ export {
 } from "./fromJSON";
 
 export { toJSON, toJSONLayer, toJSONRawMark } from "./toJSON";
+
+export {
+  inferLeafMarkKinds,
+  collectLeafMarkKinds,
+  type LeafKind,
+} from "./inferUnderlyingSpace";
+
+export {
+  typecheckChart,
+  typecheckMarkChannels,
+  elaborateChannelArg,
+  inferRowSchema,
+  type ChannelTypeError,
+  type ElaboratedArg,
+  type RowSchema,
+  type DataType,
+} from "./typecheckChannels";
+
+export {
+  underlyingSpaceToAnnotation,
+  axisSpaceToAnnotation,
+  UnderlyingSpaceInferenceError,
+} from "../ast/underlyingSpace";

--- a/packages/gofish-graphics/src/serialize/inferUnderlyingSpace.ts
+++ b/packages/gofish-graphics/src/serialize/inferUnderlyingSpace.ts
@@ -1,0 +1,100 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
+/**
+ * Cheap, pre-resolution underlying-space *kind* inference over the in-memory
+ * chart-builder AST — the early typecheck of issue #452.
+ *
+ * It walks the same `__serialize`-tagged mark tree the frontend-IR emitter
+ * reads (`toJSON.ts`) and classifies each *leaf* mark's per-axis kind via the
+ * shared, data-independent rules in `ast/underlyingSpaceRules.ts`. No data,
+ * no layout, no node construction — so it is far cheaper than resolving, and
+ * runnable on the small surface AST before chart builders are resolved.
+ *
+ * Scope (foundation): leaf-mark classification. Two things are deliberately
+ * *not* done here and are read off the resolved scenegraph instead:
+ *
+ *  - **Domains** — they need the data pipeline (today coupled to node
+ *    construction; see #457). `toJSON` fills the annotation's domain fields
+ *    from the resolved tree via `underlyingSpaceToAnnotation`.
+ *  - **Operator composition** — `spread`/`stack` turning child SIZE into a
+ *    stacked POSITION, etc. That logic lives in the operators'
+ *    `resolveUnderlyingSpace` and is faithfully reproducible at the surface
+ *    level only once elaboration is split out (#457).
+ *
+ * The cross-stage parity test treats this as the "Core Lint" check: every
+ * resolved leaf node's kind must agree with what this pass classifies.
+ */
+
+import {
+  classifyLeafMark,
+  type AxisSpaceKind,
+} from "../ast/underlyingSpaceRules";
+import { UnderlyingSpaceInferenceError } from "../ast/underlyingSpace";
+
+/** A leaf mark's inferred per-axis kinds, tagged with the mark type. */
+export interface LeafKind {
+  type: string;
+  x: AxisSpaceKind;
+  y: AxisSpaceKind;
+}
+
+interface SerializeTag {
+  type: string;
+  opts: Record<string, unknown>;
+  channels?: Record<string, string | { type?: string }>;
+  __combinator?: true;
+  children?: unknown;
+}
+
+function readTag(value: unknown): SerializeTag | undefined {
+  const tag = (value as any)?.__serialize;
+  if (!tag || typeof tag.type !== "string") return undefined;
+  return tag as SerializeTag;
+}
+
+/**
+ * Classify a single leaf mark's per-axis kinds. Throws
+ * {@link UnderlyingSpaceInferenceError} for marks that carry no channel
+ * annotations (e.g. `circle`/`line`/`area`, which aren't `createMark`-based) —
+ * those can't be classified structurally and must be resolved.
+ */
+export function inferLeafMarkKinds(mark: unknown): LeafKind {
+  const tag = readTag(mark);
+  if (!tag) {
+    throw new UnderlyingSpaceInferenceError(
+      "cannot infer underlying space: mark has no __serialize tag"
+    );
+  }
+  if (tag.__combinator) {
+    throw new UnderlyingSpaceInferenceError(
+      `cannot classify combinator mark "${tag.type}" at the leaf level; resolve to compose children`
+    );
+  }
+  if (!tag.channels) {
+    throw new UnderlyingSpaceInferenceError(
+      `cannot infer underlying space for mark "${tag.type}": no channel annotations (resolve instead)`
+    );
+  }
+  const { x, y } = classifyLeafMark(tag.channels, tag.opts);
+  return { type: tag.type, x, y };
+}
+
+/**
+ * Collect the inferred kinds of every leaf mark reachable from `mark`, walking
+ * combinator-form marks (`layer`, `spread([…])`, …) into their children.
+ * Leaf marks the cheap pass can't classify are skipped (they're validated by
+ * resolution instead), so this never throws.
+ */
+export function collectLeafMarkKinds(mark: unknown): LeafKind[] {
+  const tag = readTag(mark);
+  if (!tag) return [];
+  if (tag.__combinator) {
+    const children = Array.isArray(tag.children) ? tag.children : [];
+    return children.flatMap((c) => collectLeafMarkKinds(c));
+  }
+  if (!tag.channels) return [];
+  const { x, y } = classifyLeafMark(tag.channels, tag.opts);
+  return [{ type: tag.type, x, y }];
+}

--- a/packages/gofish-graphics/src/serialize/toJSON.ts
+++ b/packages/gofish-graphics/src/serialize/toJSON.ts
@@ -21,6 +21,7 @@
 
 import type { Frontend } from "gofish-ir";
 import type { ChartBuilder, Mark, Operator } from "./registry";
+import { underlyingSpaceToAnnotation } from "../ast/underlyingSpace";
 
 // The widget IR uses these symbol-loose shapes; toJSON returns them as-is.
 // The validator in `gofish-ir` accepts these shapes in permissive mode.
@@ -149,7 +150,34 @@ async function chartBuilderToChartIR(
   if (nodeZOrder !== undefined) {
     ir.zOrder = nodeZOrder;
   }
+  const space = await rootSpaceAnnotation(chart);
+  if (space) ir.meta = { space };
   return ir;
+}
+
+/**
+ * Read the chart's root underlying-space annotation **off the in-memory
+ * model** (never inferred from the IR). Domains require the data pipeline,
+ * which — until elaboration is split out (#457) — also builds the node tree,
+ * so we resolve the chart and read `_underlyingSpace` off the resolved root
+ * (the same value layout uses to drive axes/legends), then project it to the
+ * serializable annotation.
+ *
+ * The annotation is *derived, not authoritative*: any failure (unbound/
+ * external data, a non-linear SIZE with no closed-form extent, a mark the
+ * resolver can't build standalone) yields `undefined`, and `meta.space` is
+ * simply omitted — serialization never regresses. `meta.space` is optional
+ * per node, but complete (all required fields present) when emitted.
+ */
+async function rootSpaceAnnotation(
+  chart: ChartBuilder<any>
+): Promise<Frontend.UnderlyingSpaceAnnotation | undefined> {
+  try {
+    const node = await (chart as any).resolve();
+    return underlyingSpaceToAnnotation(node.resolveUnderlyingSpace());
+  } catch {
+    return undefined;
+  }
 }
 
 function dataToIR(data: unknown): Frontend.DataIR | null {

--- a/packages/gofish-graphics/src/serialize/typecheckChannels.ts
+++ b/packages/gofish-graphics/src/serialize/typecheckChannels.ts
@@ -1,0 +1,245 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
+/**
+ * Channel elaboration + typechecking against the inline-data schema — the
+ * data-aware half of the cheap, pre-resolution typecheck (issues #452/#457).
+ *
+ * When a chart's data is available inline, the type of each column is read off
+ * the **first row** and used as the typing context. Every channel argument is
+ * then *elaborated* to either a field access (the string names a column) or a
+ * literal (it doesn't), and *typechecked* against the type the channel expects:
+ *
+ *  - `size` / `pos` channels expect numbers — a field bound to them must be a
+ *    numeric column; a literal must be a number.
+ *  - `color` channels expect a CSS color string when given a literal; a bound
+ *    field is fine (it's mapped through a color scale, so any column type).
+ *  - `raw` channels accept any scalar.
+ *
+ * The schema is **opaque past a `derive`**: an arbitrary user transform can
+ * rename/retype columns, so once a `derive` (or any untagged operator) sits
+ * between the data and the mark, no schema is known and elaboration falls back
+ * to "opaque" — strings can't be resolved to fields, and only the type errors
+ * that need no schema (a literal number/string in the wrong slot) are reported.
+ *
+ * Mirrors the runtime channel resolvers (`inferSize`/`inferPos`/`inferColor`/
+ * `inferRaw` in `ast/channels.ts`): "string that names a column → field, else
+ * literal" is exactly their rule, lifted to a static check over `data[0]`.
+ */
+
+import { isField, isLiteral, isValue } from "../ast/data";
+
+/** The JS runtime type of a column value, as read from the first row. */
+export type DataType =
+  | "number"
+  | "string"
+  | "boolean"
+  | "null"
+  | "object"
+  | "undefined";
+
+/** A column-name → type map inferred from a single data row. */
+export type RowSchema = Record<string, DataType>;
+
+/** The result of elaborating one channel argument. */
+export type ElaboratedArg =
+  | { kind: "field"; name: string; dataType: DataType | "unknown" }
+  | { kind: "literal"; value: unknown; dataType: DataType }
+  | { kind: "opaque" }
+  | { kind: "unbound" };
+
+export interface ChannelTypeError {
+  /** The mark type the channel belongs to, e.g. "rect". */
+  mark: string;
+  /** The channel/prop name, e.g. "h". */
+  channel: string;
+  /** The channel's declared role: "size" | "pos" | "color" | "raw". */
+  channelType: string;
+  message: string;
+}
+
+interface SerializeTag {
+  type: string;
+  opts: Record<string, unknown>;
+  channels?: Record<string, string | { type?: string }>;
+  __combinator?: true;
+  children?: unknown;
+}
+
+function readTag(value: unknown): SerializeTag | undefined {
+  const tag = (value as any)?.__serialize;
+  if (!tag || typeof tag.type !== "string") return undefined;
+  return tag as SerializeTag;
+}
+
+function channelRole(spec: string | { type?: string }): string | undefined {
+  return typeof spec === "string" ? spec : spec.type;
+}
+
+function jsType(value: unknown): DataType {
+  if (value === null) return "null";
+  const t = typeof value;
+  if (t === "number" || t === "string" || t === "boolean") return t;
+  if (t === "undefined") return "undefined";
+  return "object";
+}
+
+/**
+ * Infer a column-name → type map from the first row of inline data. Returns
+ * `undefined` when no usable inline row is available (the caller treats that as
+ * an opaque schema and skips field/string elaboration).
+ */
+export function inferRowSchema(data: unknown): RowSchema | undefined {
+  if (!Array.isArray(data) || data.length === 0) return undefined;
+  const row = data[0];
+  if (row === null || typeof row !== "object" || Array.isArray(row)) {
+    return undefined;
+  }
+  const schema: RowSchema = {};
+  for (const key of Object.keys(row)) {
+    schema[key] = jsType((row as Record<string, unknown>)[key]);
+  }
+  return schema;
+}
+
+/**
+ * Elaborate a single channel argument into a field access, a literal, or an
+ * opaque value, using the row schema (when known) to decide whether a string
+ * names a column. Matches the runtime "string-in-schema → field, else literal"
+ * rule; without a schema, bare strings stay opaque (they might be columns a
+ * `derive` produced).
+ */
+export function elaborateChannelArg(
+  arg: unknown,
+  schema: RowSchema | undefined
+): ElaboratedArg {
+  if (arg === undefined) return { kind: "unbound" };
+  if (isField(arg)) {
+    return {
+      kind: "field",
+      name: arg.name,
+      dataType: schema?.[arg.name] ?? "unknown",
+    };
+  }
+  if (isLiteral(arg)) {
+    return { kind: "literal", value: arg.value, dataType: jsType(arg.value) };
+  }
+  // `v(...)` / datum wrappers and function accessors are runtime-valued.
+  if (isValue(arg as any) || typeof arg === "function")
+    return { kind: "opaque" };
+  if (typeof arg === "number" || typeof arg === "boolean") {
+    return { kind: "literal", value: arg, dataType: jsType(arg) };
+  }
+  if (typeof arg === "string") {
+    if (schema && arg in schema) {
+      return { kind: "field", name: arg, dataType: schema[arg] };
+    }
+    if (schema) return { kind: "literal", value: arg, dataType: "string" };
+    return { kind: "opaque" }; // no schema → can't tell field from literal
+  }
+  return { kind: "opaque" };
+}
+
+/** Typecheck one elaborated argument against its channel's expected type. */
+function checkArg(
+  markType: string,
+  channel: string,
+  role: string,
+  elaborated: ElaboratedArg
+): ChannelTypeError | undefined {
+  const err = (message: string): ChannelTypeError => ({
+    mark: markType,
+    channel,
+    channelType: role,
+    message,
+  });
+
+  if (role === "size" || role === "pos") {
+    if (elaborated.kind === "field" && elaborated.dataType !== "unknown") {
+      if (elaborated.dataType !== "number") {
+        return err(
+          `channel "${channel}" (${role}) expects a numeric field, but "${elaborated.name}" is a ${elaborated.dataType} column`
+        );
+      }
+    }
+    if (elaborated.kind === "literal" && elaborated.dataType !== "number") {
+      return err(
+        `channel "${channel}" (${role}) expects a number, got ${elaborated.dataType} literal ${JSON.stringify(elaborated.value)}`
+      );
+    }
+  } else if (role === "color") {
+    // A bound field is mapped through a color scale (any column type is fine);
+    // a literal color must be a string.
+    if (elaborated.kind === "literal" && elaborated.dataType !== "string") {
+      return err(
+        `channel "${channel}" (color) expects a color string literal, got ${elaborated.dataType} ${JSON.stringify(elaborated.value)}`
+      );
+    }
+  }
+  // "raw" and field-bound color accept anything.
+  return undefined;
+}
+
+/**
+ * Elaborate and typecheck a single leaf mark's channel arguments against the
+ * row schema. Returns any type errors (empty if clean or unclassifiable).
+ */
+export function typecheckMarkChannels(
+  mark: unknown,
+  schema: RowSchema | undefined
+): ChannelTypeError[] {
+  const tag = readTag(mark);
+  if (!tag || !tag.channels) return [];
+  const errors: ChannelTypeError[] = [];
+  for (const [channel, spec] of Object.entries(tag.channels)) {
+    const role = channelRole(spec);
+    if (!role) continue;
+    const elaborated = elaborateChannelArg(tag.opts[channel], schema);
+    if (elaborated.kind === "unbound" || elaborated.kind === "opaque") continue;
+    const error = checkArg(tag.type, channel, role, elaborated);
+    if (error) errors.push(error);
+  }
+  return errors;
+}
+
+/** Recursively typecheck a mark tree's leaves (walking combinator children). */
+function typecheckMarkTree(
+  mark: unknown,
+  schema: RowSchema | undefined
+): ChannelTypeError[] {
+  const tag = readTag(mark);
+  if (!tag) return [];
+  if (tag.__combinator) {
+    const children = Array.isArray(tag.children) ? tag.children : [];
+    return children.flatMap((c) => typecheckMarkTree(c, schema));
+  }
+  return typecheckMarkChannels(mark, schema);
+}
+
+/**
+ * Typecheck a chart builder's channel arguments against its inline-data schema.
+ *
+ * The schema is taken from the first data row, *unless* an opaque operator
+ * (a `derive`, or any operator the emitter can't tag) sits in the pipeline — in
+ * which case the post-transform schema is unknown and field/string elaboration
+ * is skipped. Returns all channel type errors found (empty when clean, when the
+ * data isn't inline, or when the schema is opaque).
+ */
+export function typecheckChart(chart: unknown): ChannelTypeError[] {
+  const c = chart as any;
+  const data = c?.data;
+  const operators: unknown[] = c?.operators ?? [];
+  const finalMark = c?.finalMark;
+  if (!finalMark) return [];
+
+  // Any derive — or any operator the emitter can't tag (treated as derive on
+  // the wire) — makes the downstream schema opaque.
+  const opaquePipeline = operators.some((op) => {
+    const tag = readTag(op);
+    return !tag || tag.type === "derive";
+  });
+
+  const schema = opaquePipeline ? undefined : inferRowSchema(data);
+  return typecheckMarkTree(finalMark, schema);
+}

--- a/packages/gofish-graphics/src/tests/serialize.test.ts
+++ b/packages/gofish-graphics/src/tests/serialize.test.ts
@@ -32,7 +32,28 @@ const {
   field,
   datum,
   literal,
+  Serialize,
 } = GoFish as any;
+
+/** Map a runtime UnderlyingSpace.kind (lowercase) to the IR AxisSpaceKind. */
+const KIND_TO_IR: Record<string, string> = {
+  position: "POSITION",
+  size: "SIZE",
+  difference: "DIFFERENCE",
+  ordinal: "ORDINAL",
+  undefined: "UNDEFINED",
+};
+
+/** Collect leaf GoFishNodes (no children) from a resolved tree. */
+function collectLeafNodes(node: any, out: any[] = []): any[] {
+  const children = node?.children ?? [];
+  if (children.length === 0) {
+    out.push(node);
+  } else {
+    for (const c of children) collectLeafNodes(c, out);
+  }
+  return out;
+}
 
 declare const process: { exit(code: number): never };
 
@@ -392,6 +413,164 @@ async function main() {
     check("combinator stack emits", mark.type === "stack");
     check("combinator stack is flagged", mark.__combinator === true);
     check("combinator stack has children", Array.isArray(mark.children));
+  }
+
+  // -------------------------------------------------------------------------
+  // Underlying-space annotation (meta.space) — read off the resolved model.
+  // -------------------------------------------------------------------------
+  console.log("\n# Underlying-space annotation (meta.space)");
+  {
+    const seafood = [
+      { lake: "A", species: "trout", count: 12 },
+      { lake: "A", species: "bass", count: 8 },
+      { lake: "B", species: "trout", count: 5 },
+    ];
+    const bar = Chart(seafood)
+      .flow(spread({ by: "lake", dir: "x" }))
+      .mark(rect({ h: "count", fill: "species" }));
+    const doc = await bar.toJSON();
+    validateDoc(doc, "bar chart with meta.space", true);
+    const space = (doc.root as any).meta?.space;
+    check("bar chart root carries meta.space", !!space);
+    check(
+      "bar x axis is ORDINAL over lakes",
+      space?.x?.kind === "ORDINAL" &&
+        JSON.stringify(space?.x?.domain) === JSON.stringify(["A", "B"])
+    );
+    check(
+      "bar y axis is POSITION with a numeric domain pair",
+      space?.y?.kind === "POSITION" &&
+        Array.isArray(space?.y?.domain) &&
+        space.y.domain.length === 2
+    );
+
+    // Determinism: the derived annotation is stable across emits (so a
+    // toJSON → fromJSON → toJSON round-trip re-derives it identically).
+    const doc2 = await bar.toJSON();
+    check(
+      "meta.space is deterministic across emits",
+      JSON.stringify((doc.root as any).meta) ===
+        JSON.stringify((doc2.root as any).meta)
+    );
+
+    // When the chart can't be resolved (here a bare `line()` mark, which needs
+    // refs it doesn't have), meta.space is omitted rather than thrown — the
+    // annotation is derived, so serialization never regresses.
+    const GoFishLine = (GoFish as any).line;
+    const unresolvable = await Chart([{ a: 1 }]).mark(GoFishLine()).toJSON();
+    check(
+      "unresolvable chart still emits, omitting meta.space (no throw)",
+      (unresolvable.root as any).meta?.space === undefined &&
+        (unresolvable.root as any).type === "chart"
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Cheap kind inference + cross-stage parity ("Core Lint").
+  // -------------------------------------------------------------------------
+  console.log("\n# Cheap kind inference (chart-builder AST)");
+  {
+    // Leaf classification rules (data-independent).
+    const sizeMark = Serialize.inferLeafMarkKinds(rect({ h: "count" }));
+    check(
+      "rect({h: field}) → y SIZE, x UNDEFINED",
+      sizeMark.y === "SIZE" && sizeMark.x === "UNDEFINED"
+    );
+    const diffMark = Serialize.inferLeafMarkKinds(rect({ w: 50 }));
+    check("rect({w: number}) → x DIFFERENCE", diffMark.x === "DIFFERENCE");
+    const posMark = Serialize.inferLeafMarkKinds(rect({ x: "count" }));
+    check("rect({x: field}) → x POSITION", posMark.x === "POSITION");
+
+    // Marks without channel annotations (circle) can't be classified cheaply.
+    let threw = false;
+    try {
+      Serialize.inferLeafMarkKinds(circle({ r: 4 }));
+    } catch (e: any) {
+      threw = e?.name === "UnderlyingSpaceInferenceError";
+    }
+    check("circle (no channels) raises UnderlyingSpaceInferenceError", threw);
+
+    // Parity: every resolved leaf node's kind agrees with the cheap classifier.
+    const seafood = [
+      { lake: "A", count: 12 },
+      { lake: "B", count: 5 },
+    ];
+    const mark = rect({ h: "count" });
+    const cheap = Serialize.collectLeafMarkKinds(mark)[0];
+    const node = await Chart(seafood)
+      .flow(spread({ by: "lake", dir: "x" }))
+      .mark(mark)
+      .resolve();
+    const leaves = collectLeafNodes(node).filter((n) => n?.type === "rect");
+    check("parity: resolved tree has rect leaves", leaves.length > 0);
+    const allMatch = leaves.every((leaf) => {
+      const sp = leaf.resolveUnderlyingSpace();
+      return (
+        KIND_TO_IR[sp[0].kind] === cheap.x &&
+        KIND_TO_IR[sp[1].kind] === cheap.y
+      );
+    });
+    check(
+      "parity: cheap leaf kinds match every resolved leaf node's kinds",
+      allMatch
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Channel elaboration + typecheck against the inline-data schema.
+  // -------------------------------------------------------------------------
+  console.log("\n# Channel typecheck (inline-data schema)");
+  {
+    const rows = [{ species: "trout", count: 12 }];
+
+    // Well-typed: count (number) on a size channel, species (string) on color.
+    const okChart = Chart(rows).mark(rect({ h: "count", fill: "species" }));
+    check(
+      "well-typed channels produce no errors",
+      Serialize.typecheckChart(okChart).length === 0
+    );
+
+    // Mistyped: a string column on a size channel.
+    const badSize = Chart(rows).mark(rect({ h: "species" }));
+    const badSizeErrors = Serialize.typecheckChart(badSize);
+    check(
+      "string column on size channel is a type error",
+      badSizeErrors.length === 1 &&
+        badSizeErrors[0].channel === "h" &&
+        badSizeErrors[0].channelType === "size"
+    );
+
+    // A literal number in a color slot is a type error (color wants a string).
+    const badColor = Chart(rows).mark(rect({ fill: 42 as any }));
+    check(
+      "numeric literal on color channel is a type error",
+      Serialize.typecheckChart(badColor).some((e: any) => e.channel === "fill")
+    );
+
+    // String elaboration: a column name → field, a non-column → literal.
+    const schema = Serialize.inferRowSchema(rows);
+    check(
+      "inferRowSchema reads column types off the first row",
+      schema?.count === "number" && schema?.species === "string"
+    );
+    check(
+      "string naming a column elaborates to a field",
+      Serialize.elaborateChannelArg("count", schema).kind === "field"
+    );
+    check(
+      "string not naming a column elaborates to a literal",
+      Serialize.elaborateChannelArg("steelblue", schema).kind === "literal"
+    );
+
+    // Opaque past a derive: the schema is unknown, so no field typecheck fires
+    // even though "species" would otherwise be a string-on-size error.
+    const withDerive = Chart(rows)
+      .flow(derive((d: any) => d))
+      .mark(rect({ h: "species" }));
+    check(
+      "a derive makes the schema opaque (no channel type errors)",
+      Serialize.typecheckChart(withDerive).length === 0
+    );
   }
 
   console.log(`\n${passed} passed, ${failed} failed`);

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -45,7 +45,59 @@ export const FRONTEND_IR_JSON_SCHEMA = {
     Meta: {
       type: "object",
       description:
-        "Optional inline annotations populated by later passes. v0 emitters leave it absent.",
+        "Optional inline annotations populated by later passes. The `space` slot carries the node's inferred underlying-space type; it is derived (read off the in-memory model) and dropped on deserialize.",
+      properties: {
+        space: { $ref: "#/$defs/UnderlyingSpaceAnnotation" },
+      },
+    },
+    UnderlyingSpaceAnnotation: {
+      type: "object",
+      description: "Per-axis underlying-space classification.",
+      required: ["x", "y"],
+      properties: {
+        x: { $ref: "#/$defs/AxisSpace" },
+        y: { $ref: "#/$defs/AxisSpace" },
+      },
+    },
+    AxisSpace: {
+      description:
+        "A single axis's inferred underlying space. Fields are required — inference determines them from the spec's data.",
+      oneOf: [
+        {
+          type: "object",
+          required: ["kind", "domain"],
+          properties: {
+            kind: { enum: ["POSITION", "SIZE"] },
+            domain: {
+              type: "array",
+              items: { type: "number" },
+              minItems: 2,
+              maxItems: 2,
+            },
+          },
+        },
+        {
+          type: "object",
+          required: ["kind", "width"],
+          properties: {
+            kind: { const: "DIFFERENCE" },
+            width: { type: "number" },
+          },
+        },
+        {
+          type: "object",
+          required: ["kind", "domain"],
+          properties: {
+            kind: { const: "ORDINAL" },
+            domain: { type: "array", items: { type: "string" } },
+          },
+        },
+        {
+          type: "object",
+          required: ["kind"],
+          properties: { kind: { const: "UNDEFINED" } },
+        },
+      ],
     },
     DataIR: {
       oneOf: [

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -29,11 +29,20 @@ export type FrontendIR = ChartIR | LayerIR | RawMarkIR;
  * passes (underlying-space inference, scale resolution, etc.) populate the
  * relevant fields. The slot is reserved so additive evolution doesn't
  * require a schema bump.
+ *
+ * `space` is **derived, not authoritative**: it is computed by the
+ * underlying-space inference pass over the in-memory chart-builder AST (the
+ * source of truth) and merely *read off* into the IR by the emitter — the
+ * deserializer drops it and a round-trip re-derives it. The serializer never
+ * infers from the JSON.
  */
 export interface Meta {
   /** Source-position attribution — populated by future build-time hooks. */
   loc?: SourceLocation;
-  /** Underlying-space classification — populated post-elaboration. */
+  /**
+   * Underlying-space classification — the node's inferred "type" in the
+   * underlying-space type system. Per-axis (`x` / `y`).
+   */
   space?: UnderlyingSpaceAnnotation;
   /** Open extension for unknown pass-specific annotations. */
   [key: string]: unknown;
@@ -45,9 +54,39 @@ export interface SourceLocation {
   column: number;
 }
 
+/**
+ * A node's inferred underlying space, one classification per axis.
+ *
+ * This is the serializable, data-domain view of the runtime
+ * `UnderlyingSpace` (`gofish-graphics/src/ast/underlyingSpace.ts`). Fields are
+ * **required** — inference must determine them from the spec's data, or fail
+ * with an error asking the author to annotate. The layout-time `Monotonic`
+ * that a runtime `SIZE` carries is a realization detail and is *not* part of
+ * the type; `SIZE.domain` is the data-value extent feeding the size channel.
+ */
 export interface UnderlyingSpaceAnnotation {
-  type: "SIZE" | "POSITION" | "ORDINAL" | "DIFFERENCE" | "UNDEFINED";
+  x: AxisSpace;
+  y: AxisSpace;
 }
+
+export type AxisSpaceKind =
+  | "POSITION"
+  | "SIZE"
+  | "DIFFERENCE"
+  | "ORDINAL"
+  | "UNDEFINED";
+
+export type AxisSpace =
+  /** A positional extent in data space (e.g. `x`/`x2` coordinates). */
+  | { kind: "POSITION"; domain: [number, number] }
+  /** A measured magnitude; `domain` is the data-value extent. */
+  | { kind: "SIZE"; domain: [number, number] }
+  /** A fixed pixel-space difference (constant size, no scale). */
+  | { kind: "DIFFERENCE"; width: number }
+  /** A categorical axis; `domain` is the ordered category keys. */
+  | { kind: "ORDINAL"; domain: string[] }
+  /** No underlying space (unmeasured / not positioned). */
+  | { kind: "UNDEFINED" };
 
 /** Mixin properties available on every IR node. */
 export interface BaseIRNode {

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -655,14 +655,78 @@ function walkOrigin(node: unknown, path: string, ctx: Context): void {
   if (ctx.strict) rejectUnknown(node, ["name", "stack"], path, ctx);
 }
 
-function walkMeta(node: unknown, path: string, _ctx: Context): void {
+function walkMeta(node: unknown, path: string, ctx: Context): void {
   if (!isObject(node)) {
-    _ctx.errors.push({ path, message: "meta must be an object" });
+    ctx.errors.push({ path, message: "meta must be an object" });
     return;
   }
   // Meta is intentionally open — additional keys are reserved for future
-  // passes. v0 doesn't enforce per-key shapes; that lands with the passes
-  // that populate them.
+  // passes. The `space` annotation is the one populated shape today.
+  optionalField(node, "space", path, ctx, walkUnderlyingSpace);
+}
+
+/** `meta.space` — per-axis underlying-space classification (`{x, y}`). */
+function walkUnderlyingSpace(node: unknown, path: string, ctx: Context): void {
+  if (!isObject(node)) {
+    ctx.errors.push({ path, message: "meta.space must be an object" });
+    return;
+  }
+  expectField(node, "x", path, ctx, walkAxisSpace);
+  expectField(node, "y", path, ctx, walkAxisSpace);
+  if (ctx.strict) rejectUnknown(node, ["x", "y"], path, ctx);
+}
+
+function walkAxisSpace(node: unknown, path: string, ctx: Context): void {
+  if (!isObject(node)) {
+    ctx.errors.push({ path, message: "axis space must be an object" });
+    return;
+  }
+  const kind = node.kind;
+  switch (kind) {
+    case "POSITION":
+    case "SIZE":
+      expectField(node, "domain", path, ctx, expectNumberPair);
+      if (ctx.strict) rejectUnknown(node, ["kind", "domain"], path, ctx);
+      return;
+    case "DIFFERENCE":
+      expectField(node, "width", path, ctx, expectNumber);
+      if (ctx.strict) rejectUnknown(node, ["kind", "width"], path, ctx);
+      return;
+    case "ORDINAL":
+      expectField(node, "domain", path, ctx, (v, p) => {
+        if (!Array.isArray(v) || !v.every((x) => typeof x === "string")) {
+          ctx.errors.push({
+            path: p,
+            message: "ORDINAL domain must be an array of strings",
+          });
+        }
+      });
+      if (ctx.strict) rejectUnknown(node, ["kind", "domain"], path, ctx);
+      return;
+    case "UNDEFINED":
+      if (ctx.strict) rejectUnknown(node, ["kind"], path, ctx);
+      return;
+    default:
+      ctx.errors.push({
+        path: `${path}.kind`,
+        message: `axis space kind must be one of POSITION | SIZE | DIFFERENCE | ORDINAL | UNDEFINED, got ${JSON.stringify(
+          kind
+        )}`,
+      });
+  }
+}
+
+function expectNumberPair(value: unknown, path: string, ctx: Context): void {
+  if (
+    !Array.isArray(value) ||
+    value.length !== 2 ||
+    !value.every((n) => typeof n === "number")
+  ) {
+    ctx.errors.push({
+      path,
+      message: `expected [number, number], got ${typeNameOf(value)}`,
+    });
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/gofish-ir/src/tests/schema.test.ts
+++ b/packages/gofish-ir/src/tests/schema.test.ts
@@ -467,6 +467,57 @@ check(
   validate(chart([{ type: "table", by: { x: "a", y: "b" } }])).valid
 );
 
+console.log("\n# meta.space underlying-space annotation");
+
+/** A chart whose root carries a meta.space annotation. */
+function chartWithSpace(space: any) {
+  return {
+    irVersion: 0,
+    ir: "gofish-frontend",
+    root: { type: "chart", mark: { type: "rect" }, meta: { space } },
+  } as unknown as FrontendIRDocument;
+}
+
+check(
+  "meta.space with required per-axis fields accepts (strict)",
+  validate(
+    chartWithSpace({
+      x: { kind: "ORDINAL", domain: ["A", "B"] },
+      y: { kind: "POSITION", domain: [0, 20] },
+    }),
+    { strict: true }
+  ).valid
+);
+check(
+  "meta.space SIZE/DIFFERENCE/UNDEFINED accept (strict)",
+  validate(
+    chartWithSpace({
+      x: { kind: "DIFFERENCE", width: 16 },
+      y: { kind: "SIZE", domain: [0, 25] },
+    }),
+    { strict: true }
+  ).valid &&
+    validate(
+      chartWithSpace({ x: { kind: "UNDEFINED" }, y: { kind: "UNDEFINED" } }),
+      { strict: true }
+    ).valid
+);
+check(
+  "meta.space missing an axis is rejected",
+  !validate(chartWithSpace({ x: { kind: "UNDEFINED" } })).valid
+);
+check(
+  "POSITION without a numeric domain pair is rejected",
+  !validate(
+    chartWithSpace({ x: { kind: "POSITION" }, y: { kind: "UNDEFINED" } })
+  ).valid
+);
+check(
+  "unknown axis-space kind is rejected",
+  !validate(chartWithSpace({ x: { kind: "WAT" }, y: { kind: "UNDEFINED" } }))
+    .valid
+);
+
 // ---------------------------------------------------------------------------
 // Report
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Foundation for treating underlying space (`POSITION`/`SIZE`/`DIFFERENCE`/`ORDINAL`/`UNDEFINED`) as GoFish's **type system** and carrying it into the frontend IR, plus a cheap pre-resolution typecheck on the chart-builder AST. Groundwork for elaborating axes/legends/labels into the lower-level structure (depends on correct underlying-space types at every stage).

Refs #452 (underlying space as a type system) and #457 (split elaboration into its own phase).

## What's in this PR

**`gofish-ir` — the annotation type**
- `UnderlyingSpaceAnnotation` is now per-axis (`{x, y}`) with **required, serializable** fields: `POSITION`/`SIZE` carry `domain:[min,max]`, `DIFFERENCE` a `width`, `ORDINAL` its category keys, `UNDEFINED` none. Validated in `validate.ts` + `jsonSchema.ts`.

**`gofish-graphics` — read off the model, never infer from JSON**
- `underlyingSpaceToAnnotation` — single source of truth mapping runtime `UnderlyingSpace` → IR (a linear `SIZE` `Monotonic` recovers its data extent as `[intercept, intercept+slope]`; non-linear raises `UnderlyingSpaceInferenceError`).
- `toJSON` resolves the chart and projects the root's `_underlyingSpace` into `meta.space`. **Optional per node but complete when present**; any failure (unbound/external data, unresolvable mark, non-linear SIZE) omits it, so serialization never regresses. `fromJSON` ignores `meta` (it's derived) → round-trips re-derive identically.

**Cheap pre-resolution typecheck (the early type system)**
- *Kind inference* (`underlyingSpaceRules.ts` + `serialize/inferUnderlyingSpace.ts`): classifies a leaf mark's per-axis kind from its channel annotations alone — no data, no resolve. `createMark` now stashes `channels` on the serialize tag.
- *Channel typecheck* (`serialize/typecheckChannels.ts`): with inline data, infers the column schema from `data[0]`, elaborates each channel arg to **field vs literal**, and typechecks against the channel's expected type (`size`/`pos` → number, literal `color` → string). **Opaque past a `derive`** (an arbitrary transform can retype columns).

This mirrors GHC/Lean: kinds are checkable early/cheaply on the surface AST (typecheck `HsSyn` before desugar); domains come from resolution (Core Lint re-checks lowered Core). A cross-stage parity test ("Core Lint") asserts the cheap leaf kinds agree with every resolved leaf node's kind.

## Deferred (follow-ups, naturally enabled once #457 splits elaboration)
- Per-node-deep domain annotation across the whole tree
- Operator-composition inference at the chart-builder level (e.g. `spread` turning child `SIZE` into a stacked `POSITION`)
- Explicit user-annotation escape hatch for uninferrable fields
- Layer's `type` as a discriminated union

## Notes
- **Python** is unaffected: it doesn't compute underlying space, so `to_ir()` omits the optional `meta.space` (round-trips cleanly; doesn't drive rendering).
- Docs: underlying-space + serialization essays updated with the two-stage type-system framing; mark-factory note; `covers:`/`@wiki` synced.

## Tests
- `gofish-ir`: 64/64 — `meta.space` shape acceptance + rejections.
- `gofish-graphics`: 76/76 — `meta.space` presence/determinism/graceful-omit, cheap kind inference, cross-stage parity, channel elaboration + typecheck (incl. derive-opaque).

🤖 Generated with [Claude Code](https://claude.com/claude-code)