### PR TITLE
Elaborate axis titles into ordinary shapes + constraints; delete the bespoke title path

### DIFF
--- a/apps/docs/docs/internals/frontend/axes.md
+++ b/apps/docs/docs/internals/frontend/axes.md
@@ -117,13 +117,68 @@ constraint) and from SIZE content (bars), whose alignment would break if a posSc
 leaked in. This per-child decision is what lets a data-positioned chart and its
 elaborated axis share a coordinate frame.
 
+## Axis titles
+
+Axis titles are elaborated too, by a second pass in the same file —
+`elaborateAxisTitles`. It differs from `elaborateAxes` in kind: where the axis
+pass wraps _every_ node that owns an axis anywhere in the tree, the title pass is
+a single wrap at the chart root carrying **at most one title per dim**. The two
+title strings are resolved by `gofish.tsx`'s `layout()` from the chart-level
+`axes` options plus the inferred `axisFields` (the field names the chart builder
+mapped to each axis), and `layout()` calls the pass only when at least one is
+present.
+
+A title is placed **relative to the axis shape it describes**, not the plot. The
+axis pass already builds an axis-line node per position-like dim; `AxisElaboration`
+carries it as an optional `anchor`, and `elaborateAxes` bubbles those lines up the
+recursion as a per-dim `titleAnchors` pair. Because the walk is bottom-up and each
+owner overwrites its dim slot, the **root-most** owner wins — so a chart-level
+title describes the outermost axis (the one spanning the whole plot), not an inner
+facet's. (Multiple same-dim owners across _sibling_ facets are ambiguous: they
+overwrite the same slot, so the last-visited one wins. Disambiguating that — a
+per-facet title — is out of scope; a comment in the source flags it.)
+
+`elaborateAxisTitles` then wraps the content in one more `Layer` and centers each
+title on its anchor:
+
+- The anchor per dim is `anchors[dim] ?? plotNode` — the axis line if one exists
+  (continuous/difference), else the plot node. The fallback covers **ordinal**
+  axes (just a label row, no spanning line, UNDEFINED space elaborates nothing)
+  and untitled-axis dims: the plot's own bbox stands in.
+- It is referenced with a `ref(anchorNode)` stand-in — the same direct-node `ref`
+  form `elaborateOrdinalAxis` uses. The title layer is outermost, so by the time
+  the constraints read the ref the axis line / plot is already placed; the ref
+  resolves to that placement, so `align({ [dim]: "middle" }, [ref, title])` moves
+  only the title onto the line's center.
+- A `distribute` then seats the title GAP (`TITLE_CONTENT_GAP = 8`) outside the
+  **full** content bbox — past the tick/ordinal label rows, not just the plot —
+  so it never overlaps them. Listing the title _before_ the content in the pair
+  makes `distribute`'s backward walk place the title's far edge outside the
+  content's near edge.
+- The y-title is built with the `Text` `rotate: 90` option so it reads
+  bottom-to-top in the left gutter; the x-title is horizontal below the plot.
+
+The two builders `xAxisTitle` / `yAxisTitle` are **pure, exported functions** —
+the customization seam, exactly like `elaborateAxis` for the axes and
+`legendColumn` for the legend.
+
+`elaborateAxisTitles` runs in `layout()` **before** the legend wrap: the legend
+seats itself off the titled content's bbox, so the title must already be in
+place — and conversely the title's centering must never see the legend column
+(it would drag the title off-center). The pre-title content node is also what
+defines the inferred canvas when `w`/`h` are omitted, so a long title can't
+inflate it. See [Layout & Render Passes](/internals/layout/passes) and
+[Legends](/internals/frontend/legends).
+
 ## What this replaced
 
 The former bespoke pipeline — `shapes/axis.tsx` (custom `GoFishNode`s with
 hand-written SVG `render()`), plus ~260 lines of axis budget / `innerBaseline` /
 content-shift / per-facet local-posScale machinery in `_node.ts` and a baseline
 cancellation in `spread.tsx` — has been deleted. `resolveAxes` and
-`resolveNiceDomains` remain (they feed the pass); the chart-level `axes` option and
-axis _titles_ are unchanged (titles still render in `gofish.tsx`'s `render()`; folding
-them into the elaboration is future work). Polar/coord axes are still drawn by
-`coord.tsx` and are not yet elaborated.
+`resolveNiceDomains` remain (they feed the pass); the chart-level `axes` option
+still drives both the axis pass and the title pass above. Axis titles used to
+render as raw `<text>` elements in `gofish.tsx`'s `render()` behind fixed
+40px margins; that bespoke path is gone too, replaced by the title elaboration
+described above. Polar/coord axes are still drawn by `coord.tsx` and are not yet
+elaborated.

--- a/apps/docs/docs/internals/frontend/axes.md
+++ b/apps/docs/docs/internals/frontend/axes.md
@@ -131,12 +131,18 @@ present.
 A title is placed **relative to the axis shape it describes**, not the plot. The
 axis pass already builds an axis-line node per position-like dim; `AxisElaboration`
 carries it as an optional `anchor`, and `elaborateAxes` bubbles those lines up the
-recursion as a per-dim `titleAnchors` pair. Because the walk is bottom-up and each
-owner overwrites its dim slot, the **root-most** owner wins — so a chart-level
-title describes the outermost axis (the one spanning the whole plot), not an inner
-facet's. (Multiple same-dim owners across _sibling_ facets are ambiguous: they
-overwrite the same slot, so the last-visited one wins. Disambiguating that — a
-per-facet title — is out of scope; a comment in the source flags it.)
+recursion as a per-dim `titleAnchors` pair. Any dim a node owns an axis on is
+**claimed** outright: the slot is overwritten with that node's own anchor — the
+axis line for a position-like axis, or `undefined` for an **ordinal** one, which
+has no spanning line. Because the walk is bottom-up, the **root-most** owner wins —
+so a chart-level title describes the outermost axis, not an inner facet's. The
+clearing matters for faceted charts: the root owns the ordinal facet axis while
+each facet owns a continuous axis on the _same_ dim, and without the claim the
+first facet's line would bubble past the root and drag the title onto one
+subchart; with it, the title falls back to the plot node — the span of the whole
+ordinal group. (Multiple same-dim owners across _sibling_ facets are ambiguous:
+they overwrite the same slot, so the last-visited one wins. Disambiguating that —
+a per-facet title — is out of scope; a comment in the source flags it.)
 
 `elaborateAxisTitles` then wraps the content in one more `Layer` and centers each
 title on its anchor:

--- a/apps/docs/docs/internals/frontend/legends.md
+++ b/apps/docs/docs/internals/frontend/legends.md
@@ -18,7 +18,8 @@ code at all.
 
 ## Why elaborate
 
-The legend was the **last bespoke piece of chrome**. It used to render as a
+The legend was the **second-to-last bespoke piece of chrome** (axis titles
+followed it; both are now elaborated). It used to render as a
 `<For>` over `scaleContext.unit.color` in `gofish.tsx`'s `render()`, hand-placing
 swatches at `translate(width + pad*3, …)` behind a fixed 120px `LEGEND_MARGIN`
 reserved on the right of the SVG. Because it was a render-time fixture rather
@@ -96,30 +97,45 @@ The fixed 120px `LEGEND_MARGIN` is gone. The canvas size and the legend
 reservation are read off **two different nodes**, which is what keeps the
 content centered and the legend reserved separately:
 
