### PR TITLE
feat(tests): local visual-regression signal via capture-diff (#496)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,13 @@ Key coordinate systems available:
   argument to list stories. The `/iterate-example` skill (`.claude/skills/iterate-example/`) drives
   this render → review → fix loop. Requires `dist/` to exist once
   (`pnpm --filter gofish-graphics build`); source edits are picked up live without rebuilding.
+- **Local regression signal for layout changes**: `pnpm capture-diff <base-ref> [filter]`
+  renders every story's normalized DOM at HEAD and at `<base-ref>` (checked out in a throwaway
+  worktree) and diffs them per story — a baseline-free, platform-stable "did my change move
+  anything I didn't intend?" check for an inner loop. Unlike the CI visual baselines, it works
+  on Mac (it diffs normalized geometry, not pixels, so no text-metric drift) and needs no
+  curation. Pass a substring to scope to one story or a group (`pnpm capture-diff main bar`).
+  Exits non-zero when anything moved; report at `tests/tmp/capture-diff/report.html`.
 - **Documentation**: VitePress site in `apps/docs/` with live chart examples
 - **Testing**: The `src/tests/` directory contains visual chart examples for development, not automated unit tests
 - **Development Server**: `pnpm dev` runs Vite dev server on port 3000

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test:visual:update": "pnpm --filter @gofish/tests update",
     "test:visual:js": "pnpm --filter @gofish/tests test:js",
     "capture-one": "pnpm --filter @gofish/tests capture-one",
+    "capture-diff": "pnpm --filter @gofish/tests capture-diff",
     "test:visual:review": "pnpm --filter @gofish/tests review",
     "test:visual:check-sync": "pnpm --filter @gofish/tests check-sync",
     "test:visual:python": "pnpm --filter @gofish/tests test:python",

