### PR TITLE
fix(connect): merge line/area segments at zero-extent joints into one region (#520)

### DIFF
--- a/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
@@ -426,6 +426,57 @@ export const connect = createNodeOperator(
             }
           }
 
+          // Merge consecutive segments that meet at a zero-extent joint into a
+          // single region/polyline (#520). Each pair was emitted as its own path,
+          // but adjacent segments share an edge at exact coordinates, so rendering
+          // them as separate <path>s lets antialiasing open hairline ~0.5px seams
+          // off the pixel grid. One path per run is gap-proof by construction.
+          //
+          // The joint between paths[i] and paths[i+1] is child i+1; it "has no
+          // extent" when that child collapses to a point on the connection
+          // (direction) axis (area points are zero-width; bar-like children with
+          // real width genuinely don't share an edge and must stay separate).
+          const EPS = 1e-6;
+          const jointMerges = (i: number): boolean => {
+            // center mode connects exact center points — always contiguous
+            if (mode === "center") return true;
+            // the joint between paths[i] and paths[i+1] is child i+1
+            const b = childPlaceables[i + 1].dims;
+            return Math.abs((b[dir].max ?? 0) - (b[dir].min ?? 0)) < EPS;
+          };
+
+          const flushRun = (run: Path[]): Path => {
+            if (run.length === 1) return run[0];
+            if (mode === "center") {
+              // Single-segment lines → one continuous polyline.
+              return run.flat();
+            }
+            // Each edge-mode segment is a quad
+            // [leadingEdge, endCap, trailingEdge, startCap]. Trace every leading
+            // edge forward, cap the last segment, trace every trailing edge back
+            // (reverse order; interior caps are zero-length so segments chain
+            // exactly), then cap the first — one closed region.
+            return [
+              ...run.map((p) => p[0]),
+              run[run.length - 1][1],
+              ...run
+                .slice()
+                .reverse()
+                .map((p) => p[2]),
+              run[0][3],
+            ];
+          };
+
+          const mergedPaths: Path[] = [];
+          let run: Path[] = [];
+          for (let i = 0; i < paths.length; i++) {
+            run.push(paths[i]);
+            if (i === paths.length - 1 || !jointMerges(i)) {
+              mergedPaths.push(flushRun(run));
+              run = [];
+            }
+          }
+
           // If no paths were created, use zero dimensions
           const bboxW = bboxPairs.length > 0 ? bboxMaxX - bboxMinX : 0;
           const bboxH = bboxPairs.length > 0 ? bboxMaxY - bboxMinY : 0;
@@ -446,7 +497,7 @@ export const connect = createNodeOperator(
               },
             ],
             transform: { translate: [0, 0] },
-            renderData: { paths, defaultColor },
+            renderData: { paths: mergedPaths, defaultColor },
           };
         },
         render: (
@@ -485,7 +536,11 @@ export const connect = createNodeOperator(
                           (mode === "center" ? "normal" : "multiply"),
                       }}
                       d={d}
-                      fill={resolvedFill ?? "none"}
+                      // center mode is a stroked polyline, not a filled region —
+                      // a merged multi-point path would otherwise enclose area (#520)
+                      fill={
+                        mode === "center" ? "none" : (resolvedFill ?? "none")
+                      }
                       stroke={stroke ?? resolvedFill ?? "black"}
                       stroke-width={strokeWidth ?? 0}
                       opacity={opacity ?? 1}


### PR DESCRIPTION
Closes #520.

## Problem

Connected line/area marks (`line()`, `area()`, both backed by the `connect` operator) emitted **one SVG `<path>` per segment** — one per consecutive child pair. In an area chart the children are zero-width points, so adjacent segments share an edge at exactly the same coordinates. Off the pixel grid (fractional sizes, transforms, zoom) each segment antialiases independently and hairline ~0.5px seams open between regions that are visually one shape.

#518 snapped the root translate to whole pixels, hiding the artifact at the top level, but any fractional coordinate *inside* the chart still produced seams. This is the principled fix.

## Change

A post-process merge step in the `connect` operator's `layout`: consecutive segments that meet at a **zero-extent joint** (the shared child collapses to a point on the connection axis) are merged into a single path.

- **Edge mode (areas):** one closed region — all leading edges forward, last end cap, all trailing edges in reverse, first start cap. Works for both linear and bezier (same quad structure).
- **Center mode (lines):** one continuous polyline.
- Joints with **real direction-axis extent** (bar-like children, e.g. the Ribbon story) correctly stay separate.
- Center-mode connections now render `fill="none"` — a merged multi-point polyline would otherwise enclose area (each pre-merge line was a degenerate 2-point path where the fill was invisible).

Gap-proof by construction, with far fewer DOM nodes and simpler hit-testing.

## Verification

`capture-diff` vs `main` — only `connect`-using stories moved, all visually verified correct, with large DOM-node reductions:

| Story | paths before | after |
|---|---|---|
| area / basic | ~6 | 1 |
| area / stacked | — | 5 (one per species) |
| scatter / connected | 54 | 1 |
| violin-plot | 1533 | 3 |
| stringline-chart | 1214 | 68 |

Ribbon (area over width-bearing `rect` bars) is byte-identical to `main`, confirming the no-merge path. `whisker` changed only `fill="gray"`→`fill="none"` on identical 2-point lines (visually identical). No API, docs, or IR-schema changes (purely internal rendering); Python parity unaffected.

> [!NOTE]
> Visual baselines were **not** regenerated locally (Mac text-metric drift vs CI). The merge is expected to change them — CI should update them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)