### PR TITLE
Delete the dead posDomains layout parameter

### DIFF
--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -88,8 +88,7 @@ export type Layout = (
   scaleFactors: Size<number | undefined>,
   children: GoFishAST[],
   posScales: Size<((pos: number) => number) | undefined>,
-  node: GoFishNode,
-  posDomains?: Size<[number, number] | undefined>
+  node: GoFishNode
 ) => { intrinsicDims: FancyDims; transform: FancyTransform; renderData?: any };
 
 export type Render = (
@@ -145,7 +144,6 @@ export class GoFishNode {
   public intrinsicDims?: Dimensions;
   public transform?: Transform;
   public shared: Size<boolean>;
-  // public posDomains: Size<Domain | undefined> = [undefined, undefined];
   public renderData?: any;
   public coordinateTransform?: CoordinateTransform;
   public color?: MaybeValue<string>;
@@ -474,8 +472,7 @@ export class GoFishNode {
   public layout(
     size: Size,
     scaleFactors: Size<number | undefined>,
-    posScales: Size<((pos: number) => number) | undefined>,
-    posDomains?: Size<[number, number] | undefined>
+    posScales: Size<((pos: number) => number) | undefined>
   ): Placeable {
     // Axes are no longer drawn here: they are elaborated into ordinary shapes +
     // constraints by `elaborateAxes` (src/ast/axes/elaborate.tsx) before layout,
@@ -486,8 +483,7 @@ export class GoFishNode {
       scaleFactors,
       this.children,
       posScales,
-      this,
-      posDomains
+      this
     );
 
     this.intrinsicDims = elaborateDims(intrinsicDims);

--- a/packages/gofish-graphics/src/ast/_ref.tsx
+++ b/packages/gofish-graphics/src/ast/_ref.tsx
@@ -237,8 +237,7 @@ export class GoFishRef {
   public layout(
     size: Size,
     scaleFactors: Size<number | undefined>,
-    _posScales?: Size<((pos: number) => number) | undefined>,
-    _posDomains?: Size<[number, number] | undefined>
+    _posScales?: Size<((pos: number) => number) | undefined>
   ): Placeable {
     if (!this.selectedNode) {
       throw new Error("Selected node not found");

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -215,23 +215,7 @@ export async function layout(
       : undefined,
   ];
 
-  // Seed posDomains from the root nice underlying space so axis nodes
-  // deep in a layer tree use the full shared domain for tick generation.
-  // Only defined when the root space is POSITION (undefined for ORDINAL dims,
-  // which ensures facet-inner POSITION axes fall back to their local domain).
-  const posDomains: [
-    [number, number] | undefined,
-    [number, number] | undefined,
-  ] = [
-    niceUnderlyingSpaceX.kind === "position"
-      ? [niceUnderlyingSpaceX.domain!.min!, niceUnderlyingSpaceX.domain!.max!]
-      : undefined,
-    niceUnderlyingSpaceY.kind === "position"
-      ? [niceUnderlyingSpaceY.domain!.min!, niceUnderlyingSpaceY.domain!.max!]
-      : undefined,
-  ];
-
-  child.layout([w, h], rootScaleFactors, posScales, posDomains);
+  child.layout([w, h], rootScaleFactors, posScales);
   child.place("x", x ?? transform?.x ?? 0, "baseline");
   child.place("y", y ?? transform?.y ?? 0, "baseline");
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -266,15 +266,7 @@ export const layer = createNodeOperatorSequential(
             resolveAxis(1, scaleY, posDomains.y),
           ];
         },
-        layout: (
-          shared,
-          size,
-          scaleFactors,
-          children,
-          posScales,
-          node,
-          posDomains
-        ) => {
+        layout: (shared, size, scaleFactors, children, posScales, node) => {
           // Compute size using dims (w and h) before passing to children
           size = [
             computeSize(dims[0].size, scaleFactors?.[0]!, size[0]) ?? size[0],
@@ -368,8 +360,7 @@ export const layer = createNodeOperatorSequential(
             const childPlaceable = child.layout(
               size,
               scaleFactors,
-              childScalesFor(i, targetDims),
-              posDomains
+              childScalesFor(i, targetDims)
             );
             if (!childName || !constrainedNames.has(childName)) {
               childPlaceable.place("x", 0, "baseline");

--- a/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
@@ -140,13 +140,12 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
             scaleFactors,
             layoutChildren,
             posScales,
-            _node,
-            posDomains
+            _node
           ) => {
             requireTwoChildren(layoutChildren);
 
             const childPlaceables = layoutChildren.map((child) =>
-              child.layout(size, scaleFactors, posScales, posDomains)
+              child.layout(size, scaleFactors, posScales)
             );
             childPlaceables.forEach((child) => {
               child.place("x", 0, "baseline");
@@ -227,13 +226,12 @@ export const mask = createNodeOperator(
           scaleFactors,
           layoutChildren,
           posScales,
-          _node,
-          posDomains
+          _node
         ) => {
           requireTwoChildren(layoutChildren);
 
           const childPlaceables = layoutChildren.map((child) =>
-            child.layout(size, scaleFactors, posScales, posDomains)
+            child.layout(size, scaleFactors, posScales)
           );
           childPlaceables.forEach((child) => {
             child.place("x", 0, "baseline");

--- a/packages/gofish-graphics/src/ast/graphicalOperators/position.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/position.tsx
@@ -36,15 +36,7 @@ export const position = createNodeOperator(
               : UNDEFINED,
           ];
         },
-        layout: (
-          shared,
-          size,
-          scaleFactors,
-          children,
-          posScales,
-          _node,
-          posDomains
-        ) => {
+        layout: (shared, size, scaleFactors, children, posScales, _node) => {
           if (children.length !== 1) {
             throw new Error("Position operator expects exactly one child");
           }
@@ -52,12 +44,7 @@ export const position = createNodeOperator(
           const child = children[0];
           /* TODO: maybe pass like [10, 10] to this instead of size to do a default think for
         scattering... but scatter pie is still broken... */
-          const childPlaceable = child.layout(
-            size,
-            scaleFactors,
-            posScales,
-            posDomains
-          );
+          const childPlaceable = child.layout(size, scaleFactors, posScales);
 
           // Place child at origin first to get its dimensions
           childPlaceable.place("x", 0);

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -176,15 +176,7 @@ export const Scatter = createNodeOperator(
 
           return [xSpace, ySpace];
         },
-        layout: (
-          _shared,
-          size,
-          scaleFactors,
-          childNodes,
-          posScales,
-          node,
-          posDomains
-        ) => {
+        layout: (_shared, size, scaleFactors, childNodes, posScales, node) => {
           // In a faceted context the outer x/y may be ORDINAL, giving undefined
           // posScales for those dims. Scatter has its own POSITION domain, so
           // compute local posScales as a fallback for any undefined dim.
@@ -213,7 +205,7 @@ export const Scatter = createNodeOperator(
           ];
 
           const childPlaceables = childNodes.map((child) =>
-            child.layout(size, scaleFactors, effectivePosScales, posDomains)
+            child.layout(size, scaleFactors, effectivePosScales)
           );
 
           childPlaceables.forEach((child) => {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -208,15 +208,7 @@ export const Spread = createNodeOperator(
           result[alignDir] = alignSpace;
           return result;
         },
-        layout: (
-          shared,
-          size,
-          scaleFactors,
-          children,
-          posScales,
-          node,
-          posDomains
-        ) => {
+        layout: (shared, size, scaleFactors, children, posScales, node) => {
           if (reverse) {
             children = children.reverse();
           }
@@ -312,12 +304,7 @@ export const Spread = createNodeOperator(
             const modifiedSize: Size = [0, 0];
             modifiedSize[stackDir] = childStackSizes[i] ?? 0;
             modifiedSize[alignDir] = size[alignDir];
-            return child.layout(
-              modifiedSize,
-              scaleFactors,
-              posScales,
-              posDomains
-            );
+            return child.layout(modifiedSize, scaleFactors, posScales);
           });
 
           // Fixed-position children have dims already defined (e.g. Ref to another layer)

--- a/packages/gofish-graphics/src/ast/graphicalOperators/table.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/table.tsx
@@ -80,15 +80,7 @@ export const Table = createNodeOperator(
 
           return [xSpace, ySpace];
         },
-        layout: (
-          _shared,
-          size,
-          scaleFactors,
-          children,
-          posScales,
-          node,
-          posDomains
-        ) => {
+        layout: (_shared, size, scaleFactors, children, posScales, node) => {
           const numRows = Math.ceil(children.length / numCols);
           const cellW = (size[0] - xSpacing * (numCols - 1)) / numCols;
           const cellH = (size[1] - ySpacing * (numRows - 1)) / numRows;
@@ -106,7 +98,7 @@ export const Table = createNodeOperator(
 
           const cellSize: Size = [cellW, cellH];
           const childPlaceables: Placeable[] = children.map((child) =>
-            child.layout(cellSize, scaleFactors, posScales, posDomains)
+            child.layout(cellSize, scaleFactors, posScales)
           );
 
           for (let i = 0; i < childPlaceables.length; i++) {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
@@ -136,15 +136,7 @@ export const Treemap = createNodeOperator(
               : POSITION(interval(0, 1));
           return [axisSpace(0), axisSpace(1)];
         },
-        layout: (
-          _shared,
-          size,
-          scaleFactors,
-          childAsts,
-          posScales,
-          node,
-          posDomains
-        ) => {
+        layout: (_shared, size, scaleFactors, childAsts, posScales, node) => {
           const xPos = computeAesthetic(
             dims[0].min,
             posScales?.[0]!,
@@ -298,12 +290,7 @@ export const Treemap = createNodeOperator(
                 lh = side;
               }
             }
-            const placeable = child.layout(
-              [lw, lh],
-              scaleFactors,
-              posScales,
-              posDomains
-            );
+            const placeable = child.layout([lw, lh], scaleFactors, posScales);
             placeable.place(0, x0 + w / 2, "center");
             const cy = flipY ? resolvedSize[1] - (y0 + h / 2) : y0 + h / 2;
             placeable.place(1, cy, "center");


### PR DESCRIPTION
Fixes #466.

## What

Removes the `posDomains` parameter end-to-end: the `Layout` callback type, `GoFishNode.layout()` / `GoFishRef.layout()`, the seeding block in `gofish.tsx`, and the pass-through in every operator layout callback (`layer`, `spread`, `scatter`, `porterDuff` ×2, `position`, `table`, `treemap`). Net −87 lines, zero behavior change.

The local `posDomains` in `layer.tsx`'s `resolveUnderlyingSpace` (from `collectPositionDomains`) is unrelated — it's the constraint-derived domain mechanism for hand-drawn axes — and is untouched.

## Why no push-down pass

#466 proposed replacing `posDomains` with a recursive top-down pass propagating the union domain into descendants' POSITION spaces. That mechanism became unnecessary after #490: axes are now elaborated into shapes + constraints *before* layout, and tick generation reads `space.domain` at the axis-**owning** node (`elaborationsFor` in `src/ast/axes/elaborate.tsx`). Since `resolveAxes` claims an axis at the topmost node of a shared region, that node's bottom-up `resolveUnderlyingSpace` union already *is* the merged domain. The ORDINAL/facet care case is automatic too: per-facet axis overrides elaborate at facet children, which carry their local domains. So after #490, `posDomains` was threaded everywhere but read by nothing, and the fix is pure deletion.

## Verification

- `tsc --noEmit` clean.
- Rendered `FacetedScatterDriving`, `FacetedScatterY`, `Scatter/Basic`, and `Area/Layered` via `capture-one` before and after the change: all four PNGs are hash-identical. Shared union ticks and independent per-facet domains both preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)