-- `finalW`/`finalH` (the canvas, and the basis for axis-title centering) read
-  off the **content node** — the original pre-wrap node, captured as
-  `contentNode` before `elaborateLegend` replaces `child` with the wrapper. So
-  the canvas is exactly the content's extent, never content + legend.
+- `finalW`/`finalH` (the canvas) read off the **content node** — the original
+  pre-wrap node, captured as `contentNode` _before_ both the title wrap and the
+  `elaborateLegend` wrap. So the canvas is exactly the content's extent, never
+  inflated by a title or a legend.
 - `rightOverhang` reads off the **wrapper** (`child`), whose bounding box
   includes the seated swatch column, and subtracts the content width:
 
 ```ts
 const finalW = finalDim(0, w); // off contentNode
-const rightOverhang = child !== contentNode ? legendOverhang(child, finalW) : 0;
+const rightOverhang = legendAdded ? legendOverhang(child, finalW) : 0;
 ```
 
 `legendOverhang` (in `legends/elaborate.tsx`, next to the constraint that
 creates the overhang) returns `wrapper.dims[0].max - finalW`, which is exactly
 the `LEGEND_CONTENT_GAP` plus the swatch-column width, so the render pass
 reserves precisely the legend on the right of the SVG. The measurement is gated
-on whether a legend wrapper was added (`child !== contentNode`), so legend-free
-charts keep byte-identical SVG widths.
+on an explicit `legendAdded` boolean rather than `child !== contentNode`:
+because the axis-title pass _also_ wraps `child`, the identity check would
+wrongly fire on a titles-only chart and measure a title gutter as a legend
+overhang. With the boolean, legend-free charts keep byte-identical SVG widths.
 
-Reading `finalW`/`finalH` off the content (not the wrapper) matters most when
+Reading `finalW`/`finalH` off the content (not any wrapper) matters most when
 `w`/`h` are **omitted**: the inferred graphic size is the content's computed
