### PR TITLE
Self-scaling regions + measure-typed space unification; marginal histogram (jointplot) example

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -7,6 +7,9 @@ covers:
   - packages/gofish-graphics/src/ast/underlyingSpace.ts
   - packages/gofish-graphics/src/ast/_node.ts
   - packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+  - packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+  - packages/gofish-graphics/src/ast/channels.ts
+  - packages/gofish-graphics/src/ast/data.ts
 ---
 
 # The underlying space tree
@@ -343,6 +346,150 @@ them via the `scaleFactors` parameter and apply them in `computeSize`.
 This dispatch is the practical embodiment of the underlying-space-kind
 distinction. It also happens to make the rendering pipeline more readable:
 once you know the kind, you know which arithmetic applies.
+
+## Self-scaling regions: an explicit pixel size absorbs an axis
+
+The root resolves its scales against the canvas: POSITION → a posScale onto
+the pixel box, SIZE → invert the Monotonic against the canvas size. A
+`layer` (or `frame`) given an **explicit pixel size on a dim** does the same
+thing one level down — "a chart embeds the way it renders." On that dim it
+becomes a self-contained **scaling region**: its data space is absorbed
+internally rather than contributed to whatever shared space its parent is
+building.
+
+The motivating case is a marginal histogram, seaborn-jointplot style: a
+center scatter in data units, with a count histogram pinned along each edge.
+The histograms are sized to a fixed pixel band (`Chart(data, { h: 80 })`),
+and their count axis must not union into the scatter's shared x/y domains —
+counts and beak-length millimeters are foreign units. The explicit pixel
+size is exactly the signal that this region carries its own scale.
+
+The rule lives in `layer`'s resolver and layout
+(`graphicalOperators/layer.tsx`), in two halves:
+
+- **`resolveUnderlyingSpace`.** After resolving each axis normally, for any
+  dim that has an explicit pixel size and whose resolved space is
+  POSITION-with-domain or SIZE, the real space is **stashed** and `UNDEFINED`
+  is reported upward. A parent layer's `unionChildSpaces` then ignores that
+  axis (UNDEFINED carries no opinion — see [The contract](#the-contract))
+  instead of polluting a shared domain with the absorbed region's units.
+  ORDINAL and DIFFERENCE unions are left untouched.
+- **`layout`.** The stashed space gets a **local** scale built against the
+  layer's own pixel box, applying the root's recipe: POSITION →
+  `posScaleFromSpace(stashed, size[dim])`, SIZE → a local scale factor from
+  `stashed.domain.inverse(size[dim])` (the Monotonic inverted against the
+  box). These locals override the inherited posScale / scale factor on that
+  dim — definitionally, since the inherited scale is in the parent's foreign
+  units — for both the children and the layer's own constraint resolution. If
+  the size can't be resolved (NaN), the locals are left undefined and the dim
+  degrades to the inherited path rather than producing NaN scales.
+
+Note that a histogram's count axis is **not** SIZE at the frame boundary.
+Under start/end/baseline alignment, `resolveAlignmentSpace` (`alignment.ts`)
+converts all-SIZE children into `POSITION([0, max], fromSize)` — it commits
+the data-driven extents to a positional axis so they can be aligned. Without
+the self-scaling rule, that count POSITION would union straight into the
+shared axes as if it were data units; the rule is what keeps the absorbed
+axis from leaking.
+
+The space reported upward is plain `UNDEFINED` for now. Issue #508's
+proposed CONSTANT kind — "this axis has a known fixed pixel extent" — is the
+eventual, more honest home for what a self-scaling region contributes to its
+parent.
+
+## Measures: units are types
+
+The self-scaling region above is the heavy hammer — give a sub-chart an
+explicit pixel size and its axis stops talking to the outside entirely. But
+the marginal histogram has a subtler need at the _shared_ boundary. When the
+top count histogram and the center scatter overlay on x, the union should
+succeed (both are beak-length millimeters along x) and the count axis, folded
+into a position interval, should _not_ pollute that millimeter domain. The
+shared union has to tell "same units, merge" from "foreign units, refuse"
+without a human reading the field names.
+
+That distinction is a **measure**: a unit-of-measure tag carried on a space.
+POSITION, DIFFERENCE, and SIZE each gain an optional `measure?: Measure`
+(`Measure` is just a string — a field name like `"Beak Depth (mm)"`, or
+`"count"`). It is the dead `source?` slot's replacement, but with teeth:
+spaces now **unify per measure**.
+
+```ts
+// underlyingSpace.ts
+export type POSITION_TYPE = { kind: "position"; domain: Interval; measure?: Measure; ... };
+```
+
+**Merging.** Two helpers in `underlyingSpace.ts` decide what happens when two
+measures meet. `undefined` is always permissive — it means "no claim", unifies
+with anything, and yields the other side (this is why `getMeasure` returns
+`undefined` rather than a `"unit"`/`"unknown"` sentinel: a measureless value
+must merge silently into a tagged one).
+
+- `mergeMeasures(a, b, context)` — unify as **types**. Equal measures unify to
+  themselves; two _different_ defined measures are a type error and it
+  **throws**. This is the guard on the shared union: `unionChildSpaces`'
+  mixed/POSITION collection (`alignment.ts`) and `resolveAlignmentSpace`'s
+  DIFFERENCE/POSITION branches use it, so overlaying a count axis onto a
+  millimeter axis fails loudly instead of corrupting the domain.
+- `forgetOnConflict(a, b)` — a conflict **forgets** (returns `undefined`)
+  rather than throwing. Used where composing differently-measured spaces is
+  legitimate: stacking two different fields' SIZEs produces a real extent that
+  carries no single unit, so SIZE∘SIZE composition in `unionChildSpaces`
+  forgets on conflict, and `resolveAlignmentSpace`'s all-SIZE reduce uses it
+  too.
+
+So the rule of thumb: **aligning/overlaying siblings throws on a unit clash;
+composing them into a new extent forgets.**
+
+**Where measures come from** is itself a small type system with three sources,
+checked (not silently prioritized) in `resolveMeasure` (`channels.ts`):
+
+1. **Explicit annotation** — `field(name, measure)` / `datum(v, measure)`
+   (`data.ts`). A real type claim about the channel's unit.
+2. **Inferred provenance** — a transform tags its output array. `bin()`
+   (`transforms.ts`) attaches a field→measure map under the well-known
+   `MEASURE_PROVENANCE` symbol (`data.ts`): its `start`/`end`/`size` columns
+   are still in the _source_ field's units (e.g. millimeters), and `count` is
+   `"count"`. The symbol rides the array, not each row, so it survives
+   `derive(...)`. Also a real type claim.
+3. **Field-name default** — a bare string accessor's field name. A _weak_
+   binding, not a claim; it yields to either of the above.
+
+`resolveMeasure` reads annotation and provenance together: if both are present
+and **disagree**, it throws immediately at the channel — before any space union
+runs — naming the field and both measures. Otherwise annotation refines the
+weak default, and with no annotation the result is `provenance ?? field-name`.
+This completes the field/datum/literal trichotomy of issue #266: a literal has
+no field identity (no measure), a bare field name is a weak default, and an
+annotation or provenance is a hard claim. `inferSize`/`inferPos` tag the
+`value(...)` they emit with this resolved measure, which is what eventually
+lands on the space.
+
+**Propagation through the SIZE→POSITION conversion.** A histogram's count axis
+is all-SIZE at the children, and `resolveAlignmentSpace`'s start/end/baseline
+branch converts all-SIZE children into `POSITION([0, max])`. That conversion
+now carries the merged child measure forward (a `forgetOnConflict` reduce) — it
+is load-bearing, because it is exactly how the count POSITION acquires its
+`"count"` tag so a later overlay union can recognize it as foreign and refuse.
+
+**The error and its remedies.** A clash from `mergeMeasures` reads:
+
+> Cannot unify underlying spaces with different measures: `"A"` and `"B"`. If
+> these are the same units, assert that with `field(name, measure)` or
+> `datum(v, measure)`. If they are different units, give the inner chart an
+> explicit `w`/`h` so it becomes a self-scaling region.
+
+The two remedies are the two escape hatches this essay already describes:
+annotate to declare the units _are_ the same (collapsing them to one measure),
+or wrap the foreign region in an explicit pixel size so it absorbs its own
+axis (the [self-scaling region](#self-scaling-regions-an-explicit-pixel-size-absorbs-an-axis)
+above) and never reaches the shared union at all.
+
+**Stage 2.** This is Stage 1: one measure per axis, unified or refused. The
+sequel is a measure-keyed _family_ of underlying spaces per axis — true
+multi-scale, where a single axis can host several measures at once (dual axes).
+That is also the natural place for axis titles to read a measure off the space
+they describe (cf. issues #452, #386).
 
 ## Axis inference
 

--- a/apps/docs/docs/internals/frontend/mark-factory.md
+++ b/apps/docs/docs/internals/frontend/mark-factory.md
@@ -94,6 +94,20 @@ If your prop should be a position offset (mean rather than sum), see the
 own; `createMark` could grow a `"pos"` channel the same way if a future shape
 needs one.
 
+`inferSize` and `inferPos` are two instantiations of one numeric-inference
+factory, `inferNumeric(agg)` — they differ only in the aggregation (`sumBy`
+vs `meanBy`). Both take an optional third argument, a resolved `Measure`: a
+string/`field()` accessor's produced value is tagged with its unit-of-measure
+so the underlying-space layer can unify scales per measure (see
+[Underlying Space](/internals/core/underlying-space)). When the caller doesn't
+pass one (e.g. `createMark`'s size channel), the inferer resolves it locally
+via `resolveMeasure(data, accessor)` — explicit `field(name, measure)`
+annotation, else transform provenance riding the data array (`bin()` tags its
+output), else the field name as a weak default; a contradictory
+annotation-vs-provenance pair throws at the channel. `createOperator` hoists
+`resolveMeasure` to once per channel and passes the result down, since the
+accessor and provenance are loop-invariant across split entries.
+
 A prop that does not appear in the annotations map (e.g. `Rect.cornerRadius`)
 is passed through to `shapeFn` exactly as the user wrote it.
 
@@ -166,9 +180,10 @@ channel — say `rotation: number` — passes through verbatim.
 Today's channels are `"size"` and `"color"`. To add (say) `"angle"`:
 
 1. Add `"angle"` to the `ChannelType` union in `channels.ts`.
-2. Write `inferAngle(accessor, data)` next to `inferSize` — same shape, just
-   the aggregation rule that makes sense for angles (probably a literal-or-mean
-   like `inferPos`).
+2. If a numeric aggregation fits, instantiate the existing factory —
+   `export const inferAngle = inferNumeric(meanBy)` (or whatever aggregation
+   makes sense) — and measure tagging comes along for free. Otherwise write
+   `inferAngle(accessor, data, measure?)` next to it with the same signature.
 3. Extend `DeriveMarkProps`'s conditional with the input type for `"angle"`.
 4. Extend the `if (channelType === "size") ... else if (channelType === "color")`
    chain in `withGoFish.ts` to handle it.

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -153,6 +153,10 @@ for the API.
         "connect": {
           "$ref": "#/$defs/MarkIR"
         },
+        "name": {
+          "type": "string",
+          "description": "Chart-level name so a sibling Layer constrain callback can reference this chart."
+        },
         "origin": {
           "$ref": "#/$defs/Origin"
         },
@@ -176,6 +180,13 @@ for the API.
         },
         "options": {
           "type": "object"
+        },
+        "constraints": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ConstraintIR"
+          },
+          "description": "Layer-level constraints (Layer([...]).constrain(...)), resolving refs against the child charts' names."
         },
         "origin": {
           "$ref": "#/$defs/Origin"

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -486,6 +486,10 @@ for the API.
             },
             "name": {
               "type": "string"
+            },
+            "measure": {
+              "type": "string",
+              "description": "Optional unit annotation for the channel's underlying space (a type claim; see field(name, measure))."
             }
           }
         },

--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -319,11 +319,16 @@ default-width bars and a width of `n·barWidth + spacing`). A user-supplied
 dimension is always authoritative. This computed extent — not the raw option — is
 what the render pass uses to size the SVG. The legend is now part of the laid-out
 tree (it is elaborated into the node tree during layout, see Pass 7), so it is
-included in this computed extent when `w`/`h` are omitted. When `w` _is_ given,
-`layout()` additionally measures a `rightOverhang` (how far the tree, legend
-included, extends past the authoritative width) and the render pass reserves
-exactly that on the right of the SVG — replacing the former fixed `LEGEND_MARGIN`
-constant. See [Legends](/internals/frontend/legends).
+included in this computed extent when `w`/`h` are omitted. When a dimension _is_
+given, `layout()` additionally measures how far the laid-out tree extends past the
+authoritative extent on each of the four sides — including content a constraint
+seated _beyond_ the canvas, e.g. a marginal histogram's bands above and to the
+right of a scatter — and the render pass reserves exactly that, replacing the
+former fixed `LEGEND_MARGIN` constant. The right side is split into two measured
+overhangs: a `rightOverhang` for a legend swatch column (gated on whether a legend
+was added) and a `rightContentOverhang` for any non-legend content displaced past
+the right edge — see Render Pass 2 below for why the split is necessary. See
+[Legends](/internals/frontend/legends).
 
 > Literal pixel sizes are invisible to the underlying-space tree (a fixed-size
 > shape resolves to `UNDEFINED`, not `SIZE`), which is why the unsized path relies
