### PR TITLE
Elaborate legends into ordinary shapes + constraints; delete the bespoke legend path

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -226,7 +226,10 @@ scale factors via `Monotonic.inverse`. `spread({ glue: true })` (i.e.
 operator commits the data-driven extents to a positional axis. `layer`
 and overlay-style operators use `unionChildSpaces` (`alignment.ts`),
 which preserves SIZE when every child is SIZE and otherwise unions
-intervals.
+intervals. UNDEFINED children carry no opinion and are ignored
+throughout — including in the SIZE gate, so a fixed-pixel (UNDEFINED)
+sibling never vetoes SIZE composition (it would otherwise degrade the
+union to DIFFERENCE).
 
 **Coordinate-transform operators** (`coord`) annotate the resulting
 space with the transform that will later map underlying positions to

--- a/apps/docs/docs/internals/frontend/legends.md
+++ b/apps/docs/docs/internals/frontend/legends.md
@@ -90,22 +90,41 @@ wrapper's space is just the content's space. See
 
 ## Sizing: measured overhang, not a margin
 
-The fixed 120px `LEGEND_MARGIN` is gone. Because the legend is now a real shape
-occupying real space, `layout()` measures how far the laid-out tree (legend
-included) extends past the authoritative width:
+The fixed 120px `LEGEND_MARGIN` is gone. The canvas size and the legend
+reservation are read off **two different nodes**, which is what keeps the
+content centered and the legend reserved separately:
+
+- `finalW`/`finalH` (the canvas, and the basis for axis-title centering) read
+  off the **content node** — the original pre-wrap node, captured as
+  `contentNode` before `elaborateLegend` replaces `child` with the wrapper. So
+  the canvas is exactly the content's extent, never content + legend.
+- `rightOverhang` reads off the **wrapper** (`child`), whose bounding box
+  includes the seated swatch column, and subtracts the content width:
 
 ```ts
+const finalW = finalDim(0, w); // off contentNode
 const rightOverhang = legendAdded ? Math.max(0, child.dims[0].max - finalW) : 0;
 ```
 
-and the render pass reserves exactly that on the right of the SVG. The
-measurement is gated on `legendAdded`, so legend-free charts keep byte-identical
-SVG widths.
+`wrapper.dims[0].max - finalW` is exactly the `LEGEND_CONTENT_GAP` plus the
+swatch-column width, so the render pass reserves precisely the legend on the
+right of the SVG. The measurement is gated on `legendAdded`, so legend-free
+charts keep byte-identical SVG widths.
 
-When `w` is **omitted**, this falls out for free: the computed extent (#494's
-`finalDim` readback off the root bounding box) already includes the swatch
-column, so `finalW` covers the legend and `rightOverhang` clamps to 0 — the
-legend is simply part of the inferred graphic size.
+Reading `finalW`/`finalH` off the content (not the wrapper) matters most when
+`w`/`h` are **omitted**: the inferred graphic size is the content's computed
+extent (#494's `finalDim` readback), and the legend is then reserved on top of
+it via `rightOverhang` — rather than the legend inflating the inferred size and
+dragging the x-axis title off-center with it.
+
+This relies on the content node reporting a complete, correctly-positioned
+bounding box. Most nodes do, but the polar `coord` node historically emitted an
+`{ x, y, w, h }` intrinsic-dims form that set only `min`/`size` and left
+`max`/`center` undefined — and was positionally offset from the rendered
+content. That poisoned the `distribute` constraint (it seats the column at
+`content.dims[0].max`, which was `NaN`), so the fix lives in `coord` itself
+(reporting a placed-consistent `[0, size]` box), not in special-casing the
+legend.
 
 ## The customization seam
 

--- a/apps/docs/docs/internals/frontend/legends.md
+++ b/apps/docs/docs/internals/frontend/legends.md
@@ -38,9 +38,11 @@ appears whenever a color encoding resolved to swatches). It runs after the last
 `resolveColorScale`, consuming the already-populated `scaleContext.unit.color`.
 Crucially, `resolveColorScale` is **not** re-run on the rewritten tree: legend
 swatch fills are literal color strings, never `isValue` data references, so the
-color pass has nothing to do with them. After the rewrite the pass runs
-`resolveNames()` and a memoized `resolveUnderlyingSpace()` (which computes only
-the newly inserted nodes).
+color pass has nothing to do with them. After the rewrite the pass runs only a
+memoized `resolveUnderlyingSpace()` (which computes only the newly inserted
+nodes); `resolveNames()` is unnecessary, since the legend subtree carries only
+plain string `.name()`s and its constraint refs were already resolved eagerly
+inside `elaborateLegend`.
 
 The pass wraps the chart root in a single `Layer` holding the original content
 plus a swatch column:
@@ -51,10 +53,10 @@ root = Layer([ content.name("__legendContent"), legendColumn(colorMap) ])
 
 `legendColumn` is a `Spread({ dir: "y" })` of one row per color-map entry. Each
 `legendRow` is a `Spread({ dir: "x" })` of a 10×10 `Rect` swatch and a 10px gray
-`Text` label. The rows are **reversed** before spreading: `Spread({ dir: "y" })`
+`Text` label. The column uses `Spread`'s `reverse: true`: `Spread({ dir: "y" })`
 lays children bottom→top in y-up coordinates (the first child gets the smallest
-y), so the first color-map entry has to be _last_ in the spread to render at the
-top — matching the old bespoke order, which placed entry 0 at the top.
+y), so the first color-map entry has to render _last_ in the spread to end up at
+the top — matching the old bespoke order, which placed entry 0 at the top.
 
 ### The three constraints
 
@@ -103,12 +105,14 @@ content centered and the legend reserved separately:
 
 ```ts
 const finalW = finalDim(0, w); // off contentNode
-const rightOverhang = legendAdded ? Math.max(0, child.dims[0].max - finalW) : 0;
+const rightOverhang = child !== contentNode ? legendOverhang(child, finalW) : 0;
 ```
 
-`wrapper.dims[0].max - finalW` is exactly the `LEGEND_CONTENT_GAP` plus the
-swatch-column width, so the render pass reserves precisely the legend on the
-right of the SVG. The measurement is gated on `legendAdded`, so legend-free
+`legendOverhang` (in `legends/elaborate.tsx`, next to the constraint that
+creates the overhang) returns `wrapper.dims[0].max - finalW`, which is exactly
+the `LEGEND_CONTENT_GAP` plus the swatch-column width, so the render pass
+reserves precisely the legend on the right of the SVG. The measurement is gated
+on whether a legend wrapper was added (`child !== contentNode`), so legend-free
 charts keep byte-identical SVG widths.
 
 Reading `finalW`/`finalH` off the content (not the wrapper) matters most when