--- a/tests/README.md
+++ b/tests/README.md
@@ -56,12 +56,52 @@ Both JS and Python DOM go through identical normalization (`scripts/normalize-do
 
 ## Commands
 
-| Command                       | Description                                                   |
-| ----------------------------- | ------------------------------------------------------------- |
-| `pnpm test:visual:js`         | Capture JS snapshots and compare against baselines            |
-| `pnpm test:visual:update`     | Capture and accept as new baselines                           |
-| `pnpm test:visual`            | Full test: JS capture + Python capture + compare              |
-| `pnpm test:visual:check-sync` | Check that changed JS stories have updated Python equivalents |
+| Command                       | Description                                                     |
+| ----------------------------- | --------------------------------------------------------------- |
+| `pnpm test:visual:js`         | Capture JS snapshots and compare against baselines              |
+| `pnpm test:visual:update`     | Capture and accept as new baselines                             |
+| `pnpm test:visual`            | Full test: JS capture + Python capture + compare                |
+| `pnpm test:visual:check-sync` | Check that changed JS stories have updated Python equivalents   |
+| `pnpm capture-diff <ref>`     | Diff HEAD's rendered DOM against `<ref>` — no baselines, any OS |
+
+## Local regression signal: `capture-diff`
+
+`pnpm test:visual:js` only gives a pass/fail _in CI_ — the baselines live on a
+snapshot branch and `update-baselines` must not be run on Mac (text-metric drift
+vs CI Linux produces false regressions for every text-bearing story). So locally
+there is no pass/fail signal for a layout change.
+
+`capture-diff` fills that gap. It answers **"did my change move anything I didn't
+intend?"** by capturing the normalized DOM of every story twice — once from the
+current worktree (HEAD) and once from a throwaway git worktree checked out at a
+base ref — and diffing the two per story:
+
+```bash
+pnpm capture-diff main          # whole suite vs main
+pnpm capture-diff HEAD~1        # vs the previous commit
+pnpm capture-diff main bar      # only stories matching "bar" (faster)
+pnpm capture-diff main streamgraph
+```
+
+The diff is over **normalized geometry/DOM, not rasterized pixels**, so it is
+platform-stable — no baseline curation, works on any OS, and doesn't suffer the
+text-metric drift that makes `update-baselines` unusable locally. The optional
+second argument is a case-insensitive substring filter (matched against
+`title/name` or story id) so you can scope to one story or a group.
+
+Output:
+
+```
+tests/tmp/capture-diff/head/<path>.html   normalized DOM at HEAD
+tests/tmp/capture-diff/base/<path>.html   normalized DOM at <ref>
+tests/tmp/capture-diff/report.html        side-by-side DOM diff (changed stories)
+```
+
+It prints the changed/added/removed stories and exits non-zero when anything
+moved, so it can gate an agent's inner loop. The base capture installs deps in
+the temp worktree (`pnpm install --ignore-scripts`, mostly links from the shared
+pnpm store) and is torn down automatically. Requires Playwright's chromium
+(`npx playwright install chromium`).
 
 ## Developer Workflows
 
@@ -144,7 +184,9 @@ Stories with `derive()` use a Python HTTP server (`scripts/derive-server.py`) th
 ```
 tests/
   scripts/
+    capture-core.ts            # Shared headless-capture engine (Vite + Playwright)
     capture-js-dom.ts          # Batch capture via Vite + Playwright
+    capture-diff.ts            # Diff HEAD's DOM vs a base ref (local regression signal)
     capture-python-dom.ts      # Python story capture via harness
     compare.ts                 # Compare JS vs baselines + Python vs JS
     update-baselines.ts        # Accept current snapshots as baselines

--- a/tests/package.json
+++ b/tests/package.json
@@ -9,6 +9,7 @@
     "update": "tsx scripts/capture-js-dom.ts && tsx scripts/update-baselines.ts",
     "capture-js": "tsx scripts/capture-js-dom.ts",
     "capture-one": "tsx scripts/capture-one.ts",
+    "capture-diff": "tsx scripts/capture-diff.ts",
     "update-baselines": "tsx scripts/update-baselines.ts",
     "check-sync": "tsx scripts/check-python-sync.ts",
     "check-python-sync": "tsx scripts/check-python-sync.ts",

--- a/tests/scripts/capture-core.ts
+++ b/tests/scripts/capture-core.ts
@@ -1,0 +1,236 @@
+/**
+ * capture-core.ts
+ *
+ * Shared headless-capture engine used by:
+ *   - capture-js-dom.ts  (full corpus → baselines comparison)
+ *   - capture-diff.ts     (HEAD vs base-ref geometry/DOM diff)
+ *
+ * The capture loop is identical in both: spin up a Vite dev server that serves
+ * the stories-runner page, navigate Playwright to it once, then render every
+ * (optionally filtered) story in sequence and extract + normalize its DOM.
+ *
+ * What varies between callers is ONLY which `harnessDir` the Vite server is
+ * rooted in (so capture-diff can point a second server at a base-ref worktree)
+ * and whether PNG screenshots are written. DOM normalization always runs in
+ * THIS process via the current `normalize-dom.ts`, so two captures driven from
+ * the same invocation are normalized identically — which is what makes the
+ * geometry diff platform-stable.
+ */
+
+import { chromium, type Browser } from "playwright";
+import { spawn, type ChildProcess } from "child_process";
+import { writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { normalizeDom } from "./normalize-dom.js";
+import { storyToPath } from "./path-mapping.js";
+
+export interface StoryInfo {
+  id: string;
+  title: string;
+  name: string;
+  moduleKey: string;
+  hasLoaders: boolean;
+}
+
+export interface CaptureOptions {
+  /** Directory containing vite.config.ts + stories-runner.html (the Vite root). */
+  harnessDir: string;
+  /** Port for this capture's Vite server. Must be unique among concurrent captures. */
+  port: number;
+  /** Where to write `<path>.html` (and `<path>.png` when `screenshot`). */
+  outDir: string;
+  /** Case-insensitive substring matched against `title/name` or story id. */
+  filter?: string;
+  /** Also write a PNG screenshot per story (pixel output is NOT platform-stable). */
+  screenshot?: boolean;
+  /** Wipe `outDir` before capturing (default: false — callers manage layout). */
+  cleanOutDir?: boolean;
+  /** Progress sink. Defaults to console.log; pass `() => {}` to silence. */
+  log?: (msg: string) => void;
+}
+
+export interface CaptureResult {
+  /** Relative `<path>.html` paths written (normalized DOM), sorted. */
+  captured: string[];
+  failed: { path: string; error: string }[];
+  skipped: string[];
+}
+
+function startViteServer(harnessDir: string, port: number): ChildProcess {
+  return spawn(
+    "npx",
+    [
+      "vite",
+      "--config",
+      join(harnessDir, "vite.config.ts"),
+      "--port",
+      String(port),
+    ],
+    {
+      cwd: harnessDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, NODE_ENV: "development" },
+    }
+  );
+}
+
+async function waitForVite(port: number, timeoutMs = 30_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const resp = await fetch(`http://localhost:${port}/stories-runner.html`);
+      if (resp.ok) return;
+    } catch {
+      // not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 300));
+  }
+  throw new Error(`Vite server did not start within ${timeoutMs}ms`);
+}
+
+/**
+ * Capture (a subset of) stories from a harness into `outDir`.
+ *
+ * Starts its own Vite server + Playwright browser, captures, then tears both
+ * down before returning. Safe to call twice in one process with distinct ports.
+ */
+export async function captureStories(
+  opts: CaptureOptions
+): Promise<CaptureResult> {
+  const {
+    harnessDir,
+    port,
+    outDir,
+    filter,
+    screenshot = false,
+    cleanOutDir = false,
+    log = (m: string) => console.log(m),
+  } = opts;
+
+  const result: CaptureResult = { captured: [], failed: [], skipped: [] };
+
+  const viteProc = startViteServer(harnessDir, port);
+  viteProc.stdout?.on("data", (d) => {
+    if (process.env.DEBUG) process.stdout.write(d.toString());
+  });
+  viteProc.stderr?.on("data", (d) => process.stderr.write(d.toString()));
+
+  let browser: Browser | undefined;
+
+  try {
+    await waitForVite(port);
+
+    if (cleanOutDir && existsSync(outDir)) {
+      rmSync(outDir, { recursive: true });
+    }
+    mkdirSync(outDir, { recursive: true });
+
+    browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 720 },
+    });
+    const page = await context.newPage();
+
+    page.on("console", (msg) => {
+      if (msg.type() === "error") console.error(`[browser] ${msg.text()}`);
+      else if (process.env.DEBUG)
+        console.log(`[browser:${msg.type()}] ${msg.text()}`);
+    });
+    page.on("pageerror", (err) =>
+      console.error(`[browser pageerror] ${err.message}`)
+    );
+
+    await page.goto(`http://localhost:${port}/stories-runner.html`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForFunction(
+      () => (window as any).__STORIES_RUNNER_READY__ === true,
+      { timeout: 30_000 }
+    );
+    const runnerError = await page.evaluate(
+      () => (window as any).__STORIES_RUNNER_ERROR__
+    );
+    if (runnerError)
+      throw new Error(`Stories runner failed to initialize: ${runnerError}`);
+
+    const allStories = (await page.evaluate(() =>
+      window.__listStories__()
+    )) as StoryInfo[];
+
+    const needle = filter?.toLowerCase().trim();
+    const stories = needle
+      ? allStories.filter((s) => {
+          const hay = `${s.title}/${s.name}`.toLowerCase();
+          return hay.includes(needle) || s.id.includes(needle);
+        })
+      : allStories;
+
+    log(
+      `Found ${allStories.length} stories${needle ? `, ${stories.length} matching "${needle}"` : ""}\n`
+    );
+
+    for (const story of stories) {
+      const path = storyToPath(story.title, story.name);
+      process.stdout.write(`  ${story.title}/${story.name} ... `);
+
+      try {
+        const success = await page.evaluate(
+          async (id) => window.__renderStory__(id),
+          story.id
+        );
+        if (!success) {
+          const err = await page.evaluate(() => window.__STORY_RENDER_ERROR__);
+          console.log(`FAILED: ${err}`);
+          result.failed.push({ path, error: String(err) });
+          continue;
+        }
+
+        await page.waitForFunction(
+          () => window.__STORY_RENDER_DONE__ === true,
+          { timeout: 15_000 }
+        );
+
+        const rawDom = await page.evaluate(() => {
+          const root = document.getElementById("stories-root");
+          return root ? root.innerHTML : "";
+        });
+        if (!rawDom.trim()) {
+          console.log("SKIP (empty)");
+          result.skipped.push(path);
+          continue;
+        }
+
+        const domPath = join(outDir, `${path}.html`);
+        mkdirSync(dirname(domPath), { recursive: true });
+        writeFileSync(domPath, normalizeDom(rawDom), "utf-8");
+
+        if (screenshot) {
+          const rootHandle = await page.$("#stories-root");
+          if (rootHandle) {
+            const screenshotPath = join(outDir, `${path}.png`);
+            mkdirSync(dirname(screenshotPath), { recursive: true });
+            writeFileSync(
+              screenshotPath,
+              await rootHandle.screenshot({ type: "png" })
+            );
+          }
+        }
+
+        console.log("OK");
+        result.captured.push(`${path}.html`);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`FAILED: ${msg}`);
+        result.failed.push({ path, error: msg });
+      }
+    }
+
+    result.captured.sort();
+    await context.close();
+  } finally {
+    await browser?.close();
+    viteProc.kill();
+  }
+
+  return result;
+}