@@ -444,7 +449,7 @@ return render(
 
 `render()` no longer takes `axes`/`axisFields` or the scale/space context — all
 the chrome is in the laid-out tree by now, so render only needs the computed
-extent and the three measured gutter overhangs to size the SVG.
+extent and the measured per-side overhangs to size the SVG.
 
 ### Render Pass 1: Context Restoration
 
@@ -470,16 +475,23 @@ node tree like any other shape. The former bespoke render-time path (hand-writte
 has been deleted, so `render()` has zero chart-chrome special cases left.
 
 What `render()` _does_ do is size the SVG around the measured extent of that
-chrome. `layout()` hands it three gutter measurements — `leftOverhang`,
-`bottomOverhang` (negative-space gutters off the outermost wrapper: tick/label
-rows plus the seated y-title and x-title) and `rightOverhang` (the legend
-column) — and the render pass reserves exactly enough on each side:
+chrome, on all four sides. `layout()` hands it five gutter measurements:
+`leftOverhang`, `bottomOverhang`, and `topOverhang` (negative-space gutters and
+top overflow off the outermost wrapper: tick/label rows, the seated y-title and
+x-title, and any content a constraint seated above the canvas), plus the two
+right-side overhangs — `rightOverhang` (the legend swatch column) and
+`rightContentOverhang` (non-legend content displaced past the right edge). The
+render pass reserves exactly enough on each side:
 
 ```typescript
 const EDGE_GAP = 8; // breathing room between gutter content and the SVG edge
-const reserve = (o: number) => (o > 0 ? Math.max(pad, o + EDGE_GAP) : pad);
+const reserve = (o: number) =>
+  o > 0 ? Math.ceil(Math.max(pad, o + EDGE_GAP)) : pad;
 const leftReserve = reserve(leftOverhang);
 const bottomReserve = reserve(bottomOverhang);
+const topReserve = reserve(topOverhang);
+// right side: legend column + non-legend displaced content
+// width = leftReserve + width + rightOverhang + reserve(rightContentOverhang)
 ```
 
 The `o > 0` guard keeps a chart with `padding: 0` and no chrome at zero reserve
@@ -487,8 +499,22 @@ The `o > 0` guard keeps a chart with `padding: 0` and no chrome at zero reserve
 within the existing `pad` is absorbed by it, an untitled chart with a small
 gutter stays byte-identical to the pre-chrome output. The measured-overhang
 policy also fixes a latent bug: the old fixed 40px margins silently _clipped_ any
-gutter wider than themselves (long y tick labels), whereas `reserve()` grows to
-fit whatever the laid-out chrome actually needs.
+gutter wider than themselves (long y tick labels, **or content a constraint
+seated past the canvas — marginal histogram bands, wide diagram nodes**), whereas
+`reserve()` grows to fit whatever the laid-out content actually needs.
+
+**Why the right side is special.** Left, bottom, and top each have a single kind
+of overhang (chrome or displaced content) and run through `reserve()` uniformly.
+The right side carries _two_ kinds that must be reserved _differently_: a legend
+column historically reserves `legendOverhang + pad`, while displaced content
+(like a marginal band) should run through `reserve()` like the other gutters. The
+two cannot be unified by magnitude — a single-row legend overhangs by roughly the
+same few pixels as a wide rightmost x-tick label, yet the legend must be _added_
+to the width while the tick spill must be _absorbed_ into `pad`. Only the
+color-scale flag (`legendAdded`) can tell them apart, so the legend keeps its own
+gated `rightOverhang` term; everything else flows through `rightContentOverhang`
+and `reserve()`. This is the one place a chart-chrome flag still influences
+sizing — kept deliberately, because the distinction is semantic, not geometric.
 
 ### Render Pass 3: SVG Container Creation
 

--- a/apps/docs/docs/internals/overview/architecture.md
+++ b/apps/docs/docs/internals/overview/architecture.md
@@ -61,8 +61,10 @@ render-time fixtures. Before layout, elaboration passes rewrite each of them int
 ordinary marks and constraints — `Layer`-wrapped `Rect`/`Text` nodes seated by
 `align`/`distribute`/`position` — so chrome flows through the same three passes
 as the data marks. The orchestrator (`gofish.tsx`) then sizes the SVG off the
-laid-out tree's **measured extent** (the legend's overhang past the content, the
-axis/title gutters past the origin); there are no fixed chrome margins. See
+laid-out tree's **measured extent on all four sides** — the legend's overhang
+past the content, the axis/title gutters past the origin, and any content a
+constraint seated beyond the canvas (a marginal histogram's bands above and to
+the right of a scatter); there are no fixed chrome margins. See
 [Axes](/internals/frontend/axes) (which also covers axis titles) and
 [Legends](/internals/frontend/legends).
 

--- a/apps/docs/docs/js/api/core/render.md
+++ b/apps/docs/docs/js/api/core/render.md
@@ -41,6 +41,20 @@ chart(data)
   .render(container, { h: 300 });
 ```
 
+### Explicit size makes a self-contained scale region
+
+When you give a (sub)chart an explicit `w`/`h` on a dimension, its scale on that
+dimension resolves against that pixel box rather than against any larger layout it
+is composed into. The axis becomes self-contained: a chart sized this way can be
+dropped into a bigger graphic without sharing — or polluting — the surrounding
+axes with its own units.
+
+This is what makes composed layouts like a marginal histogram work. The count
+histograms are sized to a fixed pixel band (`Chart(data, { h: 80 })` /
+`Chart(data, { w: 80 })`) and laid out alongside a center scatter; because each
+histogram absorbs its own count scale, only the scatter's data units drive the
+shared x/y axes.
+
 ## Axes
 
 The `axes` option controls per-axis visibility and titles:

--- a/apps/docs/docs/js/api/operators/derive.md
+++ b/apps/docs/docs/js/api/operators/derive.md
@@ -51,3 +51,46 @@ derive(fn);
   ]))
 )
 ```
+
+## Measures: keeping units across a transform
+
+A channel that encodes a field carries that field's **measure** — its
+unit-of-measure, like `"Beak Depth (mm)"` or `"count"`. GoFish uses measures to
+decide when two axes may share a scale: overlaying or aligning marks whose axes
+have the _same_ measure merges their domains, while mixing _different_ measures
+(say, a count axis with a millimeter axis) is refused with an error rather than
+silently corrupting the shared domain.
+
+By default the measure is just the field name, which is usually right. Two
+things change it:
+
+- **`bin()` and other built-in transforms** tag their output automatically — a
+  histogram's `start`/`end`/`size` columns keep the _source_ field's units, and
+  `count` becomes `"count"`. You don't annotate anything; the tag survives
+  through `derive`.
+- **An arbitrary `derive`** can lose that connection — once you compute a new
+  column, GoFish only knows its name, not its unit. When the new column is
+  really in some existing unit (and you want its axis to share with that unit's
+  axis), annotate the channel with the second argument to `field`:
+
+  ```ts
+  import { field } from "gofish-graphics";
+
+  // `depthMm` was derived but is still millimeters:
+  .mark(rect({ y: field("depthMm", "Beak Depth (mm)") }))
+  ```
+
+  `datum(v, measure)` does the same for a literal value.
+
+If you hit **"Cannot unify underlying spaces with different measures"**, you
+have two remedies:
+
+1. If the units really are the same, say so with `field(name, measure)` /
+   `datum(v, measure)` so the axes collapse to one measure and merge.
+2. If the units really differ, give the inner chart an explicit `w`/`h` so it
+   becomes a [self-contained scale region](/js/api/core/render#explicit-size-makes-a-self-contained-scale-region)
+   and never shares that axis.
+
+Annotating a channel whose measure contradicts a transform's provenance (e.g.
+calling `field("count", "mm")` on a `bin()` output) is itself an error — the
+annotation and the provenance are contradictory claims.

--- a/apps/docs/docs/python/api/core/chart.md
+++ b/apps/docs/docs/python/api/core/chart.md
@@ -103,7 +103,24 @@ consume directly. Use `ref("layerName")` as data for the singular case: it retur
 After a selection the stream is refs, so re-encode with a datum path —
 `group(by="datum.species")`; see
 [`spread` → path-aware `by`](/python/api/operators/spread#path-aware-by). See
-[`mark`](/python/api/core/mark) for `.name()`.
+[`mark`](/python/api/core/mark) for `.name()` on a mark.
 
 For the full reference — singular-as-data rules, node-unit selection, hygienic
 scoping, and connector use — see [`ref` / `selectAll`](/python/api/selection/ref).
+
+## Naming a chart: `.name()`
+
+A **chart-level** `.name()` — distinct from naming a mark — tags the whole
+chart so a sibling `Layer([...]).constrain(...)` callback can reference it by
+that name (mirrors JS `chart.resolve().name(...)`). The constrain lambda's
+parameter names match the charts' `.name()` strings:
+
+```python
+sc = chart(data).flow(scatter(x="x", y="y")).mark(circle(r=3)).name("scatter")
+top = chart(data, h=80).flow(...).mark(rect(h="count")).name("topHist")
+
+Layer([sc, top]).constrain(lambda scatter, topHist: [
+    Constraint.align([scatter], x="baseline", y="baseline"),
+    Constraint.position([topHist], y=410, anchor="start"),
+])
+```

--- a/apps/docs/docs/python/api/operators/derive.md
+++ b/apps/docs/docs/python/api/operators/derive.md
@@ -67,3 +67,46 @@ derive(lambda d: normalize(d, "count"))
   game.
 - Because it round-trips to Python, a `derive` step is a callback, not a static
   transform; it re-runs whenever the chart re-renders.
+
+## Measures: keeping units across a transform
+
+A channel that encodes a field carries that field's **measure** — its
+unit-of-measure, like `"Beak Depth (mm)"` or `"count"`. GoFish uses measures to
+decide when two axes may share a scale: overlaying or aligning marks whose axes
+have the _same_ measure merges their domains, while mixing _different_ measures
+(say, a count axis with a millimeter axis) is refused with an error rather than
+silently corrupting the shared domain.
+
+By default the measure is just the field name, which is usually right. Because
+`derive` round-trips through your kernel, a transform's unit provenance does
+**not** survive the bridge — once `bin()` (or your own lambda) returns new
+columns, GoFish only knows their names, not their units. When a derived column
+is really in some existing unit and its axis should share with that unit's
+axis, annotate the channel with `field(name, measure=...)`:
+
+```python
+from gofish import bin, chart, derive, field, rect, scatter
+
+# bin edges are still beak-length millimeters, not "start"/"end" units:
+chart(penguins, h=80).flow(
+    derive(bin("Beak Length (mm)")),
+    scatter(
+        xMin=field("start", measure="Beak Length (mm)"),
+        xMax=field("end", measure="Beak Length (mm)"),
+    ),
+).mark(rect(h="count"))
+```
+
+`datum(v)` values can carry a measure the same way on the JS side.
+
+If you hit **"Cannot unify underlying spaces with different measures"**, you
+have two remedies:
+
+1. If the units really are the same, say so with `field(name, measure=...)` so
+   the axes collapse to one measure and merge.
+2. If the units really differ, give the inner chart an explicit `w`/`h`
+   (`chart(data, h=80)`) so it becomes a self-contained scale region and never
+   shares that axis.
+
+An annotation that contradicts known provenance is itself an error — measures
+are type claims, and two contradictory claims fail fast at the channel.

--- a/packages/gofish-graphics/src/ast/channels.ts
+++ b/packages/gofish-graphics/src/ast/channels.ts
@@ -1,4 +1,5 @@
 // <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
 // @wiki The Mark Factory — /internals/frontend/mark-factory
 // </gofish-wiki>
 
@@ -9,8 +10,10 @@ import {
   value,
   isField,
   isLiteral,
+  getMeasureProvenance,
   type FieldAccessor,
   type LiteralValue,
+  type Measure,
 } from "./data";
 
 export type ChannelType = "size" | "pos" | "color" | "raw";
@@ -66,10 +69,74 @@ export type DeriveMarkProps<
 } & { debug?: boolean };
 
 /**
+ * Resolve a channel's {@link Measure} from its three sources, treating measures
+ * as TYPES (issue #266's field/datum/literal trichotomy, completed). The three
+ * sources, in checking order:
+ *   1. Explicit annotation — `field(name, measure)`. A real type claim.
+ *   2. Inferred provenance — the {@link getMeasureProvenance} map a transform
+ *      like `bin()` attached to the data array. Also a real type claim.
+ *   3. Field-name default — a bare string accessor's field name. A WEAK default
+ *      binding, not a claim.
+ *
+ * Checking rule:
+ *   - annotation AND provenance both present and disagree → THROW immediately
+ *     here (before any space union runs), naming the field and both measures;
+ *   - annotation present (no conflict) → annotation (refines the weak default);
+ *   - no annotation → provenance ?? field-name default.
+ *
+ * `provenanceData` is the provenance-bearing array (the operator's whole input,
+ * which retains the symbol across `derive`); when omitted it falls back to the
+ * value array. Function accessors and literals have no field identity → no
+ * measure.
+ */
+export const resolveMeasure = <T>(
+  provenanceData: T | T[],
+  accessor:
+    | string
+    | number
+    | ((d: T) => unknown)
+    | FieldAccessor
+    | LiteralValue
+    | undefined
+): Measure | undefined => {
+  let fieldName: string | undefined;
+  let annotation: Measure | undefined;
+  if (isField(accessor)) {
+    fieldName = accessor.name;
+    annotation = accessor.measure;
+  } else if (typeof accessor === "string") {
+    fieldName = accessor;
+  } else {
+    return undefined; // function / number / literal: no field identity
+  }
+  const arr = Array.isArray(provenanceData) ? provenanceData : [provenanceData];
+  const provenance = getMeasureProvenance(arr)?.[fieldName];
+  if (
+    annotation !== undefined &&
+    provenance !== undefined &&
+    annotation !== provenance
+  ) {
+    throw new Error(
+      `Measure conflict on field "${fieldName}": annotated as "${annotation}" ` +
+        `via field(name, measure) but its provenance (e.g. bin()) says ` +
+        `"${provenance}". These are contradictory type claims — drop the ` +
+        `annotation or fix the upstream transform.`
+    );
+  }
+  if (annotation !== undefined) return annotation;
+  return provenance ?? fieldName;
+};
+
+/**
  * Infer a size value from a field name, function accessor, or literal number.
  * - number: passed through as a literal.
  * - string (field name): sums the field across the data array.
  * - function: called per-row and summed across the data array.
+ *
+ * Field/string accessors are tagged with their resolved {@link Measure} (see
+ * {@link resolveMeasure}) so the underlying-space layer can unify per measure.
+ * `provenanceData` carries the measure-provenance symbol when the value array
+ * itself does not (e.g. a per-entry slice of a binned array).
  */
 export const inferSize = <T>(
   accessor:
@@ -79,16 +146,18 @@ export const inferSize = <T>(
     | FieldAccessor
     | LiteralValue
     | undefined,
-  d: T | T[]
+  d: T | T[],
+  provenanceData: T | T[] = d
 ): MaybeValue<number> | undefined => {
   if (accessor === undefined) return undefined;
   if (typeof accessor === "number") return accessor;
   if (isLiteral(accessor)) return accessor.value as number;
   const data = Array.isArray(d) ? d : [d];
+  const measure = resolveMeasure(provenanceData, accessor);
   if (isField(accessor)) {
-    return value(sumBy(data, accessor.name as any));
+    return value(sumBy(data, accessor.name as any), measure);
   }
-  return value(sumBy(data, accessor as any));
+  return value(sumBy(data, accessor as any), measure);
 };
 
 /**
@@ -105,16 +174,18 @@ export const inferPos = <T>(
     | FieldAccessor
     | LiteralValue
     | undefined,
-  d: T | T[]
+  d: T | T[],
+  provenanceData: T | T[] = d
 ): MaybeValue<number> | undefined => {
   if (accessor === undefined) return undefined;
   if (typeof accessor === "number") return accessor;
   if (isLiteral(accessor)) return accessor.value as number;
   const data = Array.isArray(d) ? d : [d];
+  const measure = resolveMeasure(provenanceData, accessor);
   if (isField(accessor)) {
-    return value(meanBy(data, accessor.name as any));
+    return value(meanBy(data, accessor.name as any), measure);
   }
-  return value(meanBy(data, accessor as any));
+  return value(meanBy(data, accessor as any), measure);
 };
 
 /**

--- a/packages/gofish-graphics/src/ast/channels.ts
+++ b/packages/gofish-graphics/src/ast/channels.ts
@@ -109,8 +109,11 @@ export const resolveMeasure = <T>(
   } else {
     return undefined; // function / number / literal: no field identity
   }
-  const arr = Array.isArray(provenanceData) ? provenanceData : [provenanceData];
-  const provenance = getMeasureProvenance(arr)?.[fieldName];
+  // Only an array can carry the provenance symbol (a transform tags the array,
+  // not each row), so skip the lookup for a single datum.
+  const provenance = Array.isArray(provenanceData)
+    ? getMeasureProvenance(provenanceData)?.[fieldName]
+    : undefined;
   if (
     annotation !== undefined &&
     provenance !== undefined &&
@@ -128,65 +131,48 @@ export const resolveMeasure = <T>(
 };
 
 /**
- * Infer a size value from a field name, function accessor, or literal number.
- * - number: passed through as a literal.
- * - string (field name): sums the field across the data array.
- * - function: called per-row and summed across the data array.
+ * Shared core of {@link inferSize} / {@link inferPos}: they differ only in the
+ * lodash aggregation (`sumBy` vs `meanBy`). Resolves a numeric value from a
+ * field name, function accessor, or literal number:
+ * - number / literal: passed through as a literal.
+ * - string (field name): aggregated across the data array.
+ * - function: called per-row and aggregated across the data array.
  *
- * Field/string accessors are tagged with their resolved {@link Measure} (see
- * {@link resolveMeasure}) so the underlying-space layer can unify per measure.
- * `provenanceData` carries the measure-provenance symbol when the value array
- * itself does not (e.g. a per-entry slice of a binned array).
+ * Field/string accessors are tagged with a resolved {@link Measure} so the
+ * underlying-space layer can unify per measure. The caller may pass a
+ * precomputed `measure` (createOperator resolves it once per channel from the
+ * provenance-bearing array); when omitted we resolve it locally from `d` — the
+ * same behavior as resolving against the value array directly.
  */
-export const inferSize = <T>(
-  accessor:
-    | string
-    | number
-    | ((d: T) => number)
-    | FieldAccessor
-    | LiteralValue
-    | undefined,
-  d: T | T[],
-  provenanceData: T | T[] = d
-): MaybeValue<number> | undefined => {
-  if (accessor === undefined) return undefined;
-  if (typeof accessor === "number") return accessor;
-  if (isLiteral(accessor)) return accessor.value as number;
-  const data = Array.isArray(d) ? d : [d];
-  const measure = resolveMeasure(provenanceData, accessor);
-  if (isField(accessor)) {
-    return value(sumBy(data, accessor.name as any), measure);
-  }
-  return value(sumBy(data, accessor as any), measure);
-};
+const inferNumeric =
+  (agg: typeof sumBy) =>
+  <T>(
+    accessor:
+      | string
+      | number
+      | ((d: T) => number)
+      | FieldAccessor
+      | LiteralValue
+      | undefined,
+    d: T | T[],
+    measure?: Measure
+  ): MaybeValue<number> | undefined => {
+    if (accessor === undefined) return undefined;
+    if (typeof accessor === "number") return accessor;
+    if (isLiteral(accessor)) return accessor.value as number;
+    const data = Array.isArray(d) ? d : [d];
+    const m = measure ?? resolveMeasure(d, accessor);
+    return value(
+      agg(data, (isField(accessor) ? accessor.name : accessor) as any),
+      m
+    );
+  };
 
-/**
- * Infer a position value from a field name, function accessor, or literal number.
- * - number: passed through as a literal.
- * - string (field name): averages the field across the data array.
- * - function: called per-row and averaged across the data array.
- */
-export const inferPos = <T>(
-  accessor:
-    | string
-    | number
-    | ((d: T) => number)
-    | FieldAccessor
-    | LiteralValue
-    | undefined,
-  d: T | T[],
-  provenanceData: T | T[] = d
-): MaybeValue<number> | undefined => {
-  if (accessor === undefined) return undefined;
-  if (typeof accessor === "number") return accessor;
-  if (isLiteral(accessor)) return accessor.value as number;
-  const data = Array.isArray(d) ? d : [d];
-  const measure = resolveMeasure(provenanceData, accessor);
-  if (isField(accessor)) {
-    return value(meanBy(data, accessor.name as any), measure);
-  }
-  return value(meanBy(data, accessor as any), measure);
-};
+/** Infer a size value (sums the field/function across the data array). */
+export const inferSize = inferNumeric(sumBy);
+
+/** Infer a position value (averages the field/function across the data array). */
+export const inferPos = inferNumeric(meanBy);
 
 /**
  * Infer a color value from a field name, function accessor, or literal string.

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -128,6 +128,12 @@ export function getPositioningConstraintRefs(
  * domain on that axis. Literal (raw-pixel) coordinates are *not* data and don't
  * contribute. The layer's `resolveUnderlyingSpace` merges this with the
  * children's spaces (see `layer.tsx`).
+ *
+ * Measure note (Stage-1 guard): these constraint-datum domains are left
+ * UNTAGGED (no Measure). The layer merges them permissively into the
+ * children's POSITION, whose measure wins. A `datum(v, measure)` coordinate's
+ * unit is therefore not yet enforced against the children's — a deliberate
+ * permissive edge until constraint domains carry measures end-to-end.
  */
 export function collectPositionDomains(constraints: ConstraintSpec[]): {
   x?: Interval.Interval;

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -19,7 +19,9 @@ import {
   isORDINAL,
   isPOSITION,
   isUNDEFINED,
+  forgetOnConflict,
 } from "../underlyingSpace";
+import type { Measure } from "../data";
 import { createNodeOperator } from "../withGoFish";
 import { computeTransformedBoundingBox } from "./coordUtils";
 import { empty, union } from "../../util/bbox";
@@ -142,13 +144,20 @@ export const coord = createNodeOperator(
             xChildrenPositionSpaces.length > 0 &&
             xChildrenOrdinalSpaces.length === 0
           ) {
-            const domain = IntervalLib.unionAll(
-              ...xChildrenPositionSpaces
-                .map((child) => child[0])
-                .filter(isPOSITION)
-                .map((space) => space.domain)
-            );
-            xSpace = POSITION(domain, coordTransform);
+            const xPos = xChildrenPositionSpaces
+              .map((child) => child[0])
+              .filter(isPOSITION);
+            const domain = IntervalLib.unionAll(...xPos.map((s) => s.domain));
+            // A coord transform maps these data positions into its own fixed
+            // coordinate space (e.g. angle/radius). Cross-unit unions are the
+            // transform's business, not the marginal-style corruption the guard
+            // targets, so forget on conflict rather than throwing.
+            const xMeasure = xPos
+              .map((s) => s.measure)
+              .reduce<
+                Measure | undefined
+              >((acc, m) => forgetOnConflict(acc, m), undefined);
+            xSpace = POSITION(domain, xMeasure, coordTransform);
           } else if (xChildrenOrdinalSpaces.length > 0) {
             // Collect and merge domains from all child ordinal spaces
             const allKeys = new Set<string>();
@@ -173,13 +182,18 @@ export const coord = createNodeOperator(
             yChildrenPositionSpaces.length > 0 &&
             yChildrenOrdinalSpaces.length === 0
           ) {
-            const domain = IntervalLib.unionAll(
-              ...yChildrenPositionSpaces
-                .map((child) => child[1])
-                .filter(isPOSITION)
-                .map((space) => space.domain)
-            );
-            ySpace = POSITION(domain, coordTransform);
+            const yPos = yChildrenPositionSpaces
+              .map((child) => child[1])
+              .filter(isPOSITION);
+            const domain = IntervalLib.unionAll(...yPos.map((s) => s.domain));
+            // See the x branch: coord maps into its own coordinate space, so
+            // forget on cross-unit conflict rather than throwing.
+            const yMeasure = yPos
+              .map((s) => s.measure)
+              .reduce<
+                Measure | undefined
+              >((acc, m) => forgetOnConflict(acc, m), undefined);
+            ySpace = POSITION(domain, yMeasure, coordTransform);
           } else if (yChildrenOrdinalSpaces.length > 0) {
             // Collect and merge domains from all child ordinal spaces
             const allKeys = new Set<string>();

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -19,9 +19,8 @@ import {
   isORDINAL,
   isPOSITION,
   isUNDEFINED,
-  forgetOnConflict,
+  forgetAllMeasures,
 } from "../underlyingSpace";
-import type { Measure } from "../data";
 import { createNodeOperator } from "../withGoFish";
 import { computeTransformedBoundingBox } from "./coordUtils";
 import { empty, union } from "../../util/bbox";
@@ -152,11 +151,7 @@ export const coord = createNodeOperator(
             // coordinate space (e.g. angle/radius). Cross-unit unions are the
             // transform's business, not the marginal-style corruption the guard
             // targets, so forget on conflict rather than throwing.
-            const xMeasure = xPos
-              .map((s) => s.measure)
-              .reduce<
-                Measure | undefined
-              >((acc, m) => forgetOnConflict(acc, m), undefined);
+            const xMeasure = forgetAllMeasures(xPos.map((s) => s.measure));
             xSpace = POSITION(domain, xMeasure, coordTransform);
           } else if (xChildrenOrdinalSpaces.length > 0) {
             // Collect and merge domains from all child ordinal spaces
@@ -188,11 +183,7 @@ export const coord = createNodeOperator(
             const domain = IntervalLib.unionAll(...yPos.map((s) => s.domain));
             // See the x branch: coord maps into its own coordinate space, so
             // forget on cross-unit conflict rather than throwing.
-            const yMeasure = yPos
-              .map((s) => s.measure)
-              .reduce<
-                Measure | undefined
-              >((acc, m) => forgetOnConflict(acc, m), undefined);
+            const yMeasure = forgetAllMeasures(yPos.map((s) => s.measure));
             ySpace = POSITION(domain, yMeasure, coordTransform);
           } else if (yChildrenOrdinalSpaces.length > 0) {
             // Collect and merge domains from all child ordinal spaces

--- a/packages/gofish-graphics/src/ast/data.ts
+++ b/packages/gofish-graphics/src/ast/data.ts
@@ -33,6 +33,25 @@ export const getMeasureProvenance = (
     ? ((data as any)[MEASURE_PROVENANCE] as MeasureProvenance | undefined)
     : undefined;
 
+/**
+ * Tag a data array with a measure-provenance map under {@link MEASURE_PROVENANCE}.
+ * Owns the non-enumerable encoding so the symbol rides the array (not each row,
+ * not an enumerable own-key that would leak into `{...d}` spreads) and survives
+ * `derive(...)`. Used by transforms like `bin()`.
+ */
+export const setMeasureProvenance = <T>(
+  data: T,
+  provenance: MeasureProvenance
+): T => {
+  Object.defineProperty(data, MEASURE_PROVENANCE, {
+    value: provenance,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  return data;
+};
+
 export type Value<T> = T | DatumValue | DatumValueImpl;
 export type MaybeValue<T> = T | Value<T>;
 

--- a/packages/gofish-graphics/src/ast/data.ts
+++ b/packages/gofish-graphics/src/ast/data.ts
@@ -1,8 +1,37 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
 import { Interval } from "./dims";
 
 export type Measure = string;
 
 export const measure = (unit: string): Measure => unit;
+
+/**
+ * Well-known symbol used to tag a data ARRAY with the *measure provenance* of
+ * its columns — a map from field name to the {@link Measure} that produced it.
+ * This is how a data-transform like `bin()` declares that its output `start`/
+ * `end`/`size` columns are still expressed in the *source* field's units (e.g.
+ * "Beak Length (mm)") rather than the literal field-name "start". The symbol
+ * rides the array (not each row) so it survives `derive(...)`, which passes the
+ * transformed array straight through to the next operator.
+ *
+ * Channel inference (`resolveMeasure` in channels.ts) reads this as one of the
+ * three measure sources; see issue #266 for the field/datum/literal trichotomy.
+ */
+export const MEASURE_PROVENANCE: unique symbol = Symbol.for(
+  "gofish.measureProvenance"
+);
+export type MeasureProvenance = Record<string, Measure>;
+
+/** Read the measure-provenance map a data array carries, if any. */
+export const getMeasureProvenance = (
+  data: unknown
+): MeasureProvenance | undefined =>
+  data != null
+    ? ((data as any)[MEASURE_PROVENANCE] as MeasureProvenance | undefined)
+    : undefined;
 
 export type Value<T> = T | DatumValue | DatumValueImpl;
 export type MaybeValue<T> = T | Value<T>;
@@ -68,16 +97,25 @@ export const value = <T>(datum: T, measure?: Measure): DatumValueImpl =>
 export const datum = value;
 
 /**
- * `field(name)` is an explicit field-accessor wrapper. The channel inference
- * functions (`inferSize` / `inferPos` / `inferColor` / `inferRaw`) recognize
- * the tag and resolve it to a per-row value, identical to passing a bare
- * string. Use this when the field name could be confused with a literal
+ * `field(name, measure?)` is an explicit field-accessor wrapper. The channel
+ * inference functions (`inferSize` / `inferPos` / `inferColor` / `inferRaw`)
+ * recognize the tag and resolve it to a per-row value, identical to passing a
+ * bare string. Use this when the field name could be confused with a literal
  * (e.g. `field("0.5")`).
+ *
+ * The optional `measure` is an *explicit unit annotation* — a real type claim
+ * about the channel's underlying space (see {@link Measure}). It is one of the
+ * three measure sources `resolveMeasure` (channels.ts) checks: a bare string
+ * accessor's field-name is only a *weak default*, whereas this annotation (and
+ * `bin()`'s {@link MEASURE_PROVENANCE}) is a hard claim that triggers a type
+ * error if it contradicts inferred provenance. Issue #266 is the field/datum/
+ * literal trichotomy this completes.
  */
-export type FieldAccessor = { type: "field"; name: string };
-export const field = (name: string): FieldAccessor => ({
+export type FieldAccessor = { type: "field"; name: string; measure?: Measure };
+export const field = (name: string, measure?: Measure): FieldAccessor => ({
   type: "field",
   name,
+  ...(measure !== undefined ? { measure } : {}),
 });
 export const isField = (v: unknown): v is FieldAccessor =>
   typeof v === "object" &&
@@ -126,11 +164,20 @@ export const getValue = <T>(value: MaybeValue<T>): T => {
   return value as T;
 };
 
-export const getMeasure = <T>(value: MaybeValue<T>): Measure => {
+/**
+ * The {@link Measure} carried by a datum value, or `undefined` when it carries
+ * none (a measureless datum) or is a raw aesthetic (not a datum at all).
+ *
+ * Returns `undefined` rather than a sentinel string ("unit"/"unknown") so that
+ * a measureless value unifies *permissively* with a tagged one — see
+ * `mergeMeasures` in underlyingSpace.ts, whose undefined-permissive rule is the
+ * whole point of distinguishing "no claim" from "a specific unit".
+ */
+export const getMeasure = <T>(value: MaybeValue<T>): Measure | undefined => {
   if (isValue(value)) {
-    return (value as DatumValue).measure ?? "unit";
+    return (value as DatumValue).measure;
   }
-  return "unknown";
+  return undefined;
 };
 
 /**

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -111,6 +111,8 @@ export async function layout(
   width: number;
   height: number;
   rightOverhang: number;
+  rightContentOverhang: number;
+  topOverhang: number;
   leftOverhang: number;
   bottomOverhang: number;
 }> {
@@ -198,8 +200,10 @@ export async function layout(
   // PRE-title, pre-legend content. This matters two ways:
   //  - The inferred canvas is measured off the content, never inflated by a long
   //    title or a tall legend column.
-  //  - Title and legend extents past the content are reserved separately as
-  //    measured gutters (`leftOverhang`/`bottomOverhang`/`rightOverhang` below).
+  //  - Title, legend, and constraint-displaced extents past the content are
+  //    reserved separately as measured per-side overhangs (`leftOverhang`,
+  //    `bottomOverhang`, `topOverhang`, the legend `rightOverhang`, and the
+  //    non-legend `rightContentOverhang` below).
   const contentNode = child;
 
   // Axis-title elaboration: seat up to two title Text nodes (x below, y rotated
@@ -335,19 +339,30 @@ export async function layout(
   const finalW = finalDim(0, w);
   const finalH = finalDim(1, h);
 
-  // Measured legend overhang past the content width — replaces the fixed
-  // LEGEND_MARGIN (see `legendOverhang`). Gated on `legendAdded`, not
-  // `child !== contentNode`: a titles-only chart also wraps `child`, so the
-  // identity check would wrongly take the branch and measure a title gutter as a
-  // legend overhang.
+  // Measured overhangs off the OUTERMOST wrapper (`child`), from its laid-out
+  // extent. Anything seated beyond the content box is reserved by its placed
+  // extent minus the content box; `render()` then sizes the SVG around them.
+  // `max!` / `min!` discipline (never a silent `?? 0`): the wrapper always emits
+  // a placed extent here — a silent 0 would clip the overhang and mask a layout
+  // bug, so assert it's present.
+  //
+  // The RIGHT side has two distinct kinds of overhang that must be reserved
+  // DIFFERENTLY, and they overlap in magnitude so the color-scale flag — not the
+  // size — is what tells them apart:
+  //  - A legend swatch column reserves `legendOverhang + pad` (see the width
+  //    formula in `render`). Gated on `legendAdded`: a single-row legend can
+  //    overhang as little as ~6px — the same as a wide rightmost x-tick label —
+  //    so we cannot recover this from magnitude alone.
+  //  - Otherwise, content displaced past the canvas by a constraint (e.g. a
+  //    marginal histogram's right band) flows through `reserve()` like the other
+  //    three gutters: a small x-tick spill is absorbed into `pad` (plain axis
+  //    charts stay byte-identical) and a large band reserves its full extent.
+  // TOP, LEFT, BOTTOM have only the second (chrome / displaced-content) kind.
   const rightOverhang = legendAdded ? legendOverhang(child, finalW) : 0;
-
-  // Measured negative-space gutters off the OUTERMOST wrapper (`child`): axis
-  // tick / ordinal label rows plus any seated titles extend past the content
-  // origin into negative coordinates. This measured extent replaces the bespoke
-  // fixed Y_TITLE_MARGIN / X_TITLE_MARGIN. Same `min!` discipline as
-  // `legendOverhang`'s `max!`: a silent `?? 0` would clip the gutter and mask a
-  // layout bug, so assert the placed min is present.
+  const rightContentOverhang = legendAdded
+    ? 0
+    : Math.max(0, child.dims[0].max! - finalW);
+  const topOverhang = Math.max(0, child.dims[1].max! - finalH);
   const leftOverhang = Math.max(0, -child.dims[0].min!);
   const bottomOverhang = Math.max(0, -child.dims[1].min!);
 
@@ -364,6 +379,8 @@ export async function layout(
     width: finalW,
     height: finalH,
     rightOverhang,
+    rightContentOverhang,
+    topOverhang,
     leftOverhang,
     bottomOverhang,
   };
@@ -411,6 +428,8 @@ export const gofish = (
     width: number;
     height: number;
     rightOverhang: number;
+    rightContentOverhang: number;
+    topOverhang: number;
     leftOverhang: number;
     bottomOverhang: number;
   };
@@ -470,6 +489,8 @@ export const gofish = (
               svgPadding,
               defs,
               rightOverhang: data.rightOverhang,
+              rightContentOverhang: data.rightContentOverhang,
+              topOverhang: data.topOverhang,
               leftOverhang: data.leftOverhang,
               bottomOverhang: data.bottomOverhang,
             },
@@ -496,6 +517,8 @@ export const render = (
     transform,
     defs,
     rightOverhang = 0,
+    rightContentOverhang = 0,
+    topOverhang = 0,
     leftOverhang = 0,
     bottomOverhang = 0,
     svgPadding,
@@ -505,6 +528,8 @@ export const render = (
     transform?: string;
     defs?: JSX.Element[];
     rightOverhang?: number;
+    rightContentOverhang?: number;
+    topOverhang?: number;
     leftOverhang?: number;
     bottomOverhang?: number;
     svgPadding?: number;
@@ -516,6 +541,9 @@ export const render = (
   // Chrome (axis tick/label rows, titles, the legend column) is now elaborated
   // into ordinary shapes that live in the node tree; `render()` only sizes the
   // SVG around their measured extent — no chart-chrome special cases remain.
+  // Content seated beyond the canvas by a constraint (e.g. marginal histogram
+  // bands above/right of a scatter) is measured the same way, via the per-side
+  // overhangs — including the new top and non-legend right gutters.
   //
   // Reserve enough on each gutter side to clear the measured overhang plus a
   // little breathing room from the SVG edge. The `o > 0` guard keeps a chart
@@ -532,18 +560,32 @@ export const render = (
     o > 0 ? Math.ceil(Math.max(pad, o + EDGE_GAP)) : pad;
   const leftReserve = reserve(leftOverhang);
   const bottomReserve = reserve(bottomOverhang);
+  const topReserve = reserve(topOverhang);
 
+  // Right gutter = legend reservation + non-legend reserve. `rightOverhang` is
+  // the legend column's overhang (0 when there's no legend); it keeps a full
+  // `pad` margin beyond the column — the legend's historical reservation — via
+  // `reserve(rightContentOverhang)`, whose floor is `pad` (so a legend chart
+  // reserves `legendOverhang + pad`, byte-identical). `rightContentOverhang` is
+  // any NON-legend content displaced past the right edge (a marginal band);
+  // routing it through the same `reserve()` as the other gutters absorbs a small
+  // x-tick spill into `pad` (plain axis charts stay byte-identical) and reserves
+  // a large band's full extent plus `EDGE_GAP`. The right gutter bears no root
+  // <g> translate, so it needn't be pixel-snapped — a fractional width is
+  // harmless (legend overhangs are fractional text widths).
   const result = (
     <svg
-      width={leftReserve + width + rightOverhang + pad}
-      height={pad + height + bottomReserve}
+      width={
+        leftReserve + width + rightOverhang + reserve(rightContentOverhang)
+      }
+      height={topReserve + height + bottomReserve}
       xmlns="http://www.w3.org/2000/svg"
     >
       <Show when={defs}>
         <defs>{defs}</defs>
       </Show>
       <g
-        transform={`scale(1, -1) translate(${leftReserve}, ${-(height + pad)})`}
+        transform={`scale(1, -1) translate(${leftReserve}, ${-(height + topReserve)})`}
       >
         <Show when={transform} keyed fallback={child.INTERNAL_render()}>
           <g transform={transform ?? ""}>{child.INTERNAL_render()}</g>

--- a/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
@@ -15,7 +15,8 @@ import {
   isSIZE,
   isUNDEFINED,
   mergeMeasures,
-  forgetOnConflict,
+  mergeAllMeasures,
+  forgetAllMeasures,
   spaceMeasure,
   UnderlyingSpace,
 } from "../underlyingSpace";
@@ -70,11 +71,7 @@ export function unionChildSpaces(
   const axisSpaces = children.map((c) => c[axis]);
   const sized = axisSpaces.filter((s) => !isUNDEFINED(s));
   if (sized.length > 0 && sized.every(isSIZE)) {
-    const measure = sized
-      .map((s) => s.measure)
-      .reduce<
-        Measure | undefined
-      >((acc, m) => forgetOnConflict(acc, m), undefined);
+    const measure = forgetAllMeasures(sized.map((s) => s.measure));
     return SIZE(Monotonic.max(...sized.map((s) => s.domain)), measure);
   }
 
@@ -114,15 +111,6 @@ export function resolveAlignmentSpace(
   spaces: UnderlyingSpace[],
   alignment: Alignment
 ): { space: UnderlyingSpace; fromSize: boolean } {
-  // Forget-merge of all child measures: shared when they agree (the marginal
-  // histogram's all-count children), undefined when they legitimately differ.
-  const mergedMeasure = (): Measure | undefined =>
-    spaces
-      .map((s) => spaceMeasure(s))
-      .reduce<
-        Measure | undefined
-      >((acc, m) => forgetOnConflict(acc, m), undefined);
-
   if (spaces.every((s) => isSIZE(s))) {
     const sizeValues = spaces.map((s) =>
       ((s as any).domain as { run: (x: number) => number }).run(1)
@@ -130,7 +118,8 @@ export function resolveAlignmentSpace(
     // LOAD-BEARING: the SIZE → POSITION conversion must carry the SIZE
     // children's measure forward — this is how a histogram's count axis (all
     // SIZE) gets a "count" tag that a later overlay union can compare against.
-    const measure = mergedMeasure();
+    // Forget-merge: shared when they agree, undefined when they differ.
+    const measure = forgetAllMeasures(spaces.map((s) => spaceMeasure(s)));
     if (
       alignment === "start" ||
       alignment === "end" ||
@@ -156,11 +145,10 @@ export function resolveAlignmentSpace(
   if (spaces.every((s) => isDIFFERENCE(s))) {
     // Sibling difference extents being aligned should agree in units — THROW
     // on a real conflict.
-    const measure = spaces
-      .map((s) => spaceMeasure(s))
-      .reduce<
-        Measure | undefined
-      >((acc, m) => mergeMeasures(acc, m, "alignment"), undefined);
+    const measure = mergeAllMeasures(
+      spaces.map((s) => spaceMeasure(s)),
+      "alignment"
+    );
     return {
       space: DIFFERENCE(
         Math.max(...spaces.map((s) => (s as any).width as number)),
@@ -175,11 +163,10 @@ export function resolveAlignmentSpace(
         (s) => (s as any).domain as ReturnType<typeof Interval.interval>
       )
     );
-    const measure = spaces
-      .map((s) => spaceMeasure(s))
-      .reduce<
-        Measure | undefined
-      >((acc, m) => mergeMeasures(acc, m, "alignment"), undefined);
+    const measure = mergeAllMeasures(
+      spaces.map((s) => spaceMeasure(s)),
+      "alignment"
+    );
     if (alignment === "middle") {
       return {
         space: DIFFERENCE(Interval.width(domain), measure),

--- a/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
@@ -14,8 +14,12 @@ import {
   isPOSITION,
   isSIZE,
   isUNDEFINED,
+  mergeMeasures,
+  forgetOnConflict,
+  spaceMeasure,
   UnderlyingSpace,
 } from "../underlyingSpace";
+import type { Measure } from "../data";
 import type { Size } from "../dims";
 import * as Interval from "../../util/interval";
 import * as Monotonic from "../../util/monotonic";
@@ -61,29 +65,44 @@ export function unionChildSpaces(
   // Preserve SIZE composition for overlay operators (layer, porterDuff):
   // when every child is SIZE on this axis, emit SIZE(Monotonic.max(...))
   // so the parent can keep solving scale factors via Monotonic.inverse.
+  // SIZE∘SIZE composition is legitimate across different fields, so FORGET
+  // the measure on conflict rather than throwing.
   const axisSpaces = children.map((c) => c[axis]);
   const sized = axisSpaces.filter((s) => !isUNDEFINED(s));
   if (sized.length > 0 && sized.every(isSIZE)) {
-    return SIZE(Monotonic.max(...sized.map((s) => s.domain)));
+    const measure = sized
+      .map((s) => s.measure)
+      .reduce<
+        Measure | undefined
+      >((acc, m) => forgetOnConflict(acc, m), undefined);
+    return SIZE(Monotonic.max(...sized.map((s) => s.domain)), measure);
   }
 
+  // Mixed/POSITION interval collection. This is where a marginal histogram's
+  // count axis (a SIZE folded into [0, run(1)]) would silently union with a
+  // scatter's millimeter POSITION — so unify the measures as TYPES and THROW
+  // on a real conflict.
   const intervals: ReturnType<typeof Interval.interval>[] = [];
   let hasPosition = false;
+  let measure: Measure | undefined;
   for (const child of children) {
     const space = child[axis];
     if (isPOSITION(space) && space.domain) {
       hasPosition = true;
       intervals.push(space.domain);
+      measure = mergeMeasures(measure, space.measure, "overlay union");
     } else if (isDIFFERENCE(space)) {
       intervals.push(Interval.interval(0, space.width));
+      measure = mergeMeasures(measure, space.measure, "overlay union");
     } else if (isSIZE(space)) {
       intervals.push(Interval.interval(0, space.domain.run(1)));
+      measure = mergeMeasures(measure, space.measure, "overlay union");
     }
   }
   if (intervals.length === 0) return UNDEFINED;
   const union = Interval.unionAll(...intervals);
-  if (!hasPosition) return DIFFERENCE(Interval.width(union));
-  return POSITION(union);
+  if (!hasPosition) return DIFFERENCE(Interval.width(union), measure);
+  return POSITION(union, measure);
 }
 
 /**
@@ -95,10 +114,23 @@ export function resolveAlignmentSpace(
   spaces: UnderlyingSpace[],
   alignment: Alignment
 ): { space: UnderlyingSpace; fromSize: boolean } {
+  // Forget-merge of all child measures: shared when they agree (the marginal
+  // histogram's all-count children), undefined when they legitimately differ.
+  const mergedMeasure = (): Measure | undefined =>
+    spaces
+      .map((s) => spaceMeasure(s))
+      .reduce<
+        Measure | undefined
+      >((acc, m) => forgetOnConflict(acc, m), undefined);
+
   if (spaces.every((s) => isSIZE(s))) {
     const sizeValues = spaces.map((s) =>
       ((s as any).domain as { run: (x: number) => number }).run(1)
     );
+    // LOAD-BEARING: the SIZE → POSITION conversion must carry the SIZE
+    // children's measure forward — this is how a histogram's count axis (all
+    // SIZE) gets a "count" tag that a later overlay union can compare against.
+    const measure = mergedMeasure();
     if (
       alignment === "start" ||
       alignment === "end" ||
@@ -106,22 +138,33 @@ export function resolveAlignmentSpace(
     ) {
       const intervals = sizeValues.map((v) => Interval.interval(0, v));
       return {
-        space: POSITION(Interval.unionAll(...intervals)),
+        space: POSITION(Interval.unionAll(...intervals), measure),
         fromSize: true,
       };
     }
     if (alignment === "middle") {
       return {
-        space: DIFFERENCE(Math.max(...sizeValues.map((v) => Math.abs(v)))),
+        space: DIFFERENCE(
+          Math.max(...sizeValues.map((v) => Math.abs(v))),
+          measure
+        ),
         fromSize: true,
       };
     }
     return { space: UNDEFINED, fromSize: true };
   }
   if (spaces.every((s) => isDIFFERENCE(s))) {
+    // Sibling difference extents being aligned should agree in units — THROW
+    // on a real conflict.
+    const measure = spaces
+      .map((s) => spaceMeasure(s))
+      .reduce<
+        Measure | undefined
+      >((acc, m) => mergeMeasures(acc, m, "alignment"), undefined);
     return {
       space: DIFFERENCE(
-        Math.max(...spaces.map((s) => (s as any).width as number))
+        Math.max(...spaces.map((s) => (s as any).width as number)),
+        measure
       ),
       fromSize: false,
     };
@@ -132,10 +175,18 @@ export function resolveAlignmentSpace(
         (s) => (s as any).domain as ReturnType<typeof Interval.interval>
       )
     );
+    const measure = spaces
+      .map((s) => spaceMeasure(s))
+      .reduce<
+        Measure | undefined
+      >((acc, m) => mergeMeasures(acc, m, "alignment"), undefined);
     if (alignment === "middle") {
-      return { space: DIFFERENCE(Interval.width(domain)), fromSize: false };
+      return {
+        space: DIFFERENCE(Interval.width(domain), measure),
+        fromSize: false,
+      };
     }
-    return { space: POSITION(domain), fromSize: false };
+    return { space: POSITION(domain, measure), fromSize: false };
   }
   return { space: UNDEFINED, fromSize: false };
 }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -1,3 +1,7 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
 import * as Monotonic from "../../util/monotonic";
 import { GoFishNode } from "../_node";
 import { isToken } from "../createName";
@@ -5,6 +9,7 @@ import { Size, elaborateDims, FancyDims } from "../dims";
 import {
   POSITION,
   SIZE,
+  UNDEFINED,
   UnderlyingSpace,
   isPOSITION,
   isSIZE,
@@ -219,6 +224,17 @@ export const layer = createNodeOperatorSequential(
 
     const dims = elaborateDims(options);
 
+    // When this layer is given an explicit pixel size on a dim, it becomes a
+    // self-contained scaling region on that dim (see resolveUnderlyingSpace
+    // below): its data space is absorbed internally and reported as UNDEFINED.
+    // The real (POSITION/SIZE) space is stashed here so `layout` can build a
+    // local scale against the layer's own pixel box. Indexed [x, y]; last write
+    // wins if resolveUnderlyingSpace runs more than once.
+    const selfScaledSpaces: [
+      UnderlyingSpace | undefined,
+      UnderlyingSpace | undefined,
+    ] = [undefined, undefined];
+
     return new GoFishNode(
       {
         type: options.box === true ? "box" : "layer",
@@ -239,7 +255,7 @@ export const layer = createNodeOperatorSequential(
             scale: number
           ): UnderlyingSpace =>
             isSIZE(space) && scale !== 1
-              ? SIZE(Monotonic.smul(scale, space.domain))
+              ? SIZE(Monotonic.smul(scale, space.domain), space.measure)
               : space;
 
           // `position` constraints contribute a POSITION-domain fragment per
@@ -259,12 +275,41 @@ export const layer = createNodeOperatorSequential(
               isPOSITION(base) && base.domain
                 ? Interval.unionAll(base.domain, iv)
                 : iv;
-            return POSITION(merged);
+            // `position`-constraint datum domains (iv) are untagged — measure
+            // flows from the children's POSITION (if any), permissively.
+            return POSITION(
+              merged,
+              isPOSITION(base) ? base.measure : undefined
+            );
           };
-          return [
+          const resolved: [UnderlyingSpace, UnderlyingSpace] = [
             resolveAxis(0, scaleX, posDomains.x),
             resolveAxis(1, scaleY, posDomains.y),
           ];
+
+          // An explicit pixel size on a dim makes this node a self-contained
+          // scaling region on that dim: its data space is absorbed internally
+          // and scales resolve against its own box at layout time, exactly like
+          // the root resolves against the canvas ("a chart embeds the way it
+          // renders"). So we stash the real POSITION/SIZE space and report
+          // UNDEFINED upward — a parent layer's union then ignores this axis
+          // rather than polluting a shared domain with foreign units (e.g. a
+          // marginal histogram's count axis vs. the center's data units). The
+          // reported space is UNDEFINED for now; issue #508's proposed CONSTANT
+          // kind is the eventual home for "known fixed pixel extent".
+          // (last write wins — resolveUnderlyingSpace may run more than once.)
+          selfScaledSpaces[0] = undefined;
+          selfScaledSpaces[1] = undefined;
+          for (const axis of [0, 1] as const) {
+            if (dims[axis].size === undefined) continue;
+            const sp = resolved[axis];
+            // DIFFERENCE/ORDINAL unions are left untouched (no stash).
+            if ((isPOSITION(sp) && sp.domain) || isSIZE(sp)) {
+              selfScaledSpaces[axis] = sp;
+              resolved[axis] = UNDEFINED;
+            }
+          }
+          return resolved;
         },
         layout: (shared, size, scaleFactors, children, posScales, node) => {
           // Compute size using dims (w and h) before passing to children
@@ -272,6 +317,32 @@ export const layer = createNodeOperatorSequential(
             computeSize(dims[0].size, scaleFactors?.[0]!, size[0]) ?? size[0],
             computeSize(dims[1].size, scaleFactors?.[1]!, size[1]) ?? size[1],
           ];
+
+          // Self-scaling regions: for any dim whose data space we absorbed in
+          // resolveUnderlyingSpace (stashed because this layer has an explicit
+          // pixel size), build a LOCAL scale against our own pixel box — the
+          // root's recipe, applied one level down. POSITION → a local posScale
+          // mapping the stashed domain onto [0, size]; SIZE → a local scale
+          // factor inverting the Monotonic against size (cf. gofish.tsx root).
+          // These locals take precedence over anything inherited from the
+          // parent (whose scale is in foreign units). When the size couldn't be
+          // resolved (NaN), we leave the locals undefined so behavior degrades
+          // to the inherited path rather than producing NaN scales.
+          const localPosScales: ConstraintPosScales = [undefined, undefined];
+          const childSfOverride: [number | undefined, number | undefined] = [
+            undefined,
+            undefined,
+          ];
+          for (const dim of [0, 1] as const) {
+            const stashed = selfScaledSpaces[dim];
+            if (stashed === undefined || !Number.isFinite(size[dim])) continue;
+            if (isPOSITION(stashed)) {
+              localPosScales[dim] = posScaleFromSpace(stashed, size[dim]);
+            } else if (isSIZE(stashed)) {
+              childSfOverride[dim] =
+                stashed.domain.inverse(size[dim]) ?? undefined;
+            }
+          }
 
           // `position` constraints with a datum coordinate contribute a data
           // domain on their axis (see collectPositionDomains); the union is what
@@ -291,12 +362,22 @@ export const layer = createNodeOperatorSequential(
           // the layer actually owns such an axis — it is used solely by
           // applyConstraints below, not passed to children.
           const space = node._underlyingSpace;
+          // `basePosScales` = the inherited scales with any self-scaled
+          // (stashed) dim overridden by its local scale. Local wins
+          // definitionally — the parent's scale is in foreign units. Used both
+          // for the per-child forwarding (`childScalesFor`) and as the floor for
+          // `effectivePosScales` so the override applies regardless of
+          // `ownsPositionAxis`.
+          const basePosScales: ConstraintPosScales = [
+            localPosScales[0] ?? posScales[0],
+            localPosScales[1] ?? posScales[1],
+          ];
           const effectivePosScales: ConstraintPosScales = ownsPositionAxis
             ? [
-                posScales[0] ?? posScaleFromSpace(space?.[0], size[0]),
-                posScales[1] ?? posScaleFromSpace(space?.[1], size[1]),
+                basePosScales[0] ?? posScaleFromSpace(space?.[0], size[0]),
+                basePosScales[1] ?? posScaleFromSpace(space?.[1], size[1]),
               ]
-            : [posScales[0], posScales[1]];
+            : [basePosScales[0], basePosScales[1]];
 
           const childPlaceables = [];
 
@@ -341,7 +422,9 @@ export const layer = createNodeOperatorSequential(
           ): ConstraintPosScales => {
             const sp = (children[i] as GoFishNode)._underlyingSpace;
             const pick = (dim: 0 | 1) => {
-              if (!ownsAxis[dim]) return posScales[dim]; // inherited, unchanged
+              // Non-owned axis: forward the inherited scale, or the local one
+              // for a self-scaled (stashed) dim (basePosScales folds that in).
+              if (!ownsAxis[dim]) return basePosScales[dim];
               if (targetDims?.has(dim)) return undefined; // placed by the constraint
               return sp && isPOSITION(sp[dim])
                 ? effectivePosScales[dim]
@@ -349,6 +432,15 @@ export const layer = createNodeOperatorSequential(
             };
             return [pick(0), pick(1)];
           };
+
+          // Fresh scale-factors array for children: a self-scaled (stashed)
+          // SIZE dim forwards its LOCAL factor instead of the inherited one.
+          // Build a new array — never mutate the parent's `scaleFactors`
+          // (unlike spread, which mutates intentionally for sibling sharing).
+          const childScaleFactors: Size<number | undefined> = [
+            childSfOverride[0] ?? scaleFactors?.[0],
+            childSfOverride[1] ?? scaleFactors?.[1],
+          ];
 
           for (let i = 0; i < children.length; i++) {
             const child = children[i];
@@ -359,7 +451,7 @@ export const layer = createNodeOperatorSequential(
                 : undefined;
             const childPlaceable = child.layout(
               size,
-              scaleFactors,
+              childScaleFactors,
               childScalesFor(i, targetDims)
             );
             if (!childName || !constrainedNames.has(childName)) {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -13,6 +13,7 @@ import {
   UnderlyingSpace,
   isPOSITION,
   isSIZE,
+  spaceMeasure,
 } from "../underlyingSpace";
 import * as Interval from "../../util/interval";
 import { computeSize, foldFinite } from "../../util";
@@ -224,12 +225,18 @@ export const layer = createNodeOperatorSequential(
 
     const dims = elaborateDims(options);
 
-    // When this layer is given an explicit pixel size on a dim, it becomes a
-    // self-contained scaling region on that dim (see resolveUnderlyingSpace
-    // below): its data space is absorbed internally and reported as UNDEFINED.
-    // The real (POSITION/SIZE) space is stashed here so `layout` can build a
-    // local scale against the layer's own pixel box. Indexed [x, y]; last write
-    // wins if resolveUnderlyingSpace runs more than once.
+    // SELF-SCALING REGIONS. When this layer is given an explicit pixel size on
+    // a dim, it becomes a self-contained scaling region on that dim: its scales
+    // resolve against its own box at layout time, exactly like the root resolves
+    // against the canvas ("a chart embeds the way it renders"). So in
+    // `resolveUnderlyingSpace` the real POSITION/SIZE space is stashed here and
+    // UNDEFINED is reported upward — a parent layer's union then ignores this
+    // axis rather than polluting a shared domain with foreign units (e.g. a
+    // marginal histogram's count axis vs. the center's data units). `layout`
+    // reads the stash back to build the LOCAL scale. The reported space is
+    // UNDEFINED for now; issue #508's proposed CONSTANT kind is the eventual
+    // home for "known fixed pixel extent". Indexed [x, y]; last write wins if
+    // resolveUnderlyingSpace runs more than once.
     const selfScaledSpaces: [
       UnderlyingSpace | undefined,
       UnderlyingSpace | undefined,
@@ -277,27 +284,16 @@ export const layer = createNodeOperatorSequential(
                 : iv;
             // `position`-constraint datum domains (iv) are untagged — measure
             // flows from the children's POSITION (if any), permissively.
-            return POSITION(
-              merged,
-              isPOSITION(base) ? base.measure : undefined
-            );
+            return POSITION(merged, spaceMeasure(base));
           };
           const resolved: [UnderlyingSpace, UnderlyingSpace] = [
             resolveAxis(0, scaleX, posDomains.x),
             resolveAxis(1, scaleY, posDomains.y),
           ];
 
-          // An explicit pixel size on a dim makes this node a self-contained
-          // scaling region on that dim: its data space is absorbed internally
-          // and scales resolve against its own box at layout time, exactly like
-          // the root resolves against the canvas ("a chart embeds the way it
-          // renders"). So we stash the real POSITION/SIZE space and report
-          // UNDEFINED upward — a parent layer's union then ignores this axis
-          // rather than polluting a shared domain with foreign units (e.g. a
-          // marginal histogram's count axis vs. the center's data units). The
-          // reported space is UNDEFINED for now; issue #508's proposed CONSTANT
-          // kind is the eventual home for "known fixed pixel extent".
-          // (last write wins — resolveUnderlyingSpace may run more than once.)
+          // Stash the absorbed POSITION/SIZE space and report UNDEFINED upward
+          // for any dim with an explicit pixel size — self-scaling region; see
+          // selfScaledSpaces above. (last write wins — may run more than once.)
           selfScaledSpaces[0] = undefined;
           selfScaledSpaces[1] = undefined;
           for (const axis of [0, 1] as const) {
@@ -318,29 +314,37 @@ export const layer = createNodeOperatorSequential(
             computeSize(dims[1].size, scaleFactors?.[1]!, size[1]) ?? size[1],
           ];
 
-          // Self-scaling regions: for any dim whose data space we absorbed in
-          // resolveUnderlyingSpace (stashed because this layer has an explicit
-          // pixel size), build a LOCAL scale against our own pixel box — the
-          // root's recipe, applied one level down. POSITION → a local posScale
-          // mapping the stashed domain onto [0, size]; SIZE → a local scale
-          // factor inverting the Monotonic against size (cf. gofish.tsx root).
-          // These locals take precedence over anything inherited from the
-          // parent (whose scale is in foreign units). When the size couldn't be
-          // resolved (NaN), we leave the locals undefined so behavior degrades
-          // to the inherited path rather than producing NaN scales.
-          const localPosScales: ConstraintPosScales = [undefined, undefined];
-          const childSfOverride: [number | undefined, number | undefined] = [
-            undefined,
-            undefined,
+          // Build the LOCAL scale for each self-scaled (stashed) dim against our
+          // own pixel box — see selfScaledSpaces above. The recipe (cf. the
+          // gofish.tsx root): POSITION → a posScale mapping the stashed domain
+          // onto [0, size]; SIZE → a scale factor inverting the Monotonic against
+          // size. A POSITION stash touches only `basePosScales`; a SIZE stash
+          // only `childScaleFactors`. When the size can't be resolved (NaN) we
+          // leave the inherited value, degrading to the inherited path rather
+          // than emitting NaN scales.
+          //
+          // `basePosScales` is reused below as the floor for `effectivePosScales`
+          // and the per-child forwarding (`childScalesFor`), so the override
+          // applies regardless of `ownsPositionAxis`. `childScaleFactors` is a
+          // fresh array — never mutate the parent's `scaleFactors` (unlike
+          // spread, which mutates intentionally for sibling sharing).
+          const basePosScales: ConstraintPosScales = [
+            posScales[0],
+            posScales[1],
+          ];
+          const childScaleFactors: Size<number | undefined> = [
+            scaleFactors?.[0],
+            scaleFactors?.[1],
           ];
           for (const dim of [0, 1] as const) {
             const stashed = selfScaledSpaces[dim];
             if (stashed === undefined || !Number.isFinite(size[dim])) continue;
             if (isPOSITION(stashed)) {
-              localPosScales[dim] = posScaleFromSpace(stashed, size[dim]);
+              basePosScales[dim] =
+                posScaleFromSpace(stashed, size[dim]) ?? posScales[dim];
             } else if (isSIZE(stashed)) {
-              childSfOverride[dim] =
-                stashed.domain.inverse(size[dim]) ?? undefined;
+              childScaleFactors[dim] =
+                stashed.domain.inverse(size[dim]) ?? scaleFactors?.[dim];
             }
           }
 
@@ -362,16 +366,8 @@ export const layer = createNodeOperatorSequential(
           // the layer actually owns such an axis — it is used solely by
           // applyConstraints below, not passed to children.
           const space = node._underlyingSpace;
-          // `basePosScales` = the inherited scales with any self-scaled
-          // (stashed) dim overridden by its local scale. Local wins
-          // definitionally — the parent's scale is in foreign units. Used both
-          // for the per-child forwarding (`childScalesFor`) and as the floor for
-          // `effectivePosScales` so the override applies regardless of
-          // `ownsPositionAxis`.
-          const basePosScales: ConstraintPosScales = [
-            localPosScales[0] ?? posScales[0],
-            localPosScales[1] ?? posScales[1],
-          ];
+          // `basePosScales` (the inherited scales with any self-scaled dim
+          // overridden — see selfScaledSpaces above) is the floor here.
           const effectivePosScales: ConstraintPosScales = ownsPositionAxis
             ? [
                 basePosScales[0] ?? posScaleFromSpace(space?.[0], size[0]),
@@ -432,15 +428,6 @@ export const layer = createNodeOperatorSequential(
             };
             return [pick(0), pick(1)];
           };
-
-          // Fresh scale-factors array for children: a self-scaled (stashed)
-          // SIZE dim forwards its LOCAL factor instead of the inherited one.
-          // Build a new array — never mutate the parent's `scaleFactors`
-          // (unlike spread, which mutates intentionally for sibling sharing).
-          const childScaleFactors: Size<number | undefined> = [
-            childSfOverride[0] ?? scaleFactors?.[0],
-            childSfOverride[1] ?? scaleFactors?.[1],
-          ];
 
           for (let i = 0; i < children.length; i++) {
             const child = children[i];

--- a/packages/gofish-graphics/src/ast/graphicalOperators/position.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/position.tsx
@@ -1,7 +1,7 @@
 import { computeAesthetic } from "../../util";
 import { GoFishNode } from "../_node";
 import { Size, elaborateDims, FancyDims } from "../dims";
-import { getValue, isValue, MaybeValue } from "../data";
+import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import { POSITION, UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
 import { interval } from "../../util/interval";
 import { createNodeOperator } from "../withGoFish";
@@ -29,10 +29,16 @@ export const position = createNodeOperator(
         ) => {
           return [
             isValue(options.x)
-              ? POSITION(interval(getValue(options.x)!, getValue(options.x)!))
+              ? POSITION(
+                  interval(getValue(options.x)!, getValue(options.x)!),
+                  getMeasure(options.x)
+                )
               : UNDEFINED,
             isValue(options.y)
-              ? POSITION(interval(getValue(options.y)!, getValue(options.y)!))
+              ? POSITION(
+                  interval(getValue(options.y)!, getValue(options.y)!),
+                  getMeasure(options.y)
+                )
               : UNDEFINED,
           ];
         },

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -1,14 +1,14 @@
 import { computeAesthetic } from "../../util";
 import { GoFishNode, Placeable } from "../_node";
 import type { AxisOptions } from "../gofish";
-import { getMeasure, getValue, isValue, MaybeValue, Measure } from "../data";
+import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import { Dimensions, elaborateDims, FancyDims, Size } from "../dims";
 import { createNodeOperator } from "../withGoFish";
 import { GoFishAST } from "../_ast";
 import { Collection } from "lodash";
 import { SplitBy, splitKeyFn } from "../datumProjection";
 import {
-  forgetOnConflict,
+  forgetAllMeasures,
   isPOSITION,
   POSITION,
   UNDEFINED,
@@ -75,25 +75,17 @@ function setAxisTranslation(
     (node.transform!.translate![axis] ?? 0) + delta;
 }
 
-/** Merge the measures of one channel's value array. They should all agree
- *  (same field); a mixed array forgets to undefined rather than throwing. */
-function mergeValueMeasures(values: MaybeValue<number>[]): Measure | undefined {
-  return values
-    .map((v) => getMeasure(v))
-    .reduce<
-      Measure | undefined
-    >((acc, m) => forgetOnConflict(acc, m), undefined);
-}
-
 function resolvePositionSpace(
   values: MaybeValue<number>[] | undefined
 ): UnderlyingSpace {
   if (!values || values.length === 0) return UNDEFINED;
   if (!values.every((value) => isValue(value))) return UNDEFINED;
   const rawValues = values.map((value) => getValue(value)!);
+  // Value measures should all agree (same field); a mixed array forgets to
+  // undefined rather than throwing.
   return POSITION(
     Interval.interval(Math.min(...rawValues), Math.max(...rawValues)),
-    mergeValueMeasures(values)
+    forgetAllMeasures(values.map((v) => getMeasure(v)))
   );
 }
 
@@ -158,10 +150,7 @@ export const Scatter = createNodeOperator(
                 Math.min(...xMin.map((v) => getValue(v)!)),
                 Math.max(...xMax.map((v) => getValue(v)!))
               ),
-              forgetOnConflict(
-                mergeValueMeasures(xMin),
-                mergeValueMeasures(xMax)
-              )
+              forgetAllMeasures([...xMin, ...xMax].map((v) => getMeasure(v)))
             );
           } else {
             const result = resolveAlignmentSpace(
@@ -181,10 +170,7 @@ export const Scatter = createNodeOperator(
                 Math.min(...yMin.map((v) => getValue(v)!)),
                 Math.max(...yMax.map((v) => getValue(v)!))
               ),
-              forgetOnConflict(
-                mergeValueMeasures(yMin),
-                mergeValueMeasures(yMax)
-              )
+              forgetAllMeasures([...yMin, ...yMax].map((v) => getMeasure(v)))
             );
           } else {
             const result = resolveAlignmentSpace(

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -1,13 +1,14 @@
 import { computeAesthetic } from "../../util";
 import { GoFishNode, Placeable } from "../_node";
 import type { AxisOptions } from "../gofish";
-import { getValue, isValue, MaybeValue } from "../data";
+import { getMeasure, getValue, isValue, MaybeValue, Measure } from "../data";
 import { Dimensions, elaborateDims, FancyDims, Size } from "../dims";
 import { createNodeOperator } from "../withGoFish";
 import { GoFishAST } from "../_ast";
 import { Collection } from "lodash";
 import { SplitBy, splitKeyFn } from "../datumProjection";
 import {
+  forgetOnConflict,
   isPOSITION,
   POSITION,
   UNDEFINED,
@@ -74,6 +75,16 @@ function setAxisTranslation(
     (node.transform!.translate![axis] ?? 0) + delta;
 }
 
+/** Merge the measures of one channel's value array. They should all agree
+ *  (same field); a mixed array forgets to undefined rather than throwing. */
+function mergeValueMeasures(values: MaybeValue<number>[]): Measure | undefined {
+  return values
+    .map((v) => getMeasure(v))
+    .reduce<
+      Measure | undefined
+    >((acc, m) => forgetOnConflict(acc, m), undefined);
+}
+
 function resolvePositionSpace(
   values: MaybeValue<number>[] | undefined
 ): UnderlyingSpace {
@@ -81,7 +92,8 @@ function resolvePositionSpace(
   if (!values.every((value) => isValue(value))) return UNDEFINED;
   const rawValues = values.map((value) => getValue(value)!);
   return POSITION(
-    Interval.interval(Math.min(...rawValues), Math.max(...rawValues))
+    Interval.interval(Math.min(...rawValues), Math.max(...rawValues)),
+    mergeValueMeasures(values)
   );
 }
 
@@ -145,6 +157,10 @@ export const Scatter = createNodeOperator(
               Interval.interval(
                 Math.min(...xMin.map((v) => getValue(v)!)),
                 Math.max(...xMax.map((v) => getValue(v)!))
+              ),
+              forgetOnConflict(
+                mergeValueMeasures(xMin),
+                mergeValueMeasures(xMax)
               )
             );
           } else {
@@ -164,6 +180,10 @@ export const Scatter = createNodeOperator(
               Interval.interval(
                 Math.min(...yMin.map((v) => getValue(v)!)),
                 Math.max(...yMax.map((v) => getValue(v)!))
+              ),
+              forgetOnConflict(
+                mergeValueMeasures(yMin),
+                mergeValueMeasures(yMax)
               )
             );
           } else {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -23,7 +23,7 @@ import {
   isDIFFERENCE,
   isPOSITION,
   isSIZE,
-  forgetOnConflict,
+  forgetAllMeasures,
   spaceMeasure,
 } from "../underlyingSpace";
 import { UnderlyingSpace } from "../underlyingSpace";
@@ -130,11 +130,7 @@ export const Spread = createNodeOperator(
           // spreading different fields is legitimate, so a conflict forgets to
           // undefined rather than throwing.
           const stackChildMeasure = (): Measure | undefined =>
-            stackSpaces
-              .map((s) => spaceMeasure(s))
-              .reduce<
-                Measure | undefined
-              >((acc, m) => forgetOnConflict(acc, m), undefined);
+            forgetAllMeasures(stackSpaces.map((s) => spaceMeasure(s)));
 
           // Explicit size on the spread overrides children-derived sizing.
           if (isValue(dims[stackDir].size)) {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -1,6 +1,6 @@
 import { GoFishNode, Placeable } from "../_node";
 import type { AxisOptions } from "../gofish";
-import { getValue, isValue, MaybeValue } from "../data";
+import { getMeasure, getValue, isValue, MaybeValue, Measure } from "../data";
 import {
   Direction,
   elaborateDims,
@@ -23,6 +23,8 @@ import {
   isDIFFERENCE,
   isPOSITION,
   isSIZE,
+  forgetOnConflict,
+  spaceMeasure,
 } from "../underlyingSpace";
 import { UnderlyingSpace } from "../underlyingSpace";
 import * as Interval from "../../util/interval";
@@ -124,11 +126,22 @@ export const Spread = createNodeOperator(
             .map((node) => node.key)
             .filter((key): key is string => key !== undefined);
 
+          // Forget-merge of the stacking children's measures. Stacking/
+          // spreading different fields is legitimate, so a conflict forgets to
+          // undefined rather than throwing.
+          const stackChildMeasure = (): Measure | undefined =>
+            stackSpaces
+              .map((s) => spaceMeasure(s))
+              .reduce<
+                Measure | undefined
+              >((acc, m) => forgetOnConflict(acc, m), undefined);
+
           // Explicit size on the spread overrides children-derived sizing.
           if (isValue(dims[stackDir].size)) {
             const explicit: Size<UnderlyingSpace> = [UNDEFINED, UNDEFINED];
             explicit[stackDir] = SIZE(
-              Monotonic.linear(getValue(dims[stackDir].size!), 0)
+              Monotonic.linear(getValue(dims[stackDir].size!), 0),
+              getMeasure(dims[stackDir].size)
             );
             explicit[alignDir] = alignSpace;
             return explicit;
@@ -147,12 +160,18 @@ export const Spread = createNodeOperator(
                     : 0
                 )
                 .reduce((a, b) => a + b, 0);
-              stackSpace = POSITION(Interval.interval(0, totalWidth));
+              stackSpace = POSITION(
+                Interval.interval(0, totalWidth),
+                stackChildMeasure()
+              );
             } else if (stackSpaces.every(isSIZE)) {
               const totalSize = stackSpaces
                 .map((s) => (s as any).domain.run(1) as number)
                 .reduce((a, b) => a + b, 0);
-              stackSpace = POSITION(Interval.interval(0, totalSize));
+              stackSpace = POSITION(
+                Interval.interval(0, totalSize),
+                stackChildMeasure()
+              );
             } else if (namedKeys.length > 0) {
               stackSpace = ORDINAL(namedKeys);
             }
@@ -187,11 +206,11 @@ export const Spread = createNodeOperator(
                       childDomains[childDomains.length - 1].run(scaleFactor) / 2
                   );
             if (dataDriven) {
-              stackSpace = SIZE(composeSize());
+              stackSpace = SIZE(composeSize(), stackChildMeasure());
             } else if (namedKeys.length > 0) {
               stackSpace = ORDINAL(namedKeys);
             } else if (allSize) {
-              stackSpace = SIZE(composeSize());
+              stackSpace = SIZE(composeSize(), stackChildMeasure());
             } else if (children.every((c) => isPOSITION(c[stackDir]))) {
               const totalWidth = children
                 .map((c) =>
@@ -200,7 +219,10 @@ export const Spread = createNodeOperator(
                     : 0
                 )
                 .reduce((a, b) => a + b, 0);
-              stackSpace = POSITION(Interval.interval(0, totalWidth));
+              stackSpace = POSITION(
+                Interval.interval(0, totalWidth),
+                stackChildMeasure()
+              );
             }
           }
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
@@ -13,7 +13,7 @@ import { GoFishNode, Placeable } from "../_node";
 import { GoFishAST } from "../_ast";
 import { createNodeOperator } from "../withGoFish";
 import { FancyDims, Size, Direction, elaborateDims } from "../dims";
-import { getValue, isValue, MaybeValue } from "../data";
+import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import { computeAesthetic, computeSize } from "../../util";
 import {
   POSITION,
@@ -132,7 +132,10 @@ export const Treemap = createNodeOperator(
           // positioned box that fills the slot it is given.
           const axisSpace = (i: Direction): UnderlyingSpace =>
             isValue(dims[i].size)
-              ? SIZE(Monotonic.linear(getValue(dims[i].size!)!, 0))
+              ? SIZE(
+                  Monotonic.linear(getValue(dims[i].size!)!, 0),
+                  getMeasure(dims[i].size)
+                )
               : POSITION(interval(0, 1));
           return [axisSpace(0), axisSpace(1)];
         },

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -38,7 +38,8 @@ import {
   resolveMarkResult,
   stashLayerName,
 } from "./chartBuilder";
-import { inferSize, inferPos, inferColor } from "../channels";
+import { inferSize, inferPos, inferColor, resolveMeasure } from "../channels";
+import type { Measure } from "../data";
 import type { MaybeValue, Value } from "../data";
 import type { LabelAccessor, LabelOptions } from "../labels/labelPlacement";
 import type { NameableMark } from "../withGoFish";
@@ -333,19 +334,20 @@ export type DualModeOperator<Datum, Options> = {
 };
 
 /**
- * Run a single channel inference over a data slice. `provenanceData` is the
- * operator's whole input array, which carries the measure-provenance symbol
- * (e.g. from `bin()`) even when `data` is a per-entry slice that does not — so
- * `inferSize`/`inferPos` resolve the right measure for a split entry.
+ * Run a single channel inference over a data slice. `measure` is the channel's
+ * resolved {@link Measure}, computed once per channel from the operator's whole
+ * input array (which carries the measure-provenance symbol even when `data` is a
+ * per-entry slice that does not) and passed down so `inferSize`/`inferPos` don't
+ * recompute it per split entry.
  */
 function runChannel(
   type: ChannelType,
   val: any,
   data: any[],
-  provenanceData: any[]
+  measure: Measure | undefined
 ): any {
-  if (type === "size") return inferSize(val, data, provenanceData);
-  if (type === "pos") return inferPos(val, data, provenanceData);
+  if (type === "size") return inferSize(val, data, measure);
+  if (type === "pos") return inferPos(val, data, measure);
   if (type === "color") return inferColor(val, data);
   return val;
 }
@@ -381,15 +383,23 @@ function applyChannels<Options extends Record<string, any>>(
     if (Array.isArray(val)) continue;
     const type: ChannelType = typeof spec === "string" ? spec : spec.type;
     const perEntry = typeof spec === "object" && spec.entry === true;
+    // The measure is loop-invariant across split entries (it depends only on
+    // the accessor and `wholeData`'s provenance, not on which items a given
+    // entry holds), so resolve it once per channel. Only size/pos consume it;
+    // computing it for color/raw would add a spurious conflict-throw site.
+    const measure =
+      type === "size" || type === "pos"
+        ? resolveMeasure(wholeData, val)
+        : undefined;
     if (perEntry && entries !== undefined) {
-      // Value aggregation uses each entry's items; measure provenance comes
-      // from `wholeData` (the binned array still carries the symbol — each
-      // per-entry slice does not).
+      // Value aggregation uses each entry's items; the measure comes from
+      // `wholeData` (the binned array still carries the symbol — each per-entry
+      // slice does not).
       out[key] = [...entries.values()].map((items) =>
-        runChannel(type, val, items, wholeData)
+        runChannel(type, val, items, measure)
       );
     } else {
-      out[key] = runChannel(type, val, wholeData, wholeData);
+      out[key] = runChannel(type, val, wholeData, measure);
     }
   }
   return out as Options;

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -332,10 +332,20 @@ export type DualModeOperator<Datum, Options> = {
   ): NameableMark<Datum>;
 };
 
-/** Run a single channel inference over a data slice. */
-function runChannel(type: ChannelType, val: any, data: any[]): any {
-  if (type === "size") return inferSize(val, data);
-  if (type === "pos") return inferPos(val, data);
+/**
+ * Run a single channel inference over a data slice. `provenanceData` is the
+ * operator's whole input array, which carries the measure-provenance symbol
+ * (e.g. from `bin()`) even when `data` is a per-entry slice that does not — so
+ * `inferSize`/`inferPos` resolve the right measure for a split entry.
+ */
+function runChannel(
+  type: ChannelType,
+  val: any,
+  data: any[],
+  provenanceData: any[]
+): any {
+  if (type === "size") return inferSize(val, data, provenanceData);
+  if (type === "pos") return inferPos(val, data, provenanceData);
   if (type === "color") return inferColor(val, data);
   return val;
 }
@@ -372,11 +382,14 @@ function applyChannels<Options extends Record<string, any>>(
     const type: ChannelType = typeof spec === "string" ? spec : spec.type;
     const perEntry = typeof spec === "object" && spec.entry === true;
     if (perEntry && entries !== undefined) {
+      // Value aggregation uses each entry's items; measure provenance comes
+      // from `wholeData` (the binned array still carries the symbol — each
+      // per-entry slice does not).
       out[key] = [...entries.values()].map((items) =>
-        runChannel(type, val, items)
+        runChannel(type, val, items, wholeData)
       );
     } else {
-      out[key] = runChannel(type, val, wholeData);
+      out[key] = runChannel(type, val, wholeData, wholeData);
     }
   }
   return out as Options;

--- a/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
@@ -97,11 +97,11 @@ export const Ellipse = ({
           if (isValue(d.min)) {
             // position; treat it like a position space w/ a single element
             const min = getValue(d.min) ?? 0;
-            return POSITION(interval(min, min));
+            return POSITION(interval(min, min), getMeasure(d.min));
           }
           if (isValue(d.size)) {
             // data-driven size only — literals are handled at layout time.
-            return SIZE(axisDomain);
+            return SIZE(axisDomain, getMeasure(d.size));
           }
           return UNDEFINED;
         };

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -2,7 +2,13 @@ import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic } from "../../util";
 import { interval } from "../../util/interval";
 import { GoFishNode } from "../_node";
-import { getValue, inferEmbedded, isAesthetic, isValue } from "../data";
+import {
+  getMeasure,
+  getValue,
+  inferEmbedded,
+  isAesthetic,
+  isValue,
+} from "../data";
 import { Dimensions, elaborateDims, FancyDims, Transform } from "../dims";
 import {
   DIFFERENCE,
@@ -251,15 +257,24 @@ export const Image = ({
           if (isValue(pos)) {
             const min = getValue(pos) ?? 0;
             if (isValue(dims[axis].size)) {
-              return DIFFERENCE(getValue(dims[axis].size)!);
+              return DIFFERENCE(
+                getValue(dims[axis].size)!,
+                getMeasure(dims[axis].size)
+              );
             }
-            return POSITION(interval(min, min));
+            return POSITION(interval(min, min), getMeasure(pos));
           }
           if (isAesthetic(pos) && isValue(dims[axis].size)) {
-            return DIFFERENCE(getValue(dims[axis].size)!);
+            return DIFFERENCE(
+              getValue(dims[axis].size)!,
+              getMeasure(dims[axis].size)
+            );
           }
           if (!isValue(pos) && isValue(dims[axis].size)) {
-            return SIZE(Monotonic.linear(getValue(dims[axis].size)!, 0));
+            return SIZE(
+              Monotonic.linear(getValue(dims[axis].size)!, 0),
+              getMeasure(dims[axis].size)
+            );
           }
           // No data position, no data size — image's intrinsic dimensions
           // are resolved at layout time via resolveRenderedDimensions.

--- a/packages/gofish-graphics/src/ast/shapes/petal.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/petal.tsx
@@ -85,11 +85,11 @@ export const Petal = ({
           const d = dims[axis];
           if (isValue(d.min)) {
             const min = getValue(d.min) ?? 0;
-            return POSITION(interval(min, min));
+            return POSITION(interval(min, min), getMeasure(d.min));
           }
           if (isValue(d.size)) {
             // data-driven size only — literals handled at layout time.
-            return SIZE(sizeDomain(axis));
+            return SIZE(sizeDomain(axis), getMeasure(d.size));
           }
           return UNDEFINED;
         };

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -36,6 +36,7 @@ import {
   SIZE,
   UNDEFINED,
   UnderlyingSpace,
+  forgetOnConflict,
 } from "../underlyingSpace";
 import { interval } from "../../util/interval";
 import { createMark } from "../withGoFish";
@@ -130,7 +131,10 @@ export const Rect = ({
         ): UnderlyingSpace => {
           const d = dims[axis];
           if (isValue(d.min) && isValue(d.max)) {
-            return POSITION(interval(getValue(d.min)!, getValue(d.max)!));
+            return POSITION(
+              interval(getValue(d.min)!, getValue(d.max)!),
+              forgetOnConflict(getMeasure(d.min), getMeasure(d.max))
+            );
           }
           if (!isValue(d.min) && !isValue(d.size)) {
             // Nothing data-driven on this axis. Literal pixel sizes are
@@ -139,16 +143,16 @@ export const Rect = ({
             return UNDEFINED;
           }
           if (isAesthetic(d.min) && isValue(d.size)) {
-            return DIFFERENCE(getValue(d.size)!);
+            return DIFFERENCE(getValue(d.size)!, getMeasure(d.size));
           }
           if (!isValue(d.min) && isValue(d.size)) {
             // No data position; data-driven size → SIZE with Monotonic.
-            return SIZE(axisDomain);
+            return SIZE(axisDomain, getMeasure(d.size));
           }
           // has position (data-driven), maybe with literal/no size → POSITION.
           const min = isValue(d.min) ? getValue(d.min)! : 0;
           const size = isValue(d.size) ? getValue(d.size)! : 0;
-          return POSITION(interval(min, min + size));
+          return POSITION(interval(min, min + size), getMeasure(d.min));
         };
 
         return [resolveAxis(0, wDomain), resolveAxis(1, hDomain)];

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -3,6 +3,7 @@ import { computeAesthetic } from "../../util";
 import { interval } from "../../util/interval";
 import { GoFishNode } from "../_node";
 import {
+  getMeasure,
   getValue,
   inferEmbedded,
   isAesthetic,
@@ -210,15 +211,24 @@ export const Text = ({
           if (isValue(pos)) {
             const min = getValue(pos) ?? 0;
             if (isValue(dims[axis].size)) {
-              return DIFFERENCE(getValue(dims[axis].size)!);
+              return DIFFERENCE(
+                getValue(dims[axis].size)!,
+                getMeasure(dims[axis].size)
+              );
             }
-            return POSITION(interval(min, min));
+            return POSITION(interval(min, min), getMeasure(pos));
           }
           if (isAesthetic(pos) && isValue(dims[axis].size)) {
-            return DIFFERENCE(getValue(dims[axis].size)!);
+            return DIFFERENCE(
+              getValue(dims[axis].size)!,
+              getMeasure(dims[axis].size)
+            );
           }
           if (!isValue(pos) && isValue(dims[axis].size)) {
-            return SIZE(Monotonic.linear(getValue(dims[axis].size)!, 0));
+            return SIZE(
+              Monotonic.linear(getValue(dims[axis].size)!, 0),
+              getMeasure(dims[axis].size)
+            );
           }
           // No data position, no data size — text's intrinsic extent is
           // handled at layout time, not via the underlying-space tree.

--- a/packages/gofish-graphics/src/ast/transforms.ts
+++ b/packages/gofish-graphics/src/ast/transforms.ts
@@ -1,5 +1,5 @@
 import { bin as d3bin } from "d3-array";
-import { MEASURE_PROVENANCE, type MeasureProvenance } from "./data";
+import { setMeasureProvenance, type MeasureProvenance } from "./data";
 
 type BinResult = { start: number; end: number; size: number; count: number };
 
@@ -35,13 +35,7 @@ function runBin<T extends Record<string, any>>(
     size: field,
     count: "count",
   };
-  Object.defineProperty(result, MEASURE_PROVENANCE, {
-    value: provenance,
-    enumerable: false,
-    configurable: true,
-    writable: true,
-  });
-  return result;
+  return setMeasureProvenance(result, provenance);
 }
 
 export function bin<T extends Record<string, any>>(

--- a/packages/gofish-graphics/src/ast/transforms.ts
+++ b/packages/gofish-graphics/src/ast/transforms.ts
@@ -1,4 +1,5 @@
 import { bin as d3bin } from "d3-array";
+import { MEASURE_PROVENANCE, type MeasureProvenance } from "./data";
 
 type BinResult = { start: number; end: number; size: number; count: number };
 
@@ -15,7 +16,7 @@ function runBin<T extends Record<string, any>>(
     ? binnerBase.thresholds(thresholds as number[])
     : binnerBase.thresholds(thresholds as number);
   const bins = binner(data.filter((d) => d[field] != null));
-  return bins
+  const result = bins
     .filter((b) => b.x0 !== undefined && b.x1 !== undefined)
     .map((b) => ({
       start: b.x0!,
@@ -23,6 +24,24 @@ function runBin<T extends Record<string, any>>(
       size: b.x1! - b.x0!,
       count: b.length,
     }));
+  // Provenance: `start`/`end`/`size` are still in the SOURCE field's units
+  // (e.g. "Beak Length (mm)"), not the literal column-name "start"; `count` is
+  // a count. This rides the array (not each row) so it survives `derive(...)`,
+  // letting channel inference unify a histogram's edges with the raw field's
+  // axis instead of seeing a false measure conflict (see resolveMeasure).
+  const provenance: MeasureProvenance = {
+    start: field,
+    end: field,
+    size: field,
+    count: "count",
+  };
+  Object.defineProperty(result, MEASURE_PROVENANCE, {
+    value: provenance,
+    enumerable: false,
+    configurable: true,
+    writable: true,
+  });
+  return result;
 }
 
 export function bin<T extends Record<string, any>>(

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -6,6 +6,7 @@
 import { interval, Interval } from "../util/interval";
 import { CoordinateTransform } from "./coordinateTransforms/coord";
 import * as Monotonic from "../util/monotonic";
+import type { Measure } from "./data";
 
 export type UnderlyingSpaceKind =
   | "position"
@@ -19,7 +20,9 @@ export type POSITION_TYPE = {
   domain: Interval;
   spacing?: number;
   ordinalGroupId?: string;
-  source?: string;
+  /** The measure (unit) of this axis. Spaces unify per measure — see
+   *  {@link mergeMeasures}. Undefined = "no claim" (permissive). */
+  measure?: Measure;
   coordinateTransform?: CoordinateTransform;
 };
 
@@ -28,7 +31,7 @@ export type DIFFERENCE_TYPE = {
   width: number;
   spacing?: number;
   ordinalGroupId?: string;
-  source?: string;
+  measure?: Measure;
 };
 
 export type SIZE_TYPE = {
@@ -36,14 +39,13 @@ export type SIZE_TYPE = {
   domain: Monotonic.Monotonic;
   spacing?: number;
   ordinalGroupId?: string;
-  source?: string;
+  measure?: Measure;
 };
 
 export type ORDINAL_TYPE = {
   kind: "ordinal";
   spacing?: number;
   ordinalGroupId?: string;
-  source?: string;
   domain?: string[]; // Top-level category keys for axis labels
 };
 
@@ -51,7 +53,6 @@ export type UNDEFINED_TYPE = {
   kind: "undefined";
   spacing?: number;
   ordinalGroupId?: string;
-  source?: string;
 };
 
 export type UnderlyingSpace =
@@ -63,27 +64,37 @@ export type UnderlyingSpace =
 
 export const POSITION = (
   domain: Interval,
+  measure?: Measure,
   coordinateTransform?: CoordinateTransform
 ): UnderlyingSpace => ({
   kind: "position",
   domain,
+  ...(measure !== undefined ? { measure } : {}),
   coordinateTransform,
 });
 
 export const isPOSITION = (space: UnderlyingSpace): space is POSITION_TYPE =>
   space.kind === "position";
 
-export const DIFFERENCE = (width: number): UnderlyingSpace => ({
+export const DIFFERENCE = (
+  width: number,
+  measure?: Measure
+): UnderlyingSpace => ({
   kind: "difference",
   width,
+  ...(measure !== undefined ? { measure } : {}),
 });
 export const isDIFFERENCE = (
   space: UnderlyingSpace
 ): space is DIFFERENCE_TYPE => space.kind === "difference";
 
-export const SIZE = (domain: Monotonic.Monotonic): UnderlyingSpace => ({
+export const SIZE = (
+  domain: Monotonic.Monotonic,
+  measure?: Measure
+): UnderlyingSpace => ({
   kind: "size",
   domain,
+  ...(measure !== undefined ? { measure } : {}),
 });
 export const isSIZE = (space: UnderlyingSpace): space is SIZE_TYPE =>
   space.kind === "size";
@@ -98,3 +109,51 @@ export const isORDINAL = (space: UnderlyingSpace): space is ORDINAL_TYPE =>
 export const UNDEFINED: UnderlyingSpace = { kind: "undefined" };
 export const isUNDEFINED = (space: UnderlyingSpace): space is UNDEFINED_TYPE =>
   space.kind === "undefined";
+
+/** Read the measure of any space, or undefined for the measureless kinds. */
+export const spaceMeasure = (
+  space: UnderlyingSpace | undefined
+): Measure | undefined =>
+  space && (isPOSITION(space) || isDIFFERENCE(space) || isSIZE(space))
+    ? space.measure
+    : undefined;
+
+/**
+ * Unify two measures as TYPES (the Stage-1 guard). Undefined is permissive —
+ * it means "no claim", so it unifies with anything and yields the other side.
+ * Two equal measures unify to themselves. Two *different* defined measures are
+ * a type error: unioning spaces in incompatible units (e.g. a marginal
+ * histogram's count axis vs. a scatter's millimeters) is silent corruption, so
+ * we throw loudly instead.
+ */
+export const mergeMeasures = (
+  a: Measure | undefined,
+  b: Measure | undefined,
+  context?: string
+): Measure | undefined => {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  if (a === b) return a;
+  throw new Error(
+    `Cannot unify underlying spaces with different measures: ` +
+      `"${a}" and "${b}"${context ? ` (${context})` : ""}.\n` +
+      `If these are the same units, assert that with field(name, measure) ` +
+      `or datum(v, measure). If they are different units, give the inner ` +
+      `chart an explicit w/h so it becomes a self-scaling region.`
+  );
+};
+
+/**
+ * Like {@link mergeMeasures}, but a conflict *forgets* (returns undefined)
+ * instead of throwing. Used where composing differently-measured spaces is
+ * legitimate — e.g. stacking two different fields' SIZEs: the composed extent
+ * is real but carries no single unit.
+ */
+export const forgetOnConflict = (
+  a: Measure | undefined,
+  b: Measure | undefined
+): Measure | undefined => {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return a === b ? a : undefined;
+};

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -69,7 +69,7 @@ export const POSITION = (
 ): UnderlyingSpace => ({
   kind: "position",
   domain,
-  ...(measure !== undefined ? { measure } : {}),
+  measure,
   coordinateTransform,
 });
 
@@ -82,7 +82,7 @@ export const DIFFERENCE = (
 ): UnderlyingSpace => ({
   kind: "difference",
   width,
-  ...(measure !== undefined ? { measure } : {}),
+  measure,
 });
 export const isDIFFERENCE = (
   space: UnderlyingSpace
@@ -94,7 +94,7 @@ export const SIZE = (
 ): UnderlyingSpace => ({
   kind: "size",
   domain,
-  ...(measure !== undefined ? { measure } : {}),
+  measure,
 });
 export const isSIZE = (space: UnderlyingSpace): space is SIZE_TYPE =>
   space.kind === "size";
@@ -157,3 +157,28 @@ export const forgetOnConflict = (
   if (b === undefined) return a;
   return a === b ? a : undefined;
 };
+
+/**
+ * Fold an array of measures with {@link mergeMeasures} (throws on a real
+ * conflict). The array form of the pairwise unify-as-types guard.
+ */
+export const mergeAllMeasures = (
+  ms: (Measure | undefined)[],
+  context?: string
+): Measure | undefined =>
+  ms.reduce<Measure | undefined>(
+    (acc, m) => mergeMeasures(acc, m, context),
+    undefined
+  );
+
+/**
+ * Fold an array of measures with {@link forgetOnConflict} (a conflict forgets
+ * to undefined). The array form of the permissive composition merge.
+ */
+export const forgetAllMeasures = (
+  ms: (Measure | undefined)[]
+): Measure | undefined =>
+  ms.reduce<Measure | undefined>(
+    (acc, m) => forgetOnConflict(acc, m),
+    undefined
+  );

--- a/packages/gofish-graphics/stories/seaborn/MarginalHistogram.stories.tsx
+++ b/packages/gofish-graphics/stories/seaborn/MarginalHistogram.stories.tsx
@@ -3,8 +3,13 @@ import { initializeContainer } from "../helper";
 import { Chart, scatter, circle, rect, derive, bin, layer, Constraint } from "../../src/lib";
 import { penguins } from "../../src/data/penguins";
 
+// Mirrors seaborn's jointplot:
+//   sns.jointplot(data=penguins, x="bill_length_mm", y="bill_depth_mm")
+// https://seaborn.pydata.org/generated/seaborn.jointplot.html
+// (Our penguins export renames the fields to "Beak ..." rather than "bill ...".)
+
 const meta: Meta = {
-  title: "Vega-Lite/Marginal Histogram",
+  title: "Seaborn/Marginal Histogram",
   argTypes: {
     w: { control: { type: "number", min: 100, max: 1000, step: 10 } },
     h: {

--- a/packages/gofish-graphics/stories/vega-lite/MarginalHistogram.stories.tsx
+++ b/packages/gofish-graphics/stories/vega-lite/MarginalHistogram.stories.tsx
@@ -58,15 +58,20 @@ export const Default: StoryObj<Args> = {
         .resolve();
       rightHist.name("rightHist");
 
+      const GAP = 10;
       await layer([sc, topHist, rightHist])
         .constrain(({ scatter, topHist, rightHist }: any) => [
           Constraint.align({ x: "baseline", y: "baseline" } as any, [scatter]),
           Constraint.align({ x: "baseline" } as any, [scatter, topHist]),
           Constraint.align({ y: "baseline" } as any, [scatter, rightHist]),
-          Constraint.distribute({ dir: "y", spacing: 10 }, [scatter, topHist]),
-          Constraint.distribute({ dir: "x", spacing: 10 }, [scatter, rightHist]),
+          Constraint.position({ y: args.h + GAP, anchor: "start" } as any, [topHist]),
+          Constraint.position({ x: args.w + GAP, anchor: "start" } as any, [rightHist]),
         ])
-        .render(container, { w: args.w, h: args.h, axes: true } as any);
+        .render(container, {
+          w: args.w,
+          h: args.h,
+          axes: { x: { title: "Beak Length (mm)" }, y: { title: "Beak Depth (mm)" } },
+        } as any);
     })();
 
     return container;

--- a/packages/gofish-graphics/stories/vega-lite/MarginalHistogram.stories.tsx
+++ b/packages/gofish-graphics/stories/vega-lite/MarginalHistogram.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import { Chart, scatter, circle, rect, derive, bin, layer, Constraint } from "../../src/lib";
+import { penguins } from "../../src/data/penguins";
+
+const meta: Meta = {
+  title: "Vega-Lite/Marginal Histogram",
+  argTypes: {
+    w: { control: { type: "number", min: 100, max: 1000, step: 10 } },
+    h: {
+      control: { type: "number", min: 100, max: 1000, step: 10 },
+    },
+  },
+};
+
+export default meta;
+
+type Args = { w: number; h: number };
+
+export const Default: StoryObj<Args> = {
+  args: { w: 400, h: 400 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    // Our penguins export uses "Beak ..." rather than seaborn's "bill ..." field names.
+    const data = penguins
+      .filter(
+        (d) =>
+          (d as any)["Beak Length (mm)"] != null &&
+          (d as any)["Beak Depth (mm)"] != null
+      )
+      .map((d, i) => ({ ...d, id: i }));
+
+    (async () => {
+      const sc = await Chart(data)
+        .flow(
+          scatter({ by: "id", x: "Beak Length (mm)", y: "Beak Depth (mm)" } as any)
+        )
+        .mark(circle({ r: 3, fill: "steelblue", fillOpacity: 0.6 }))
+        .resolve();
+      sc.name("scatter");
+
+      const topHist = await Chart(data, { h: 80 })
+        .flow(
+          derive(bin("Beak Length (mm)")),
+          scatter({ xMin: "start", xMax: "end" } as any)
+        )
+        .mark(rect({ h: "count", fill: "steelblue" } as any))
+        .resolve();
+      topHist.name("topHist");
+
+      const rightHist = await Chart(data, { w: 80 })
+        .flow(
+          derive(bin("Beak Depth (mm)")),
+          scatter({ yMin: "start", yMax: "end" } as any)
+        )
+        .mark(rect({ w: "count", fill: "steelblue" } as any))
+        .resolve();
+      rightHist.name("rightHist");
+
+      await layer([sc, topHist, rightHist])
+        .constrain(({ scatter, topHist, rightHist }: any) => [
+          Constraint.align({ x: "baseline", y: "baseline" } as any, [scatter]),
+          Constraint.align({ x: "baseline" } as any, [scatter, topHist]),
+          Constraint.align({ y: "baseline" } as any, [scatter, rightHist]),
+          Constraint.distribute({ dir: "y", spacing: 10 }, [scatter, topHist]),
+          Constraint.distribute({ dir: "x", spacing: 10 }, [scatter, rightHist]),
+        ])
+        .render(container, { w: args.w, h: args.h, axes: true } as any);
+    })();
+
+    return container;
+  },
+};

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -295,6 +295,11 @@ export const FRONTEND_IR_JSON_SCHEMA = {
           properties: {
             type: { const: "field" },
             name: { type: "string" },
+            measure: {
+              type: "string",
+              description:
+                "Optional unit annotation for the channel's underlying space (a type claim; see field(name, measure)).",
+            },
           },
         },
         {

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -87,6 +87,11 @@ export const FRONTEND_IR_JSON_SCHEMA = {
         options: { type: "object" },
         zOrder: { type: "number" },
         connect: { $ref: "#/$defs/MarkIR" },
+        name: {
+          type: "string",
+          description:
+            "Chart-level name so a sibling Layer constrain callback can reference this chart.",
+        },
         origin: { $ref: "#/$defs/Origin" },
         meta: { $ref: "#/$defs/Meta" },
       },
@@ -98,6 +103,12 @@ export const FRONTEND_IR_JSON_SCHEMA = {
         type: { const: "layer" },
         charts: { type: "array", items: { $ref: "#/$defs/ChartIR" } },
         options: { type: "object" },
+        constraints: {
+          type: "array",
+          items: { $ref: "#/$defs/ConstraintIR" },
+          description:
+            "Layer-level constraints (Layer([...]).constrain(...)), resolving refs against the child charts' names.",
+        },
         origin: { $ref: "#/$defs/Origin" },
         meta: { $ref: "#/$defs/Meta" },
       },

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -83,6 +83,13 @@ export interface ChartIR extends BaseIRNode {
    * in the IR.
    */
   connect?: MarkIR;
+  /**
+   * Chart-level name (from `chart(...).name("scatter")` in Python /
+   * `node.name(...)` on a resolved chart in JS) so a sibling
+   * `Layer([...]).constrain(...)` callback can reference this chart. A
+   * `createName(...)` token sentinel is also accepted on the wire.
+   */
+  name?: string;
 }
 
 /** Multiple charts composed on the same canvas. */
@@ -90,6 +97,9 @@ export interface LayerIR extends BaseIRNode {
   type: "layer";
   charts: ChartIR[];
   options?: Record<string, unknown>;
+  /** Layer-level constraints (from `Layer([...]).constrain(...)`), resolving
+   *  refs against the child charts' `name`s. */
+  constraints?: ConstraintIR[];
 }
 
 /** A bare mark, used when no chart-level wrapping is needed. */

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -312,8 +312,18 @@ export type ChannelValue =
   | number
   | boolean
   | null
+  | FieldAccessor
   | DatumValue
   | BridgeLambdaSentinel;
+
+/** Explicit field-accessor form, emitted by `field(name, measure?)`. The
+ *  optional `measure` is a unit annotation on the channel's underlying space
+ *  (a type claim — see gofish-graphics' `resolveMeasure`). */
+export interface FieldAccessor {
+  type: "field";
+  name: string;
+  measure?: string;
+}
 
 export interface DatumValue {
   type: "datum";

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -134,6 +134,7 @@ function walkChart(
   optionalField(node, "options", path, ctx, expectObject);
   optionalField(node, "zOrder", path, ctx, expectNumber);
   optionalField(node, "connect", path, ctx, walkMark);
+  optionalField(node, "name", path, ctx, expectNameOrToken);
   if (ctx.strict) {
     rejectUnknown(
       node,
@@ -145,6 +146,7 @@ function walkChart(
         "options",
         "zOrder",
         "connect",
+        "name",
         "origin",
         "meta",
       ],
@@ -164,10 +166,13 @@ function walkLayer(
     walkArray(v, p, ctx, walkRootChart)
   );
   optionalField(node, "options", path, ctx, expectObject);
+  optionalField(node, "constraints", path, ctx, (v, p) =>
+    walkArray(v, p, ctx, walkConstraint)
+  );
   if (ctx.strict) {
     rejectUnknown(
       node,
-      ["type", "charts", "options", "origin", "meta"],
+      ["type", "charts", "options", "constraints", "origin", "meta"],
       path,
       ctx
     );

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -414,6 +414,13 @@ function walkChannelValue(value: unknown, path: string, ctx: Context): void {
         message: 'field channel must have a string "name"',
       });
     }
+    // Optional unit annotation (field(name, measure)); a string when present.
+    if (obj.measure !== undefined && typeof obj.measure !== "string") {
+      ctx.errors.push({
+        path: `${path}.measure`,
+        message: 'field "measure" must be a string when present',
+      });
+    }
     return;
   }
   if (obj.type === "literal") {

--- a/packages/gofish-python/gofish/__init__.py
+++ b/packages/gofish-python/gofish/__init__.py
@@ -50,7 +50,9 @@ from .ast import (
     connect,
     Connect,
     datum,
+    field,
 )
+from .transforms import bin
 
 __all__ = [
     "chart",
@@ -100,6 +102,8 @@ __all__ = [
     "connect",
     "Connect",
     "datum",
+    "field",
+    "bin",
 ]
 
 __version__ = "0.1.0"

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -750,6 +750,7 @@ class ChartBuilder:
         self._mark: Optional[Mark] = None
         self._connect: Optional["Mark"] = None
         self._z_order = z_order
+        self._name: Optional[Union[str, "Token"]] = None
 
     def flow(self, *ops: Operator) -> "ChartBuilder":
         """
@@ -824,6 +825,24 @@ class ChartBuilder:
         new_builder._connect = mark
         return new_builder
 
+    def name(self, name_or_token: Union[str, "Token"]) -> "ChartBuilder":
+        """Tag this chart with a name so a `Layer([...]).constrain(...)` callback
+        can reference it (mirrors JS `chart.resolve().name(...)`).
+
+        Args:
+            name_or_token: A flat string name, or a `Token` from `createName(...)`.
+
+        Returns:
+            New ChartBuilder carrying the name.
+        """
+        new_builder = ChartBuilder(
+            self.data, self.options, self.operators, z_order=self._z_order
+        )
+        new_builder._mark = self._mark
+        new_builder._connect = self._connect
+        new_builder._name = name_or_token
+        return new_builder
+
     def zOrder(self, value: float) -> "ChartBuilder":
         """Set z-order for this chart when rendered inside a Layer."""
         new_builder = ChartBuilder(
@@ -831,6 +850,7 @@ class ChartBuilder:
         )
         new_builder._mark = self._mark
         new_builder._connect = self._connect
+        new_builder._name = self._name
         return new_builder
 
     def zIndex(self, value: float) -> "ChartBuilder":
@@ -1565,6 +1585,38 @@ def datum(value: Any) -> DatumValue:
     return DatumValue({"type": "datum", "datum": value})
 
 
+def field(name: str, measure: Optional[str] = None) -> dict:
+    """
+    Explicit field-accessor wrapper. Mirrors the JS `field(...)` constructor
+    in `packages/gofish-graphics/src/ast/data.ts` (the field/datum/literal
+    trichotomy). Equivalent to passing a bare field-name string, plus an
+    optional **measure annotation** — a unit-of-measure type claim for the
+    channel (see the underlying-space measure system).
+
+    Use the measure annotation when a transform has renamed fields so the
+    weak field-name default would mis-tag the channel. The canonical case is
+    Python-side `bin()`: its provenance map can't cross the RPC bridge, so
+    bin edges arrive as fields named "start"/"end" even though they are in
+    the source field's units:
+
+        scatter(
+            xMin=field("start", measure="Beak Length (mm)"),
+            xMax=field("end", measure="Beak Length (mm)"),
+        )
+
+    Emits the canonical `{type: "field", name, measure?}` wire shape; an
+    annotation that contradicts JS-side provenance is a type error.
+
+    Args:
+        name: The field name to read from each row.
+        measure: Optional unit-of-measure annotation for the channel.
+    """
+    out: dict = {"type": "field", "name": name}
+    if measure is not None:
+        out["measure"] = measure
+    return out
+
+
 # Data utilities (for use inside derive() callbacks)
 
 
@@ -2021,14 +2073,58 @@ class LayerBuilder:
     ):
         self.children = children
         self.options = options or {}
+        self._constraints: Optional[List[Any]] = None
+
+    def constrain(self, callback: Callable[..., List[Any]]) -> "LayerBuilder":
+        """Apply constraints relating the named children of this layer.
+
+        Mirrors the JS storybook spelling
+        ``layer([sc.name("a"), other.name("b")]).constrain(({a, b}) => [...])``:
+        each child must be tagged with ``.name(...)`` so the callback can
+        reference it. The callback receives one ``RefSentinel`` per named child
+        as a kwarg and returns a list of constraint specs
+        (``Constraint.align(...)`` / ``Constraint.position(...)`` / ...).
+
+        Returns:
+            A new LayerBuilder carrying the resolved constraints.
+        """
+
+        def _name_key(child: ChartBuilder) -> Optional[str]:
+            n = getattr(child, "_name", None)
+            if n is None:
+                return None
+            return n.tag if isinstance(n, Token) else n
+
+        refs: Dict[str, RefSentinel] = {}
+        for child in self.children:
+            key = _name_key(child)
+            if key is None:
+                raise ValueError(
+                    "every child of Layer(...) used with .constrain() must be "
+                    "named via .name(...) so the callback can reference it"
+                )
+            if key in refs:
+                raise ValueError(
+                    f".constrain() children must have unique names; saw "
+                    f"duplicate: {key!r}"
+                )
+            refs[key] = RefSentinel(key)
+
+        constraints = callback(**refs)
+        new_layer = LayerBuilder(self.children, self.options)
+        new_layer._constraints = list(constraints)
+        return new_layer
 
     def to_ir(self) -> dict:
         """Convert the layer specification to JSON IR."""
-        return {
+        result: dict = {
             "type": "layer",
             "charts": [child.to_ir() for child in self.children],
             "options": self.options,
         }
+        if self._constraints is not None:
+            result["constraints"] = [c.to_dict() for c in self._constraints]
+        return result
 
     def render(
         self,

--- a/packages/gofish-python/gofish/transforms.py
+++ b/packages/gofish-python/gofish/transforms.py
@@ -1,0 +1,163 @@
+"""Data transforms for use inside ``derive(...)``.
+
+Currently exposes ``bin`` — a faithful Python port of the JS ``bin`` transform
+(``packages/gofish-graphics/src/ast/transforms.ts``), which delegates to
+d3-array's ``d3.bin().thresholds(10)``. The d3 algorithm (``tickStep`` /
+``nice`` / ``ticks``) is reproduced exactly so the emitted bins are
+byte-identical to what the JS side produces for the same field.
+"""
+
+import math
+from typing import Any, Callable, List, Optional, Union
+
+_SQRT50 = math.sqrt(50)
+_SQRT10 = math.sqrt(10)
+_SQRT2 = math.sqrt(2)
+
+
+def _tick_step(start: float, stop: float, count: int) -> float:
+    """Port of d3-array's tickStep — chooses a 'nice' step for `count` bins."""
+    step0 = abs(stop - start) / max(0, count)
+    if step0 == 0:
+        return 0
+    step1 = 10 ** math.floor(math.log10(step0))
+    error = step0 / step1
+    if error >= _SQRT50:
+        step1 *= 10
+    elif error >= _SQRT10:
+        step1 *= 5
+    elif error >= _SQRT2:
+        step1 *= 2
+    return -step1 if stop < start else step1
+
+
+def _nice(start: float, stop: float, count: int) -> tuple:
+    """Port of d3-array's nice — expand domain to align with tickStep."""
+    prestep = None
+    while True:
+        step = _tick_step(start, stop, count)
+        if step == prestep:
+            return start, stop
+        if step > 0:
+            start = math.floor(start / step) * step
+            stop = math.ceil(stop / step) * step
+        elif step < 0:
+            start = math.ceil(start * step) / step
+            stop = math.floor(stop * step) / step
+        else:
+            return start, stop
+        prestep = step
+
+
+def _ticks(start: float, stop: float, count: int) -> list:
+    """Port of d3-array's ticks — equally spaced thresholds within domain."""
+    if start == stop and count > 0:
+        return [start]
+    reverse = stop < start
+    if reverse:
+        start, stop = stop, start
+    step = _tick_step(start, stop, count)
+    if step == 0 or math.isinf(step):
+        return []
+    out = []
+    if step > 0:
+        r0 = math.ceil(start / step)
+        r1 = math.floor(stop / step)
+        n = math.ceil(r1 - r0 + 1)
+        out = [(r0 + i) * step for i in range(int(n))]
+    else:
+        step = -step
+        r0 = math.ceil(start * step)
+        r1 = math.floor(stop * step)
+        n = math.ceil(r1 - r0 + 1)
+        out = [(r0 + i) / step for i in range(int(n))]
+    if reverse:
+        out.reverse()
+    return out
+
+
+def _run_bin(
+    data: List[dict],
+    field: str,
+    thresholds: Union[int, List[float], None] = None,
+) -> List[dict]:
+    """Bin ``data`` on ``field`` into ``{start, end, size, count}`` rows.
+
+    Mirrors ``d3.bin().value(d => d[field]).thresholds(thresholds)`` with a
+    default of 10 bins (``thresholds=None``). Pass an int for a target bin
+    count, or an explicit list of threshold edges.
+    """
+    count = 10 if thresholds is None else thresholds
+    values = [d[field] for d in data if d.get(field) is not None]
+    if not values:
+        return []
+
+    if isinstance(count, list):
+        edges = list(count)
+    else:
+        vmin = min(values)
+        vmax = max(values)
+        x0, x1 = _nice(vmin, vmax, count)
+        edges = _ticks(x0, x1, count)
+    if len(edges) < 2:
+        return []
+
+    # d3.bin: bin[i] covers [edges[i], edges[i+1]); the last bin also includes
+    # edges[-1] (the upper edge).
+    n_bins = len(edges) - 1
+    counts = [0] * n_bins
+    last_edge = edges[-1]
+    for v in values:
+        if v == last_edge:
+            counts[-1] += 1
+            continue
+        for i in range(n_bins):
+            if edges[i] <= v < edges[i + 1]:
+                counts[i] += 1
+                break
+
+    return [
+        {
+            "start": edges[i],
+            "end": edges[i + 1],
+            "size": edges[i + 1] - edges[i],
+            "count": counts[i],
+        }
+        for i in range(n_bins)
+    ]
+
+
+def bin(
+    data_or_field: Union[List[dict], str],
+    field: Optional[str] = None,
+    *,
+    thresholds: Union[int, List[float], None] = None,
+) -> Union[List[dict], Callable[[List[dict]], List[dict]]]:
+    """Bin numeric data into histogram buckets.
+
+    Mirrors the JS ``bin`` transform: it delegates to d3-array's
+    ``d3.bin().thresholds(10)`` by default, producing one row per bucket with
+    ``{start, end, size, count}``.
+
+    Two calling conventions, like the JS overloads:
+
+    - **Curried** (for ``derive``): ``bin("field")`` returns a function
+      ``data -> rows`` so you can write ``.flow(derive(bin("field")))``.
+    - **Direct**: ``bin(data, "field")`` returns the rows immediately.
+
+    Args:
+        data_or_field: Either the field name (curried form) or the data list
+            (direct form).
+        field: The field name (direct form only).
+        thresholds: Target bin count (default 10) or an explicit list of edges.
+
+    Returns:
+        A list of ``{start, end, size, count}`` dicts (direct form), or a
+        ``data -> rows`` callable (curried form).
+    """
+    if isinstance(data_or_field, str):
+        field_name = data_or_field
+        return lambda data: _run_bin(data, field_name, thresholds)
+    if field is None:
+        raise TypeError("bin(data, field): `field` is required in direct form")
+    return _run_bin(data_or_field, field, thresholds=thresholds)

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -98,6 +98,9 @@ interface ChartHarnessSpec {
   options: Record<string, any>;
   zOrder?: number | null;
   connect?: MarkSpec | null;
+  // Name tagged via `Layer([chart.name(...), ...])` so a layer-level
+  // `.constrain(...)` callback can reference the resolved child node.
+  name?: string | TokenSentinel | null;
 }
 
 interface SingleChartHarnessSpec extends ChartHarnessSpec {
@@ -109,6 +112,8 @@ interface LayerHarnessSpec {
   type: "layer";
   charts: ChartHarnessSpec[];
   options: Record<string, any>;
+  // Constraints relating the named children of a `Layer([...]).constrain(...)`.
+  constraints?: ConstraintSpec[];
   deriveServerUrl?: string;
 }
 
@@ -131,7 +136,7 @@ interface OperatorSpec {
 }
 
 interface ConstraintSpec {
-  type: "align" | "distribute" | "zAbove" | "zBelow";
+  type: "align" | "distribute" | "position" | "zAbove" | "zBelow";
   // Positioning constraints carry `options`; z-order constraints don't.
   options?: Record<string, any>;
   refs: string[];
@@ -721,17 +726,54 @@ function renderChart(spec: HarnessSpec) {
           buildChartFromSpec(c, spec.deriveServerUrl, resolveToken)
         );
 
-        const layerNode =
-          Object.keys(layerOpts).length > 0
-            ? Layer(layerOpts as any, childCharts)
-            : Layer(childCharts);
+        if (spec.constraints && spec.constraints.length > 0) {
+          // Constrained layer-of-charts. Mirror the JS storybook spelling:
+          // resolve each chart to a node, `.name(...)` it, then wrap the
+          // resolved nodes in the combinator-form `layer([...]).constrain(...)`.
+          const constraints = spec.constraints;
+          const resolvedNodes: any[] = [];
+          for (let i = 0; i < childCharts.length; i++) {
+            const node: any = await (childCharts[i] as any).resolve();
+            const nm = resolveNameField(spec.charts[i].name, resolveToken);
+            if (nm != null) node.name(nm);
+            resolvedNodes.push(node);
+          }
+          let layerMark: any =
+            Object.keys(layerOpts).length > 0
+              ? layer(layerOpts as any, resolvedNodes)
+              : layer(resolvedNodes);
+          layerMark = layerMark.constrain((refs: Record<string, any>) =>
+            constraints.map((c) => {
+              if (c.type === "zAbove" || c.type === "zBelow") {
+                return (Constraint as any)[c.type](
+                  ...c.refs.map((name) => refs[name])
+                );
+              }
+              return (Constraint as any)[c.type](
+                c.options,
+                c.refs.map((name) => refs[name])
+              );
+            })
+          );
+          await layerMark.render(container, {
+            w,
+            h,
+            axes: axes ?? false,
+            debug: debug ?? false,
+          } as any);
+        } else {
+          const layerNode =
+            Object.keys(layerOpts).length > 0
+              ? Layer(layerOpts as any, childCharts)
+              : Layer(childCharts);
 
-        await layerNode.render(container, {
-          w,
-          h,
-          axes: axes ?? false,
-          debug: debug ?? false,
-        } as any);
+          await layerNode.render(container, {
+            w,
+            h,
+            axes: axes ?? false,
+            debug: debug ?? false,
+          } as any);
+        }
       } else {
         // Single-chart path. Only w/h/debug are render options; rest are chart-level.
         const allOpts = spec.options || {};

--- a/tests/python-stories/seaborn/test_marginal_histogram.py
+++ b/tests/python-stories/seaborn/test_marginal_histogram.py
@@ -46,8 +46,9 @@ def story_default():
     # Python bin()'s measure provenance can't cross the derive RPC bridge
     # (JSON drops the JS-side symbol), so the bin-edge channels would tag as
     # "start"/"end" and falsely conflict with the center's field measure.
-    # Annotate explicitly with field(name, measure=...) — the Stage-1 escape
-    # hatch the measure type error prescribes.
+    # Annotate explicitly with field(name, measure=...) — the escape hatch the
+    # measure type error prescribes. The JS story needs no annotations; #537
+    # tracks carrying provenance across the bridge so this collapses too.
     top_hist = (
         chart(data, h=80)
         .flow(

--- a/tests/python-stories/seaborn/test_marginal_histogram.py
+++ b/tests/python-stories/seaborn/test_marginal_histogram.py
@@ -1,0 +1,95 @@
+"""Equivalent of seaborn/MarginalHistogram.stories.tsx — Seaborn/Marginal Histogram.
+
+Mirrors seaborn's jointplot:
+    sns.jointplot(data=penguins, x="bill_length_mm", y="bill_depth_mm")
+https://seaborn.pydata.org/generated/seaborn.jointplot.html
+(Our penguins export renames the fields to "Beak ..." rather than "bill ...".)
+"""
+
+from gofish import (
+    Constraint,
+    Layer,
+    bin,
+    chart,
+    circle,
+    derive,
+    field,
+    rect,
+    scatter,
+)
+from python_stories.data import PENGUINS
+
+
+def story_default():
+    w = 400
+    h = 400
+    GAP = 10
+
+    # Our penguins export uses "Beak ..." rather than seaborn's "bill ..." field names.
+    data = [
+        {**d, "id": i}
+        for i, d in enumerate(
+            d
+            for d in PENGUINS
+            if d["Beak Length (mm)"] is not None
+            and d["Beak Depth (mm)"] is not None
+        )
+    ]
+
+    sc = (
+        chart(data)
+        .flow(scatter(by="id", x="Beak Length (mm)", y="Beak Depth (mm)"))
+        .mark(circle(r=3, fill="steelblue", fillOpacity=0.6))
+        .name("scatter")
+    )
+
+    # Python bin()'s measure provenance can't cross the derive RPC bridge
+    # (JSON drops the JS-side symbol), so the bin-edge channels would tag as
+    # "start"/"end" and falsely conflict with the center's field measure.
+    # Annotate explicitly with field(name, measure=...) — the Stage-1 escape
+    # hatch the measure type error prescribes.
+    top_hist = (
+        chart(data, h=80)
+        .flow(
+            derive(bin("Beak Length (mm)")),
+            scatter(
+                xMin=field("start", measure="Beak Length (mm)"),
+                xMax=field("end", measure="Beak Length (mm)"),
+            ),
+        )
+        .mark(rect(h="count", fill="steelblue"))
+        .name("topHist")
+    )
+
+    right_hist = (
+        chart(data, w=80)
+        .flow(
+            derive(bin("Beak Depth (mm)")),
+            scatter(
+                yMin=field("start", measure="Beak Depth (mm)"),
+                yMax=field("end", measure="Beak Depth (mm)"),
+            ),
+        )
+        .mark(rect(w="count", fill="steelblue"))
+        .name("rightHist")
+    )
+
+    return (
+        Layer([sc, top_hist, right_hist]).constrain(
+            lambda scatter, topHist, rightHist: [
+                Constraint.align([scatter], x="baseline", y="baseline"),
+                Constraint.align([scatter, topHist], x="baseline"),
+                Constraint.align([scatter, rightHist], y="baseline"),
+                Constraint.position([topHist], y=h + GAP, anchor="start"),
+                Constraint.position([rightHist], x=w + GAP, anchor="start"),
+            ]
+        ),
+        {
+            "w": w,
+            "h": h,
+            "axes": {
+                "x": {"title": "Beak Length (mm)"},
+                "y": {"title": "Beak Depth (mm)"},
+            },
+        },
+    )

--- a/tests/python-stories/vega-lite/histogram/test_histogram.py
+++ b/tests/python-stories/vega-lite/histogram/test_histogram.py
@@ -1,116 +1,7 @@
 """Equivalent of Histogram/Histogram.stories.tsx — Vega-Lite/Histogram/Histogram."""
 
-import math
-
-from gofish import chart, derive, scatter, rect
+from gofish import bin, chart, derive, rect, scatter
 from python_stories.vega_data_urls import read_json
-
-# JS uses `bin("IMDB Rating")` which delegates to d3-array's d3.bin with
-# the default `thresholds(10)` setting. Replicate that here in Python so
-# the derive's output matches byte-for-byte with what JS would produce.
-
-_SQRT50 = math.sqrt(50)
-_SQRT10 = math.sqrt(10)
-_SQRT2 = math.sqrt(2)
-
-
-def _tick_step(start: float, stop: float, count: int) -> float:
-    """Port of d3-array's tickStep — chooses a 'nice' step for `count` bins."""
-    step0 = abs(stop - start) / max(0, count)
-    if step0 == 0:
-        return 0
-    step1 = 10 ** math.floor(math.log10(step0))
-    error = step0 / step1
-    if error >= _SQRT50:
-        step1 *= 10
-    elif error >= _SQRT10:
-        step1 *= 5
-    elif error >= _SQRT2:
-        step1 *= 2
-    return -step1 if stop < start else step1
-
-
-def _nice(start: float, stop: float, count: int) -> tuple:
-    """Port of d3-array's nice — expand domain to align with tickStep."""
-    prestep = None
-    while True:
-        step = _tick_step(start, stop, count)
-        if step == prestep:
-            return start, stop
-        if step > 0:
-            start = math.floor(start / step) * step
-            stop = math.ceil(stop / step) * step
-        elif step < 0:
-            start = math.ceil(start * step) / step
-            stop = math.floor(stop * step) / step
-        else:
-            return start, stop
-        prestep = step
-
-
-def _ticks(start: float, stop: float, count: int) -> list:
-    """Port of d3-array's ticks — equally spaced thresholds within domain."""
-    if start == stop and count > 0:
-        return [start]
-    reverse = stop < start
-    if reverse:
-        start, stop = stop, start
-    step = _tick_step(start, stop, count)
-    if step == 0 or math.isinf(step):
-        return []
-    out = []
-    if step > 0:
-        r0 = math.ceil(start / step)
-        r1 = math.floor(stop / step)
-        n = math.ceil(r1 - r0 + 1)
-        out = [(r0 + i) * step for i in range(int(n))]
-    else:
-        step = -step
-        r0 = math.ceil(start * step)
-        r1 = math.floor(stop * step)
-        n = math.ceil(r1 - r0 + 1)
-        out = [(r0 + i) / step for i in range(int(n))]
-    if reverse:
-        out.reverse()
-    return out
-
-
-def _bin_field(data, field, count=10):
-    """Port of gofish' `bin(field)` (d3-array's d3.bin().thresholds(count))."""
-    values = [d[field] for d in data if d.get(field) is not None]
-    if not values:
-        return []
-    vmin = min(values)
-    vmax = max(values)
-    x0, x1 = _nice(vmin, vmax, count)
-    thresholds = _ticks(x0, x1, count)
-    if len(thresholds) < 2:
-        return []
-    # d3.bin: bin[i] covers [thresholds[i], thresholds[i+1]); the last bin
-    # also includes thresholds[-1] (the upper edge).
-    n_bins = len(thresholds) - 1
-    counts = [0] * n_bins
-    last_edge = thresholds[-1]
-    for v in values:
-        if v == last_edge:
-            counts[-1] += 1
-            continue
-        # Binary search would be more faithful, but linear scan suffices
-        # for our small thresholds list.
-        for i in range(n_bins):
-            if thresholds[i] <= v < thresholds[i + 1]:
-                counts[i] += 1
-                break
-
-    return [
-        {
-            "start": thresholds[i],
-            "end": thresholds[i + 1],
-            "size": thresholds[i + 1] - thresholds[i],
-            "count": counts[i],
-        }
-        for i in range(n_bins)
-    ]
 
 
 def story_default():
@@ -119,7 +10,7 @@ def story_default():
     return (
         chart(movies)
         .flow(
-            derive(lambda d: _bin_field(d, "IMDB Rating")),
+            derive(bin("IMDB Rating")),
             scatter(xMin="start", xMax="end"),
         )
         .mark(rect(h="count")),

--- a/tests/scripts/capture-python-dom.ts
+++ b/tests/scripts/capture-python-dom.ts
@@ -132,6 +132,9 @@ type ChartIR = {
   data: any;
   zOrder?: number | null;
   connect?: any;
+  // Set when a chart is layered via `Layer([chart.name(...), ...])` so a
+  // `.constrain(...)` callback can reference it by name.
+  name?: string | any | null;
 };
 
 type IRResult =
@@ -144,6 +147,7 @@ type IRResult =
       charts: ChartIR[];
       options: any;
       deriveIds: string[];
+      constraints?: any[];
     }
   | {
       kind: "raw-mark";
@@ -197,6 +201,7 @@ async function loadStory(story: PythonStory): Promise<IRResult> {
       charts: json.charts,
       options: json.options ?? {},
       deriveIds: json.deriveIds ?? [],
+      constraints: json.constraints,
     };
   }
   if (json && json._kind === "raw-mark") {
@@ -314,6 +319,7 @@ async function captureStory(
       type: "layer",
       charts: ir.charts,
       options: ir.options,
+      constraints: ir.constraints,
       deriveServerUrl,
     };
   } else if (ir.kind === "raw-mark") {
@@ -399,7 +405,16 @@ async function captureStory(
 async function main() {
   console.log("=== Capturing Python DOM snapshots ===\n");
 
-  const stories = discoverPythonStories();
+  // Optional substring filter (like `capture-one` on the JS side):
+  //   pnpm capture-python "marginal"
+  // matches against the story id (e.g. seaborn/marginal-histogram--default).
+  const filter = process.argv[2]?.toLowerCase();
+
+  let stories = discoverPythonStories();
+  if (filter) {
+    stories = stories.filter((s) => s.path.toLowerCase().includes(filter));
+    console.log(`Filter "${filter}" matched ${stories.length} story(ies)\n`);
+  }
   if (stories.length === 0) {
     console.log("No Python stories found. Skipping.");
     return;
@@ -413,6 +428,10 @@ async function main() {
   const harnessProc = startHarnessServer();
 
   let browser: Browser | undefined;
+
+  // Uncaught in-page errors for the story currently being captured; cleared
+  // per story, checked after captureStory (see the pageerror listener).
+  const pageErrors: string[] = [];
 
   // Hoisted to function scope so the outer `finally` (and the
   // `flushCaptureResults` helper it relies on) can persist whatever
@@ -462,6 +481,19 @@ async function main() {
       viewport: { width: 1280, height: 720 },
     });
     const page = await context.newPage();
+    // Surface in-page failures in the capture log AND fail the story — an
+    // uncaught exception thrown from an async render microtask escapes the
+    // harness's try/catch (so __GOFISH_RENDER_ERROR__ never gets set), and
+    // the story would otherwise "capture OK" with a Loading/blank DOM.
+    page.on("pageerror", (err) => {
+      console.log(`    [pageerror] ${err.message}`);
+      pageErrors.push(err.message);
+    });
+    page.on("console", (msg) => {
+      if (msg.type() === "error" || msg.type() === "warning") {
+        console.log(`    [console.${msg.type()}] ${msg.text()}`);
+      }
+    });
 
     for (const story of stories) {
       process.stdout.write(
@@ -520,12 +552,16 @@ async function main() {
       }
 
       try {
+        pageErrors.length = 0;
         const { dom, screenshot } = await captureStory(
           page,
           `http://localhost:${HARNESS_PORT}`,
           story,
           ir
         );
+        if (pageErrors.length > 0) {
+          throw new Error(`uncaught page error: ${pageErrors.join(" | ")}`);
+        }
         const normalized = normalizeDom(dom);
 
         const domPath = join(TMP_DIR, `${story.path}.html`);

--- a/tests/scripts/derive-server.py
+++ b/tests/scripts/derive-server.py
@@ -166,6 +166,7 @@ class DeriveHandler(BaseHTTPRequestHandler):
                 DeriveOperator,
                 LayerBuilder,
                 Mark,
+                Token,
                 _RefProxy,
                 _collect_mark_lambdas,
                 _MarkFn,
@@ -234,6 +235,12 @@ class DeriveHandler(BaseHTTPRequestHandler):
 
                     _registry[mark_fn.lambda_id] = _mark_fn_wrapped
 
+                # A chart layered with `.name(...)` carries its name so a
+                # `Layer([...]).constrain(...)` callback can reference it.
+                child_name = getattr(child, "_name", None)
+                if isinstance(child_name, Token):
+                    child_name = child_name.to_dict()
+
                 return (
                     {
                         "type": "chart",
@@ -243,6 +250,7 @@ class DeriveHandler(BaseHTTPRequestHandler):
                         "data": child_data,
                         "zOrder": child_ir.get("zOrder"),
                         "connect": child_ir.get("connect"),
+                        "name": child_name,
                     },
                     child_derive_ids,
                 )
@@ -271,12 +279,19 @@ class DeriveHandler(BaseHTTPRequestHandler):
                     child_payloads.append(payload)
                     derive_ids.extend(child_derive_ids)
 
-                self._json_response(200, {
+                layer_payload = {
                     "_kind": "layer",
                     "charts": child_payloads,
                     "options": {**(builder.options or {}), **options},
                     "deriveIds": derive_ids,
-                })
+                }
+                # `.constrain(...)` constraints relating the named children.
+                layer_constraints = getattr(builder, "_constraints", None)
+                if layer_constraints is not None:
+                    layer_payload["constraints"] = [
+                        c.to_dict() for c in layer_constraints
+                    ]
+                self._json_response(200, layer_payload)
                 return
 
             chart_payload, derive_ids = serialize_chart(builder)

--- a/tests/scripts/validate-python-ir.ts
+++ b/tests/scripts/validate-python-ir.ts
@@ -156,6 +156,9 @@ function wrap(serverIR: any): Frontend.FrontendIRDocument {
       type: "layer",
       charts: serverIR.charts,
       ...(serverIR.options ? { options: serverIR.options } : {}),
+      // Part of the canonical schema (LayerIR.constraints) — pass through so
+      // constrained-layer stories actually exercise the validator.
+      ...(serverIR.constraints ? { constraints: serverIR.constraints } : {}),
     } as Frontend.LayerIR;
   } else if (serverIR && serverIR._kind === "raw-mark") {
     root = {


### PR DESCRIPTION
Progress towards #528.

## What

A seaborn-jointplot-style **marginal histogram** as a fully compositional GoFish spec, plus the two underlying-space resolution changes that make it work. No bespoke `jointplot()` API — the example is one `layer` of three ordinary charts with baseline pins and two `distribute` seatings:

```ts
const topHist = await Chart(data, { h: 80 })   // band thickness = the one presentation input
  .flow(derive(bin("Beak Length (mm)")), scatter({ xMin: "start", xMax: "end" }))
  .mark(rect({ h: "count", fill: "steelblue" })).resolve();

layer([sc, topHist, rightHist])
  .constrain(({ scatter, topHist, rightHist }) => [
    Constraint.align({ x: "baseline", y: "baseline" }, [scatter]),
    Constraint.align({ x: "baseline" }, [scatter, topHist]),
    Constraint.align({ y: "baseline" }, [scatter, rightHist]),
    Constraint.distribute({ dir: "y", spacing: 10 }, [scatter, topHist]),
    Constraint.distribute({ dir: "x", spacing: 10 }, [scatter, rightHist]),
  ])
  .render(container, { w, h, axes: true });
```

Marginals share the center's data scales per axis automatically; axes elaborate from the union domain and hug the scatter.

## Resolution change 1: self-scaling regions (`layer.tsx`)

A layer/frame with an **explicit pixel size on a dim** absorbs that dim's data space — reports `UNDEFINED` upward (#508's CONSTANT is the eventual home) and resolves a **local scale against its own box** (the root recipe one level down: "a chart embeds the way it renders"). This is the range-allocation mechanism for marginals (seaborn's `ratio=`): the count axis scales into its 80px band instead of polluting the shared domain.

## Resolution change 2: measures are types

Without `h: 80`, a count axis (`POSITION([0,35])` in counts) used to silently union with a mm axis (`POSITION([13,21.5])`) — the corrupted render that motivated this. Now `POSITION`/`SIZE`/`DIFFERENCE` spaces carry a `measure` tag and **unify per measure**:

- same measure or untagged → union exactly as before;
- both tagged & different → loud error:
  > Cannot unify underlying spaces with different measures: "Beak Depth (mm)" and "count" (overlay union). If these are the same units, assert that with field(name, measure) or datum(v, measure). If they are different units, give the inner chart an explicit w/h so it becomes a self-scaling region.
- `SIZE∘SIZE` stacking composition forgets on conflict (stacking different fields stays legal).

Measure sources are **type-checked**, not priority-overridden: explicit annotations (`field(name, measure)` — new param; `datum(v, measure)` existed) and inferred provenance (`bin()` now tags its output: start/end/size → source field, count → "count") are real type claims — disagreement throws at the channel; the bare field-name fallback is a weak default that yields to either. Completes the #266 trichotomy. The dead `source?` slot on space types is deleted; the field-accessor wire shape gains optional `measure` in all three gofish-ir encodings (Python has no `field()` yet).

## Verification

- New story renders correctly (see `stories/vega-lite/MarginalHistogram.stories.tsx`; `pnpm capture-one "Marginal Histogram"`).
- **Full `capture-diff main` sweep: geometry-identical across every story** — the only flagged diffs are the 11 known image-href false positives (#526) plus the added story.
- Negative test: removing `{ h: 80 }` fails with the measure type error above (manually verified, story restored).
- `tsc --noEmit` clean; `check-backlinks` in sync; `validate-python-ir` 119/119.
- Wiki: `internals/core/underlying-space.md` gains "Self-scaling regions" and "Measures: units are types" sections (covers: extended to layer.tsx, channels.ts, data.ts); public docs in `js/api/core/render.md` and `js/api/operators/derive.md`.

## Follow-ups

- #525 — Stage 2: measure-keyed space *families* per axis (true multi-scale, per-measure root scales, dual axes; retires the childPosScales workaround).
- #526 — capture-diff image-href false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: review cleanup, clipping fix, titles, plot-box seating

**`/simplify` review pass** (4 angles; commit `refactor(spaces)`): array-level `mergeAllMeasures`/`forgetAllMeasures` replace eight hand-rolled folds across five files; layer.tsx folds four scale arrays into two and reuses `spaceMeasure`; `setMeasureProvenance` owns the provenance encoding next to its getter; `inferSize`/`inferPos` dedup via a shared factory and `resolveMeasure` is hoisted to once per channel (was recomputed per split entry). Zero geometry movement. Two findings were real but behavior-changing, filed instead of fixed here: #534 (provenance doesn't reach mark channels), #535 (coord branch lacks self-scaling).

**SVG clipping fix** (commit `fix(render)`): the marginal bands were clipped in Storybook because the root measured overhangs on left/bottom only, with right gated to legends and top getting fixed padding. Now all four sides size from the laid-out extent (top overhang + non-legend right content overhang through the existing `reserve()`); the legend gate is retained deliberately — it's a semantic distinction (a 6px legend column must be *added*; a 9px tick spill must be *absorbed*; magnitude can't tell them apart). Legend and titled stories are byte-identical. ⚠️ Four stories with previously-clipped content now render fully contained (`faceted-chart` ×2, `ribbon--polar`, `python-tutor`) — **their visual baselines need a Linux-side update** (inner geometry unchanged; only the canvas grew).

**Story**: marginals now seat against the **plot box** (literal `Constraint.position` at `h+GAP`/`w+GAP`, anchor `start`) instead of `distribute` off the point cloud — the bands sit flush with the niced domain edge instead of floating at the topmost point. (The literal-pixel seating is a workaround: `distribute` can only target the content bbox — the point cloud — not the chart space the scale ranges over. #536 tracks letting constraints target the range box directly.) Explicit axis titles via `axes: { x: { title }, y: { title } }` (title inference needs v3 encoding tags that a hand-built `layer()` doesn't carry). Moved to a `Seaborn/` story group — it replicates `sns.jointplot`, not Vega-Lite's `concat_marginal_histograms`.

**Python parity**: `tests/python-stories/seaborn/test_marginal_histogram.py` renders DOM byte-identical to the JS story. One bridge-specific wrinkle: `bin()`'s measure provenance can't cross the derive RPC (JSON drops the symbol), so the Python story annotates the bin-edge channels with the new `field(name, measure=...)` wrapper — #537 tracks carrying provenance across the bridge so the Python spelling collapses to the JS one. Capture tooling gained a story filter, console piping, and fatal pageerrors (a story could previously "capture OK" as a `Loading...` DOM).