--- a/apps/docs/docs/internals/frontend/legends.md
+++ b/apps/docs/docs/internals/frontend/legends.md
@@ -1,0 +1,123 @@
+---
+title: Legends
+section: Frontend
+order: 51
+status: draft
+covers:
+  - packages/gofish-graphics/src/ast/legends/elaborate.tsx
+---
+
+# Legends
+
+GoFish draws a color legend — a column of swatches and labels — automatically
+from the categorical color scale it infers. Like [axes](/internals/frontend/axes),
+a legend is **not a privileged node type**. It is _elaborated_ into ordinary
+GoFish shapes (`rect`, `text`) and operators (`spread`, `layer`) wired together
+with constraints (`align`, `distribute`). The render pass has no legend-specific
+code at all.
+
+## Why elaborate
+
+The legend was the **last bespoke piece of chrome**. It used to render as a
+`<For>` over `scaleContext.unit.color` in `gofish.tsx`'s `render()`, hand-placing
+swatches at `translate(width + pad*3, …)` behind a fixed 120px `LEGEND_MARGIN`
+reserved on the right of the SVG. Because it was a render-time fixture rather
+than a node, it could not participate in **space allocation** (#493) — its width
+was a guessed constant, not a measured extent — nor in **size inference** (#494):
+a chart with `w`/`h` omitted had no way to fold the legend into its computed
+extent. Elaborating it into the laid-out tree fixes both, and opens the **same
+customization seam** axes got in #490: the legend is now built by pure, exported
+functions a future public API can override.
+
+## The elaboration pass
+
+`elaborateLegend` (`src/ast/legends/elaborate.tsx`) runs inside `gofish.tsx`'s
+`layout()`, _after_ the axis-elaboration block and after the nice-space capture,
+and is gated on a **non-empty color map** (not on the `axes` option — a legend
+appears whenever a color encoding resolved to swatches). It runs after the last
+`resolveColorScale`, consuming the already-populated `scaleContext.unit.color`.
+Crucially, `resolveColorScale` is **not** re-run on the rewritten tree: legend
+swatch fills are literal color strings, never `isValue` data references, so the
+color pass has nothing to do with them. After the rewrite the pass runs
+`resolveNames()` and a memoized `resolveUnderlyingSpace()` (which computes only
+the newly inserted nodes).
+
+The pass wraps the chart root in a single `Layer` holding the original content
+plus a swatch column:
+
+```
+root = Layer([ content.name("__legendContent"), legendColumn(colorMap) ])
+```
+
+`legendColumn` is a `Spread({ dir: "y" })` of one row per color-map entry. Each
+`legendRow` is a `Spread({ dir: "x" })` of a 10×10 `Rect` swatch and a 10px gray
+`Text` label. The rows are **reversed** before spreading: `Spread({ dir: "y" })`
+lays children bottom→top in y-up coordinates (the first child gets the smallest
+y), so the first color-map entry has to be _last_ in the spread to render at the
+top — matching the old bespoke order, which placed entry 0 at the top.
+
+### The three constraints
+
+The wrapper is wired with three constraints, and **the order matters** because
+the first one places the anchor the other two read:
+
+1. `align({ x: "baseline", y: "baseline" })` on the content — a _baseline_
+   (origin) pin meaning "stay exactly where you were laid out". The content is
+   referenced by the `distribute` below, and a constraint-referenced child skips
+   the layer's phase-1 baseline placement (placement is first-write-wins), so the
+   pin re-states that placement explicitly. It pins the **baseline**, not the
+   bounding-box corner, so the content never moves regardless of axis-label
+   overhang.
+2. `distribute({ dir: "x", spacing: 20 }, [content, column])` — seats the column
+   just right of the content's **full** bounding box, including its axis labels.
+3. `align({ y: "end" }, [content, column])` — top-aligns the column with the
+   content top (in y-up coordinates, `end` is the top).
+
+The wrapper inherits the wrapped node's `key` and `_name` (moved off the content
+via the identity dance), so faceting, refs, and `select` keep resolving to the
+wrapped node.
+
+### Why the wrapper preserves the content's spaces
+
+Inserting a `Layer` around the content could in principle disturb the chart's
+inferred underlying space — and the nice spaces captured just above this pass
+must stay valid. They do, because of `unionChildSpaces`' rule that an
+**UNDEFINED** sibling contributes "no opinion" and is ignored in the all-SIZE
+gate (the same way ORDINAL siblings are filtered). The swatch column resolves to
+UNDEFINED on both axes (fixed-pixel shapes, no data-driven extent), so the
+wrapper's space is just the content's space. See
+[Underlying Space](/internals/core/underlying-space).
+
+## Sizing: measured overhang, not a margin
+
+The fixed 120px `LEGEND_MARGIN` is gone. Because the legend is now a real shape
+occupying real space, `layout()` measures how far the laid-out tree (legend
+included) extends past the authoritative width:
+
+```ts
+const rightOverhang = legendAdded ? Math.max(0, child.dims[0].max - finalW) : 0;
+```
+
+and the render pass reserves exactly that on the right of the SVG. The
+measurement is gated on `legendAdded`, so legend-free charts keep byte-identical
+SVG widths.
+
+When `w` is **omitted**, this falls out for free: the computed extent (#494's
+`finalDim` readback off the root bounding box) already includes the swatch
+column, so `finalW` covers the legend and `rightOverhang` clamps to 0 — the
+legend is simply part of the inferred graphic size.
+
+## The customization seam
+
+`legendRow` and `legendColumn` are **pure, exported builders** (no mutation, no
+context) — the seam a future public legend API would override, exactly as
+`elaborateAxis` is for axes. The visual constants (swatch size, gaps, label font
+and color) live as module constants chosen to match the previous bespoke styling.
+
+## Limitations
+
+- A **gradient** color config currently yields one swatch row per color-map
+  entry, matching the bespoke path. A continuous **colorbar** is a follow-up.
+- A **tall legend** (more entries than the content is tall) can extend below the
+  content bottom. This is a pre-existing failure mode carried over from the
+  bespoke layout and is out of scope here.

--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -67,7 +67,7 @@ Three per-run session contexts are initialized:
 
 - **`scopeContext`**: Manages variable scoping and data bindings (type: `Map`)
 - **`scaleContext`**: Stores computed color scales and scale mappings (type: `{ unit: { color: Map<any, string> } }`)
-- **`keyContext`**: Maps string keys to nodes for axis labeling and legends (type: `{ [key: string]: GoFishNode }`)
+- **`keyContext`**: Maps string keys to nodes for axis labeling (type: `{ [key: string]: GoFishNode }`)
 
 These are attached to the render session and propagated to the node tree, rather than stored as module-global mutable state. This establishes clean state for the rendering process and ensures no interference between multiple chart renders.
 
@@ -114,7 +114,9 @@ child.resolveKeys();
 Assigns unique keys to nodes. These keys are critical for:
 
 - **Axis labeling**: Ordinal axes use keys to position category labels
-- **Legend generation**: Keys identify which nodes to include in legends
+
+(Legends do not use keys — they are elaborated from the resolved color map; see
+[Legends](/internals/frontend/legends).)
 
 **Example**: In a bar chart using `spread("category", { dir: "x" })`, each bar gets a key like `"category-value"`, which is later used to position the x-axis labels.
 
@@ -219,6 +221,13 @@ See [Axes](/internals/frontend/axes) for the full elaboration story (the
 two-tier structure, baseline pins, negative-space gutters, and the
 continuous/difference/ordinal kinds).
 
+**Legend elaboration** follows the axis block in the same `layout()`, gated on a
+non-empty color map (not on the `axes` option). `elaborateLegend` wraps the chart
+root in a `Layer` holding the content plus a swatch column of `rect`/`text` rows,
+seated to the right with `align`/`distribute` constraints — the same elaborate-
+into-ordinary-nodes treatment axes get. See
+[Legends](/internals/frontend/legends).
+
 ### Pass 8: Position Scale Computation
 
 **Location**: `src/ast/gofish.tsx:183-202`
@@ -284,7 +293,13 @@ reads the chart's _final_ extent back off the root via `child.dims[i].size`, so 
 unsized axis still yields a concrete SVG size (e.g. a no-width bar chart gets
 default-width bars and a width of `n·barWidth + spacing`). A user-supplied
 dimension is always authoritative. This computed extent — not the raw option — is
-what the render pass uses to size the SVG and place chrome like the legend.
+what the render pass uses to size the SVG. The legend is now part of the laid-out
+tree (it is elaborated into the node tree during layout, see Pass 7), so it is
+included in this computed extent when `w`/`h` are omitted. When `w` _is_ given,
+`layout()` additionally measures a `rightOverhang` (how far the tree, legend
+included, extends past the authoritative width) and the render pass reserves
+exactly that on the right of the SVG — replacing the former fixed `LEGEND_MARGIN`
+constant. See [Legends](/internals/frontend/legends).
 
 > Literal pixel sizes are invisible to the underlying-space tree (a fixed-size
 > shape resolves to `UNDEFINED`, not `SIZE`), which is why the unsized path relies
@@ -569,29 +584,14 @@ Elaboration and [Axes](/internals/frontend/axes)), so they render through the
 normal node-tree pass above with no special casing. The only axis artifact
 still drawn directly at render time is the title text (Render Pass 2).
 