-extent (#494's `finalDim` readback), and the legend is then reserved on top of
-it via `rightOverhang` — rather than the legend inflating the inferred size and
-dragging the x-axis title off-center with it.
+extent (#494's `finalDim` readback), and the title and legend are then reserved
+on top of it via the measured gutters — rather than a long title or a tall
+legend inflating the inferred size.
+
+## Interplay with axis titles
+
+Axis titles are elaborated just before the legend (see
+[Axes](/internals/frontend/axes)), so the two wraps **nest**: the title wrap goes
+on first, then `elaborateLegend` wraps that titled subtree. This ordering is what
+lets the legend seat itself off the content's _full, titled_ bbox while the title
+centering never sees the legend column. `contentNode` stays pointed at the
+pre-title, pre-legend content throughout, so neither wrapper feeds back into the
+inferred canvas. The title gutters (left for the rotated y-title, bottom for the
+x-title) are reserved separately from `rightOverhang` as `leftOverhang` /
+`bottomOverhang`, measured off the outermost wrapper. See
+[Layout & Render Passes](/internals/layout/passes).
 
 This relies on the content node reporting a complete, correctly-positioned
 bounding box. Most nodes do, but the polar `coord` node historically emitted an

--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -39,7 +39,7 @@ const runGofish = async (): Promise<LayoutData> => {
     };
 
     const layoutResult = await layout(
-      { w, h, x, y, transform, debug, defs, axes },
+      { w, h, x, y, transform, debug, defs, axes, axisFields },
       child,
       contexts
     );
@@ -221,7 +221,31 @@ See [Axes](/internals/frontend/axes) for the full elaboration story (the
 two-tier structure, baseline pins, negative-space gutters, and the
 continuous/difference/ordinal kinds).
 
-**Legend elaboration** follows the axis block in the same `layout()`, gated on a
+**Axis-title elaboration** follows the axis block (after the nice-space capture)
+and runs _before_ the legend. `elaborateAxisTitles` wraps the chart in one more
+`Layer` carrying up to two title `Text` nodes — the x-title horizontal below the
+plot, the y-title rotated to read bottom-to-top in the left gutter — each
+centered on the axis line it describes via a `ref()` stand-in (`elaborateAxes`
+hands back those axis-line nodes as `titleAnchors`; an ordinal or absent axis
+has no line, so the title falls back to centering on the plot node). Two extra
+references thread through here:
+
+- `plotNode` — the original root content, captured _before_ `elaborateAxes`, so
+  it survives every wrapping pass and stands in as the fallback title anchor.
+- `contentNode` — the node captured _just before_ the title wrap (and so before
+  the legend wrap too). It is what `finalW`/`finalH` read off below, so a long
+  title or a tall legend can never inflate the inferred canvas; their extents
+  past the content are reserved separately as measured gutters instead.
+
+The ordering is deliberate: titles must be seated before the legend, because the
+legend distributes off the titled content's bbox — and conversely the title's
+centering must never see the legend column (it would drag the title off-center).
+This is the same elaborate-into-ordinary-nodes treatment axes and legends get;
+the former bespoke render-time title path is gone. See
+[Axes](/internals/frontend/axes) for the title recipe and the
+sibling-facet anchor limitation.
+
+**Legend elaboration** follows the title block in the same `layout()`, gated on a
 non-empty color map (not on the `axes` option). `elaborateLegend` wraps the chart
 root in a `Layer` holding the content plus a swatch column of `rect`/`text` rows,
 seated to the right with `align`/`distribute` constraints — the same elaborate-
@@ -406,21 +430,21 @@ The render function is called from `gofish()` after layout data is available:
 ```tsx
 return render(
   {
-    width: w,
-    height: h,
+    width: data.width,
+    height: data.height,
+    svgPadding,
     defs,
-    axes,
-    scaleContext: data.scaleContext,
-    keyContext: data.keyContext,
-    sizeDomains: data.sizeDomains,
-    underlyingSpaceX: data.underlyingSpaceX,
-    underlyingSpaceY: data.underlyingSpaceY,
-    posScales: data.posScales,
-    ordinalScales: data.ordinalScales,
+    rightOverhang: data.rightOverhang,
+    leftOverhang: data.leftOverhang,
+    bottomOverhang: data.bottomOverhang,
   },
   data.child
 );
 ```
+
+`render()` no longer takes `axes`/`axisFields` or the scale/space context — all
+the chrome is in the laid-out tree by now, so render only needs the computed
+extent and the three measured gutter overhangs to size the SVG.
 
 ### Render Pass 1: Context Restoration
 
@@ -433,40 +457,65 @@ keyContext = keyContextParam;
 
 The global contexts are restored so that render functions can access them.
 
-### Render Pass 2: Axis Titles
+### Render Pass 2: Chrome Reservation
 
 **Location**: `src/ast/gofish.tsx` (`render()`)
 
-Only axis **titles** are still drawn at render time. Tick marks, tick labels,
-axis lines, and ordinal category labels are no longer computed here — they
-were elaborated into ordinary nodes during layout (see Pass 7: Axis
-Elaboration) and render as part of the node tree like any other shape.
+`render()` draws **no chart chrome of its own** — no axis lines, tick marks, tick
+labels, ordinal category labels, _or titles_, and no legend swatches. All of it
+was elaborated into ordinary nodes during layout (see Pass 7: Axis Elaboration,
+the title block that follows it, and the legend block) and renders as part of the
+node tree like any other shape. The former bespoke render-time path (hand-written
+`<text>` title elements behind fixed `Y_TITLE_MARGIN` / `X_TITLE_MARGIN` gutters)
+has been deleted, so `render()` has zero chart-chrome special cases left.
+
+What `render()` _does_ do is size the SVG around the measured extent of that
+chrome. `layout()` hands it three gutter measurements — `leftOverhang`,
+`bottomOverhang` (negative-space gutters off the outermost wrapper: tick/label
+rows plus the seated y-title and x-title) and `rightOverhang` (the legend
+column) — and the render pass reserves exactly enough on each side:
+
+```typescript
+const EDGE_GAP = 8; // breathing room between gutter content and the SVG edge
+const reserve = (o: number) => (o > 0 ? Math.max(pad, o + EDGE_GAP) : pad);
+const leftReserve = reserve(leftOverhang);
+const bottomReserve = reserve(bottomOverhang);
+```
+
+The `o > 0` guard keeps a chart with `padding: 0` and no chrome at zero reserve
+(don't invent `EDGE_GAP` px on an empty gutter). Because a gutter that fits
+within the existing `pad` is absorbed by it, an untitled chart with a small
+gutter stays byte-identical to the pre-chrome output. The measured-overhang
+policy also fixes a latent bug: the old fixed 40px margins silently _clipped_ any
+gutter wider than themselves (long y tick labels), whereas `reserve()` grows to
+fit whatever the laid-out chrome actually needs.
 
 ### Render Pass 3: SVG Container Creation
 
-**Location**: `src/ast/gofish.tsx:407-417`
+**Location**: `src/ast/gofish.tsx` (`render()`)
 
 ```typescript
 <svg
-  width={width + PADDING * 6 + (axes ? 100 : 0)}
-  height={height + PADDING * 6 + (axes ? 100 : 0)}
+  width={leftReserve + width + rightOverhang + pad}
+  height={pad + height + bottomReserve}
   xmlns="http://www.w3.org/2000/svg"
 >
 ```
 
-The SVG container is created with padding and extra space for axes.
+The SVG container is sized to the content (`width`/`height`, read off the
+pre-chrome content node in layout) plus the measured reserves on each side.
 
 ### Render Pass 4: Coordinate Transform
 
-**Location**: `src/ast/gofish.tsx:416-421`
+**Location**: `src/ast/gofish.tsx` (`render()`)
 
 ```typescript
-<g
-  transform={`scale(1, -1) translate(${PADDING * 4}, ${-height - PADDING * 4})`}
->
+<g transform={`scale(1, -1) translate(${leftReserve}, ${-(height + pad)})`}>
 ```
 
-The coordinate system is flipped (Y-axis inverted) to match mathematical conventions, and the chart is positioned with padding.
+The coordinate system is flipped (Y-axis inverted) to match mathematical
+conventions, and the chart is shifted right by `leftReserve` (the left gutter)
+and down by the top `pad`.
 
 ### Render Pass 5: Node Tree Rendering
 
@@ -581,8 +630,9 @@ The bespoke axis-rendering pass that used to live here (hand-written SVG for
 continuous/ordinal axes, ~400 lines of `gofish.tsx`) was **deleted**. Axes are
 now elaborated into ordinary GoFish nodes during layout (see Pass 7: Axis
 Elaboration and [Axes](/internals/frontend/axes)), so they render through the
-normal node-tree pass above with no special casing. The only axis artifact
-still drawn directly at render time is the title text (Render Pass 2).
+normal node-tree pass above with no special casing. Axis **titles** were the
+last artifact still drawn here; they too are now elaborated during layout
+(see Render Pass 2), so nothing axis-related is drawn directly at render time.
 
 ### Render Pass 8: Legend Rendering (removed)
 
@@ -653,8 +703,8 @@ This creates:
    ```
 
 2. **Axes**: already part of the node tree (elaborated during layout), so
-   the category labels and the y tick marks render in step 1 with everything
-   else; only the axis titles are drawn separately
+   the category labels, the y tick marks, and the axis titles all render in
+   step 1 with everything else — nothing axis-related is drawn separately
 
 ## Debug Support
 

--- a/apps/docs/docs/internals/overview/architecture.md
+++ b/apps/docs/docs/internals/overview/architecture.md
@@ -56,6 +56,16 @@ a full rebuild. The [`coord` operator](/internals/layout/coord-flattening) is th
 notable special case: it flattens its subtree into a flat, absolutely-positioned list
 before applying its coordinate transform.
 
+**Chrome is just more tree.** Axes, legends, and axis titles are not privileged
+render-time fixtures. Before layout, elaboration passes rewrite each of them into
+ordinary marks and constraints — `Layer`-wrapped `Rect`/`Text` nodes seated by
+`align`/`distribute`/`position` — so chrome flows through the same three passes
+as the data marks. The orchestrator (`gofish.tsx`) then sizes the SVG off the
+laid-out tree's **measured extent** (the legend's overhang past the content, the
+axis/title gutters past the origin); there are no fixed chrome margins. See
+[Axes](/internals/frontend/axes) (which also covers axis titles) and
+[Legends](/internals/frontend/legends).
+
 The full, code-level walkthrough of all three passes is
 [Layout & Render Passes](/internals/layout/passes).
 

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -55,6 +55,11 @@ export type AxisElaboration = {
   nodes: GoFishNode[];
   /** Builds this axis's constraints from the layer's name→ref map. */
   constraints: (g: Record<string, any>) => any[];
+  /** The node a chart-level axis title should center on — the axis line.
+   *  Position-like axes (continuous/difference) set it; ordinal axes leave it
+   *  unset (they're just a label row, with no spanning line to center on, so
+   *  the title pass falls back to the plot bbox). */
+  anchor?: GoFishNode;
 };
 
 const dirName = (dim: 0 | 1) => (dim === 0 ? "x" : "y");
@@ -218,7 +223,14 @@ function positionAxis(opts: {
     return cs;
   };
 
-  return { nodes: [line, ...tickNodes, ...labelNodes], constraints };
+  // `line` is the title anchor: a chart-level title for this dim centers on the
+  // axis line's span (which may be narrower than the plot — a difference axis
+  // spans the data width, a facet-owned axis spans its facet).
+  return {
+    nodes: [line, ...tickNodes, ...labelNodes],
+    constraints,
+    anchor: line,
+  };
 }
 
 /** One continuous (POSITION) axis. Mirrors the hand-drawn ContinuousYAxis.
@@ -374,9 +386,13 @@ function collectKeyMap(node: GoFishNode): Record<string, GoFishNode> {
 function elaborationsFor(node: GoFishNode): {
   constrained: AxisElaboration[];
   refBased: AxisElaboration[];
+  /** Per-dim [x, y] title anchor (the axis line) for the constrained axes this
+   *  node owns; undefined where the node owns no position-like axis on that dim. */
+  anchors: [GoFishNode | undefined, GoFishNode | undefined];
 } {
   const space = node._underlyingSpace;
-  if (!space) return { constrained: [], refBased: [] };
+  if (!space)
+    return { constrained: [], refBased: [], anchors: [undefined, undefined] };
   const owns = (dim: 0 | 1) => (dim === 0 ? node.axis.x : node.axis.y) === true;
   // Niced [min, max] per owned POSITION dim, computed ONCE: it feeds both that
   // axis's own line/ticks and the other axis's `crossFloor` (the plot corner),
@@ -396,17 +412,23 @@ function elaborationsFor(node: GoFishNode): {
   let keyMap: Record<string, GoFishNode> | undefined;
   const constrained: AxisElaboration[] = [];
   const refBased: AxisElaboration[] = [];
+  const anchors: [GoFishNode | undefined, GoFishNode | undefined] = [
+    undefined,
+    undefined,
+  ];
   for (const dim of [0, 1] as (0 | 1)[]) {
     if (!owns(dim)) continue;
     const s = space[dim];
     const prefix = dim === 1 ? "__y" : "__x";
     const crossFloor = floors[cross(dim)];
     if (isPOSITION(s) && s.domain) {
-      constrained.push(
-        elaborateContinuousAxis(dim, nices[dim]!, prefix, crossFloor)
-      );
+      const e = elaborateContinuousAxis(dim, nices[dim]!, prefix, crossFloor);
+      constrained.push(e);
+      anchors[dim] = e.anchor;
     } else if (isDIFFERENCE(s)) {
-      constrained.push(elaborateDifferenceAxis(dim, s, prefix, crossFloor));
+      const e = elaborateDifferenceAxis(dim, s, prefix, crossFloor);
+      constrained.push(e);
+      anchors[dim] = e.anchor;
     } else if (isORDINAL(s)) {
       keyMap ??= collectKeyMap(node);
       refBased.push(elaborateOrdinalAxis(dim, s, keyMap, prefix));
@@ -416,7 +438,7 @@ function elaborationsFor(node: GoFishNode): {
     if (dim === 0) node.axis.x = undefined;
     else node.axis.y = undefined;
   }
-  return { constrained, refBased };
+  return { constrained, refBased, anchors };
 }
 
 /**
@@ -424,17 +446,42 @@ function elaborationsFor(node: GoFishNode): {
  * inner facet's axis is wrapped before its parent reads keys; the wrapper
  * inherits the wrapped node's `key`/`_name` so faceting and external refs keep
  * resolving to it.
+ *
+ * Alongside the elaborated tree it bubbles up `titleAnchors` — the per-dim
+ * [x, y] axis-line node a chart-level title should center on. Anchors flow up
+ * from the children (a child's anchor fills a still-empty dim slot), then this
+ * node's OWN axis-line anchors overwrite their dim slots. Because the walk is
+ * bottom-up (children first, then self), overwriting means the ROOT-most owner
+ * of a dim wins — which is what a chart-level title should describe (the
+ * outermost axis spanning the whole plot, not an inner facet's axis).
+ *
+ * Known limitation: multiple same-dim axis owners across SIBLING facets are
+ * ambiguous here — they overwrite the same slot, so whichever sibling is
+ * visited last wins. We don't try to disambiguate (a per-facet title is out of
+ * scope); the chart-level title just tracks one of them.
  */
-export async function elaborateAxes(
-  node: GoFishNode
-): Promise<{ node: GoFishNode; changed: boolean }> {
+export async function elaborateAxes(node: GoFishNode): Promise<{
+  node: GoFishNode;
+  changed: boolean;
+  titleAnchors: [GoFishNode | undefined, GoFishNode | undefined];
+}> {
   let changed = false;
+  const titleAnchors: [GoFishNode | undefined, GoFishNode | undefined] = [
+    undefined,
+    undefined,
+  ];
   // Bottom-up: replace each child with its elaborated form.
   for (let i = 0; i < node.children.length; i++) {
     const child = node.children[i];
     if (child instanceof GoFishNode) {
       const res = await elaborateAxes(child);
       if (res.changed) changed = true;
+      // A child's anchor fills a dim slot we haven't claimed yet.
+      for (const dim of [0, 1] as (0 | 1)[]) {
+        if (titleAnchors[dim] === undefined && res.titleAnchors[dim]) {
+          titleAnchors[dim] = res.titleAnchors[dim];
+        }
+      }
       if (res.node !== child) {
         node.children[i] = res.node;
         res.node.parent = node;
@@ -442,9 +489,15 @@ export async function elaborateAxes(
     }
   }
 
-  const { constrained, refBased } = elaborationsFor(node);
+  const { constrained, refBased, anchors } = elaborationsFor(node);
+  // This node's own axis-line anchors win their dim slots over any bubbled up
+  // from children — bottom-up recursion makes the root-most owner the winner.
+  for (const dim of [0, 1] as (0 | 1)[]) {
+    if (anchors[dim]) titleAnchors[dim] = anchors[dim];
+  }
+
   if (constrained.length === 0 && refBased.length === 0) {
-    return { node, changed };
+    return { node, changed, titleAnchors };
   }
 
   // Move identity off the content onto whatever ends up outermost (so the
@@ -492,5 +545,161 @@ export async function elaborateAxes(
     return outerRoot;
   });
 
-  return { node: root, changed: true };
+  return { node: root, changed: true, titleAnchors };
+}
+
+// ── Axis titles ──────────────────────────────────────────────────────────────
+//
+// The CHART-level title pass. Unlike the per-owner axis pass above (which wraps
+// every node that owns an axis, anywhere in the tree), titles are a single pass
+// at the root: at most one title per dim, resolved by the orchestrator from the
+// `axes` options + the inferred `axisFields`. A title is placed RELATIVE TO the
+// elaborated axis shape it describes — the axis line for that dim, which may
+// span less than the whole plot (a difference axis spans the data width; a
+// facet-owned axis spans its facet). `elaborateAxes` hands us those axis-line
+// nodes as `anchors`; we center the title on the one for its dim.
+//
+// This must run BEFORE the legend wrap: the legend seats itself off the titled
+// content's bbox, so the title must already be in place — and conversely the
+// title's centering must never see the legend column (it'd drag the title
+// off-center). Same ordering argument the legend pass makes about itself.
+
+const TITLE_FONT_SIZE = 11;
+const TITLE_COLOR = "gray";
+const TITLE_CONTENT_GAP = 8; // gap between a title and the full content bbox
+const TITLE_CONTENT_NAME = "__titleContent";
+const X_TITLE_ANCHOR_NAME = "__xTitleAnchor";
+const Y_TITLE_ANCHOR_NAME = "__yTitleAnchor";
+const X_TITLE_NAME = "__xAxisTitle";
+const Y_TITLE_NAME = "__yAxisTitle";
+
+/** The x-axis title: horizontal text below the plot. The customization seam
+ *  (like `legendColumn` / `tickMark`) — a future public API can override it. */
+export function xAxisTitle(text: string): GoFishNode {
+  return Text({ text, fontSize: TITLE_FONT_SIZE, fill: TITLE_COLOR }).name(
+    X_TITLE_NAME
+  );
+}
+
+/** The y-axis title: `rotate: 90` (the Text rotate option) makes it read
+ *  bottom-to-top in the left gutter. Customization seam, like `xAxisTitle`. */
+export function yAxisTitle(text: string): GoFishNode {
+  return Text({
+    text,
+    fontSize: TITLE_FONT_SIZE,
+    fill: TITLE_COLOR,
+    rotate: 90,
+  }).name(Y_TITLE_NAME);
+}
+
+/**
+ * Wrap `node` in a Layer carrying up to two axis titles, each centered on the
+ * axis shape it describes and seated outside the full content bbox.
+ *
+ * Per titled dim the anchor is `anchors[dim] ?? plotNode`: the axis line node
+ * elaboration produced for that dim if one exists (continuous / difference),
+ * else the plot node itself. The fallback covers ordinal axes — they're just a
+ * label row with no spanning line, and their UNDEFINED underlying space
+ * elaborates no line node — so the plot's own bbox stands in as the thing to
+ * center the title on. We reference the anchor with a `ref(node)` stand-in (the
+ * direct-node `ref` form `elaborateOrdinalAxis` already uses): the title layer
+ * is outermost, so by the time `align` reads the ref the axis line / plot is
+ * already placed, and the ref resolves to that placement — so `align` moves
+ * only the title.
+ *
+ * Both title Texts resolve UNDEFINED underlying spaces on both dims (they carry
+ * no data-bound position), so `wrapPreservingIdentity` preserves the wrapped
+ * content's underlying spaces unchanged — the same argument the legend pass
+ * makes for its swatch column.
+ *
+ * The caller owns the "is there any title at all?" guard; this always wraps and
+ * returns the new root.
+ */
+export async function elaborateAxisTitles(
+  node: GoFishNode,
+  opts: {
+    xTitle?: string;
+    yTitle?: string;
+    anchors: [GoFishNode | undefined, GoFishNode | undefined];
+    plotNode: GoFishNode;
+  }
+): Promise<GoFishNode> {
+  const { xTitle, yTitle, anchors, plotNode } = opts;
+
+  return wrapPreservingIdentity(node, async (content) => {
+    content.name(TITLE_CONTENT_NAME);
+
+    const refs: GoFishNode[] = [];
+    const titles: GoFishNode[] = [];
+    if (xTitle !== undefined) {
+      const anchorNode = anchors[0] ?? plotNode;
+      refs.push(
+        (ref(anchorNode) as any).name(X_TITLE_ANCHOR_NAME) as GoFishNode
+      );
+      titles.push(xAxisTitle(xTitle));
+    }
+    if (yTitle !== undefined) {
+      const anchorNode = anchors[1] ?? plotNode;
+      refs.push(
+        (ref(anchorNode) as any).name(Y_TITLE_ANCHOR_NAME) as GoFishNode
+      );
+      titles.push(yAxisTitle(yTitle));
+    }
+
+    const root = (await (layer as any)([
+      content,
+      ...refs,
+      ...titles,
+    ])) as GoFishNode;
+
+    // Constraint order matters; placement is first-write-wins.
+    root.constrain((g) => {
+      const cs: any[] = [
+        // Pin the content at its origin; it never moves. Everything else seats
+        // off the (already-placed) ref stand-ins and this content bbox.
+        Constraint.align({ x: "baseline", y: "baseline" }, [
+          g[TITLE_CONTENT_NAME],
+        ]),
+      ];
+      if (xTitle !== undefined) {
+        // Center the x-title on the axis line's horizontal span (the ref is
+        // already placed, so only the title moves) …
+        cs.push(
+          Constraint.align({ x: "middle" }, [
+            g[X_TITLE_ANCHOR_NAME],
+            g[X_TITLE_NAME],
+          ])
+        );
+        // … and seat it below the FULL content bbox: title listed BEFORE the
+        // placed content anchor, so distribute's backward walk places the
+        // title's far (max) edge GAP below the content's min edge — clearing
+        // the tick/ordinal label rows that are part of the content bbox.
+        cs.push(
+          Constraint.distribute({ dir: "y", spacing: TITLE_CONTENT_GAP }, [
+            g[X_TITLE_NAME],
+            g[TITLE_CONTENT_NAME],
+          ])
+        );
+      }
+      if (yTitle !== undefined) {
+        // Mirror for the y-title: center on the axis line's vertical span …
+        cs.push(
+          Constraint.align({ y: "middle" }, [
+            g[Y_TITLE_ANCHOR_NAME],
+            g[Y_TITLE_NAME],
+          ])
+        );
+        // … and seat it left of the full content bbox (the gutter).
+        cs.push(
+          Constraint.distribute({ dir: "x", spacing: TITLE_CONTENT_GAP }, [
+            g[Y_TITLE_NAME],
+            g[TITLE_CONTENT_NAME],
+          ])
+        );
+      }
+      return cs;
+    });
+
+    return root;
+  });
 }

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -389,10 +389,19 @@ function elaborationsFor(node: GoFishNode): {
   /** Per-dim [x, y] title anchor (the axis line) for the constrained axes this
    *  node owns; undefined where the node owns no position-like axis on that dim. */
   anchors: [GoFishNode | undefined, GoFishNode | undefined];
+  /** Per-dim [x, y]: did this node own (and elaborate) an axis on that dim at
+   *  all — including an ordinal one, which contributes no `anchors` entry. An
+   *  owner CLAIMS the dim for title-anchoring purposes (see `elaborateAxes`). */
+  owned: [boolean, boolean];
 } {
   const space = node._underlyingSpace;
   if (!space)
-    return { constrained: [], refBased: [], anchors: [undefined, undefined] };
+    return {
+      constrained: [],
+      refBased: [],
+      anchors: [undefined, undefined],
+      owned: [false, false],
+    };
   const owns = (dim: 0 | 1) => (dim === 0 ? node.axis.x : node.axis.y) === true;
   // Niced [min, max] per owned POSITION dim, computed ONCE: it feeds both that
   // axis's own line/ticks and the other axis's `crossFloor` (the plot corner),
@@ -416,6 +425,7 @@ function elaborationsFor(node: GoFishNode): {
     undefined,
     undefined,
   ];
+  const owned: [boolean, boolean] = [false, false];
   for (const dim of [0, 1] as (0 | 1)[]) {
     if (!owns(dim)) continue;
     const s = space[dim];
@@ -435,10 +445,11 @@ function elaborationsFor(node: GoFishNode): {
     } else {
       continue;
     }
+    owned[dim] = true;
     if (dim === 0) node.axis.x = undefined;
     else node.axis.y = undefined;
   }
-  return { constrained, refBased, anchors };
+  return { constrained, refBased, anchors, owned };
 }
 
 /**
@@ -449,11 +460,17 @@ function elaborationsFor(node: GoFishNode): {
  *
  * Alongside the elaborated tree it bubbles up `titleAnchors` — the per-dim
  * [x, y] axis-line node a chart-level title should center on. Anchors flow up
- * from the children (a child's anchor fills a still-empty dim slot), then this
- * node's OWN axis-line anchors overwrite their dim slots. Because the walk is
- * bottom-up (children first, then self), overwriting means the ROOT-most owner
- * of a dim wins — which is what a chart-level title should describe (the
- * outermost axis spanning the whole plot, not an inner facet's axis).
+ * from the children (a child's anchor fills a still-empty dim slot), then any
+ * dim this node OWNS an axis on is CLAIMED outright: the slot is overwritten
+ * with this node's own anchor — the axis line for a position-like axis, or
+ * `undefined` for an ordinal one (no spanning line; the title pass falls back
+ * to the plot node, i.e. the span of the whole ordinal group). Because the
+ * walk is bottom-up (children first, then self), the ROOT-most owner of a dim
+ * wins — which is what a chart-level title should describe. The clearing
+ * matters for faceted charts: the root owns the ordinal facet axis while each
+ * facet owns a continuous axis on the SAME dim, and without the claim the
+ * first facet's line would bubble past the root and drag the title onto one
+ * subchart.
  *
  * Known limitation: multiple same-dim axis owners across SIBLING facets are
  * ambiguous here — they overwrite the same slot, so whichever sibling is
@@ -489,11 +506,13 @@ export async function elaborateAxes(node: GoFishNode): Promise<{
     }
   }
 
-  const { constrained, refBased, anchors } = elaborationsFor(node);
-  // This node's own axis-line anchors win their dim slots over any bubbled up
-  // from children — bottom-up recursion makes the root-most owner the winner.
+  const { constrained, refBased, anchors, owned } = elaborationsFor(node);
+  // Any dim this node owns an axis on is claimed — its own anchor replaces
+  // whatever bubbled up from children, INCLUDING replacing it with undefined
+  // when the owned axis is ordinal (so the title pass falls back to the plot
+  // instead of centering on a nested facet's line).
   for (const dim of [0, 1] as (0 | 1)[]) {
-    if (anchors[dim]) titleAnchors[dim] = anchors[dim];
+    if (owned[dim]) titleAnchors[dim] = anchors[dim];
   }
 
   if (constrained.length === 0 && refBased.length === 0) {

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -17,7 +17,7 @@ import { computePosScale } from "./domain";
 import type { Size } from "./dims";
 import { isSIZE, type UnderlyingSpace } from "./underlyingSpace";
 import { continuous } from "./domain";
-import { elaborateAxes } from "./axes/elaborate";
+import { elaborateAxes, elaborateAxisTitles } from "./axes/elaborate";
 import { elaborateLegend, legendOverhang } from "./legends/elaborate";
 
 export type CategoricalScale = {
@@ -84,6 +84,7 @@ export async function layout(
     transform,
     debug = false,
     axes = false,
+    axisFields,
   }: {
     w?: number;
     h?: number;
@@ -93,6 +94,7 @@ export async function layout(
     debug?: boolean;
     defs?: JSX.Element[];
     axes?: AxesOptions;
+    axisFields?: { x?: string; y?: string };
   },
   child: GoFishNode | Promise<GoFishNode>,
   contexts?: {
@@ -109,6 +111,8 @@ export async function layout(
   width: number;
   height: number;
   rightOverhang: number;
+  leftOverhang: number;
+  bottomOverhang: number;
 }> {
   child = await child;
   if (contexts?.session) {
@@ -130,6 +134,20 @@ export async function layout(
   child.resolveNames();
   child.resolveLabels();
   child.resolveUnderlyingSpace();
+
+  // The original root content object stays in the tree as the plot after any
+  // wrapping below (axis / legend / title elaboration each wrap, never replace,
+  // the content). Captured here so the title pass can center on it as the
+  // fallback anchor when a dim has no elaborated axis line. If axis elaboration
+  // changes nothing, `plotNode === child`.
+  const plotNode = child;
+
+  // Per-dim axis-line node for chart-level title centering (root-most owner
+  // wins). Defaults to no anchors when the `axes` block below doesn't run.
+  let titleAnchors: [GoFishNode | undefined, GoFishNode | undefined] = [
+    undefined,
+    undefined,
+  ];
 
   // Node-based axis pipeline: mark axis nodes and apply nice-rounding in-place
   if (axes) {
@@ -154,6 +172,7 @@ export async function layout(
     // pass doesn't handle (e.g. an UNDEFINED space) is inert — nothing else
     // consumes `node.axis`.
     const elaborated = await elaborateAxes(child);
+    titleAnchors = elaborated.titleAnchors;
     if (elaborated.changed) {
       child = elaborated.node;
       if (contexts?.session) child.setRenderSession(contexts.session);
@@ -173,24 +192,54 @@ export async function layout(
   const niceUnderlyingSpaceX = child._underlyingSpace![0];
   const niceUnderlyingSpaceY = child._underlyingSpace![1];
 
-  // Legend elaboration: turn the color scale into an ordinary swatch-column
-  // subtree seated beside the content (src/ast/legends/elaborate.tsx). Runs
-  // after the last resolveColorScale (it consumes the populated color map;
-  // legend fills are literal strings, never isValue, so the scale pass is NOT
-  // re-run). The wrapper preserves the content's underlying spaces
-  // (unionChildSpaces ignores the legend's UNDEFINED spaces), so the nice
-  // spaces captured above remain valid.
-  // Reference to the content node whose extent defines the final canvas. When a
-  // legend is added, `child` becomes the wrapper Layer (content + swatch column)
-  // and `contentNode` keeps pointing at the original content, so the final
-  // width/height (and the axis-title centering that reads them) stay measured off
-  // the content, not the content+legend bbox. The legend is reserved separately
-  // via `rightOverhang` below.
+  // Reference to the content node whose extent defines the final canvas
+  // (`finalW`/`finalH` via the `finalDim` readback below). Both the title pass
+  // and the legend pass wrap `child`, so `contentNode` keeps pointing at the
+  // PRE-title, pre-legend content. This matters two ways:
+  //  - The inferred canvas is measured off the content, never inflated by a long
+  //    title or a tall legend column.
+  //  - Title and legend extents past the content are reserved separately as
+  //    measured gutters (`leftOverhang`/`bottomOverhang`/`rightOverhang` below).
   const contentNode = child;
+
+  // Axis-title elaboration: seat up to two title Text nodes (x below, y rotated
+  // left) as ordinary shapes + constraints (src/ast/axes/elaborate.tsx), each
+  // centered on the axis line it describes via a `ref()` stand-in (falling back
+  // to the plot node). Runs BEFORE the legend block on purpose: the legend
+  // distributes off the titled content's bbox, and title centering must never
+  // see the legend column. Title Texts resolve UNDEFINED spaces on both dims, so
+  // the wrapper preserves the content's underlying spaces and the nice spaces
+  // captured above remain valid. The caller owns the "any title?" guard.
+  const { xTitle, yTitle } = resolveAxisTitles(axes, axisFields);
+  if (xTitle !== undefined || yTitle !== undefined) {
+    child = await elaborateAxisTitles(child, {
+      xTitle,
+      yTitle,
+      anchors: titleAnchors,
+      plotNode,
+    });
+    if (contexts?.session) child.setRenderSession(contexts.session);
+    // The title pass introduces `ref()` stand-ins (to the axis line / plot) that
+    // resolve their `selectedNode` during name resolution — without this they'd
+    // throw "Selected node not found" at layout time. Mirror the axes block:
+    // re-resolve names, then underlying space (memoized — only the new nodes).
+    child.resolveNames();
+    child.resolveUnderlyingSpace();
+  }
+
+  // Legend elaboration: turn the color scale into an ordinary swatch-column
+  // subtree seated beside the (now possibly titled) content
+  // (src/ast/legends/elaborate.tsx). Runs after the last resolveColorScale (it
+  // consumes the populated color map; legend fills are literal strings, never
+  // isValue, so the scale pass is NOT re-run). The wrapper preserves the
+  // content's underlying spaces (unionChildSpaces ignores the legend's UNDEFINED
+  // spaces), so the nice spaces captured above remain valid.
+  let legendAdded = false;
   const unitScale = contexts?.session.scaleContext.unit;
   const colorMap = isCategoricalScale(unitScale) ? unitScale.color : undefined;
   if (colorMap && colorMap.size > 0) {
     child = await elaborateLegend(child, colorMap);
+    legendAdded = true;
     if (contexts?.session) child.setRenderSession(contexts.session);
     child.resolveUnderlyingSpace(); // memoized: computes only the new nodes
   }
@@ -275,9 +324,9 @@ export async function layout(
   // Final extent: a user-given dimension is authoritative; otherwise prefer the
   // content's laid-out intrinsic size (shrink-to-fit), falling back to the
   // canvas default when the content didn't report one. Read off `contentNode`
-  // (== `child` when no legend), never the legend wrapper — so the canvas and
-  // the axis titles that center on `finalW`/`finalH` stay content-relative; the
-  // legend is reserved separately via `rightOverhang`.
+  // (== `child` when no title/legend wrapper), never an outer wrapper — so the
+  // canvas stays content-relative; title and legend extents are reserved
+  // separately as measured gutters below.
   const finalDim = (i: 0 | 1, given: number | undefined): number => {
     if (given !== undefined) return given;
     const s = contentNode.dims[i]?.size;
@@ -287,11 +336,20 @@ export async function layout(
   const finalH = finalDim(1, h);
 
   // Measured legend overhang past the content width — replaces the fixed
-  // LEGEND_MARGIN (see `legendOverhang`). Gated on whether a legend wrapper was
-  // added (`child !== contentNode`) so legend-free charts keep byte-identical
-  // widths.
-  const rightOverhang =
-    child !== contentNode ? legendOverhang(child, finalW) : 0;
+  // LEGEND_MARGIN (see `legendOverhang`). Gated on `legendAdded`, not
+  // `child !== contentNode`: a titles-only chart also wraps `child`, so the
+  // identity check would wrongly take the branch and measure a title gutter as a
+  // legend overhang.
+  const rightOverhang = legendAdded ? legendOverhang(child, finalW) : 0;
+
+  // Measured negative-space gutters off the OUTERMOST wrapper (`child`): axis
+  // tick / ordinal label rows plus any seated titles extend past the content
+  // origin into negative coordinates. This measured extent replaces the bespoke
+  // fixed Y_TITLE_MARGIN / X_TITLE_MARGIN. Same `min!` discipline as
+  // `legendOverhang`'s `max!`: a silent `?? 0` would clip the gutter and mask a
+  // layout bug, so assert the placed min is present.
+  const leftOverhang = Math.max(0, -child.dims[0].min!);
+  const bottomOverhang = Math.max(0, -child.dims[1].min!);
 
   if (debug) {
     console.log("🌳 Node Tree:");
@@ -306,6 +364,8 @@ export async function layout(
     width: finalW,
     height: finalH,
     rightOverhang,
+    leftOverhang,
+    bottomOverhang,
   };
 }
 
@@ -351,6 +411,8 @@ export const gofish = (
     width: number;
     height: number;
     rightOverhang: number;
+    leftOverhang: number;
+    bottomOverhang: number;
   };
 
   const runGofish = async (): Promise<LayoutData> => {
@@ -377,7 +439,7 @@ export const gofish = (
       }
 
       const layoutResult = await layout(
-        { w, h, x, y, transform, debug, defs, axes },
+        { w, h, x, y, transform, debug, defs, axes, axisFields },
         child,
         contexts
       );
@@ -407,9 +469,9 @@ export const gofish = (
               height: data.height,
               svgPadding,
               defs,
-              axes,
-              axisFields,
               rightOverhang: data.rightOverhang,
+              leftOverhang: data.leftOverhang,
+              bottomOverhang: data.bottomOverhang,
             },
             data.child
           );
@@ -433,72 +495,53 @@ export const render = (
     height,
     transform,
     defs,
-    axes,
-    axisFields,
     rightOverhang = 0,
+    leftOverhang = 0,
+    bottomOverhang = 0,
     svgPadding,
   }: {
     width: number;
     height: number;
     transform?: string;
     defs?: JSX.Element[];
-    axes?: AxesOptions;
-    axisFields?: { x?: string; y?: string };
     rightOverhang?: number;
+    leftOverhang?: number;
+    bottomOverhang?: number;
     svgPadding?: number;
   },
   child: GoFishNode
 ): JSX.Element => {
   const pad = svgPadding ?? PADDING;
 
-  const { xTitle, yTitle } = resolveAxisTitles(axes, axisFields);
-  const Y_TITLE_MARGIN = PADDING; // 40px left of content for rotated y-title
-  const X_TITLE_MARGIN = PADDING; // 30px below content for x-title
-  const leftMargin = yTitle ? Y_TITLE_MARGIN : 0;
-  const bottomMargin = xTitle ? X_TITLE_MARGIN : 0;
-  // Right-side space reserved for a legend overhanging the content width
-  // (measured by `layout()`; 0 when no legend / no overhang).
+  // Chrome (axis tick/label rows, titles, the legend column) is now elaborated
+  // into ordinary shapes that live in the node tree; `render()` only sizes the
+  // SVG around their measured extent — no chart-chrome special cases remain.
+  //
+  // Reserve enough on each gutter side to clear the measured overhang plus a
+  // little breathing room from the SVG edge. The `o > 0` guard keeps a chart
+  // with `padding: 0` and no chrome at zero reserve (don't invent EDGE_GAP px on
+  // an empty gutter); and because gutters ≤ `pad - EDGE_GAP` are absorbed by the
+  // existing `pad`, an untitled chart stays byte-identical to the pre-chrome
+  // output.
+  const EDGE_GAP = 8; // breathing room between gutter content and the SVG edge
+  const reserve = (o: number) => (o > 0 ? Math.max(pad, o + EDGE_GAP) : pad);
+  const leftReserve = reserve(leftOverhang);
+  const bottomReserve = reserve(bottomOverhang);
 
   const result = (
     <svg
-      width={width + leftMargin + pad + rightOverhang + pad}
-      height={height + pad + bottomMargin + pad}
+      width={leftReserve + width + rightOverhang + pad}
+      height={pad + height + bottomReserve}
       xmlns="http://www.w3.org/2000/svg"
     >
       <Show when={defs}>
         <defs>{defs}</defs>
       </Show>
       <g
-        transform={`scale(1, -1) translate(${leftMargin + pad}, ${-(height + pad)})`}
+        transform={`scale(1, -1) translate(${leftReserve}, ${-(height + pad)})`}
       >
         <Show when={transform} keyed fallback={child.INTERNAL_render()}>
           <g transform={transform ?? ""}>{child.INTERNAL_render()}</g>
-        </Show>
-        {/* x axis title */}
-        <Show when={xTitle}>
-          <text
-            transform="scale(1, -1)"
-            x={width / 2}
-            y={bottomMargin * 0.6}
-            text-anchor="middle"
-            dominant-baseline="hanging"
-            font-size="11px"
-            fill="gray"
-          >
-            {xTitle}
-          </text>
-        </Show>
-        {/* y axis title */}
-        <Show when={yTitle}>
-          <text
-            transform={`translate(${-(leftMargin * 0.5 + pad)}, ${height / 2}) scale(1, -1) rotate(-90)`}
-            text-anchor="middle"
-            dominant-baseline="middle"
-            font-size="11px"
-            fill="gray"
-          >
-            {yTitle}
-          </text>
         </Show>
       </g>
     </svg>

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -524,7 +524,12 @@ export const render = (
   // existing `pad`, an untitled chart stays byte-identical to the pre-chrome
   // output.
   const EDGE_GAP = 8; // breathing room between gutter content and the SVG edge
-  const reserve = (o: number) => (o > 0 ? Math.max(pad, o + EDGE_GAP) : pad);
+  // Ceil: the reserve becomes the root <g> translate, and a fractional
+  // translate (measured overhangs are routinely fractional — text widths)
+  // shifts every shape off the pixel grid: adjacent area/bar segments grow
+  // hairline antialiasing seams and text rasterizes fuzzy.
+  const reserve = (o: number) =>
+    o > 0 ? Math.ceil(Math.max(pad, o + EDGE_GAP)) : pad;
   const leftReserve = reserve(leftOverhang);
   const bottomReserve = reserve(bottomOverhang);
 

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -80,6 +80,39 @@ type TextLayout = {
   anchor: { x: number; y: number };
 };
 
+type RelBBox = { minX: number; minY: number; maxX: number; maxY: number };
+
+/**
+ * Rotate an anchor-relative bbox by `deg` (degrees, CCW in the chart's y-up
+ * world frame) about the anchor and return the axis-aligned min/max of the
+ * rotated corners. Standard rotation matrix: x' = x·cosθ − y·sinθ,
+ * y' = x·sinθ + y·cosθ.
+ *
+ * Sanity for rotate:90 — x∈[0,w], y∈[descent,ascent] (the unrotated relative
+ * box, anchor at the start baseline) maps to x∈[−ascent,−descent], y∈[0,w]:
+ * a narrow strip left of the anchor extending up — exactly the footprint a
+ * conventional y-axis title occupies in the left gutter.
+ */
+const rotateRelBBox = (b: RelBBox, deg: number): RelBBox => {
+  const rad = (deg * Math.PI) / 180;
+  const cos = Math.cos(rad);
+  const sin = Math.sin(rad);
+  const corners: [number, number][] = [
+    [b.minX, b.minY],
+    [b.maxX, b.minY],
+    [b.maxX, b.maxY],
+    [b.minX, b.maxY],
+  ];
+  const xs = corners.map(([x, y]) => x * cos - y * sin);
+  const ys = corners.map(([x, y]) => x * sin + y * cos);
+  return {
+    minX: Math.min(...xs),
+    minY: Math.min(...ys),
+    maxX: Math.max(...xs),
+    maxY: Math.max(...ys),
+  };
+};
+
 const resolveTextLayout = (
   text: string,
   fontSize: number,
@@ -125,6 +158,7 @@ export const Text = ({
   fontSize = 12,
   fontFamily = "system-ui, sans-serif",
   debugBoundingBox = false,
+  rotate = 0,
   ...fancyDims
 }: {
   key?: string;
@@ -137,6 +171,10 @@ export const Text = ({
   fontSize?: number;
   fontFamily?: string;
   debugBoundingBox?: boolean;
+  /** Rotation in degrees, applied in the chart's y-up world frame about the
+   *  text anchor. `rotate: 90` yields a conventional y-axis title — it reads
+   *  bottom-to-top with glyph tops facing left. */
+  rotate?: number;
 } & FancyDims<MaybeValue<number>>) => {
   const dims = elaborateDims(fancyDims).map(inferEmbedded);
 
@@ -160,6 +198,7 @@ export const Text = ({
         fontFamily,
         textAnchor,
         debugBoundingBox,
+        rotate,
         dims,
       },
       color: fill,
@@ -200,10 +239,21 @@ export const Text = ({
           dominantBaseline
         );
 
-        const minX = layout.bbox.minX - layout.anchor.x;
-        const maxX = layout.bbox.maxX - layout.anchor.x;
-        const minY = layout.bbox.minY - layout.anchor.y;
-        const maxY = layout.bbox.maxY - layout.anchor.y;
+        // Anchor-relative bbox. When the text is rotated, its layout footprint
+        // is the rotated box (e.g. rotate:90 turns a wide label into a tall
+        // strip left of the anchor — a y-title gutter), so we measure the
+        // axis-aligned extent of the rotated corners. rotate:0 is the identity
+        // here, but we skip the matrix so unrotated text is bit-for-bit
+        // unchanged.
+        const relRaw: RelBBox = {
+          minX: layout.bbox.minX - layout.anchor.x,
+          maxX: layout.bbox.maxX - layout.anchor.x,
+          minY: layout.bbox.minY - layout.anchor.y,
+          maxY: layout.bbox.maxY - layout.anchor.y,
+        };
+        const { minX, maxX, minY, maxY } = rotate
+          ? rotateRelBBox(relRaw, rotate)
+          : relRaw;
 
         const positionX =
           computeAesthetic(dims[0].center, posScales?.[0]!, undefined) ??
@@ -283,10 +333,19 @@ export const Text = ({
         const bboxDash = "4 3";
         const showDebugBoundingBox = debugBoundingBox;
 
-        const minXRel = layout.bbox.minX - layout.anchor.x;
-        const maxXRel = layout.bbox.maxX - layout.anchor.x;
-        const minYRel = layout.bbox.minY - layout.anchor.y;
-        const maxYRel = layout.bbox.maxY - layout.anchor.y;
+        // Debug rect shows the TRUE (rotated) footprint, so route the relative
+        // box through the same rotation the layout pass used.
+        const relRaw = {
+          minX: layout.bbox.minX - layout.anchor.x,
+          minY: layout.bbox.minY - layout.anchor.y,
+          maxX: layout.bbox.maxX - layout.anchor.x,
+          maxY: layout.bbox.maxY - layout.anchor.y,
+        };
+        const relRot = rotate ? rotateRelBBox(relRaw, rotate) : relRaw;
+        const minXRel = relRot.minX;
+        const maxXRel = relRot.maxX;
+        const minYRel = relRot.minY;
+        const maxYRel = relRot.maxY;
 
         const bbox =
           showDebugBoundingBox &&
@@ -306,13 +365,25 @@ export const Text = ({
             />
           ) : null;
 
+        // Unrotated: byte-identical markup to before (capture-diff must not
+        // see unrotated text move). Rotated: scale(1,-1) flips glyph space into
+        // the y-up world orientation, rotate(θ) is then the SAME matrix as
+        // rotateRelBBox (so render and the measured bbox agree), and translate
+        // moves the anchor to the placed position — emitted x/y are 0 because
+        // the translate already carries the placement.
+        const textTransform = rotate
+          ? `translate(${anchorX}, ${anchorY}) rotate(${rotate}) scale(1, -1)`
+          : "scale(1, -1)";
+        const textX = rotate ? 0 : anchorX;
+        const textY = rotate ? 0 : -anchorY;
+
         return (
           <>
             {bbox}
             <text
-              transform="scale(1, -1)"
-              x={anchorX}
-              y={-anchorY}
+              transform={textTransform}
+              x={textX}
+              y={textY}
               fill={resolvedFill}
               stroke={resolvedStroke}
               stroke-width={strokeWidth ?? 0}


### PR DESCRIPTION
Closes #515. Closes #390. Closes #93.

Completes the chrome-elaboration arc started by axes (#490) and legends (#512): axis titles were the last bespoke render-time chrome — raw `<text>` elements behind fixed 40px `Y_TITLE_MARGIN`/`X_TITLE_MARGIN` in `render()`. They are now ordinary GoFish shapes + constraints produced by an elaboration pass, and `render()` contains zero chart-chrome special cases.

## What changed

- **`elaborateAxisTitles`** (`axes/elaborate.tsx`): a chart-level pass (one title per dim, resolved from `axes` options + inferred `axisFields`) that wraps the chart in a Layer seating up to two title `Text` nodes. Each title **centers on the elaborated axis line it describes** via a `ref()` stand-in — so a difference axis (spans the data width) or a facet-owned axis (spans its facet) gets a correctly-tracking title — falling back to the plot node for ordinal axes. Titles `distribute` past the full content bbox, so they clear tick/ordinal label rows (the bespoke path could overlap them). `xAxisTitle`/`yAxisTitle` are exported pure builders (the customization seam, like `legendColumn`).
- **Title anchors**: `AxisElaboration` gains `anchor?: GoFishNode` (the axis line) and `elaborateAxes` returns per-dim `titleAnchors`, root-most owner wins. Sibling facets owning the same dim's axis remain ambiguous (flagged in a comment, not solved).
- **`Text` gains `rotate`** (degrees, y-up world frame about the anchor; `rotate: 90` = conventional y-title). Layout measures the rotated bbox; unrotated markup is byte-identical to before. JS-side only — nothing crosses the IR bridge, so no schema change.
- **Measured chrome reservation** (`gofish.tsx`): `layout()` returns `leftOverhang`/`bottomOverhang` measured off the laid-out tree; `render()` reserves `max(pad, overhang + 8)` per edge instead of fixed title margins, continuing #509's size-chrome-off-computed-extent direction. This also **fixes the silent clipping** of gutters wider than the 40px pad (e.g. whisker's `100000` y labels, stringline's left labels).
- The legend gate becomes an explicit `legendAdded` boolean (`child !== contentNode` would misfire on titles-only charts). Pass ordering: axes → titles → legend, with `contentNode` captured pre-title so a long title can't inflate the inferred canvas.
- Internals wiki essays (`layout/passes`, `frontend/axes`, `frontend/legends`) updated in the same change.

## Verification

- `pnpm capture-diff` vs the base commit: **91 stories changed, 0 added/removed**, fully categorized: titled charts re-seated with measured margins (most), the intended clipping fix (whisker ×3, stringline, constraints ×2), and ~11 false positives from absolute image `href` paths in the diff harness's temp worktree.
- Visually inspected axes permutations (bool/per-dim/custom/suppressed titles), scatter (continuous x+y + corner), stacked bar + legend, mosaic (difference axes), faceted chart. y-titles read bottom-to-top centered on the y-axis line; x-titles center on the x-axis and clear labels; legends seat unchanged.
- `validate-python-ir`: 119/119 pass. Build + lint clean. Rebased onto #513 (ref unification) and re-verified.

## Notes for reviewers

- **Visual baselines need CI regeneration** — expected diffs are exactly the titled stories plus the clipping-fix stories above.
- A very wide x-title on a legend-free chart could in principle poke past the right `pad`; left to the existing right-edge `pad` for scope (worth a follow-up issue if it bites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review follow-ups (second commit)

- **Faceted charts: titles centered on one subchart** (`faceted-chart--faceted-scatter-driving`/`--faceted-scatter-y`): the root owns the ordinal facet axis while each facet owns a continuous axis on the *same* dim; ordinal elaborations contribute no anchor, so the first facet's axis line bubbled past the root and the chart-level title centered on it. An axis owner now **claims** every dim it owns — overwriting the bubbled slot with its own anchor, or with `undefined` for an ordinal axis, so the title falls back to the plot node (the span of the whole ordinal group).
- **Edge reserves snapped to whole pixels**: the reserve becomes the root `<g>` translate, and measured overhangs are routinely fractional (text widths). A fractional translate shifts every shape off the pixel grid — hairline antialiasing seams between adjacent area/bar segments, fuzzy text. `reserve()` now ceils.
- Verified vs `origin/main`: same 91-story changed set as before, zero fractional root translates remain, faceted titles now seat below/left of the ordinal label rows centered on the whole group. (The reported `area--basic` / `bar/with-labels--default` shifts turned out to be incidental — byte-identical to `origin/main`; the local `main` ref is 5 commits stale, so diffs against it pick up #509/#512/#513 churn.)