--- a/tests/scripts/capture-core.ts
+++ b/tests/scripts/capture-core.ts
@@ -45,8 +45,6 @@ export interface CaptureOptions {
   screenshot?: boolean;
   /** Wipe `outDir` before capturing (default: false — callers manage layout). */
   cleanOutDir?: boolean;
-  /** Progress sink. Defaults to console.log; pass `() => {}` to silence. */
-  log?: (msg: string) => void;
 }
 
 export interface CaptureResult {
@@ -104,7 +102,6 @@ export async function captureStories(
     filter,
     screenshot = false,
     cleanOutDir = false,
-    log = (m: string) => console.log(m),
   } = opts;
 
   const result: CaptureResult = { captured: [], failed: [], skipped: [] };
@@ -165,7 +162,7 @@ export async function captureStories(
         })
       : allStories;
 
-    log(
+    console.log(
       `Found ${allStories.length} stories${needle ? `, ${stories.length} matching "${needle}"` : ""}\n`
     );
 

--- a/tests/scripts/capture-diff.ts
+++ b/tests/scripts/capture-diff.ts
@@ -1,0 +1,310 @@
+/**
+ * capture-diff.ts
+ *
+ * Local visual-regression signal for agent loops (issue #496): answer the
+ * question "did my change move anything I didn't intend?" WITHOUT stored
+ * baselines or CI.
+ *
+ * It captures the normalized DOM of every (optionally filtered) story twice —
+ * once from the current worktree (HEAD) and once from a throwaway git worktree
+ * checked out at <base-ref> — then diffs the two per story. Because the diff is
+ * over normalized geometry/DOM (not rasterized pixels), it is platform-stable:
+ * it does not suffer the text-metric drift that makes `update-baselines`
+ * unusable on Mac, so it gives a real pass/fail layout signal locally.
+ *
+ * Usage:
+ *   tsx scripts/capture-diff.ts <base-ref> [filter]
+ *
+ *   tsx scripts/capture-diff.ts main            # whole suite vs main
+ *   tsx scripts/capture-diff.ts HEAD~1          # vs the previous commit
+ *   tsx scripts/capture-diff.ts main bar        # only stories matching "bar"
+ *   tsx scripts/capture-diff.ts main "streamgraph"
+ *
+ * Output:
+ *   tests/tmp/capture-diff/head/<path>.html   normalized DOM at HEAD
+ *   tests/tmp/capture-diff/base/<path>.html   normalized DOM at <base-ref>
+ *   tests/tmp/capture-diff/report.html        side-by-side DOM diff (changed stories)
+ *
+ * Exit code 0 = nothing moved, 1 = at least one story changed/added/removed
+ * (so it doubles as a pass/fail gate in an inner loop).
+ */
+
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync, rmSync, mkdirSync, existsSync } from "fs";
+import { join } from "path";
+import { captureStories } from "./capture-core.js";
+import { formatDomDiff, escapeHtml } from "./diff-utils.js";
+
+const TESTS_DIR = join(import.meta.dirname, "..");
+const HARNESS_DIR = join(TESTS_DIR, "harness");
+const OUT_DIR = join(TESTS_DIR, "tmp/capture-diff");
+const HEAD_DIR = join(OUT_DIR, "head");
+const BASE_DIR = join(OUT_DIR, "base");
+const REPORT_PATH = join(OUT_DIR, "report.html");
+
+const HEAD_PORT = 3001; // reuse capture-js-dom's port (it isn't running concurrently)
+const BASE_PORT = 3003; // distinct so the base worktree's server can coexist
+
+// ---------------------------------------------------------------------------
+// git helpers
+// ---------------------------------------------------------------------------
+
+function git(
+  cmd: string,
+  opts: { cwd?: string; ignoreError?: boolean } = {}
+): string {
+  try {
+    return execSync(cmd, {
+      cwd: opts.cwd,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch (e) {
+    if (opts.ignoreError) return "";
+    throw e;
+  }
+}
+
+const REPO_ROOT = git("git rev-parse --show-toplevel", { cwd: TESTS_DIR });
+
+function removeWorktree(wtPath: string): void {
+  git(`git worktree remove --force "${wtPath}"`, {
+    cwd: REPO_ROOT,
+    ignoreError: true,
+  });
+  if (existsSync(wtPath)) {
+    rmSync(wtPath, { recursive: true, force: true });
+    git("git worktree prune", { cwd: REPO_ROOT, ignoreError: true });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Report
+// ---------------------------------------------------------------------------
+
+interface Change {
+  path: string;
+  kind: "changed" | "added" | "removed";
+  baseDom: string | null;
+  headDom: string | null;
+}
+
+function generateReport(
+  baseRef: string,
+  filter: string | undefined,
+  changes: Change[]
+): string {
+  const kindColor: Record<Change["kind"], string> = {
+    changed: "#e74c3c",
+    added: "#3498db",
+    removed: "#95a5a6",
+  };
+  const kindLabel: Record<Change["kind"], string> = {
+    changed: "CHANGED",
+    added: `ADDED (not in ${baseRef})`,
+    removed: `REMOVED (only in ${baseRef})`,
+  };
+
+  const entryHtml = changes
+    .map((c) => {
+      const body =
+        c.kind === "changed" && c.baseDom && c.headDom
+          ? formatDomDiff(c.baseDom, c.headDom)
+          : `<pre style="margin:0;white-space:pre-wrap;padding:8px;">${escapeHtml(
+              c.headDom ?? c.baseDom ?? ""
+            )}</pre>`;
+      return `
+    <div style="border:1px solid #ddd;margin:16px 0;border-radius:6px;overflow:hidden;">
+      <div style="padding:12px 16px;background:${kindColor[c.kind]}22;border-bottom:1px solid #ddd;">
+        <span style="font-weight:bold;color:${kindColor[c.kind]};">${kindLabel[c.kind]}</span>
+        <span style="margin-left:12px;font-family:monospace;">${escapeHtml(c.path)}</span>
+      </div>
+      <details ${c.kind === "changed" ? "open" : ""} style="padding:0;">
+        <summary style="cursor:pointer;font-weight:bold;font-size:13px;padding:8px 16px;">DOM diff (− ${escapeHtml(baseRef)}, + HEAD)</summary>
+        <div style="max-height:600px;overflow:auto;border-top:1px solid #e0e0e0;">
+          ${body}
+        </div>
+      </details>
+    </div>`;
+    })
+    .join("\n");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>capture-diff: HEAD vs ${escapeHtml(baseRef)}</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; max-width: 1200px; margin: 0 auto; padding: 24px; color: #333; }
+    h1 { border-bottom: 2px solid #333; padding-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <h1>capture-diff: HEAD vs ${escapeHtml(baseRef)}</h1>
+  <p>${changes.length} story(ies) moved${filter ? ` (filter: <code>${escapeHtml(filter)}</code>)` : ""}. Diff is over normalized geometry/DOM, so it is platform-stable.</p>
+  ${entryHtml}
+</body>
+</html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const baseRef = process.argv[2];
+  const filter = process.argv[3];
+
+  if (!baseRef) {
+    console.error(
+      "Usage: tsx scripts/capture-diff.ts <base-ref> [filter]\n" +
+        "  e.g. tsx scripts/capture-diff.ts main\n" +
+        "       tsx scripts/capture-diff.ts HEAD~1 bar"
+    );
+    process.exit(2);
+  }
+
+  // Resolve the ref now so we fail fast on a typo (and pin to a sha so the
+  // worktree is stable even if the branch moves mid-run).
+  const baseSha = git(`git rev-parse "${baseRef}"`, {
+    cwd: REPO_ROOT,
+    ignoreError: true,
+  });
+  if (!baseSha) {
+    console.error(
+      `Cannot resolve base ref "${baseRef}". Is it a valid commit/branch?`
+    );
+    process.exit(2);
+  }
+  const baseShort = baseSha.slice(0, 9);
+
+  // Fresh output dir each run.
+  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  // 1. Capture HEAD from the current worktree.
+  console.log(`=== Capturing HEAD (current worktree) ===\n`);
+  const headResult = await captureStories({
+    harnessDir: HARNESS_DIR,
+    port: HEAD_PORT,
+    outDir: HEAD_DIR,
+    filter,
+  });
+
+  // 2. Capture <base-ref> from a throwaway worktree.
+  const wtPath = join("/tmp", `gofish-capture-diff-${process.pid}`);
+  removeWorktree(wtPath);
+  let baseResult;
+  try {
+    console.log(
+      `\n=== Checking out ${baseRef} (${baseShort}) into a temp worktree ===`
+    );
+    git(`git worktree add --detach "${wtPath}" ${baseSha}`, { cwd: REPO_ROOT });
+
+    // The worktree has no node_modules — install so its harness can run Vite.
+    // --ignore-scripts skips husky/postinstall (not needed for a headless render)
+    // and keeps the install fast; the pnpm store is shared so it's mostly links.
+    console.log(
+      `Installing dependencies in the temp worktree (this can take a minute)...`
+    );
+    execSync("pnpm install --ignore-scripts", {
+      cwd: wtPath,
+      stdio: "inherit",
+    });
+
+    console.log(`\n=== Capturing ${baseRef} (${baseShort}) ===\n`);
+    baseResult = await captureStories({
+      harnessDir: join(wtPath, "tests/harness"),
+      port: BASE_PORT,
+      outDir: BASE_DIR,
+      filter,
+    });
+  } finally {
+    removeWorktree(wtPath);
+  }
+
+  // 3. Diff per story.
+  const headSet = new Set(headResult.captured);
+  const baseSet = new Set(baseResult.captured);
+  const all = [
+    ...new Set([...headResult.captured, ...baseResult.captured]),
+  ].sort();
+
+  const changes: Change[] = [];
+  for (const path of all) {
+    const inHead = headSet.has(path);
+    const inBase = baseSet.has(path);
+    if (inHead && inBase) {
+      const headDom = readFileSync(join(HEAD_DIR, path), "utf-8");
+      const baseDom = readFileSync(join(BASE_DIR, path), "utf-8");
+      if (headDom !== baseDom)
+        changes.push({ path, kind: "changed", baseDom, headDom });
+    } else if (inHead) {
+      changes.push({
+        path,
+        kind: "added",
+        baseDom: null,
+        headDom: readFileSync(join(HEAD_DIR, path), "utf-8"),
+      });
+    } else {
+      changes.push({
+        path,
+        kind: "removed",
+        baseDom: readFileSync(join(BASE_DIR, path), "utf-8"),
+        headDom: null,
+      });
+    }
+  }
+
+  // 4. Report.
+  console.log(`\n=== Result: HEAD vs ${baseRef} (${baseShort}) ===\n`);
+
+  const changed = changes.filter((c) => c.kind === "changed");
+  const added = changes.filter((c) => c.kind === "added");
+  const removed = changes.filter((c) => c.kind === "removed");
+
+  if (changes.length === 0) {
+    console.log(
+      `  No layout changes. ${headResult.captured.length} story(ies) identical.`
+    );
+  } else {
+    if (changed.length) {
+      console.log(`  ${changed.length} changed:`);
+      for (const c of changed) console.log(`    ~ ${c.path}`);
+    }
+    if (added.length) {
+      console.log(`  ${added.length} added (not in ${baseRef}):`);
+      for (const c of added) console.log(`    + ${c.path}`);
+    }
+    if (removed.length) {
+      console.log(`  ${removed.length} removed (only in ${baseRef}):`);
+      for (const c of removed) console.log(`    - ${c.path}`);
+    }
+  }
+
+  // Render failures are worth surfacing — a crash in either ref is a real signal.
+  const renderFailures = [
+    ...headResult.failed.map((f) => ({ ...f, ref: "HEAD" })),
+    ...baseResult.failed.map((f) => ({ ...f, ref: baseRef })),
+  ];
+  if (renderFailures.length) {
+    console.log(`\n  ${renderFailures.length} render failure(s):`);
+    for (const f of renderFailures)
+      console.log(`    ! [${f.ref}] ${f.path}: ${f.error}`);
+  }
+
+  writeFileSync(REPORT_PATH, generateReport(baseRef, filter, changes), "utf-8");
+  if (changes.length) {
+    console.log(`\n  DOM written to ${HEAD_DIR} and ${BASE_DIR}`);
+    console.log(`  Diff report: ${REPORT_PATH}`);
+  }
+
+  // Non-zero when anything moved so this can gate an inner loop.
+  process.exit(changes.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(2);
+});

--- a/tests/scripts/capture-diff.ts
+++ b/tests/scripts/capture-diff.ts
@@ -34,6 +34,7 @@ import { readFileSync, writeFileSync, rmSync, mkdirSync, existsSync } from "fs";
 import { join } from "path";
 import { captureStories } from "./capture-core.js";
 import { formatDomDiff, escapeHtml } from "./diff-utils.js";
+import { git, removeWorktree } from "./snapshot-branch.js";
 
 const TESTS_DIR = join(import.meta.dirname, "..");
 const HARNESS_DIR = join(TESTS_DIR, "harness");
@@ -44,39 +45,6 @@ const REPORT_PATH = join(OUT_DIR, "report.html");
 
 const HEAD_PORT = 3001; // reuse capture-js-dom's port (it isn't running concurrently)
 const BASE_PORT = 3003; // distinct so the base worktree's server can coexist
-
-// ---------------------------------------------------------------------------
-// git helpers
-// ---------------------------------------------------------------------------
-
-function git(
-  cmd: string,
-  opts: { cwd?: string; ignoreError?: boolean } = {}
-): string {
-  try {
-    return execSync(cmd, {
-      cwd: opts.cwd,
-      encoding: "utf-8",
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
-  } catch (e) {
-    if (opts.ignoreError) return "";
-    throw e;
-  }
-}
-
-const REPO_ROOT = git("git rev-parse --show-toplevel", { cwd: TESTS_DIR });
-
-function removeWorktree(wtPath: string): void {
-  git(`git worktree remove --force "${wtPath}"`, {
-    cwd: REPO_ROOT,
-    ignoreError: true,
-  });
-  if (existsSync(wtPath)) {
-    rmSync(wtPath, { recursive: true, force: true });
-    git("git worktree prune", { cwd: REPO_ROOT, ignoreError: true });
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Report
@@ -167,10 +135,7 @@ async function main() {
 
   // Resolve the ref now so we fail fast on a typo (and pin to a sha so the
   // worktree is stable even if the branch moves mid-run).
-  const baseSha = git(`git rev-parse "${baseRef}"`, {
-    cwd: REPO_ROOT,
-    ignoreError: true,
-  });
+  const baseSha = git(`git rev-parse "${baseRef}"`, { ignoreError: true });
   if (!baseSha) {
     console.error(
       `Cannot resolve base ref "${baseRef}". Is it a valid commit/branch?`
@@ -200,7 +165,7 @@ async function main() {
     console.log(
       `\n=== Checking out ${baseRef} (${baseShort}) into a temp worktree ===`
     );
-    git(`git worktree add --detach "${wtPath}" ${baseSha}`, { cwd: REPO_ROOT });
+    git(`git worktree add --detach "${wtPath}" ${baseSha}`);
 
     // The worktree has no node_modules — install so its harness can run Vite.
     // --ignore-scripts skips husky/postinstall (not needed for a headless render)
@@ -227,34 +192,23 @@ async function main() {
   // 3. Diff per story.
   const headSet = new Set(headResult.captured);
   const baseSet = new Set(baseResult.captured);
-  const all = [
-    ...new Set([...headResult.captured, ...baseResult.captured]),
-  ].sort();
+  const all = Array.from(new Set([...headSet, ...baseSet])).sort();
 
   const changes: Change[] = [];
   for (const path of all) {
-    const inHead = headSet.has(path);
-    const inBase = baseSet.has(path);
-    if (inHead && inBase) {
-      const headDom = readFileSync(join(HEAD_DIR, path), "utf-8");
-      const baseDom = readFileSync(join(BASE_DIR, path), "utf-8");
-      if (headDom !== baseDom)
-        changes.push({ path, kind: "changed", baseDom, headDom });
-    } else if (inHead) {
-      changes.push({
-        path,
-        kind: "added",
-        baseDom: null,
-        headDom: readFileSync(join(HEAD_DIR, path), "utf-8"),
-      });
-    } else {
-      changes.push({
-        path,
-        kind: "removed",
-        baseDom: readFileSync(join(BASE_DIR, path), "utf-8"),
-        headDom: null,
-      });
-    }
+    const headDom = headSet.has(path)
+      ? readFileSync(join(HEAD_DIR, path), "utf-8")
+      : null;
+    const baseDom = baseSet.has(path)
+      ? readFileSync(join(BASE_DIR, path), "utf-8")
+      : null;
+
+    if (baseDom === null)
+      changes.push({ path, kind: "added", baseDom, headDom });
+    else if (headDom === null)
+      changes.push({ path, kind: "removed", baseDom, headDom });
+    else if (headDom !== baseDom)
+      changes.push({ path, kind: "changed", baseDom, headDom });
   }
 
   // 4. Report.

--- a/tests/scripts/capture-js-dom.ts
+++ b/tests/scripts/capture-js-dom.ts
@@ -1,214 +1,38 @@
 /**
  * Capture DOM snapshots and screenshots from every Storybook story.
  *
- * Instead of building Storybook and navigating to each story URL, this script:
- * 1. Starts a Vite dev server serving the stories-runner page
- * 2. Navigates Playwright to that page ONCE
- * 3. Calls window.__renderStory__(id) for each story in sequence
- * 4. Extracts + normalizes DOM and takes a screenshot after each render
+ * Renders the full story corpus headlessly into `tmp/js/` (normalized DOM +
+ * PNG screenshots) for comparison against the checked-in baselines.
  *
- * This is much faster than per-story navigation because there's no page load
- * or network-idle wait between stories — just JS execution in the same page.
+ * The actual capture loop lives in `capture-core.ts` (shared with
+ * `capture-diff.ts`): it starts a Vite dev server serving the stories-runner
+ * page, navigates Playwright to it once, and renders each story in sequence by
+ * calling `window.__renderStory__(id)` — much faster than per-story navigation
+ * because there's no page load between stories, just JS execution.
  */
 
-import { chromium, type Browser, type Page } from "playwright";
-import { spawn, type ChildProcess } from "child_process";
-import { writeFileSync, mkdirSync, rmSync, existsSync } from "fs";
-import { join, dirname } from "path";
-import { normalizeDom } from "./normalize-dom.js";
-import { storyToPath } from "./path-mapping.js";
-
-// ---------------------------------------------------------------------------
-// Config
-// ---------------------------------------------------------------------------
+import { join } from "path";
+import { captureStories } from "./capture-core.js";
 
 const TESTS_DIR = join(import.meta.dirname, "..");
 const HARNESS_DIR = join(TESTS_DIR, "harness");
 const TMP_DIR = join(TESTS_DIR, "tmp/js");
 const VITE_PORT = 3001;
 
-// ---------------------------------------------------------------------------
-// Start Vite dev server
-// ---------------------------------------------------------------------------
-
-function startViteServer(): ChildProcess {
-  const proc = spawn(
-    "npx",
-    [
-      "vite",
-      "--config",
-      join(HARNESS_DIR, "vite.config.ts"),
-      "--port",
-      String(VITE_PORT),
-    ],
-    {
-      cwd: HARNESS_DIR,
-      stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, NODE_ENV: "development" },
-    }
-  );
-
-  return proc;
-}
-
-async function waitForVite(port: number, timeoutMs = 30_000): Promise<void> {
-  const start = Date.now();
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const resp = await fetch(`http://localhost:${port}/stories-runner.html`);
-      if (resp.ok) return;
-    } catch {
-      // not ready yet
-    }
-    await new Promise((r) => setTimeout(r, 300));
-  }
-  throw new Error(`Vite server did not start within ${timeoutMs}ms`);
-}
-
-// ---------------------------------------------------------------------------
-// Main
-// ---------------------------------------------------------------------------
-
 async function main() {
   console.log("=== Capturing JS DOM snapshots (batch mode) ===\n");
 
-  // 1. Start Vite
-  console.log("Starting Vite dev server...");
-  const viteProc = startViteServer();
-
-  // Log Vite output — always show errors, show all output in DEBUG mode
-  viteProc.stdout?.on("data", (d) => {
-    if (process.env.DEBUG) process.stdout.write(d.toString());
-  });
-  viteProc.stderr?.on("data", (d) => {
-    process.stderr.write(d.toString());
+  const result = await captureStories({
+    harnessDir: HARNESS_DIR,
+    port: VITE_PORT,
+    outDir: TMP_DIR,
+    screenshot: true,
+    cleanOutDir: true,
   });
 
-  let browser: Browser | undefined;
-
-  try {
-    await waitForVite(VITE_PORT);
-    console.log("Vite server ready");
-
-    // Clean tmp dir from previous runs
-    if (existsSync(TMP_DIR)) {
-      rmSync(TMP_DIR, { recursive: true });
-    }
-    console.log("");
-
-    // 2. Launch browser and navigate ONCE
-    browser = await chromium.launch({ headless: true });
-    const context = await browser.newContext({
-      viewport: { width: 1280, height: 720 },
-    });
-    const page = await context.newPage();
-
-    // Surface browser console errors immediately
-    page.on("console", (msg) => {
-      if (msg.type() === "error") console.error(`[browser] ${msg.text()}`);
-      else if (process.env.DEBUG)
-        console.log(`[browser:${msg.type()}] ${msg.text()}`);
-    });
-    page.on("pageerror", (err) =>
-      console.error(`[browser pageerror] ${err.message}`)
-    );
-
-    await page.goto(`http://localhost:${VITE_PORT}/stories-runner.html`, {
-      waitUntil: "domcontentloaded",
-    });
-
-    // Wait for the runner to be ready (or to report an error)
-    await page.waitForFunction(
-      () => (window as any).__STORIES_RUNNER_READY__ === true,
-      { timeout: 30_000 }
-    );
-
-    const runnerError = await page.evaluate(
-      () => (window as any).__STORIES_RUNNER_ERROR__
-    );
-    if (runnerError)
-      throw new Error(`Stories runner failed to initialize: ${runnerError}`);
-
-    // 3. Get the story list
-    const stories = await page.evaluate(() => window.__listStories__());
-    console.log(`Found ${stories.length} stories\n`);
-
-    mkdirSync(TMP_DIR, { recursive: true });
-
-    let captured = 0;
-    let failed = 0;
-    let skipped = 0;
-
-    // 4. Render each story in sequence (no navigation!)
-    for (const story of stories) {
-      const path = storyToPath(story.title, story.name);
-      process.stdout.write(`  ${story.title}/${story.name} → ${path} ... `);
-
-      try {
-        const success = await page.evaluate(async (id) => {
-          return window.__renderStory__(id);
-        }, story.id);
-
-        if (!success) {
-          const err = await page.evaluate(() => window.__STORY_RENDER_ERROR__);
-          console.log(`FAILED: ${err}`);
-          failed++;
-          continue;
-        }
-
-        // Wait for render to settle
-        await page.waitForFunction(
-          () => window.__STORY_RENDER_DONE__ === true,
-          {
-            timeout: 15_000,
-          }
-        );
-
-        // Extract DOM from #stories-root
-        const rawDom = await page.evaluate(() => {
-          const root = document.getElementById("stories-root");
-          return root ? root.innerHTML : "";
-        });
-
-        if (!rawDom.trim()) {
-          console.log("SKIP (empty)");
-          skipped++;
-          continue;
-        }
-
-        const normalized = normalizeDom(rawDom);
-
-        // Write DOM
-        const domPath = join(TMP_DIR, `${path}.html`);
-        mkdirSync(dirname(domPath), { recursive: true });
-        writeFileSync(domPath, normalized, "utf-8");
-
-        // Screenshot the root element
-        const rootHandle = await page.$("#stories-root");
-        if (rootHandle) {
-          const screenshotPath = join(TMP_DIR, `${path}.png`);
-          mkdirSync(dirname(screenshotPath), { recursive: true });
-          const screenshot = await rootHandle.screenshot({ type: "png" });
-          writeFileSync(screenshotPath, screenshot);
-        }
-
-        console.log("OK");
-        captured++;
-      } catch (err) {
-        console.log(`FAILED: ${err instanceof Error ? err.message : err}`);
-        failed++;
-      }
-    }
-
-    console.log(
-      `\nDone: ${captured} captured, ${failed} failed, ${skipped} skipped`
-    );
-
-    await context.close();
-  } finally {
-    await browser?.close();
-    viteProc.kill();
-  }
+  console.log(
+    `\nDone: ${result.captured.length} captured, ${result.failed.length} failed, ${result.skipped.length} skipped`
+  );
 }
 
 main()

--- a/tests/scripts/snapshot-branch.ts
+++ b/tests/scripts/snapshot-branch.ts
@@ -25,7 +25,7 @@ const GITATTRIBUTES_CONTENT =
   "screenshots/**/*.png filter=lfs diff=lfs merge=lfs -text\n";
 
 // ---------------------------------------------------------------------------
-// Internal helpers
+// Shared git helpers (also used by capture-diff.ts)
 // ---------------------------------------------------------------------------
 
 interface GitOptions {
@@ -34,7 +34,7 @@ interface GitOptions {
   ignoreError?: boolean;
 }
 
-function git(cmd: string, opts: GitOptions = {}): string {
+export function git(cmd: string, opts: GitOptions = {}): string {
   const { cwd = ROOT, input, ignoreError = false } = opts;
   try {
     return execSync(cmd, {
@@ -49,7 +49,7 @@ function git(cmd: string, opts: GitOptions = {}): string {
   }
 }
 
-function removeWorktree(wtPath: string): void {
+export function removeWorktree(wtPath: string): void {
   try {
     git(`git worktree remove --force "${wtPath}"`);
   } catch {


### PR DESCRIPTION
Closes #496.

## What

Adds `pnpm capture-diff <base-ref> [filter]` — a baseline-free, platform-stable layout regression check an agent can run in its inner loop. It answers *"did my change move anything I didn't intend?"* without CI or stored baselines (issue option 2).

It renders every (optionally filtered) story's **normalized DOM** at HEAD (current worktree) and at `<base-ref>` (checked out into a throwaway git worktree), diffs them per story, and reports **changed / added / removed**. Exits non-zero when anything moved, so it doubles as a pass/fail gate.

```bash
pnpm capture-diff main          # whole suite vs main
pnpm capture-diff HEAD~1        # vs the previous commit
pnpm capture-diff main bar      # only stories matching "bar" (faster)
```

## Why it works locally where the CI baselines don't

The diff is over **normalized geometry/DOM, not rasterized pixels**, so it's platform-stable: it works on Mac where `update-baselines` can't (no text-metric drift vs CI Linux) and needs no baseline curation. The optional substring filter scopes to a single story or a group — satisfying the "individual or groups of tests" follow-up in the issue comment.

Output:
```
tests/tmp/capture-diff/head/<path>.html   normalized DOM at HEAD
tests/tmp/capture-diff/base/<path>.html   normalized DOM at <ref>
tests/tmp/capture-diff/report.html        side-by-side DOM diff (changed stories)
```

The base capture installs deps in the temp worktree (`pnpm install --ignore-scripts`, mostly links from the shared pnpm store) and tears the worktree down automatically.

## How

- **`tests/scripts/capture-core.ts`** (new) — extracted the shared headless-capture engine (Vite + Playwright render loop). Both refs are captured from one process, so they normalize identically — that's what makes the geometry diff stable.
- **`tests/scripts/capture-diff.ts`** (new) — the command.
- **`tests/scripts/capture-js-dom.ts`** — refactored onto `capture-core` (behavior-preserving; 212 → ~50 lines).
- `package.json` / `tests/package.json` — `capture-diff` script.
- `tests/README.md` / `CLAUDE.md` — documented the workflow.

## Verification

- `pnpm capture-diff HEAD~1 scatter` correctly flagged all 8 scatter stories as changed (commit #490 reworked the axis pipeline), wrote the report, and cleaned up the temp worktree.
- Refactored `capture-js-dom` still captures the full corpus: 151 captured, 0 failed.
- Prettier + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)