-### Render Pass 8: Legend Rendering
+### Render Pass 8: Legend Rendering (removed)
 
-**Location**: `src/ast/gofish.tsx:801-830`
-
-Color legends are rendered from the `scaleContext.unit.color` map:
-
-```typescript
-<For
-  each={Array.from(
-    (scaleContext?.unit && "color" in scaleContext.unit
-      ? scaleContext.unit.color
-      : new Map()
-  ).entries()
-)}
->
-  {([key, value], i) => (
-    <g transform={`translate(${width + PADDING * 3}, ${height - i() * 20})`}>
-      <rect x={-20} y={-5} width={10} height={10} fill={value} />
-      <text ...>{key}</text>
-    </g>
-  )}
-</For>
-```
+The bespoke legend-rendering pass that used to live here (a `<For>` over
+`scaleContext.unit.color` hand-placing swatches behind a fixed `LEGEND_MARGIN`)
+was **deleted**. Color legends are now elaborated into ordinary GoFish nodes
+during layout (see Pass 7: Axis Elaboration, which the legend pass follows, and
+[Legends](/internals/frontend/legends)), so they render through the normal
+node-tree pass above with no special casing.
 
 ## Complete Example: Bar Chart Rendering
 

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -9,6 +9,7 @@ import { Spread } from "../graphicalOperators/spread";
 import { layer } from "../graphicalOperators/layer";
 import { ref } from "../shapes/ref";
 import { Constraint } from "../constraints";
+import { wrapPreservingIdentity } from "../elaborationUtils";
 import { datum } from "../data";
 import { ticks as d3Ticks, nice as d3Nice } from "d3-array";
 import {
@@ -446,52 +447,50 @@ export async function elaborateAxes(
     return { node, changed };
   }
 
-  // Move identity off the content onto whatever ends up outermost, so the
-  // parent (faceting/refs/select) still resolves to this node.
-  const origName = node._name;
-  const origKey = node.key;
-  node._name = undefined;
-  node.key = undefined;
+  // Move identity off the content onto whatever ends up outermost (so the
+  // parent — faceting/refs/select — still resolves to this node), build the
+  // axis tiers, then restore the identity onto the outermost wrapper.
+  const root = await wrapPreservingIdentity(node, async (content) => {
+    // Inner tier: content + constraint-based (continuous/difference) axes. The
+    // content is pinned at its own ORIGIN (baseline anchor, translate 0) so each
+    // axis grows into negative gutter space; this keeps the content on the
+    // posScale grid both axes' ticks use. The anchor must be `baseline`, not
+    // `start`: nested content (facets carrying their own ordinal labels) has a
+    // bbox extending past its origin, and pinning bbox-min would slide the marks
+    // off the tick grid by that overhang.
+    let inner: GoFishNode = content;
+    if (constrained.length > 0) {
+      content.name(CONTENT_NAME);
+      const axisNodes = constrained.flatMap((e) => e.nodes);
+      inner = (await (layer as any)([content, ...axisNodes])) as GoFishNode;
+      inner.constrain((g) => [
+        Constraint.align({ x: "baseline", y: "baseline" } as any, [
+          g[CONTENT_NAME],
+        ]),
+        ...constrained.flatMap((e) => e.constraints(g)),
+      ]);
+    }
 
-  // Inner tier: content + constraint-based (continuous/difference) axes. The
-  // content is pinned at its own ORIGIN (baseline anchor, translate 0) so each
-  // axis grows into negative gutter space; this keeps the content on the
-  // posScale grid both axes' ticks use. The anchor must be `baseline`, not
-  // `start`: nested content (facets carrying their own ordinal labels) has a
-  // bbox extending past its origin, and pinning bbox-min would slide the marks
-  // off the tick grid by that overhang.
-  let inner: GoFishNode = node;
-  if (constrained.length > 0) {
-    node.name(CONTENT_NAME);
-    const axisNodes = constrained.flatMap((e) => e.nodes);
-    inner = (await (layer as any)([node, ...axisNodes])) as GoFishNode;
-    inner.constrain((g) => [
-      Constraint.align({ x: "baseline", y: "baseline" } as any, [
-        g[CONTENT_NAME],
-      ]),
-      ...constrained.flatMap((e) => e.constraints(g)),
-    ]);
-  }
+    // Outer tier: ref-based (ordinal) labels. The labels `distribute` against
+    // `inner`, whose bbox includes any nested inner-facet labels — so an outer
+    // label row stacks below the inner row. For that anchor to be "placed",
+    // `inner` is baseline-pinned: its 0 point stays the layer's 0 point, and the
+    // labels seat past its bbox edge in negative gutter space.
+    let outerRoot = inner;
+    if (refBased.length > 0) {
+      inner.name(INNER_REF_NAME);
+      const labelNodes = refBased.flatMap((e) => e.nodes);
+      outerRoot = (await (layer as any)([inner, ...labelNodes])) as GoFishNode;
+      outerRoot.constrain((g) => [
+        Constraint.align({ x: "baseline", y: "baseline" } as any, [
+          g[INNER_REF_NAME],
+        ]),
+        ...refBased.flatMap((e) => e.constraints(g)),
+      ]);
+    }
 
-  // Outer tier: ref-based (ordinal) labels. The labels `distribute` against
-  // `inner`, whose bbox includes any nested inner-facet labels — so an outer
-  // label row stacks below the inner row. For that anchor to be "placed",
-  // `inner` is baseline-pinned: its 0 point stays the layer's 0 point, and the
-  // labels seat past its bbox edge in negative gutter space.
-  let root = inner;
-  if (refBased.length > 0) {
-    inner.name(INNER_REF_NAME);
-    const labelNodes = refBased.flatMap((e) => e.nodes);
-    root = (await (layer as any)([inner, ...labelNodes])) as GoFishNode;
-    root.constrain((g) => [
-      Constraint.align({ x: "baseline", y: "baseline" } as any, [
-        g[INNER_REF_NAME],
-      ]),
-      ...refBased.flatMap((e) => e.constraints(g)),
-    ]);
-  }
+    return outerRoot;
+  });
 
-  if (origName !== undefined) root._name = origName;
-  if (origKey !== undefined) root.setKey(origKey);
   return { node: root, changed: true };
 }

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -266,23 +266,19 @@ export const coord = createNodeOperator(
             maxY: screenBboxMaxY,
           } = screenBbox;
 
-          // When axes are enabled the circle must be centered in the full
-          // allocated space so labels aren't clipped at the edges.
-          // Without axes (e.g. pie glyphs in scatter) use the tighter
-          // content-bbox sizing so the glyph doesn't claim excess space.
+          // When axes are enabled and no placed min was allocated, the circle
+          // must be centered in the full allocated space so labels aren't
+          // clipped at the edges. Otherwise (a placed min exists, or there are
+          // no axes — e.g. pie glyphs in scatter) use the tighter content-bbox
+          // sizing so the glyph doesn't claim excess space.
           const hasAxes = !!axes;
-          const [intrinsicW, intrinsicH] =
-            dims[0].min !== undefined
-              ? [
-                  screenBboxMaxX - screenBboxMinX,
-                  screenBboxMaxY - screenBboxMinY,
-                ]
-              : hasAxes
-                ? [origW, origH]
-                : [
-                    screenBboxMaxX - screenBboxMinX,
-                    screenBboxMaxY - screenBboxMinY,
-                  ];
+          const useAllocated = dims[0].min === undefined && hasAxes;
+          const intrinsicW = useAllocated
+            ? origW
+            : screenBboxMaxX - screenBboxMinX;
+          const intrinsicH = useAllocated
+            ? origH
+            : screenBboxMaxY - screenBboxMinY;
 
           const half = Math.min(origW, origH) / 2;
           const translateX =

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -271,22 +271,18 @@ export const coord = createNodeOperator(
           // Without axes (e.g. pie glyphs in scatter) use the tighter
           // content-bbox sizing so the glyph doesn't claim excess space.
           const hasAxes = !!axes;
-          const intrinsicDims =
+          const [intrinsicW, intrinsicH] =
             dims[0].min !== undefined
-              ? {
-                  x: 0,
-                  y: 0,
-                  w: screenBboxMaxX - screenBboxMinX,
-                  h: screenBboxMaxY - screenBboxMinY,
-                }
+              ? [
+                  screenBboxMaxX - screenBboxMinX,
+                  screenBboxMaxY - screenBboxMinY,
+                ]
               : hasAxes
-                ? { x: 0, y: 0, w: origW, h: origH }
-                : {
-                    x: 0,
-                    y: 0,
-                    w: screenBboxMaxX - screenBboxMinX,
-                    h: screenBboxMaxY - screenBboxMinY,
-                  };
+                ? [origW, origH]
+                : [
+                    screenBboxMaxX - screenBboxMinX,
+                    screenBboxMaxY - screenBboxMinY,
+                  ];
 
           const half = Math.min(origW, origH) / 2;
           const translateX =
@@ -303,6 +299,35 @@ export const coord = createNodeOperator(
               : hasAxes
                 ? half
                 : -screenBboxMinY;
+
+          // Intrinsic bbox. Historically this was `{ x: 0, y: 0, w, h }`, which
+          // elaborateDims turns into min+size only — `max`/`center` stay
+          // undefined. Two problems: (1) any consumer reading the *placed* max —
+          // notably the legend's `distribute` constraint, which seats the swatch
+          // column at `content.dims[0].max` — got `NaN`; and (2) even the `min`
+          // it did report was positionally inconsistent: with the local min
+          // pinned at 0 and a preset `translate`, the placed box `[translate,
+          // size+translate]` didn't coincide with the rendered content (which is
+          // drawn centered on the coord origin, i.e. on the `translate` point).
+          //
+          // We now emit a *complete*, positionally consistent bbox on every
+          // branch by biasing the local min by `-translate`, so the placed box
+          // is exactly `[0, size]` on each axis — the same region the parent
+          // allocates (`finalW`/`finalH` read `size`). Anything reading the
+          // placed min/center/max now sees the true content box. One deliberate
+          // consequence: a polar glyph embedded in a `scatter` (placed by its
+          // `center`) is now centered on its datum, where before it sat ~radius
+          // off because the fallback `center = min + size/2` read the offset box.
+          const intrinsicDims = {
+            x: -translateX,
+            y: -translateY,
+            w: intrinsicW,
+            h: intrinsicH,
+            x2: intrinsicW - translateX,
+            y2: intrinsicH - translateY,
+            cx: intrinsicW / 2 - translateX,
+            cy: intrinsicH / 2 - translateY,
+          };
 
           return {
             intrinsicDims,

--- a/packages/gofish-graphics/src/ast/elaborationUtils.ts
+++ b/packages/gofish-graphics/src/ast/elaborationUtils.ts
@@ -1,0 +1,19 @@
+import { GoFishNode } from "./_node";
+
+/** Run `build` to wrap `node` in new structure, moving the node's identity
+ * (_name/key) onto whatever `build` returns — so the parent (faceting/refs/
+ * select) still resolves to this node. Shared by the axis and legend
+ * elaboration passes. */
+export async function wrapPreservingIdentity(
+  node: GoFishNode,
+  build: (node: GoFishNode) => GoFishNode | Promise<GoFishNode>
+): Promise<GoFishNode> {
+  const origName = node._name;
+  const origKey = node.key;
+  node._name = undefined;
+  node.key = undefined;
+  const root = await build(node);
+  if (origName !== undefined) root._name = origName;
+  if (origKey !== undefined) root.setKey(origKey);
+  return root;
+}

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -18,7 +18,7 @@ import type { Size } from "./dims";
 import { isSIZE, type UnderlyingSpace } from "./underlyingSpace";
 import { continuous } from "./domain";
 import { elaborateAxes } from "./axes/elaborate";
-import { elaborateLegend } from "./legends/elaborate";
+import { elaborateLegend, legendOverhang } from "./legends/elaborate";
 
 export type CategoricalScale = {
   color: Map<any, string>;
@@ -180,7 +180,6 @@ export async function layout(
   // re-run). The wrapper preserves the content's underlying spaces
   // (unionChildSpaces ignores the legend's UNDEFINED spaces), so the nice
   // spaces captured above remain valid.
-  let legendAdded = false;
   // Reference to the content node whose extent defines the final canvas. When a
   // legend is added, `child` becomes the wrapper Layer (content + swatch column)
   // and `contentNode` keeps pointing at the original content, so the final
@@ -189,17 +188,11 @@ export async function layout(
   // via `rightOverhang` below.
   const contentNode = child;
   const unitScale = contexts?.session.scaleContext.unit;
-  const colorMap =
-    unitScale && "color" in unitScale ? unitScale.color : undefined;
+  const colorMap = isCategoricalScale(unitScale) ? unitScale.color : undefined;
   if (colorMap && colorMap.size > 0) {
-    const res = await elaborateLegend(child, colorMap);
-    if (res.changed) {
-      child = res.node;
-      if (contexts?.session) child.setRenderSession(contexts.session);
-      child.resolveNames();
-      child.resolveUnderlyingSpace(); // memoized: computes only the new nodes
-      legendAdded = true;
-    }
+    child = await elaborateLegend(child, colorMap);
+    if (contexts?.session) child.setRenderSession(contexts.session);
+    child.resolveUnderlyingSpace(); // memoized: computes only the new nodes
   }
 
   if (debug) {
@@ -294,12 +287,11 @@ export async function layout(
   const finalH = finalDim(1, h);
 
   // Measured legend overhang past the content width — replaces the fixed
-  // LEGEND_MARGIN. The wrapper's max bbox includes the seated swatch column, so
-  // `wrapper.max - finalW` is exactly the gap + legend width to reserve on the
-  // right. Gated on legendAdded so legend-free charts keep byte-identical widths.
-  const rightOverhang = legendAdded
-    ? Math.max(0, (child.dims[0]?.max ?? 0) - finalW)
-    : 0;
+  // LEGEND_MARGIN (see `legendOverhang`). Gated on whether a legend wrapper was
+  // added (`child !== contentNode`) so legend-free charts keep byte-identical
+  // widths.
+  const rightOverhang =
+    child !== contentNode ? legendOverhang(child, finalW) : 0;
 
   if (debug) {
     console.log("🌳 Node Tree:");
@@ -417,7 +409,7 @@ export const gofish = (
               defs,
               axes,
               axisFields,
-              rightMargin: data.rightOverhang,
+              rightOverhang: data.rightOverhang,
             },
             data.child
           );
@@ -443,7 +435,7 @@ export const render = (
     defs,
     axes,
     axisFields,
-    rightMargin,
+    rightOverhang = 0,
     svgPadding,
   }: {
     width: number;
@@ -452,7 +444,7 @@ export const render = (
     defs?: JSX.Element[];
     axes?: AxesOptions;
     axisFields?: { x?: string; y?: string };
-    rightMargin?: number;
+    rightOverhang?: number;
     svgPadding?: number;
   },
   child: GoFishNode
@@ -465,12 +457,11 @@ export const render = (
   const leftMargin = yTitle ? Y_TITLE_MARGIN : 0;
   const bottomMargin = xTitle ? X_TITLE_MARGIN : 0;
   // Right-side space reserved for a legend overhanging the content width
-  // (measured by `layout()` as `rightOverhang`; 0 when no legend / no overhang).
-  const rightSpace = rightMargin ?? 0;
+  // (measured by `layout()`; 0 when no legend / no overhang).
 
   const result = (
     <svg
-      width={width + leftMargin + pad + rightSpace + pad}
+      width={width + leftMargin + pad + rightOverhang + pad}
       height={height + pad + bottomMargin + pad}
       xmlns="http://www.w3.org/2000/svg"
     >

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -3,7 +3,7 @@
 // @wiki Architecture Overview — /internals/overview/architecture
 // </gofish-wiki>
 
-import { createResource, For, Show, Suspense, type JSX } from "solid-js";
+import { createResource, Show, Suspense, type JSX } from "solid-js";
 import { type ColorConfig } from "./colorSchemes";
 import { render as solidRender } from "solid-js/web";
 import {
@@ -18,6 +18,7 @@ import type { Size } from "./dims";
 import { isSIZE, type UnderlyingSpace } from "./underlyingSpace";
 import { continuous } from "./domain";
 import { elaborateAxes } from "./axes/elaborate";
+import { elaborateLegend } from "./legends/elaborate";
 
 export type CategoricalScale = {
   color: Map<any, string>;
@@ -107,6 +108,7 @@ export async function layout(
   child: GoFishNode;
   width: number;
   height: number;
+  rightOverhang: number;
 }> {
   child = await child;
   if (contexts?.session) {
@@ -170,6 +172,28 @@ export async function layout(
   // Use (possibly nice-rounded) underlying spaces for posScales
   const niceUnderlyingSpaceX = child._underlyingSpace![0];
   const niceUnderlyingSpaceY = child._underlyingSpace![1];
+
+  // Legend elaboration: turn the color scale into an ordinary swatch-column
+  // subtree seated beside the content (src/ast/legends/elaborate.tsx). Runs
+  // after the last resolveColorScale (it consumes the populated color map;
+  // legend fills are literal strings, never isValue, so the scale pass is NOT
+  // re-run). The wrapper preserves the content's underlying spaces
+  // (unionChildSpaces ignores the legend's UNDEFINED spaces), so the nice
+  // spaces captured above remain valid.
+  let legendAdded = false;
+  const unitScale = contexts?.session.scaleContext.unit;
+  const colorMap =
+    unitScale && "color" in unitScale ? unitScale.color : undefined;
+  if (colorMap && colorMap.size > 0) {
+    const res = await elaborateLegend(child, colorMap);
+    if (res.changed) {
+      child = res.node;
+      if (contexts?.session) child.setRenderSession(contexts.session);
+      child.resolveNames();
+      child.resolveUnderlyingSpace(); // memoized: computes only the new nodes
+      legendAdded = true;
+    }
+  }
 
   if (debug) {
     console.log("🌳 Underlying Space Tree:");
@@ -259,6 +283,13 @@ export async function layout(
   const finalW = finalDim(0, w);
   const finalH = finalDim(1, h);
 
+  // Measured legend overhang past the authoritative width — replaces the fixed
+  // LEGEND_MARGIN. Gated on legendAdded so legend-free charts keep byte-identical
+  // SVG widths. With w omitted, finalW already includes the legend → clamps to 0.
+  const rightOverhang = legendAdded
+    ? Math.max(0, (child.dims[0]?.max ?? 0) - finalW)
+    : 0;
+
   if (debug) {
     console.log("🌳 Node Tree:");
     debugNodeTree(child);
@@ -271,6 +302,7 @@ export async function layout(
     child,
     width: finalW,
     height: finalH,
+    rightOverhang,
   };
 }
 
@@ -315,7 +347,7 @@ export const gofish = (
     child: GoFishNode;
     width: number;
     height: number;
-    scaleContext: ScaleContext;
+    rightOverhang: number;
   };
 
   const runGofish = async (): Promise<LayoutData> => {
@@ -347,12 +379,7 @@ export const gofish = (
         contexts
       );
 
-      const result = {
-        ...layoutResult,
-        scaleContext: session.scaleContext,
-      };
-
-      return result;
+      return layoutResult;
     } finally {
       if (debug) {
         console.log("scaleContext", session.scaleContext);
@@ -379,7 +406,7 @@ export const gofish = (
               defs,
               axes,
               axisFields,
-              scaleContext: data.scaleContext,
+              rightMargin: data.rightOverhang,
             },
             data.child
           );
@@ -391,7 +418,6 @@ export const gofish = (
 };
 
 const PADDING = 40;
-const LEGEND_MARGIN = 120; // right-side buffer for legend swatches + labels
 
 /**
  * Finds the translation from the top-level coord node.
@@ -406,7 +432,7 @@ export const render = (
     defs,
     axes,
     axisFields,
-    scaleContext: scaleContextParam,
+    rightMargin,
     svgPadding,
   }: {
     width: number;
@@ -415,12 +441,11 @@ export const render = (
     defs?: JSX.Element[];
     axes?: AxesOptions;
     axisFields?: { x?: string; y?: string };
-    scaleContext: ScaleContext | null;
+    rightMargin?: number;
     svgPadding?: number;
   },
   child: GoFishNode
 ): JSX.Element => {
-  const scaleContext = scaleContextParam;
   const pad = svgPadding ?? PADDING;
 
   const { xTitle, yTitle } = resolveAxisTitles(axes, axisFields);
@@ -428,17 +453,13 @@ export const render = (
   const X_TITLE_MARGIN = PADDING; // 30px below content for x-title
   const leftMargin = yTitle ? Y_TITLE_MARGIN : 0;
   const bottomMargin = xTitle ? X_TITLE_MARGIN : 0;
-  // Only reserve right-side legend space when a color legend will actually
-  // render — the legend `<For>` below iterates an empty Map otherwise, so
-  // stories without a color scale would pay 120 px for nothing.
-  const hasLegend =
-    !!(scaleContext?.unit && "color" in scaleContext.unit) &&
-    (scaleContext.unit.color as Map<unknown, unknown>).size > 0;
-  const rightMargin = hasLegend ? LEGEND_MARGIN : 0;
+  // Right-side space reserved for a legend overhanging the content width
+  // (measured by `layout()` as `rightOverhang`; 0 when no legend / no overhang).
+  const rightSpace = rightMargin ?? 0;
 
   const result = (
     <svg
-      width={width + leftMargin + pad + rightMargin + pad}
+      width={width + leftMargin + pad + rightSpace + pad}
       height={height + pad + bottomMargin + pad}
       xmlns="http://www.w3.org/2000/svg"
     >
@@ -451,34 +472,6 @@ export const render = (
         <Show when={transform} keyed fallback={child.INTERNAL_render()}>
           <g transform={transform ?? ""}>{child.INTERNAL_render()}</g>
         </Show>
-        {/* legend (discrete color for now) */}
-        <For
-          each={Array.from(
-            (scaleContext?.unit && "color" in scaleContext.unit
-              ? scaleContext.unit.color
-              : new Map()
-            ).entries()
-          )}
-        >
-          {([key, value], i) => (
-            <g
-              transform={`translate(${width + pad * 3}, ${height - i() * 20})`}
-            >
-              <rect x={-20} y={-5} width={10} height={10} fill={value} />
-              <text
-                transform="scale(1, -1)"
-                x={-5}
-                y={0}
-                text-anchor="start"
-                dominant-baseline="middle"
-                font-size="10px"
-                fill="gray"
-              >
-                {key}
-              </text>
-            </g>
-          )}
-        </For>
         {/* x axis title */}
         <Show when={xTitle}>
           <text

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -181,6 +181,13 @@ export async function layout(
   // (unionChildSpaces ignores the legend's UNDEFINED spaces), so the nice
   // spaces captured above remain valid.
   let legendAdded = false;
+  // Reference to the content node whose extent defines the final canvas. When a
+  // legend is added, `child` becomes the wrapper Layer (content + swatch column)
+  // and `contentNode` keeps pointing at the original content, so the final
+  // width/height (and the axis-title centering that reads them) stay measured off
+  // the content, not the content+legend bbox. The legend is reserved separately
+  // via `rightOverhang` below.
+  const contentNode = child;
   const unitScale = contexts?.session.scaleContext.unit;
   const colorMap =
     unitScale && "color" in unitScale ? unitScale.color : undefined;
@@ -274,18 +281,22 @@ export async function layout(
 
   // Final extent: a user-given dimension is authoritative; otherwise prefer the
   // content's laid-out intrinsic size (shrink-to-fit), falling back to the
-  // canvas default when the content didn't report one.
+  // canvas default when the content didn't report one. Read off `contentNode`
+  // (== `child` when no legend), never the legend wrapper — so the canvas and
+  // the axis titles that center on `finalW`/`finalH` stay content-relative; the
+  // legend is reserved separately via `rightOverhang`.
   const finalDim = (i: 0 | 1, given: number | undefined): number => {
     if (given !== undefined) return given;
-    const s = child.dims[i]?.size;
+    const s = contentNode.dims[i]?.size;
     return s !== undefined && Number.isFinite(s) ? s : DEFAULT_CANVAS_SIZE;
   };
   const finalW = finalDim(0, w);
   const finalH = finalDim(1, h);
 
-  // Measured legend overhang past the authoritative width — replaces the fixed
-  // LEGEND_MARGIN. Gated on legendAdded so legend-free charts keep byte-identical
-  // SVG widths. With w omitted, finalW already includes the legend → clamps to 0.
+  // Measured legend overhang past the content width — replaces the fixed
+  // LEGEND_MARGIN. The wrapper's max bbox includes the seated swatch column, so
+  // `wrapper.max - finalW` is exactly the gap + legend width to reserve on the
+  // right. Gated on legendAdded so legend-free charts keep byte-identical widths.
   const rightOverhang = legendAdded
     ? Math.max(0, (child.dims[0]?.max ?? 0) - finalW)
     : 0;

--- a/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
@@ -13,6 +13,7 @@ import {
   isORDINAL,
   isPOSITION,
   isSIZE,
+  isUNDEFINED,
   UnderlyingSpace,
 } from "../underlyingSpace";
 import type { Size } from "../dims";
@@ -32,6 +33,11 @@ export type Alignment = "start" | "middle" | "end" | "baseline";
  * union) — the extent is known but the position is not, preserving the "no
  * inherent position" semantic so axis rendering uses interval (difference)
  * ticks rather than absolute positions.
+ *
+ * UNDEFINED children carry no opinion and are ignored throughout: the ORDINAL
+ * filter skips them, the interval-collection path skips them, and the SIZE gate
+ * filters them out before checking whether the remaining children are all SIZE.
+ * So a fixed-pixel (UNDEFINED) sibling never vetoes SIZE composition.
  */
 export function unionChildSpaces(
   children: Size<UnderlyingSpace>[],
@@ -56,8 +62,9 @@ export function unionChildSpaces(
   // when every child is SIZE on this axis, emit SIZE(Monotonic.max(...))
   // so the parent can keep solving scale factors via Monotonic.inverse.
   const axisSpaces = children.map((c) => c[axis]);
-  if (axisSpaces.length > 0 && axisSpaces.every(isSIZE)) {
-    return SIZE(Monotonic.max(...axisSpaces.map((s) => s.domain)));
+  const sized = axisSpaces.filter((s) => !isUNDEFINED(s));
+  if (sized.length > 0 && sized.every(isSIZE)) {
+    return SIZE(Monotonic.max(...sized.map((s) => s.domain)));
   }
 
   const intervals: ReturnType<typeof Interval.interval>[] = [];

--- a/packages/gofish-graphics/src/ast/legends/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/legends/elaborate.tsx
@@ -1,0 +1,104 @@
+import { GoFishNode } from "../_node";
+import { Rect } from "../shapes/rect";
+import { Text } from "../shapes/text";
+import { Spread } from "../graphicalOperators/spread";
+import { layer } from "../graphicalOperators/layer";
+import { Constraint } from "../constraints";
+
+/**
+ * Legend elaboration: turn the resolved categorical color scale into ordinary
+ * GoFish shapes + constraints, the same way axes/elaborate.tsx turns an axis
+ * into Rect/Text/Spread/Layer nodes. This replaces the bespoke render-time
+ * legend (the `<For>` over `scaleContext.unit.color` in gofish.tsx that
+ * hand-placed swatches at `translate(width + pad*3, ...)` behind a fixed
+ * `LEGEND_MARGIN`): the legend is no longer a privileged render-time fixture,
+ * it's a swatch column wrapped in a `Layer` beside the content, participating
+ * in normal layout (so its extent is measured, not reserved as a constant).
+ *
+ * `legendRow` / `legendColumn` are pure builders (the customization seam): a
+ * future public API can override how a legend renders.
+ *
+ * Note: a gradient color config currently yields one row per color-map entry
+ * (parity with the bespoke path). A continuous colorbar is a follow-up.
+ */
+
+// Visual constants — chosen to match the previous bespoke legend styling.
+const SWATCH_SIZE = 10;
+const SWATCH_LABEL_GAP = 5; // gap between a swatch and its label
+const ROW_GAP = 8; // vertical gap between legend rows
+const LABEL_FONT_SIZE = 10;
+const LABEL_COLOR = "gray";
+const LEGEND_CONTENT_GAP = 20; // gap between content and the legend column
+const CONTENT_NAME = "__legendContent";
+const LEGEND_NAME = "__legend";
+
+/** One legend row: a color swatch followed by its label, aligned on a row. */
+function legendRow(key: any, color: string): GoFishNode {
+  return (Spread as any)(
+    { dir: "x", spacing: SWATCH_LABEL_GAP, alignment: "middle" },
+    [
+      Rect({ w: SWATCH_SIZE, h: SWATCH_SIZE, fill: color }),
+      Text({ text: String(key), fontSize: LABEL_FONT_SIZE, fill: LABEL_COLOR }),
+    ]
+  ) as GoFishNode;
+}
+
+/**
+ * The swatch column. Rows are REVERSED because `Spread({dir:"y"})` lays children
+ * bottom→top (first child gets the smallest y) in y-up coordinates, so the first
+ * color-map entry must be last in the spread to render at the top (parity with
+ * the bespoke legend, which placed entry 0 at the top).
+ */
+export function legendColumn(colorMap: Map<any, string>): GoFishNode {
+  const rows = [...colorMap.entries()]
+    .map(([key, color]) => legendRow(key, color))
+    .reverse();
+  return (Spread as any)(
+    { dir: "y", spacing: ROW_GAP, alignment: "start" },
+    rows
+  ).name(LEGEND_NAME) as GoFishNode;
+}
+
+/**
+ * Wrap `node` in a Layer with a swatch column seated to its right. Mirrors the
+ * axes/elaborate.tsx wrapper recipe (identity move → layer wrap → constrain via
+ * the name→ref map → identity restore).
+ */
+export async function elaborateLegend(
+  node: GoFishNode,
+  colorMap: Map<any, string>
+): Promise<{ node: GoFishNode; changed: boolean }> {
+  if (colorMap.size === 0) return { node, changed: false };
+
+  // Move identity off the content onto the outer layer, so the parent
+  // (faceting/refs/select) still resolves to this node.
+  const origName = node._name;
+  const origKey = node.key;
+  node._name = undefined;
+  node.key = undefined;
+  node.name(CONTENT_NAME);
+
+  const root = (await (layer as any)([
+    node,
+    legendColumn(colorMap),
+  ])) as GoFishNode;
+
+  // Constraint order matters: the content pin places the anchor the others read.
+  root.constrain((g) => [
+    // Pin the content at its origin; it never moves.
+    Constraint.align({ x: "baseline", y: "baseline" } as any, [
+      g[CONTENT_NAME],
+    ]),
+    // Seat the column just right of the full content bbox (incl. axis labels).
+    Constraint.distribute({ dir: "x", spacing: LEGEND_CONTENT_GAP }, [
+      g[CONTENT_NAME],
+      g[LEGEND_NAME],
+    ]),
+    // Top-align the column with the content top (y-up: end = top).
+    Constraint.align({ y: "end" } as any, [g[CONTENT_NAME], g[LEGEND_NAME]]),
+  ]);
+
+  if (origName !== undefined) root._name = origName;
+  if (origKey !== undefined) root.setKey(origKey);
+  return { node: root, changed: true };
+}

--- a/packages/gofish-graphics/src/ast/legends/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/legends/elaborate.tsx
@@ -1,3 +1,7 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Legends — /internals/frontend/legends
+// </gofish-wiki>
+
 import { GoFishNode } from "../_node";
 import { Rect } from "../shapes/rect";
 import { Text } from "../shapes/text";

--- a/packages/gofish-graphics/src/ast/legends/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/legends/elaborate.tsx
@@ -8,6 +8,7 @@ import { Text } from "../shapes/text";
 import { Spread } from "../graphicalOperators/spread";
 import { layer } from "../graphicalOperators/layer";
 import { Constraint } from "../constraints";
+import { wrapPreservingIdentity } from "../elaborationUtils";
 
 /**
  * Legend elaboration: turn the resolved categorical color scale into ordinary
@@ -48,17 +49,16 @@ function legendRow(key: any, color: string): GoFishNode {
 }
 
 /**
- * The swatch column. Rows are REVERSED because `Spread({dir:"y"})` lays children
- * bottom→top (first child gets the smallest y) in y-up coordinates, so the first
- * color-map entry must be last in the spread to render at the top (parity with
- * the bespoke legend, which placed entry 0 at the top).
+ * The swatch column. `reverse: true` because `Spread({dir:"y"})` lays children
+ * bottom→top in y-up coordinates, so the first color-map entry must render last
+ * (at the top), matching the bespoke legend.
  */
 export function legendColumn(colorMap: Map<any, string>): GoFishNode {
-  const rows = [...colorMap.entries()]
-    .map(([key, color]) => legendRow(key, color))
-    .reverse();
+  const rows = [...colorMap.entries()].map(([key, color]) =>
+    legendRow(key, color)
+  );
   return (Spread as any)(
-    { dir: "y", spacing: ROW_GAP, alignment: "start" },
+    { dir: "y", spacing: ROW_GAP, alignment: "start", reverse: true },
     rows
   ).name(LEGEND_NAME) as GoFishNode;
 }
@@ -66,43 +66,48 @@ export function legendColumn(colorMap: Map<any, string>): GoFishNode {
 /**
  * Wrap `node` in a Layer with a swatch column seated to its right. Mirrors the
  * axes/elaborate.tsx wrapper recipe (identity move → layer wrap → constrain via
- * the name→ref map → identity restore).
+ * the name→ref map → identity restore, via `wrapPreservingIdentity`).
+ *
+ * The caller owns the "is there anything to draw?" guard (a non-empty color
+ * map); this always wraps and returns the new root.
  */
 export async function elaborateLegend(
   node: GoFishNode,
   colorMap: Map<any, string>
-): Promise<{ node: GoFishNode; changed: boolean }> {
-  if (colorMap.size === 0) return { node, changed: false };
+): Promise<GoFishNode> {
+  return wrapPreservingIdentity(node, async (content) => {
+    content.name(CONTENT_NAME);
 
-  // Move identity off the content onto the outer layer, so the parent
-  // (faceting/refs/select) still resolves to this node.
-  const origName = node._name;
-  const origKey = node.key;
-  node._name = undefined;
-  node.key = undefined;
-  node.name(CONTENT_NAME);
+    const root = (await (layer as any)([
+      content,
+      legendColumn(colorMap),
+    ])) as GoFishNode;
 
-  const root = (await (layer as any)([
-    node,
-    legendColumn(colorMap),
-  ])) as GoFishNode;
+    // Constraint order matters: the content pin places the anchor the others read.
+    root.constrain((g) => [
+      // Pin the content at its origin; it never moves.
+      Constraint.align({ x: "baseline", y: "baseline" }, [g[CONTENT_NAME]]),
+      // Seat the column just right of the full content bbox (incl. axis labels).
+      Constraint.distribute({ dir: "x", spacing: LEGEND_CONTENT_GAP }, [
+        g[CONTENT_NAME],
+        g[LEGEND_NAME],
+      ]),
+      // Top-align the column with the content top (y-up: end = top).
+      Constraint.align({ y: "end" }, [g[CONTENT_NAME], g[LEGEND_NAME]]),
+    ]);
 
-  // Constraint order matters: the content pin places the anchor the others read.
-  root.constrain((g) => [
-    // Pin the content at its origin; it never moves.
-    Constraint.align({ x: "baseline", y: "baseline" } as any, [
-      g[CONTENT_NAME],
-    ]),
-    // Seat the column just right of the full content bbox (incl. axis labels).
-    Constraint.distribute({ dir: "x", spacing: LEGEND_CONTENT_GAP }, [
-      g[CONTENT_NAME],
-      g[LEGEND_NAME],
-    ]),
-    // Top-align the column with the content top (y-up: end = top).
-    Constraint.align({ y: "end" } as any, [g[CONTENT_NAME], g[LEGEND_NAME]]),
-  ]);
+    return root;
+  });
+}
 
-  if (origName !== undefined) root._name = origName;
-  if (origKey !== undefined) root.setKey(origKey);
-  return { node: root, changed: true };
+/**
+ * Measured width the seated legend column adds past the content width. The
+ * wrapper's max bbox includes the swatch column that the `distribute({dir:"x"})`
+ * constraint above seated to the right of the content, so this is exactly the
+ * `LEGEND_CONTENT_GAP` plus the column width to reserve on the right. `max!`,
+ * not `?.max ?? 0`: the wrapper layer always emits a placed max here — a silent
+ * 0 would clip the legend and mask the bug.
+ */
+export function legendOverhang(wrapper: GoFishNode, contentW: number): number {
+  return Math.max(0, wrapper.dims[0].max! - contentW);
 }


### PR DESCRIPTION
Closes #495.

## What

Replaces the bespoke render-time legend with an **elaboration pass**, the same treatment axes got in #490: the color scale becomes ordinary GoFish shapes (`rect` swatches + `text` labels in a `spread` column) wrapped in a `layer` with `align`/`distribute` constraints, seated beside the content. The legend is no longer privileged chrome — it participates in normal layout, so its size and placement fall out of ordinary passes (#493, #494) and it gains the same customization seam axes have (a pure, overridable builder function).

## How

Staged as refactor-then-easy-change:

1. **`unionChildSpaces` fix** (68e40b2b): UNDEFINED children no longer veto the all-SIZE gate — UNDEFINED means "no opinion" everywhere else in the union (the ORDINAL filter and the interval path both skip it). Behavior-preserving today (axis-elaborated SIZE roots are promoted to POSITION by their datum constraints regardless; verified zero story diffs), but required so the legend wrapper preserves a SIZE-rooted chart's underlying space instead of degrading it to DIFFERENCE and collapsing the bars.

2. **Legend elaboration** (4473985c): new `src/ast/legends/elaborate.tsx`. `elaborateLegend(node, colorMap)` runs in `layout()` after the axes block, consuming the populated color map, and wraps the root in a `Layer` with three constraints (in order — the content pin places the anchor the others read):
   - `align({x: "baseline", y: "baseline"})` pins the content at its origin; it never moves.
   - `distribute({dir: "x"})` seats the swatch column just right of the content's **full bbox** (including elaborated axis labels).
   - `align({y: "end"})` top-aligns the column with the content.

   `legendRow`/`legendColumn` are pure and exported — the customization seam. Rows are reversed so the first color-map entry renders on top (y-up coords). Swatch fills are literal hex strings (never `isValue`), so `resolveColorScale` is not re-run.

3. **Docs** (0c7aef19): new internals essay (`/internals/frontend/legends`), `passes.md` stale-mention fixes, generated `@wiki` backlinks.

## Deleted

- The legend `<For>` in `gofish.tsx`'s `render()` (hand-placed at `translate(width + pad*3, height - i*20)`).
- `LEGEND_MARGIN = 120` — the fixed right-side reservation. The SVG now reserves a **measured** overhang (`max(0, dims[0].max - finalW)`, gated on a legend being added); with `w`/`h` omitted the legend is simply part of the computed extent from #494.
- `render()`'s `scaleContext` parameter (legend-only).

## Verification

- `pnpm capture-diff` against the branch parent: 63 stories changed; **every one** programmatically classified as either legend-bearing (bespoke swatch present in its base DOM — the intentional diff, as in #490) or the known `/@fs/` asset-path artifact. Zero geometry diffs on legend-free stories.
- Visually verified via `pnpm capture-one`: `LegendTracksComputedExtent` (SIZE-rooted bars at full canvas height, legend tracking the computed extent), the ColorScales palette/gradient/selective stories (legend clears axis labels, nothing clipped, gradients keep one-row-per-entry parity).
- `pnpm test`: 57/57. `check-backlinks` in sync. No IR schema or Python changes — legends never cross the bridge; parity stories change identically on both sides.

> [!NOTE]
> Visual baselines should be regenerated in CI (not on macOS), as with #490 — the legend geometry change is by design.

**Follow-ups noted in the essay**: continuous colorbar for gradient scales (today: one swatch row per map entry, parity with the bespoke path); tall legends extending below short content (pre-existing failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Updates since the original description (review round 1)

Two regressions reported in review, both fixed:

**Polar charts rendered the legend at the bottom-left** (`c73db143`). Root cause was a pre-existing coord-node bbox bug the legend made load-bearing: polar `coord` returned intrinsic dims as `{x, y, w, h}`, which `elaborateDims` maps to `min`/`size` only — `max` stayed `undefined`. The legend's `distribute` seats the column at `content.dims[0].max + spacing` → `NaN`, and SVG drops the invalid `translate(NaN, …)`, leaving the column untransformed at the bottom-left. Fixed at the source: `coord` now emits a complete, placed-consistent bbox (placed box = `[0, size]`, the allocated region) on every branch. Side effect, flagged deliberately: `Scatter/WithPieGlyphs` glyphs are now centered **on** their data points — scatter places by `center`, and the old `min + size/2` fallback read the offset box, seating every glyph ~radius off its datum. Only the 6 glyph translates changed; axes/ticks/SVG size byte-identical. Worth auditing other coord-bbox consumers for similar latent compensation (follow-up).

**x-axis title shifted right when `w`/`h` omitted** (`bc118908`, e.g. vega-lite grouped bar). `finalW` was read off the legend *wrapper*, so the title centered over content+legend. Now `finalW`/`finalH` come from the content node (kept across the wrap) and the measured `rightOverhang` reserves the legend — title back to content-center, SVG still includes the legend.

Verified: zero `NaN` in any story DOM at HEAD (5 polar stories had them at base); capture-diff vs the legend commit shows only the 5 polar legends repaired, the 6 glyph re-centerings, and the grouped-bar title/SVG-width fix; 57/57 tests.
