### PR TITLE
Unify operators and constraints: one machinery for space folds, budget solve, and placement

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -10,6 +10,9 @@ covers:
   - packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
   - packages/gofish-graphics/src/ast/channels.ts
   - packages/gofish-graphics/src/ast/data.ts
+  - packages/gofish-graphics/src/ast/constraints/folds.ts
+  - packages/gofish-graphics/src/ast/constraints/distribute.ts
+  - packages/gofish-graphics/src/ast/constraints/align.ts
 ---
 
 # The underlying space tree
@@ -203,14 +206,34 @@ Returns the node's own `[xSpace, ySpace]`, computed bottom-up from the
 already-resolved child spaces. The traversal is memoized at `_node.ts`'s
 `resolveUnderlyingSpace()`.
 
-The `constraints` argument lets constraints contribute a _fragment_ of the
-space: `layer` folds the _datum_ coordinates of its `Constraint.position`
-constraints into a POSITION domain on the constrained axis
-(`collectPositionDomains`), unioned with the children's spaces. (Literal-pixel
-coordinates are not data and don't contribute.) That domain is what the layer
-later turns into a data→pixel scale to resolve those position constraints — see
-[[operators-vs-constraints]] for why this is the seam for expressing a
-data-positioned operator as a union of constraints.
+The `constraints` argument lets constraints participate in space resolution —
+each positioning-constraint kind carries a **space fold**, a typing rule that
+composes its targets' spaces into the layer's claim on that axis:
+
+- `Constraint.position` contributes a _fragment_: the layer folds the _datum_
+  coordinates into a POSITION domain on the constrained axis
+  (`collectPositionDomains`), unioned with the children's spaces.
+  (Literal-pixel coordinates are not data and don't contribute.) That domain
+  is what the layer later turns into a data→pixel scale to resolve those
+  constraints.
+- `Constraint.distribute` contributes the stack fold (`distributeSpaceFold`,
+  `constraints/distribute.ts`): all-SIZE data-driven targets compose to
+  `SIZE(Monotonic.add(...) + spacing·(n−1))`; with `glue: true` (stack
+  semantics) the extents are committed to an anchored `POSITION([0, Σ])`;
+  constant-sized keyed targets fall back to ORDINAL.
+- `Constraint.align` contributes the alignment fold (`alignSpaceFold` →
+  `resolveAlignmentSpace`) on its axis.
+
+The layer composes these per axis — children not covered by a constraint
+max-union in as overlay siblings — and at layout time **solves the budget**:
+a fold-produced SIZE claim is inverted against the layer's allotted size to
+derive a local scale factor, and distribute-covered fill children are
+proposed slices from the shared allocator (`allocateSlices`,
+`constraints/folds.ts`). This is what makes constraint-assembled layers reach
+the same expressive ceiling as the spread pipeline, auto-fit included
+(issue #475). Composition beyond one distribute (+ one align) per axis falls
+back to `unionChildSpaces`; the general algebra is sketched in
+[[constraints-as-core]].
 
 Three patterns cover most operators:
 
@@ -226,7 +249,11 @@ combine children's spaces. `spread({ glue: false })` keeps SIZE
 composition along the stack direction so a parent can solve for shared
 scale factors via `Monotonic.inverse`. `spread({ glue: true })` (i.e.
 `stack`) sums children's SIZE values into a `POSITION([0, sum])` — the
-operator commits the data-driven extents to a positional axis. `layer`
+operator commits the data-driven extents to a positional axis. Since the
+operator/constraint unification, these folds have one home: spread's
+resolver _is_ `distributeSpaceFold` on the stack axis and
+`alignSpaceFold` on the cross axis — the same functions the constraint
+path uses (see [The contract](#the-contract)). `layer`
 and overlay-style operators use `unionChildSpaces` (`alignment.ts`),
 which preserves SIZE when every child is SIZE and otherwise unions
 intervals. UNDEFINED children carry no opinion and are ignored
@@ -342,6 +369,14 @@ spread.layout (each spread/stack node):
 
 Leaf shapes never need to compute their own scale factors — they receive
 them via the `scaleFactors` parameter and apply them in `computeSize`.
+
+A `layer` whose constraints fold to a SIZE claim runs the same inversion
+as spread's first branch — `fold.inverse(size[axis])` against its allotted
+size — to derive a local scale factor for its constrained children (and
+warns before falling back when the fold isn't invertible at that budget).
+Unlike spread, the layer never mutates the inherited `scaleFactors`
+array; sibling scale sharing via mutation is a spread-only behavior
+(`sharedScale`).
 
 This dispatch is the practical embodiment of the underlying-space-kind
 distinction. It also happens to make the rendering pipeline more readable:
@@ -597,6 +632,8 @@ companion thesis repo).
 - Per-operator resolvers (each colocated with the operator):
   `src/ast/graphicalOperators/{spread,layer,scatter,enclose,porterDuff,position,connect,arrow,table,coord}.tsx`.
 - Overlay union helpers: `src/ast/graphicalOperators/alignment.ts`.
+- Constraint space folds + the shared slice allocator:
+  `src/ast/constraints/{distribute,align,folds}.ts`.
 - The Monotonic algebra used by SIZE composition: `src/util/monotonic.ts`.
 - Layout consumption: `gofish.tsx`'s `layout()` for root-level dispatch;
   `spread.tsx`'s `layout` for the per-node `computeScaleFactor`.

--- a/apps/docs/docs/internals/design/constraints-as-core.md
+++ b/apps/docs/docs/internals/design/constraints-as-core.md
@@ -481,14 +481,21 @@ what accessibility tooling (screen-reader navigation à la Olli / Data
 Navigator, which the Bluefish paper's future-work section points at) and any
 later analysis want to read. So the Python wrapper keeps serializing the
 high-level vocabulary unchanged, and compilation to the constraint core
-happens inside the JS engine, _after_ the bridge. The unification is invisible
-to `gofish-ir`.
+happens inside the JS engine, _after_ the bridge. The unification's machinery
+is invisible to `gofish-ir`; its new surface _options_ are not — see below.
 
 A serialized **core IR** (layers + constraints + marks, the post-compilation
 form) remains a coherent artifact to define — it would be the natural input
 for a non-JS renderer, a layout debugger, or an optimizer — but it is
 deferred until such a consumer exists; today the in-memory compiled form _is_
 the core, and inventing a wire format nothing reads would be speculative.
-(New constraint kinds still pay the three-encoding schema tax only if and
-when they are exposed to Python; the unification itself adds nothing to the
-schema.)
+A corollary of the high-level-IR decision, per the maintainer's parity rule
+("everything writable in JS should be writable in Python"): new _surface
+options_ do cross the bridge even when the machinery doesn't. The
+unification's `glue`/`weights` (distribute constraint) and `stackWeights`
+(spread) are exposed to Python — wrapper kwargs plus the typed
+`SpreadOperator` fields and validators in `gofish-ir` — and the 12
+`ConstraintParity` stories have byte-identical Python ports
+(`tests/python-stories/low-level-syntax/test_constraint_parity.py`). Parity
+exemptions are reserved for stories that aren't pure gofish specs; "this only
+tests the JS engine" is not a valid exemption reason.

--- a/apps/docs/docs/internals/design/constraints-as-core.md
+++ b/apps/docs/docs/internals/design/constraints-as-core.md
@@ -458,11 +458,21 @@ level.
 
 ## Python / IR implications
 
-Constraints are plain serializable data; operators are closures. If the JS
-core reduces to Layer + constraints + marks, the frontend IR can converge on
-that small vocabulary, with operator sugar elaborated per language _before_
-the bridge — fewer constructs crossing `gofish-ir`, and the Python wrapper
-gets the unified model #354 asks about for free, regardless of how long the JS
-surface keeps both spellings. (Every new constraint kind still pays the
-three-encoding schema tax — one more reason to design size-setting constraints
-once rather than per-operator.)
+**Decision: the high-level IR stays the Python bridge target.** Operators
+carry semantic information — _this is a spread of revenue by month_ — that a
+compiled layers-plus-constraints form erases, and that information is exactly
+what accessibility tooling (screen-reader navigation à la Olli / Data
+Navigator, which the Bluefish paper's future-work section points at) and any
+later analysis want to read. So the Python wrapper keeps serializing the
+high-level vocabulary unchanged, and compilation to the constraint core
+happens inside the JS engine, _after_ the bridge. The unification is invisible
+to `gofish-ir`.
+
+A serialized **core IR** (layers + constraints + marks, the post-compilation
+form) remains a coherent artifact to define — it would be the natural input
+for a non-JS renderer, a layout debugger, or an optimizer — but it is
+deferred until such a consumer exists; today the in-memory compiled form _is_
+the core, and inventing a wire format nothing reads would be speculative.
+(New constraint kinds still pay the three-encoding schema tax only if and
+when they are exposed to Python; the unification itself adds nothing to the
+schema.)

--- a/apps/docs/docs/internals/design/constraints-as-core.md
+++ b/apps/docs/docs/internals/design/constraints-as-core.md
@@ -438,23 +438,34 @@ suggest it will not be needed.
 
 ## Suggested staging (refactor-first)
 
-1. **Consolidate the two align implementations** (`graphicalOperators/alignment.ts`
-   vs `constraints/align.ts`) — pure refactor, already flagged in
-   [[operators-vs-constraints]].
-2. **Constraint space folds + Layer budget solve** — productionize the
-   prototype; closes #475 (constraints reach operator expressive power,
-   including under coord). Bring `contain` back from the gotree branch with
-   its fold.
-3. **Compile `spread`/`stack` to Layer + constraints**; delete the duplicated
-   placement code in `spread.tsx` (per the no-back-compat norm: migrate
-   callsites, no shims). `capture-diff` is the safety net.
+1. ✅ **Consolidate the two align implementations** — done: `alignTargets` +
+   `AlignBaselinePolicy` (`constraints/align.ts`) is the single walk; both
+   callsites keep their policies. The end/middle fallback divergence turned
+   out to be a genuine two-policy fact (scale-origin vs box-edge), kept
+   explicit rather than reconciled.
+2. ✅ **Constraint space folds + Layer budget solve** — done:
+   `distributeSpaceFold` (full spread dispatch incl. glue/explicit-size),
+   `alignSpaceFold`, `allocateSlices`, per-axis composition in the layer with
+   max-union for uncovered overlay siblings, budget inversion with a warning
+   on non-invertible folds. Parity certified for bar/fit/fill/weights/glue.
+   Addresses #475. (`contain` was not revived here — it lives with the
+   size-setting design, residual 1.)
+3. ✅ **`spread`/`stack` on the shared machinery** — done as _delegation_
+   rather than literal `Layer.constrain()` compilation: spread keeps its node
+   type (home for sharedScale mutation, scaleContext, axisDir, reverse,
+   explicit-dims translate, measure-and-report) but its fold, slicing, align
+   walk, and distribute walk are the constraint implementations; the bespoke
+   copies are deleted (−128 lines). `capture-diff` vs main: zero geometry
+   changes. Literal compilation is now a small step if a reason for it
+   appears, since both spellings already share one engine.
 4. **`scatter`/`position` via `Constraint.position`** (fold already exists);
-   design the size-setting facet alongside (residual 1).
+   design the size-setting facet alongside (residual 1; see also #541 for
+   treemap as a derived-constraint generator on top of that facet).
 5. **`table` as nested folds; revisit `sharedScale` as claim hoisting** with
    the multi-scale-per-axis design.
 
 Each step is independently shippable and behavior-preserving at the story
-level.
+level (1–3 verified so on the `unify-constraints-operators` branch).
 
 ## Python / IR implications
 

--- a/apps/docs/docs/internals/design/constraints-as-core.md
+++ b/apps/docs/docs/internals/design/constraints-as-core.md
@@ -1,0 +1,468 @@
+---
+title: "Feasibility: Constraints as the Core Language"
+section: Speculative Notes
+order: 31
+status: speculative
+---
+
+# Feasibility: Constraints as the Core Language
+
+**Question.** Can every layout operator be expressed in terms of constraints, so
+that the core language reduces to _layers of constraints, marks, and derived
+marks_ (line/area/connect/enclose)? Concretely: the Bluefish analogy
+`spread ≈ align + distribute` is roughly true — can it be made _exactly_ true,
+possibly with more constraint kinds? And if so, what happens to the two pieces
+of machinery Bluefish never had to face: the SwiftUI/Compose-style **proposed
+size** ("size constraints") passed down during layout, and **underlying-space
+resolution**?
+
+**Verdict.** Feasible, with one specific architecture: constraints acquire a
+_space-fold_ facet (a typing rule on underlying spaces, mirroring what each
+operator's `resolveUnderlyingSpace` already does) and the **Layer becomes the
+sole mediator** of the budget solve — composing its constraints' folds into a
+claim, inverting that claim against its allotted size, and proposing per-child
+sizes. A working prototype (see [Empirical evidence](#empirical-evidence)
+below) reproduces `spread` exactly — including Monotonic-inversion auto-fit —
+from `layer + align + distribute`. Three things do **not** reduce to today's
+align/distribute and are the genuine design work: a _fill policy_ for
+unclaimed children (the proposed-size slice), _size-setting_ constraints
+(contain, treemap slots, min/max-pinned extents), and a principled replacement
+for `sharedScale`'s mutation-based sibling sharing. None of them looks like a
+blocker; each has a natural home in the same architecture.
+
+This note subsumes the narrower
+[#475](https://github.com/gofish-graphics/gofish-graphics/issues/475)
+(constraints lack spread's auto-fit) and answers most of
+[#354](https://github.com/gofish-graphics/gofish-graphics/issues/354)'s
+questions; it builds on [[operators-vs-constraints]], whose "option 1:
+operators compile to constraints" is the shape proposed here.
+
+## What `spread` actually does beyond align + distribute
+
+Reading `spread.tsx` against `constraints/align.ts` + `constraints/distribute.ts`,
+the placement halves are already the same algorithm:
+
+- spread's align step (`spread.tsx:357-365`, via `alignChildren`) ≅
+  `Constraint.align` — pick a baseline from the first fixed child, move the
+  rest (`constraints/align.ts`).
+- spread's distribute walk (`spread.tsx:367-425`) ≅ `Constraint.distribute` —
+  anchor on the first placed child, walk bidirectionally placing by
+  min/center with spacing (`constraints/distribute.ts:32-104`). Even the
+  fixed-child handling matches (spread warns on inconsistency; the constraint
+  silently respects placement — a conflict-semantics choice, not a structural
+  difference).
+
+What spread does _in addition_ is exactly four mechanisms, and they are the
+whole gap:
+
+1. **The space fold** (`spread.tsx:112-229`). On the stack axis it composes
+   children's claims: all-SIZE & data-driven → `SIZE(Monotonic.add(children) +
+spacing·(n−1))` (edge mode; center mode is an `unknown` Monotonic over the
+   first/last halves); all-SIZE constant + named → `ORDINAL`; all-POSITION →
+   summed POSITION; `glue` (= stack) → children concatenated into a single
+   anchored `POSITION(0, Σ run(1))`. On the cross axis it applies the
+   alignment fold (`resolveAlignmentSpace`). Measures forget-merge
+   (`forgetAllMeasures`) because spreading different fields is legitimate.
+2. **The scale solve** (`spread.tsx:258-302`). Given its allotted size, it
+   derives a scale factor by dispatching on its _own_ resolved space — SIZE →
+   `domain.inverse(budget)`, POSITION → `budget / width(domain)`, DIFFERENCE →
+   `budget / width` — and, when `sharedScale`, _mutates_ the inherited
+   `scaleFactors` array so later siblings see it, and writes `scaleContext`.
+3. **The budget slice** (`spread.tsx:304-327`). It proposes to each child
+   `[slice, fullCross]` where the slice is `(budget − spacing·(n−1))/n` or
+   weight-proportional (`stackWeights`). Important nuance: a data-sized child
+   _ignores_ the slice (it computes `value · scaleFactor`); the slice is only
+   consumed by "fill" children with no size claim of their own. The proposal
+   is a fallback, not the primary sizing mechanism.
+4. **Measure-and-report** (`spread.tsx:439-482`). Union the placed children's
+   extents into `intrinsicDims`, return a partial translate (undefined unless
+   pinned) — the "parent can place me" protocol. `Layer` already does this
+   identically (`layer.tsx:495-512`), so this one is shared, not extra.
+
+So the exact statement is:
+
+> `spread = align + distribute + (space fold) + (budget solve) + (fill slice)`
+
+and the reduction question becomes: can the last three live on the
+constraint/layer side? The prototype says yes.
+
+## Why the Bluefish analogy is only _roughly_ true
+
+Bluefish's `StackV` really is cleanly `Align + Distribute` at the placement
+level — Algorithm 1 in the paper separates into an x-line (align) and a y-line
+(distribute), and §5.2.4 makes the split explicit. But two things stop the
+analogy from being exact when transported to GoFish:
+
+1. **Bluefish relations never size children.** The paper's own limitations
+   section (§6.2, "Width and Height Alignment") calls this out: relations set
+   positions only, sizes are fixed before layout, and the authors note UI
+   frameworks solve sizing by letting parents query/propose child sizes — "We
+   could adopt a similar approach." GoFish _did_ adopt that approach (the
+   proposed-size pass), which is precisely the part with no Bluefish answer to
+   copy. Splitting `StackV` into Align + Distribute in Bluefish also silently
+   drops the `w: maxBy, h: sumBy + spacing` bbox that Algorithm 1 returns —
+   tolerable there because nothing downstream solves against that bbox.
+   In GoFish that composed extent is load-bearing: it is the Monotonic that
+   auto-fit inverts.
+2. **Bluefish has no underlying space.** Relations relate pixels; there are no
+   domains, measures, or scale factors to resolve. GoFish's operators carry
+   space-typing rules (`resolveUnderlyingSpace`), so "operator = constraints"
+   demands those rules move somewhere.
+
+Both gaps point at the same answer: the constraint primitives need a second,
+_compositional_ facet beyond placement — a fold on underlying spaces — and the
+Layer needs to mediate the down-flowing size negotiation.
+
+## The unifying theory: folds, max-plus closure, and the budget adjoint
+
+The pleasant surprise is that the needed algebra already exists in the
+codebase, split across operators:
+
+- **align / overlay fold = max/union.** `unionChildSpaces`
+  (`alignment.ts:47-103`) folds all-SIZE children with `Monotonic.max`;
+  `resolveAlignmentSpace` (`alignment.ts:110-179`) is the alignment-aware
+  variant.
+- **distribute fold = sum (+ constant).** `spread.tsx:192-203` folds with
+  `Monotonic.add` and `Monotonic.adds(·, spacing·(n−1))`.
+- **contain fold = inner + padding** — another `adds` (the gotree-branch
+  `Constraint.contain`; not on main yet).
+
+Sum, max, +constant, and scalar multiples of monotone functions are monotone
+and closed under composition — a **max-plus algebra** over Monotonics. That
+closure is the feasibility theorem in miniature: _the extent of any network of
+align/distribute/contain constraints over children with monotone size claims
+is itself a Monotonic, hence invertible, hence auto-fittable._ Nothing about
+nesting or mixing the constraints breaks the solve; `spread`'s special status
+evaporates.
+
+The down-flowing "size constraint" then has a crisp characterization: the
+**budget solve is the adjoint of the claim fold**. Bottom-up, the fold maps
+child extents-as-functions-of-σ to the parent's extent-as-a-function-of-σ.
+Top-down, the parent inverts the fold at its allotted budget to recover σ
+(`Monotonic.inverse` is a Galois connection for monotone maps — exact where
+invertible, best-approximation elsewhere) and pushes σ back through each
+child's own claim to obtain that child's extent. The per-child _proposal_ is
+just the child's claim evaluated at the solved σ — except for children with no
+claim (UNDEFINED / "fill"), for which a **fill policy** must supply the answer
+(equal slices or `stackWeights` today). The fill policy is genuinely extra
+information beyond align + distribute — it is the flex-layout fragment of the
+language — and it is the one place "spread = align + distribute" can never be
+made literally true without adding _something_. The smallest something: the
+distribute constraint carries the policy (weights / equal / none), and the
+Layer applies it to unclaimed children only.
+
+**Degrees of freedom: the "two of three" rule.** Per axis, every
+spread/distribute situation is one budget equation —
+`container = Σ childSizes(σ) + spacing·(n−1)` — and the folkloric rule
+"spread works when two of {container, spacing, child sizes} are known" is
+exactly the condition that the equation has **one free variable**, which is
+exactly when one Monotonic inversion solves it. The model states the rule
+precisely where the operator only gestures at it:
+
+- container + spacing known → solve σ (auto-fit; the prototype's Fit pair) or
+  slice fill children (the fill policy supplies the answer for claim-less
+  children).
+- child sizes + spacing known → the fold _is_ the container (shrink-to-fit /
+  the upward claim).
+- container + child sizes known → solve **spacing** (justify/space-between).
+  Spread does **not** support this today — `spacing` is always a constant prop
+  (`spread.tsx:49`); nothing in the codebase solves for it. In the fold model
+  it is a one-line variant, not new machinery: hold σ fixed and the same fold
+  is `Monotonic.linear(n−1, Σ sizes)` _in spacing_ — same inversion, different
+  unknown (`distribute({ spacing: "auto" })`).
+- all three known → over-determined: a consistency check (conflict-semantics
+  bucket, residual 4).
+- one known → under-determined: a policy must designate which unknown it
+  fills — that is what `stackWeights`/equal-slices is. (E.g. data-driven
+  children _plus_ auto spacing is two unknowns; σ must be pinned — say to an
+  inherited shared scale — before spacing is solvable.)
+- glue (stack) pins spacing ≡ 0, so the unknown must be σ or the container —
+  consistent with `stack` exposing no spacing option.
+
+Notably, `layer.tsx` is already most of the way to being this mediator: the
+self-scaling-region path (`layer.tsx:317-349`) stashes a composed claim and
+inverts it against the layer's own pixel box (`stashed.domain.inverse(size[dim])`)
+to produce local `childScaleFactors`. The prototype below generalizes exactly
+this — fold from constraints, invert against the _allotted_ size rather than
+only an explicit `w`/`h`.
+
+In this picture each constraint kind is a pair:
+
+| facet                        | direction             | role                                                                                                 |
+| ---------------------------- | --------------------- | ---------------------------------------------------------------------------------------------------- |
+| **space fold** (typing rule) | bottom-up, pre-layout | compose child claims into the layer's claim; merge measures (throw or forget per the existing rules) |
+| **placement rule**           | post-child-layout     | today's `applyAlign` / `applyDistribute` / `applyPosition` on `Placeable.place()`                    |
+
+and the Layer's layout becomes a fixed pipeline: resolve size → solve σ per
+axis from the folded claim → propose per-child sizes (claim at σ, else fill
+policy) → lay out children → apply placement rules → fill unplaced at
+baseline → measure. `spread({dir, spacing, alignment, sharedScale})` compiles
+to `Layer(children).constrain(c => [align({[cross]: alignment}, all),
+distribute({dir, spacing}, all)])` and disappears as machinery, surviving only
+as surface sugar — option 1 of [[operators-vs-constraints]], now with the
+missing two facets identified.
+
+This is also the underlying-space story for constraints in general: the folds
+_are_ typing rules, and the measure-typed unification work (8f7e7a3e) already
+defined the unification semantics they should use (`mergeMeasures` where
+agreement is required, `forgetAllMeasures` where heterogeneity is legitimate).
+Constraints stop being outside the type system — issue #475's gap — by
+construction, not by patching.
+
+## Empirical evidence
+
+A working prototype (uncommitted, in the working tree of the
+`sprightly-wobbling-cloud` worktree) implements the architecture above for the
+"one distribute (+ optional align) covering all named children" shape and
+demonstrates **exact** parity with `spread` on paired Storybook stories
+(`stories/lowlevel/ConstraintParity.stories.tsx`), verified via `capture-one`
+normalized-DOM diffs:
+
+| pair                                                                             | result                                                                                                                                                             |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SpreadBar` vs `ConstraintBar` — data-driven heights, fixed widths               | exact match: both render `[x=0 w=40 h=75], [x=48 w=40 h=200], [x=96 w=40 h=125]`                                                                                   |
+| `SpreadFit` vs `ConstraintFit` — data-driven widths auto-fit into a 200px budget | exact match: both render widths `53.8537, 89.7561, 40.3902` — the Monotonic-sum inversion reproduced bit-for-bit (Σ widths = 184.0, + 2·8px spacing = exactly 200) |
+
+The Fit pair is the load-bearing one: it is precisely the case issue #475 says
+constraints cannot express. `pnpm capture-diff main` shows zero geometry
+changes to existing stories (the new path is gated on the recognized
+constraint shape).
+
+What it took — six mechanisms, all small, all in the places the theory
+predicts:
+
+1. `distributeSpaceFold` (`constraints/distribute.ts:63`) — the distribute
+   fold, mirroring spread's stack-axis dispatch exactly (SIZE sum + spacing /
+   ORDINAL / POSITION cases, forget-merged measures).
+2. `alignSpaceFold` (`constraints/align.ts:23`) — delegates to spread's own
+   `resolveAlignmentSpace` unchanged (shared anchor vocabulary).
+3. `resolveConstraintFold` (`layer.tsx:81`) — recognizes the covered-children
+   shape and returns per-axis space overrides + a budget descriptor.
+4. Fold wiring in Layer's `resolveUnderlyingSpace` (`layer.tsx:417`) — applied
+   _before_ the self-scaling stash loop, so an explicit-size layer gets a
+   local scale from the folded space through the **already-existing**
+   self-scaling machinery, with no new code.
+5. Budget solve in Layer's `layout` (`layer.tsx:493`) — inverts the folded
+   SIZE Monotonic against the _allotted_ size (generalizing the self-scaled
+   recipe beyond explicit `w`/`h`); idempotent with the root's inversion.
+6. `childSizeFor` (`layer.tsx:516`) — proposes spread's equal-slice budget to
+   constrained children instead of Layer's blanket full-size proposal.
+
+Two findings sharpen the theory:
+
+- **The crux is the fold, not the walk.** Auto-fit parity required _no_ new
+  inversion machinery — the root already inverts whatever SIZE claim reaches
+  it, and the Layer's local solve is interchangeable and idempotent with it.
+  The only thing constraints were missing was _reporting the same composed
+  SIZE upward_ that spread reports. `sharedScale`/`scaleContext` never had to
+  move. In other words: the placement halves were already equivalent; the
+  entire semantic content of "spread beyond align + distribute" lives in
+  `resolveUnderlyingSpace`.
+- **One real divergence between the duplicate align implementations.**
+  Spread's `alignChildren` seats the cross-axis baseline at `posScale(0)`;
+  `applyAlign`'s fallback seats it on the layer box
+  (`{start: 0, middle: size/2, end: size}`). These coincide at `"start"` but
+  diverge for `"end"`/`"middle"` (the pre-existing `SpreadY_AlignMiddle` story
+  already hand-pins around this). Exact parity for those alignments requires
+  the consolidation in staging step 1 to teach the constraint fallback to
+  consult the posScale — a known, bounded fix, not a structural obstacle.
+
+## Operator-by-operator reduction
+
+| operator                      | reduces to                                      | notes                                                                                                                                                                                                                                                                                                                                                                                                            |
+| ----------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `spread` / `spreadX/Y`        | `align + distribute` + fold/solve/fill on Layer | demonstrated by the prototype, including auto-fit                                                                                                                                                                                                                                                                                                                                                                |
+| `stack` / `stackX/Y`          | `distribute(spacing: 0, glue)`                  | glue is a _fold variant_, not a placement variant: same walk, but the fold emits anchored `POSITION(0, Σ run(1))` instead of a SIZE sum — the kind-switch that makes stacked bars an addressable position space. Needs a `glue` (or `mode: "glue"`) option on the distribute fold                                                                                                                                |
+| `layer`                       | the substrate itself                            | its overlay fold is `unionChildSpaces` = the trivial (empty-constraint) case                                                                                                                                                                                                                                                                                                                                     |
+| `scatter`, `position`         | `Constraint.position`                           | the domain-fragment fold already exists (`collectPositionDomains` → layer union, `layer.tsx:268-292`). Residual: `xMin/xMax`-style interval channels pin _two_ anchors on one axis, which sets a size from positions — today `place()` is write-once per axis, so this needs a size-setting rule (see below) or stays a mark channel                                                                             |
+| `enclose`, `arrow`, `connect` | derived marks                                   | already the plan; `connect` is the canonical example (bbox derived from refs, no space claim of its own)                                                                                                                                                                                                                                                                                                         |
+| `frame`                       | `layer` (or `coord`)                            | already sugar                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `group`                       | data combinator                                 | not a layout operator; untouched                                                                                                                                                                                                                                                                                                                                                                                 |
+| `table`                       | nested folds                                    | a grid is row-distributes × column-aligns; extents are max-plus (row height = max, total = sum), so it folds and solves. Worth doing only after spread/stack                                                                                                                                                                                                                                                     |
+| `treemap`                     | **does not reduce** to align/distribute         | d3 computes slot rects from data and _scales children into them_ — a global algorithm assigning positions _and sizes_. Either (a) keep as a custom layout node (Bluefish's answer: arbitrary layouts are nodes; constraints are the core, not the whole), or (b) recast as a _derived-constraint_ generator: run the algorithm, emit position constraints + size assignments. (b) needs size-setting constraints |
+| `porterDuff`                  | stays                                           | a compositing/render concept, not layout                                                                                                                                                                                                                                                                                                                                                                         |
+| `coord`                       | stays, orthogonal                               | coordinate transforms warp the space the constraint network solves in; the constraint reduction is what finally lets coord-wrapped constraint pipelines auto-fit (the #475 NestedPietree failure), because the Layer's solve runs regardless of whether content was assembled by operators or constraints                                                                                                        |
+
+So the core language lands where the question hoped: **Layer (constraints) +
+marks + derived marks + coord**, with operators as compile-time sugar. The
+only container is Layer, which dodges the bbox-ownership ambiguity that made
+Bluefish's unified relations awkward (§8.2 of the paper: "should Arrow's bbox
+contain its endpoints?") — relations here never own boxes; the Layer they're
+attached to does.
+
+## The genuine residuals
+
+These are the places where "yes, feasible" carries real design work rather
+than mechanical migration.
+
+**1. Size-setting constraints (the missing fourth kind).** Today's protocol is
+single-assignment _positions_ (`place()` write-once per axis = Bluefish's
+dimension-level ownership). Three pressures want single-assignment _sizes_
+too: `contain` (outer's size := inner + padding — bottom-up), treemap-style
+slot assignment (top-down), and Bluefish's own unsolved "width alignment"
+(§6.2: make these elements equal-width — a max fold pushed back down, i.e.
+exactly claim-at-solved-σ). All three are the same shape as the budget
+adjoint: a size assignment derived from a fold. The clean move is to extend
+`Placeable` with a write-once size facet per axis and let constraints own
+dims the way they own positions. This should be designed once, not three
+times.
+
+**2. The fill policy.** Where do `stackWeights` / equal-slices live? Options:
+(a) on the distribute constraint (smallest; the prototype's choice); (b) as a
+separate `Constraint.share`/flex kind, keeping distribute purely relational;
+(c) on the child (`flex: n`, SwiftUI/CSS style). (c) matches UI-toolkit
+intuition and keeps the constraint set per-axis pure, but moves layout
+information onto marks; (a) is the pragmatic default. The prototype had to
+re-derive spread's slice arithmetic inside Layer's layout; the lesson is that
+the policy should travel _with the fold descriptor_ so spread and the
+constraint path consume one shared budget allocator. Note the parity stories
+could not exercise this (all their rects carried explicit sizes, which ignore
+the slice) — fill children are exactly where an untested divergence would
+hide, so the compiled form needs a fill-child parity story.
+
+**3. `sharedScale` and scale sharing.** Spread's mutation of the inherited
+`scaleFactors` array (first sibling solves, later siblings inherit) is
+order-dependent and imperative — `layer.tsx` already pointedly refuses to copy
+it ("never mutate the parent's `scaleFactors`"). The principled replacement is
+_claim hoisting_: a shared scale exists iff the SIZE claim bubbles to the
+common ancestor, which folds siblings with `max` and solves once; a local
+scale exists iff the node absorbs its claim (self-scaling region). That makes
+`sharedScale: true/false` a _scoping annotation on the claim_ rather than a
+mutation, and it is the same mechanism the measure-keyed multi-scale-per-axis
+idea wants. Migration can keep the mutation initially (the prototype does);
+the hoisting redesign should ride with the multi-scale work.
+
+**4. Composition and conflict semantics for general networks.** The operator
+image (one distribute + one align per axis, covering all children) is total
+and order-independent, so equivalence is exact there — the prototype's
+recognizer deliberately bails to `unionChildSpaces` for anything else (e.g.
+the existing `SubsetSelection` story, where a distribute touches a subset).
+The general case needs a _per-axis composition algebra_ rather than an
+override: two distributes over disjoint subsets compose to a `max` of their
+sub-sums (two independent stacks overlaid); a distribute interleaved with a
+`position`-pinned anchor must solve its sum _relative to_ the pin. The extents
+remain max-plus (longest path through the network), so the solve stays
+well-defined, but the current one-space-per-axis model has no way to say
+"this fragment is a sub-stack" — that wants either sub-domain tagging (the
+existing `ordinalGroupId` field gestures at this) or the measure-keyed
+multi-scale-per-axis design, which this would share machinery with. Separately,
+over-constraint needs a decision: today `place()` silently no-ops on the
+second write and spread warns; Bluefish throws with ownership info. Recommend:
+keep write-once ownership, upgrade the silent no-op to a structured error at
+the Layer, and reject cycles as z-order already does (Kahn's algorithm).
+
+**5. Order of application.** Constraints apply in declaration order with
+first-placed-anchor semantics. That is expressive (it is how axis elaboration
+chains placements today) but means the compiled form must emit constraints in
+a canonical order. Fine for compilation; document it for hand-written use.
+
+## Complexity and what the "solver" actually is
+
+**Asymptotics: unchanged.** The operator pipeline is one visit per node per
+pass with O(children) work per node — O(N) total. The constraint form adds,
+per layer: the fold (O(references)), the ref map (O(children)), and
+`applyConstraints` (O(references)). Constraint references are part of the
+input spec, and the compiled operator image emits exactly two references per
+child per axis — so the totals stay O(N), with a small constant factor
+(roughly one extra sweep and one map build per layer, on affected nodes only).
+Even the _general_ algebra stays linear: longest-path extents and cycle
+rejection on the constraint DAG are Kahn-style O(V+E), and conflict detection
+under write-once ownership is O(1) per write. There is no fixpoint iteration
+anywhere. (Bluefish's evaluation corroborates the architecture class: render
+time linear in scenegraph size, paper Fig. 9.)
+
+**The solve itself.** This is not a constraint solver in the Cassowary/Z3
+sense. It is three stages: (1) a bottom-up symbolic fold — and here the
+`Linear` fast path matters: `add`/`adds`/`smul` of linears fold to a single
+closed-form `Linear` (`monotonic.ts:78-105`), so the common case (bar charts,
+stacks of data-sized rects) inverts in O(1) with **zero** numeric search;
+(2) a per-axis **one-unknown** inversion — closed-form for linear claims,
+bracketed bisection hard-capped at ~70 closure evaluations for `unknown`
+claims (`util.ts:9-54`; produced by center mode, `max` over different
+intercepts, mixed compositions); (3) single-pass local propagation for
+placement in declaration order with write-once ownership — "the dumb thing,"
+kept deliberately. So: Bluefish-class local propagation for positions, plus an
+analytic one-unknown size solve Bluefish lacked. The known superlinear
+lurkers, both pre-existing and shared with operators today: nested
+_non-linear_ folds make an ancestor's inversion cost O(subtree closure size · 70) (mitigated by the linear fast path; could memoize `run` per σ), and
+`collectConstraintRefs`' descent into nested plain layers is O(subtree) per
+layer in the worst case (memoizable). Neither is quadratic in spec size.
+
+**Brittleness and linear-cost robustness fixes.** Today's constraint path is
+brittle in five identifiable ways, none of which needs a cleverer solver:
+
+1. _Declaration-order sensitivity_ — first-placed-anchor semantics plus
+   guessy fallbacks when nothing is placed. Fix: canonical emission order for
+   compiled forms (free) and a topological pre-sort of hand-written
+   constraints by shared targets (O(V+E)).
+2. _Silent conflict swallowing_ — `place()` no-ops on the second write. Fix:
+   record an owner per (node, axis) — O(1) per write — and report both
+   writers, exactly Bluefish's `bboxOwners`.
+3. _Divergent align fallbacks_ — `posScale(0)` vs layer box (found by the
+   prototype). Fix: the consolidation in staging step 1.
+4. _Underdetermination hidden_ — children the constraints never reach are
+   silently nailed at origin. Fix: a diagnostic listing them.
+5. _Inversion failure modes_ — bisection's growth cap can fail and spread's
+   `inverse(...) ?? 0` then zeroes the scale factor (content vanishes). Fix:
+   seed the bracket from the claim evaluated at σ=1 and surface failures as
+   structured warnings — O(1).
+
+All five are bookkeeping, not solving; robustness here is a diagnostics
+problem, not a performance trade. The one expressiveness ceiling to be honest
+about: one-unknown-per-axis local propagation cannot express genuinely
+simultaneous systems (the paper's equilateral-triangle example) — that is the
+intentional boundary of the design, unchanged from today.
+
+Finally, because compilation is deterministic, `spread` can always keep a
+fused fast path (today's specialized code) guaranteed to produce identical
+output to its compiled form — standard operator fusion. The numbers above
+suggest it will not be needed.
+
+## What this is _not_
+
+- Not a constraint _solver_. Everything stays local propagation — the solve is
+  one Monotonic inversion per axis per layer, preserving the
+  one-pass-per-node, debuggable architecture (the Bluefish paper's §5.2
+  argument against global solvers applies unchanged, as does its Basalt
+  comparison: low-level constraint languages are viscous; ours stay bundled
+  behind operator sugar).
+- Not a removal of operators from the _surface_. `spread`/`stack` remain the
+  v3 vocabulary; they become guaranteed-faithful sugar (per
+  [[operators-vs-constraints]] option 1), which is also what keeps authoring
+  viscosity low — the paper's §8.2 lesson is that making users assemble
+  relations by hand pushes specs diffuse early.
+- Not a claim that _every_ layout is constraint-expressible. Anything
+  requiring discrete reflow against measured sizes (line wrapping) or global
+  optimization stays a custom layout node. The claim is that the _core_ is
+  constraints; custom nodes plug into the same fold/solve interface.
+
+## Suggested staging (refactor-first)
+
+1. **Consolidate the two align implementations** (`graphicalOperators/alignment.ts`
+   vs `constraints/align.ts`) — pure refactor, already flagged in
+   [[operators-vs-constraints]].
+2. **Constraint space folds + Layer budget solve** — productionize the
+   prototype; closes #475 (constraints reach operator expressive power,
+   including under coord). Bring `contain` back from the gotree branch with
+   its fold.
+3. **Compile `spread`/`stack` to Layer + constraints**; delete the duplicated
+   placement code in `spread.tsx` (per the no-back-compat norm: migrate
+   callsites, no shims). `capture-diff` is the safety net.
+4. **`scatter`/`position` via `Constraint.position`** (fold already exists);
+   design the size-setting facet alongside (residual 1).
+5. **`table` as nested folds; revisit `sharedScale` as claim hoisting** with
+   the multi-scale-per-axis design.
+
+Each step is independently shippable and behavior-preserving at the story
+level.
+
+## Python / IR implications
+
+Constraints are plain serializable data; operators are closures. If the JS
+core reduces to Layer + constraints + marks, the frontend IR can converge on
+that small vocabulary, with operator sugar elaborated per language _before_
+the bridge — fewer constructs crossing `gofish-ir`, and the Python wrapper
+gets the unified model #354 asks about for free, regardless of how long the JS
+surface keeps both spellings. (Every new constraint kind still pays the
+three-encoding schema tax — one more reason to design size-setting constraints
+once rather than per-operator.)

--- a/apps/docs/docs/internals/design/constraints-as-core.md
+++ b/apps/docs/docs/internals/design/constraints-as-core.md
@@ -465,7 +465,12 @@ suggest it will not be needed.
    the multi-scale-per-axis design.
 
 Each step is independently shippable and behavior-preserving at the story
-level (1–3 verified so on the `unify-constraints-operators` branch).
+level (1–3 verified so on the `unify-constraints-operators` branch). The
+deferred remainder is tracked in
+[#550](https://github.com/gofish-graphics/gofish-graphics/issues/550), with
+sub-issues for size-setting constraints (#545), scatter/position (#546),
+treemap (#541), the general composition algebra (#547), table (#548), and
+sharedScale claim hoisting (#549).
 
 ## Python / IR implications
 

--- a/apps/docs/docs/internals/design/operators-vs-constraints.md
+++ b/apps/docs/docs/internals/design/operators-vs-constraints.md
@@ -7,6 +7,17 @@ status: speculative
 
 # Re-unifying Operators and Constraints
 
+> **Status update.** Option 1 below (operators-on-top-of-constraints, one
+> machinery) **has landed** for the spread/stack family: constraints carry
+> space folds (`distributeSpaceFold`/`alignSpaceFold`), the layer solves
+> budgets against folded claims, and `spread`/`stack` delegate their space
+> resolution, slicing, align walk, and distribute walk to that shared
+> machinery — verified geometry-identical across all stories. The feasibility
+> analysis and the remaining program (scatter/position, size-setting
+> constraints, sharedScale-as-claim-hoisting) live in [[constraints-as-core]].
+> The sections below predate that work and are kept for the motivating
+> history; the `scatter`/`connect` questions at the bottom are still open.
+
 Open design question: should the layout operators (`spread`, `stack`, `layer`,
 `connect`, ...) and the constraint primitives (`Constraint.align`,
 `Constraint.distribute`, `Constraint.zAbove` / `zBelow`) sit on the same axis,

--- a/apps/docs/docs/js/api/constraints/constrain.md
+++ b/apps/docs/docs/js/api/constraints/constrain.md
@@ -268,7 +268,9 @@ differs. `Spread` aligns to the data-scale origin (`posScale(0)`), while the
 `align` constraint falls back to the layer's box edge (`end` → the full
 extent). For `"start"` the two coincide; for `"end"`/`"middle"` they diverge
 by the box extent. Pre-place one child (or use `Constraint.position`) when you
-need spread-identical `end`/`middle` alignment.
+need spread-identical `end`/`middle` alignment. (Unifying the two fallbacks is
+tracked in
+[#552](https://github.com/gofish-graphics/gofish-graphics/issues/552).)
 
 ## Partial placement
 

--- a/apps/docs/docs/js/api/constraints/constrain.md
+++ b/apps/docs/docs/js/api/constraints/constrain.md
@@ -91,14 +91,30 @@ Stacks a set of children end-to-end along an axis, with optional spacing.
 Constraint.distribute({ dir, spacing, mode, order }, [ref1, ref2, ...])
 ```
 
-| Option    | Type                     | Default     | Description                                                  |
-| --------- | ------------------------ | ----------- | ------------------------------------------------------------ |
-| `dir`     | `"x" \| "y"`             | —           | Axis to distribute along                                     |
-| `spacing` | `number`                 | `8`         | Gap between each element                                     |
-| `mode`    | `"edge" \| "center"`     | `"edge"`    | Whether spacing is measured edge-to-edge or center-to-center |
-| `order`   | `"forward" \| "reverse"` | `"forward"` | Order to place elements                                      |
+| Option    | Type                     | Default     | Description                                                                                            |
+| --------- | ------------------------ | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `dir`     | `"x" \| "y"`             | —           | Axis to distribute along                                                                               |
+| `spacing` | `number`                 | `8`         | Gap between each element (forced to `0` when `glue` is set)                                            |
+| `mode`    | `"edge" \| "center"`     | `"edge"`    | Whether spacing is measured edge-to-edge or center-to-center                                           |
+| `order`   | `"forward" \| "reverse"` | `"forward"` | Order to place elements                                                                                |
+| `glue`    | `boolean`                | `false`     | Stack semantics: children touch, and their data-driven extents commit to one positional axis           |
+| `weights` | `number[]`               | —           | Per-child budget weights (one per child, positional) — how fill children share the layer's slice space |
 
 The first already-placed child acts as an anchor. Unplaced children after it are distributed forward (increasing position); unplaced children before it are distributed backward so they stack flush against the anchor's leading edge.
+
+### Space resolution and auto-fit
+
+`distribute` (and `align`) don't just position children after layout — they
+participate in **underlying-space resolution**, exactly like the operators
+built on them. A `distribute` over data-sized children composes their size
+claims (sum + spacing) into the layer's claim on that axis; when the layer is
+then given a size (an explicit `w`/`h`, or an allotted budget from its parent
+or a coordinate transform), it solves for the scale factor that makes the
+children fit, and proposes budget slices (equal, or per `weights`) to children
+with no size claim of their own. With `glue: true` the composed extents commit
+to an anchored positional axis instead — that's a stacked bar chart. In other
+words: a constraint-assembled layer auto-fits the same way a `Spread`/`Stack`
+does.
 
 ::: starfish
 
@@ -233,7 +249,10 @@ override it for the pairs they name.
 
 ## Spread equivalences
 
-Constraints are a lower-level primitive that `Spread` is built on. These pairs are equivalent:
+Constraints are the primitive `Spread` and `Stack` are built on — literally:
+the operators delegate their space resolution, budget slicing, and placement
+walks to the same machinery the constraint path uses. These pairs are
+equivalent, **including** scale solving and auto-fit, not just placement:
 
 | Spread                                                       | Constraint equivalent                                           |
 | ------------------------------------------------------------ | --------------------------------------------------------------- |
@@ -241,6 +260,15 @@ Constraints are a lower-level primitive that `Spread` is built on. These pairs a
 | `Spread({ dir: "x", alignment: "end", spacing: 10 }, items)` | `align({ y: "end" })` + `distribute({ dir: "x", spacing: 10 })` |
 | `Spread({ dir: "x", spacing: 60, mode: "center" }, items)`   | `distribute({ dir: "x", spacing: 60, mode: "center" })`         |
 | `Spread({ dir: "y", reverse: true }, items)`                 | `distribute({ dir: "y", order: "reverse" })`                    |
+| `Stack({ dir: "y" }, items)`                                 | `distribute({ dir: "y", glue: true })`                          |
+| `Spread({ dir: "x", stackWeights: [2, 1] }, items)`          | `distribute({ dir: "x", weights: [2, 1] })`                     |
+
+One caveat: when **no child is pre-placed**, the cross-axis `align` fallback
+differs. `Spread` aligns to the data-scale origin (`posScale(0)`), while the
+`align` constraint falls back to the layer's box edge (`end` → the full
+extent). For `"start"` the two coincide; for `"end"`/`"middle"` they diverge
+by the box extent. Pre-place one child (or use `Constraint.position`) when you
+need spread-identical `end`/`middle` alignment.
 
 ## Partial placement
 

--- a/apps/docs/docs/python/api/constraints/constrain.md
+++ b/apps/docs/docs/python/api/constraints/constrain.md
@@ -60,15 +60,17 @@ unplaced refs move to match it.
 Stacks a set of refs end-to-end along an axis, with optional spacing.
 
 ```python
-Constraint.distribute(refs, *, dir, spacing=None, mode=None, order=None)
+Constraint.distribute(refs, *, dir, spacing=None, mode=None, order=None, glue=None, weights=None)
 ```
 
-| Parameter | Type                       | Default     | Description                                        |
-| --------- | -------------------------- | ----------- | -------------------------------------------------- |
-| `dir`     | `"x"` \| `"y"`             | —           | **Required.** Axis to distribute along.            |
-| `spacing` | `int`                      | `8`         | Gap between each element.                          |
-| `mode`    | `"edge"` \| `"center"`     | `"edge"`    | Spacing measured edge-to-edge or center-to-center. |
-| `order`   | `"forward"` \| `"reverse"` | `"forward"` | Order to place elements.                           |
+| Parameter | Type                       | Default     | Description                                                                                             |
+| --------- | -------------------------- | ----------- | ------------------------------------------------------------------------------------------------------- |
+| `dir`     | `"x"` \| `"y"`             | —           | **Required.** Axis to distribute along.                                                                 |
+| `spacing` | `int`                      | `8`         | Gap between each element (forced to `0` when `glue` is set).                                            |
+| `mode`    | `"edge"` \| `"center"`     | `"edge"`    | Spacing measured edge-to-edge or center-to-center.                                                      |
+| `order`   | `"forward"` \| `"reverse"` | `"forward"` | Order to place elements.                                                                                |
+| `glue`    | `bool`                     | `False`     | Stack semantics: children touch, and their data-driven extents commit to one positional axis.           |
+| `weights` | `list[float]`              | —           | Per-child budget weights (one per child, positional) — how fill children share the layer's slice space. |
 
 The first already-placed ref acts as an anchor; unplaced refs after it are
 distributed forward, and those before it backward so they stack flush.
@@ -82,6 +84,33 @@ layer([
     lambda a, b, c: [
         Constraint.align([a, b, c], x="start"),
         Constraint.distribute([a, b, c], dir="y", spacing=8),
+    ]
+)
+```
+
+### Space resolution and auto-fit
+
+`distribute` (and `align`) don't just position refs after layout — they
+participate in **underlying-space resolution**, exactly like the operators
+built on them. A `distribute` over data-sized children composes their size
+claims (sum + spacing) into the layer's claim on that axis; when the layer is
+then given a size (an explicit `w`/`h`, or an allotted budget from its parent
+or a coordinate transform), it solves for the scale factor that makes the
+children fit, and proposes budget slices (equal, or per `weights`) to children
+with no size claim of their own. With `glue=True` the composed extents commit
+to an anchored positional axis instead — that's a stacked bar chart. In other
+words: a constraint-assembled layer auto-fits the same way a `spread`/`stack`
+does.
+
+```python
+layer([
+    rect(w=60, h=datum(30), fill="#e63946").name("a"),
+    rect(w=60, h=datum(50), fill="#457b9d").name("b"),
+    rect(w=60, h=datum(20), fill="#2a9d8f").name("c"),
+]).constrain(
+    lambda a, b, c: [
+        Constraint.align([a, b, c], x="start"),
+        Constraint.distribute([a, b, c], dir="y", glue=True),
     ]
 )
 ```

--- a/apps/docs/docs/python/api/operators/spread.md
+++ b/apps/docs/docs/python/api/operators/spread.md
@@ -22,13 +22,15 @@ spread(*, by=None, dir, **options) -> Operator
 
 ## Parameters
 
-| Parameter   | Type                | Description                                                                                                      |
-| ----------- | ------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `by`        | `str` \| `Callable` | Field, dotted path, or callable to partition by (see [path-aware `by`](#path-aware-by)). Omit to spread per row. |
-| `dir`       | `"x"` \| `"y"`      | **Required.** Axis to lay groups out along.                                                                      |
-| `spacing`   | `int`               | Gap between groups in pixels.                                                                                    |
-| `alignment` | `str`               | Cross-axis alignment of the groups.                                                                              |
-| `label`     | `bool`              | Whether to emit an axis label for the partition field.                                                           |
+| Parameter      | Type                | Description                                                                                                                                                                                                                                        |
+| -------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `by`           | `str` \| `Callable` | Field, dotted path, or callable to partition by (see [path-aware `by`](#path-aware-by)). Omit to spread per row.                                                                                                                                   |
+| `dir`          | `"x"` \| `"y"`      | **Required.** Axis to lay groups out along.                                                                                                                                                                                                        |
+| `spacing`      | `int`               | Gap between groups in pixels. Ignored when `glue=True`.                                                                                                                                                                                            |
+| `alignment`    | `str`               | Cross-axis alignment of the groups.                                                                                                                                                                                                                |
+| `glue`         | `bool`              | Glue children together: collapse data-driven sizes into a single positional axis at this level. [`stack`](/python/api/operators/stack) sets this.                                                                                                  |
+| `stackWeights` | `list[float]`       | **Combinator form only** (explicit child list, e.g. `spread([m1, m2], ...)`). When its length matches the number of children, space along `dir` is split in proportion to these weights (after `spacing`); otherwise children share space equally. |
+| `label`        | `bool`              | Whether to emit an axis label for the partition field.                                                                                                                                                                                             |
 
 Returns an `Operator` for use inside [`.flow()`](/python/api/core/flow).
 

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -89,6 +89,59 @@ export const placeAtAnchor = (
   else target.place(axis, value, "max");
 };
 
+/**
+ * Where the enforced alignment coordinate (the "baseline") comes from. This is
+ * the one genuine divergence between the two align callsites, so it is an
+ * explicit parameter and each callsite supplies its own:
+ *
+ *  - `readPlaced` reads the baseline off the *first already-placed* target, at
+ *    that target's anchor. The constraint path reads the target's real extent /
+ *    origin (so a `"baseline"` anchor takes its actual `transform.translate`);
+ *    spread pins a `"baseline"` anchor to 0 and tolerates missing extents.
+ *  - `fallback` supplies the baseline when *nothing* is pre-placed. The
+ *    constraint path returns the layer's own box edge (start→0, middle→size/2,
+ *    end→size, baseline→0) — axis-title elaboration relies on a title pinning to
+ *    the plot box. Spread instead returns the data scale's origin
+ *    (`posScale(0)`, or `size/2` for middle, or 0 with no scale) so a
+ *    SIZE-derived cross axis aligns at the scale's zero, not the box edge. Both
+ *    are load-bearing; neither subsumes the other.
+ */
+export interface AlignBaselinePolicy {
+  readPlaced: (target: Placeable, idx: 0 | 1, anchor: AlignAnchor) => number;
+  fallback: (anchors: AlignAnchor[], idx: 0 | 1) => number;
+}
+
+/**
+ * Place `targets` on one axis so each lands at a single shared baseline,
+ * read at its own anchor. The baseline is taken from the first already-placed
+ * target (via `policy.readPlaced`), or from `policy.fallback` when none is
+ * placed; already-placed targets are left untouched. This is the single
+ * placement walk shared by the `align` constraint and spread's cross-axis
+ * alignment — only the baseline policy differs (see `AlignBaselinePolicy`).
+ */
+export function alignTargets(
+  targets: Placeable[],
+  axis: Axis,
+  anchors: AlignAnchor[],
+  policy: AlignBaselinePolicy
+): void {
+  const idx = axisIndex(axis);
+
+  let baseline: number | undefined;
+  for (let i = 0; i < targets.length; i++) {
+    if (isPlacedOn(targets[i], idx)) {
+      baseline = policy.readPlaced(targets[i], idx, anchors[i]);
+      break;
+    }
+  }
+  if (baseline === undefined) baseline = policy.fallback(anchors, idx);
+
+  for (let i = 0; i < targets.length; i++) {
+    if (isPlacedOn(targets[i], idx)) continue;
+    placeAtAnchor(targets[i], axis, baseline, anchors[i]);
+  }
+}
+
 const fallbackFor = (
   fallback: AlignFallbackBaseline | undefined,
   a: AlignAnchor
@@ -108,8 +161,6 @@ function applyAlignAxis(
   targets: Placeable[],
   fallback?: AlignFallbackBaseline
 ): void {
-  const idx = axisIndex(axis);
-
   // Normalize to a per-child anchor array.
   let anchors: AlignAnchor[];
   if (Array.isArray(spec)) {
@@ -123,26 +174,12 @@ function applyAlignAxis(
     anchors = new Array<AlignAnchor>(targets.length).fill(spec);
   }
 
-  // Baseline = the coordinate the alignment is enforcing. Taken from the
-  // first already-placed child, read at *that child's* anchor. With a
-  // shared anchor the per-child anchor lookup collapses to the legacy
-  // behavior (read .min/.center/.max consistently).
-  let baseline: number | undefined;
-  for (let i = 0; i < targets.length; i++) {
-    if (isPlacedOn(targets[i], idx)) {
-      baseline = anchorValue(targets[i], idx, anchors[i]);
-      break;
-    }
-  }
-  if (baseline === undefined) {
-    // No placed siblings: fall back to the layer's box baseline.
-    baseline = fallbackFor(fallback, anchors[0]);
-  }
-
-  for (let i = 0; i < targets.length; i++) {
-    if (isPlacedOn(targets[i], idx)) continue;
-    placeAtAnchor(targets[i], axis, baseline, anchors[i]);
-  }
+  // Layer-box policy: read a placed sibling's real extent/origin; with no
+  // placed sibling, fall back to the layer's own box baseline.
+  alignTargets(targets, axis, anchors, {
+    readPlaced: anchorValue,
+    fallback: (as) => fallbackFor(fallback, as[0]),
+  });
 }
 
 export function applyAlign(

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -6,6 +6,26 @@ import {
   axisIndex,
   isPlacedOn,
 } from "./shared";
+import type { UnderlyingSpace } from "../underlyingSpace";
+import { resolveAlignmentSpace } from "../graphicalOperators/alignment";
+
+/**
+ * PROTOTYPE (issue #475): the align constraint's *space-resolution*
+ * contribution — the cross-axis half of the spread reduction. Defers entirely
+ * to spread's own `resolveAlignmentSpace`, so the fold is the same one spread
+ * uses (SIZE→POSITION for start/end/baseline; SIZE→DIFFERENCE for middle;
+ * POSITION union otherwise). `AlignAnchor` and spread's `Alignment` share the
+ * same string vocabulary, so the anchor passes through unchanged.
+ *
+ * Only the uniform-anchor form is handled (a single string, not a per-child
+ * array): a heterogeneous anchor array has no single spread equivalent.
+ */
+export function alignSpaceFold(
+  targetSpaces: UnderlyingSpace[],
+  anchor: AlignAnchor
+): UnderlyingSpace {
+  return resolveAlignmentSpace(targetSpaces, anchor).space;
+}
 
 /**
  * Anchor spec for one axis of an `align` constraint. A single anchor

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -1,3 +1,7 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
 import type { Placeable } from "../_node";
 import {
   AlignAnchor,

--- a/packages/gofish-graphics/src/ast/constraints/distribute.ts
+++ b/packages/gofish-graphics/src/ast/constraints/distribute.ts
@@ -1,3 +1,7 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
 import type { Placeable } from "../_node";
 import { Axis, ConstraintRef, axisIndex, isPlacedOn } from "./shared";
 import { getMeasure, getValue, isValue, type MaybeValue } from "../data";

--- a/packages/gofish-graphics/src/ast/constraints/distribute.ts
+++ b/packages/gofish-graphics/src/ast/constraints/distribute.ts
@@ -165,8 +165,17 @@ export type DistributeInconsistencyReporter = (
   actual: number
 ) => void;
 
+/** The subset of a distribute constraint the placement walk reads. The
+ *  constraint path passes its full constraint (which satisfies this shape
+ *  structurally); spread passes just these fields — `children` is never
+ *  consumed here, since targets arrive as Placeables. */
+export type DistributeWalkOptions = Pick<
+  DistributeConstraint,
+  "dir" | "spacing" | "mode" | "order"
+>;
+
 export function applyDistribute(
-  constraint: DistributeConstraint,
+  constraint: DistributeWalkOptions,
   targets: Placeable[],
   onInconsistency?: DistributeInconsistencyReporter
 ): void {

--- a/packages/gofish-graphics/src/ast/constraints/distribute.ts
+++ b/packages/gofish-graphics/src/ast/constraints/distribute.ts
@@ -1,5 +1,6 @@
 import type { Placeable } from "../_node";
 import { Axis, ConstraintRef, axisIndex, isPlacedOn } from "./shared";
+import { getMeasure, getValue, isValue, type MaybeValue } from "../data";
 import {
   ORDINAL,
   POSITION,
@@ -19,6 +20,13 @@ export interface DistributeOptions {
   spacing?: number;
   mode?: "edge" | "center";
   order?: "forward" | "reverse";
+  /** Stack semantics: glue children together (sizes sum into a POSITION at the
+   *  layer) instead of slicing a budget. Forces `spacing` to 0. Mirrors
+   *  spread's `glue`. */
+  glue?: boolean;
+  /** Flex weights aligned to placement order (spread's `stackWeights`); splits
+   *  the budget in proportion to these instead of equally. */
+  weights?: number[];
 }
 
 export interface DistributeConstraint {
@@ -27,6 +35,8 @@ export interface DistributeConstraint {
   spacing: number;
   mode: "edge" | "center";
   order: "forward" | "reverse";
+  glue: boolean;
+  weights?: number[];
   children: ConstraintRef[];
 }
 
@@ -36,68 +46,108 @@ export const createDistributeConstraint = (
 ): DistributeConstraint => ({
   type: "distribute",
   dir: options.dir,
-  spacing: options.spacing ?? 8,
+  // Glue pins spacing ≡ 0 — both for the space fold and for `applyDistribute`'s
+  // post-layout placement (which reads this `spacing`), so glued children touch.
+  spacing: options.glue ? 0 : (options.spacing ?? 8),
   mode: options.mode ?? "edge",
   order: options.order ?? "forward",
+  glue: options.glue ?? false,
+  weights: options.weights,
   children,
 });
 
 /**
- * PROTOTYPE (issue #475): the distribute constraint's *space-resolution*
- * contribution — the missing half that makes `layer + distribute` claim the
- * same underlying space a `spread` does. Mirrors spread.tsx's non-glue stack
- * dispatch exactly (resolveUnderlyingSpace, ~lines 174-223):
- *   - all-SIZE & data-driven (some non-constant Monotonic) → SIZE composition
- *     (Monotonic.add of the children + spacing·(n−1) for "edge"; the
- *     unknown-Monotonic center form for "center"), so a parent can solve a
- *     scale factor via Monotonic.inverse (auto-fit).
- *   - all-SIZE constant + named (carry a `key`) → ORDINAL.
- *   - all-SIZE constant + unnamed → SIZE composition.
- *   - all-POSITION → POSITION([0, Σ widths]).
- *   - anything else → UNDEFINED (caller falls back to its default union).
- * Measures forget-merge on conflict, like spread.
+ * The distribute constraint's *space-resolution* contribution — the bottom-up
+ * half that makes `layer + distribute` claim the same underlying space a
+ * `spread` does. Mirrors spread.tsx's stack-axis dispatch exactly (spread's
+ * `resolveUnderlyingSpace`), including the explicit-size override and the glue
+ * (stack) variant, so phase-3 spread can delegate to it wholesale:
  *
- * `keys` are the targets' ordinal keys (node.key) in the same order as
- * `targetSpaces`; only used to pick the ORDINAL branch.
+ *  - explicit `opts.size` (a value) → SIZE(linear(value, 0)) — the spread's own
+ *    size wins over any children-derived claim.
+ *  - glue → POSITION([0, Σ widths]) when all-POSITION; POSITION([0, Σ run(1)])
+ *    when all-SIZE; ORDINAL(keys) when any child is keyed; else UNDEFINED.
+ *  - non-glue, all-SIZE & data-driven (some non-constant Monotonic) → SIZE
+ *    composition (Monotonic.add + spacing·(n−1) for "edge"; the
+ *    unknown-Monotonic center form for "center"), so a parent can solve a scale
+ *    factor via Monotonic.inverse (auto-fit).
+ *  - non-glue, any child keyed → ORDINAL.
+ *  - non-glue, all-SIZE constant → SIZE composition.
+ *  - non-glue, all-POSITION → POSITION([0, Σ widths]).
+ *  - anything else → UNDEFINED (caller falls back to its default union).
+ *
+ * Measures forget-merge on conflict, like spread. `keys` are the targets'
+ * ordinal keys (node.key) in the same order as `targetSpaces`; only used to
+ * pick the ORDINAL branch. This is ref-independent (plain arrays) so spread can
+ * call it with its positional children and the layer with its name-resolved
+ * targets.
  */
 export function distributeSpaceFold(
   targetSpaces: UnderlyingSpace[],
-  constraint: Pick<DistributeConstraint, "spacing" | "mode">,
-  keys: (string | undefined)[] = []
+  keys: (string | undefined)[],
+  opts: {
+    spacing: number;
+    mode: "edge" | "center";
+    glue?: boolean;
+    /** Explicit size on the spread/layer's stack axis; overrides children. */
+    size?: MaybeValue<number>;
+  }
 ): UnderlyingSpace {
   const n = targetSpaces.length;
   if (n === 0) return UNDEFINED;
-  const namedKeys = keys.filter((k): k is string => k !== undefined);
   const measure = forgetAllMeasures(targetSpaces.map((s) => spaceMeasure(s)));
 
+  // Explicit size on the stack axis dominates the children-derived claim.
+  if (opts.size !== undefined && isValue(opts.size)) {
+    return SIZE(
+      Monotonic.linear(getValue(opts.size)!, 0),
+      getMeasure(opts.size)
+    );
+  }
+
+  const namedKeys = keys.filter((k): k is string => k !== undefined);
+  const spacing = opts.glue ? 0 : opts.spacing;
   const allSize = targetSpaces.every(isSIZE);
+  const allPosition = targetSpaces.every((s) => isPOSITION(s) && s.domain);
+  const sumWidths = (): number =>
+    targetSpaces
+      .map((s) => Interval.width((s as any).domain))
+      .reduce((a, b) => a + b, 0);
+
+  if (opts.glue) {
+    // STACK semantics: collapse children into a single POSITION at this level
+    // using their intrinsic extent at scale = 1.
+    if (allPosition)
+      return POSITION(Interval.interval(0, sumWidths()), measure);
+    if (allSize) {
+      const total = targetSpaces
+        .map((s) => (s as any).domain.run(1) as number)
+        .reduce((a, b) => a + b, 0);
+      return POSITION(Interval.interval(0, total), measure);
+    }
+    if (namedKeys.length > 0) return ORDINAL(namedKeys);
+    return UNDEFINED;
+  }
+
   const childDomains = allSize
     ? targetSpaces.map((s) => (s as any).domain as Monotonic.Monotonic)
     : [];
   const dataDriven =
     allSize && childDomains.some((d) => !Monotonic.isConstant(d));
   const composeSize = (): Monotonic.Monotonic =>
-    constraint.mode === "center"
+    opts.mode === "center"
       ? Monotonic.unknown(
           (scaleFactor: number) =>
             childDomains[0].run(scaleFactor) / 2 +
-            constraint.spacing * (n - 1) +
+            spacing * (n - 1) +
             childDomains[childDomains.length - 1].run(scaleFactor) / 2
         )
-      : Monotonic.adds(
-          Monotonic.add(...childDomains),
-          constraint.spacing * (n - 1)
-        );
+      : Monotonic.adds(Monotonic.add(...childDomains), spacing * (n - 1));
 
   if (dataDriven) return SIZE(composeSize(), measure);
-  if (namedKeys.length === n && n > 0) return ORDINAL(namedKeys);
+  if (namedKeys.length > 0) return ORDINAL(namedKeys);
   if (allSize) return SIZE(composeSize(), measure);
-  if (targetSpaces.every((s) => isPOSITION(s) && s.domain)) {
-    const total = targetSpaces
-      .map((s) => Interval.width((s as any).domain))
-      .reduce((a, b) => a + b, 0);
-    return POSITION(Interval.interval(0, total), measure);
-  }
+  if (allPosition) return POSITION(Interval.interval(0, sumWidths()), measure);
   return UNDEFINED;
 }
 

--- a/packages/gofish-graphics/src/ast/constraints/distribute.ts
+++ b/packages/gofish-graphics/src/ast/constraints/distribute.ts
@@ -1,5 +1,18 @@
 import type { Placeable } from "../_node";
 import { Axis, ConstraintRef, axisIndex, isPlacedOn } from "./shared";
+import {
+  ORDINAL,
+  POSITION,
+  SIZE,
+  UNDEFINED,
+  UnderlyingSpace,
+  forgetAllMeasures,
+  isPOSITION,
+  isSIZE,
+  spaceMeasure,
+} from "../underlyingSpace";
+import * as Monotonic from "../../util/monotonic";
+import * as Interval from "../../util/interval";
 
 export interface DistributeOptions {
   dir: Axis;
@@ -28,6 +41,65 @@ export const createDistributeConstraint = (
   order: options.order ?? "forward",
   children,
 });
+
+/**
+ * PROTOTYPE (issue #475): the distribute constraint's *space-resolution*
+ * contribution — the missing half that makes `layer + distribute` claim the
+ * same underlying space a `spread` does. Mirrors spread.tsx's non-glue stack
+ * dispatch exactly (resolveUnderlyingSpace, ~lines 174-223):
+ *   - all-SIZE & data-driven (some non-constant Monotonic) → SIZE composition
+ *     (Monotonic.add of the children + spacing·(n−1) for "edge"; the
+ *     unknown-Monotonic center form for "center"), so a parent can solve a
+ *     scale factor via Monotonic.inverse (auto-fit).
+ *   - all-SIZE constant + named (carry a `key`) → ORDINAL.
+ *   - all-SIZE constant + unnamed → SIZE composition.
+ *   - all-POSITION → POSITION([0, Σ widths]).
+ *   - anything else → UNDEFINED (caller falls back to its default union).
+ * Measures forget-merge on conflict, like spread.
+ *
+ * `keys` are the targets' ordinal keys (node.key) in the same order as
+ * `targetSpaces`; only used to pick the ORDINAL branch.
+ */
+export function distributeSpaceFold(
+  targetSpaces: UnderlyingSpace[],
+  constraint: Pick<DistributeConstraint, "spacing" | "mode">,
+  keys: (string | undefined)[] = []
+): UnderlyingSpace {
+  const n = targetSpaces.length;
+  if (n === 0) return UNDEFINED;
+  const namedKeys = keys.filter((k): k is string => k !== undefined);
+  const measure = forgetAllMeasures(targetSpaces.map((s) => spaceMeasure(s)));
+
+  const allSize = targetSpaces.every(isSIZE);
+  const childDomains = allSize
+    ? targetSpaces.map((s) => (s as any).domain as Monotonic.Monotonic)
+    : [];
+  const dataDriven =
+    allSize && childDomains.some((d) => !Monotonic.isConstant(d));
+  const composeSize = (): Monotonic.Monotonic =>
+    constraint.mode === "center"
+      ? Monotonic.unknown(
+          (scaleFactor: number) =>
+            childDomains[0].run(scaleFactor) / 2 +
+            constraint.spacing * (n - 1) +
+            childDomains[childDomains.length - 1].run(scaleFactor) / 2
+        )
+      : Monotonic.adds(
+          Monotonic.add(...childDomains),
+          constraint.spacing * (n - 1)
+        );
+
+  if (dataDriven) return SIZE(composeSize(), measure);
+  if (namedKeys.length === n && n > 0) return ORDINAL(namedKeys);
+  if (allSize) return SIZE(composeSize(), measure);
+  if (targetSpaces.every((s) => isPOSITION(s) && s.domain)) {
+    const total = targetSpaces
+      .map((s) => Interval.width((s as any).domain))
+      .reduce((a, b) => a + b, 0);
+    return POSITION(Interval.interval(0, total), measure);
+  }
+  return UNDEFINED;
+}
 
 export function applyDistribute(
   constraint: DistributeConstraint,

--- a/packages/gofish-graphics/src/ast/constraints/distribute.ts
+++ b/packages/gofish-graphics/src/ast/constraints/distribute.ts
@@ -151,13 +151,35 @@ export function distributeSpaceFold(
   return UNDEFINED;
 }
 
+/** Reports a fixed (already-placed) child whose position disagrees with where
+ *  the running distribute walk expected it. spread.tsx passes this to surface
+ *  the warning it used to emit from its own walk; the constraint path omits it
+ *  (no warning), so console output there is unchanged. Fires only past the
+ *  `1e-6` tolerance. */
+export type DistributeInconsistencyReporter = (
+  expected: number,
+  actual: number
+) => void;
+
 export function applyDistribute(
   constraint: DistributeConstraint,
-  targets: Placeable[]
+  targets: Placeable[],
+  onInconsistency?: DistributeInconsistencyReporter
 ): void {
   const idx = axisIndex(constraint.dir);
   const ordered =
     constraint.order === "reverse" ? [...targets].reverse() : targets;
+
+  // Compare a fixed child's actual edge/center against the running expected
+  // position and report past tolerance. The anchor itself is never checked —
+  // it *defines* the running position, so it is consistent by construction
+  // (matches spread's single-forward-walk, which back-computes its origin from
+  // the first fixed child).
+  const checkInconsistent = (expected: number, actual: number): void => {
+    if (onInconsistency && Math.abs(expected - actual) > 1e-6) {
+      onInconsistency(expected, actual);
+    }
+  };
 
   // Find the first already-placed child (the anchor)
   const anchorIdx = ordered.findIndex((t) => isPlacedOn(t, idx));
@@ -183,6 +205,7 @@ export function applyDistribute(
     for (let i = anchorIdx + 1; i < ordered.length; i++) {
       const t = ordered[i];
       if (isPlacedOn(t, idx)) {
+        checkInconsistent(pos, t.dims[idx].min!);
         pos = t.dims[idx].max! + constraint.spacing;
       } else {
         t.place(constraint.dir, pos);
@@ -206,6 +229,7 @@ export function applyDistribute(
     for (let i = anchorIdx + 1; i < ordered.length; i++) {
       const t = ordered[i];
       if (isPlacedOn(t, idx)) {
+        checkInconsistent(pos, t.dims[idx].center!);
         pos = t.dims[idx].center! + constraint.spacing;
       } else {
         t.place(constraint.dir, pos, "center");

--- a/packages/gofish-graphics/src/ast/constraints/folds.ts
+++ b/packages/gofish-graphics/src/ast/constraints/folds.ts
@@ -1,0 +1,45 @@
+// Shared layout machinery for the distribute constraint and (phase 3) spread.
+//
+// A constraint's *space fold* (bottom-up, pre-layout) composes child claims
+// into the parent's claim — that lives in each constraint file
+// (`distributeSpaceFold` in distribute.ts, `alignSpaceFold` in align.ts). This
+// file holds the *budget adjoint* (top-down, layout-time): once the parent has
+// solved its scale factor σ against an allotted size, it must hand each
+// claim-less ("fill") child a concrete size. `allocateSlices` is that fill
+// policy — the one piece of information beyond align + distribute, i.e. the
+// flex-layout fragment (see
+// apps/docs/docs/internals/design/constraints-as-core.md, "folds, max-plus
+// closure, and the budget adjoint").
+
+/**
+ * Divide a one-dimensional `budget` (pixels) among `n` slots after reserving
+ * `spacing` between adjacent slots. Equal split by default; with a valid
+ * `weights` array (length `n`, all finite and ≥ 0, positive sum) the available
+ * space is split in proportion to the weights. Extracted verbatim from spread's
+ * slice arithmetic (spread.tsx, "Calculate available space for children …") so
+ * the two paths cannot drift.
+ *
+ * `weights` are positional: `weights[i]` is the share of slot `i` in placement
+ * order (the same order distribute walks), so a reversed distribute must pass
+ * weights already aligned to that reversed order.
+ */
+export function allocateSlices(
+  budget: number,
+  spacing: number,
+  n: number,
+  weights?: number[]
+): number[] {
+  const totalSpacing = spacing * (n - 1);
+  const available = budget - totalSpacing;
+  const weightsOk =
+    weights !== undefined &&
+    weights.length === n &&
+    weights.every((w) => Number.isFinite(w) && w >= 0);
+  const weightSum = weightsOk
+    ? weights!.reduce((acc, w) => acc + Math.max(w, 0), 0)
+    : 0;
+  const useWeights = weightsOk && weightSum > 0;
+  return useWeights
+    ? weights!.map((w) => (Math.max(w, 0) / weightSum) * available)
+    : Array.from({ length: n }, () => available / n);
+}

--- a/packages/gofish-graphics/src/ast/constraints/folds.ts
+++ b/packages/gofish-graphics/src/ast/constraints/folds.ts
@@ -1,3 +1,7 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
 // Shared layout machinery for the distribute constraint and (phase 3) spread.
 //
 // A constraint's *space fold* (bottom-up, pre-layout) composes child claims

--- a/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
@@ -22,6 +22,8 @@ import {
 } from "../underlyingSpace";
 import type { Measure } from "../data";
 import type { Size } from "../dims";
+import { alignTargets } from "../constraints/align";
+import type { AlignAnchor } from "../constraints/shared";
 import * as Interval from "../../util/interval";
 import * as Monotonic from "../../util/monotonic";
 
@@ -179,7 +181,11 @@ export function resolveAlignmentSpace(
 }
 
 /**
- * Align children on a single axis using spread-style semantics.
+ * Align children on a single axis using spread-style semantics. Thin wrapper
+ * over the shared `alignTargets` walk (see `constraints/align.ts`) supplying
+ * spread's baseline policy: a `"baseline"` anchor pins to 0, and an unplaced
+ * fallback resolves to the data scale's origin (`posScale(0)`) rather than the
+ * layer box.
  *
  * Guard: when children already have data-driven positions via posScale
  * (fromSize is false and alignment !== "middle"), skip — the children
@@ -197,36 +203,17 @@ export function alignChildren(
   // SIZE space (no inherent position) or middle alignment forces centering.
   if (posScale && !fromSize && alignment !== "middle") return;
 
-  const isFixed = (child: Placeable) => child.dims[axis].min !== undefined;
-  const fixedChildren = children.filter(isFixed);
-
-  const anchorMap = {
-    start: "min",
-    middle: "center",
-    end: "max",
-    baseline: "baseline",
-  } as const;
-
-  const getBaseline = (child: Placeable): number => {
-    const dim = child.dims[axis];
-    const anchor = anchorMap[alignment];
-    if (anchor === "baseline") return 0;
-    return dim[anchor] ?? dim.min ?? 0;
-  };
-
-  const baseline =
-    fixedChildren.length > 0
-      ? getBaseline(fixedChildren[0])
-      : alignment === "middle"
-        ? size / 2
-        : posScale
-          ? posScale(0)
-          : 0;
-
-  const placeAnchor = anchorMap[alignment];
-
-  for (const child of children) {
-    if (isFixed(child)) continue;
-    child.place(axis, baseline, placeAnchor);
-  }
+  const anchors = new Array<AlignAnchor>(children.length).fill(alignment);
+  alignTargets(children, axis === 0 ? "x" : "y", anchors, {
+    readPlaced: (child, idx, a) =>
+      a === "baseline"
+        ? 0
+        : a === "start"
+          ? (child.dims[idx].min ?? 0)
+          : a === "middle"
+            ? (child.dims[idx].center ?? child.dims[idx].min ?? 0)
+            : (child.dims[idx].max ?? child.dims[idx].min ?? 0),
+    fallback: (as) =>
+      as[0] === "middle" ? size / 2 : posScale ? posScale(0) : 0,
+  });
 }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -37,6 +37,7 @@ import {
   type DistributeConstraint,
 } from "../constraints/distribute";
 import { alignSpaceFold, type AlignConstraint } from "../constraints/align";
+import { allocateSlices } from "../constraints/folds";
 import { axisIndex } from "../constraints/shared";
 import { unionChildSpaces } from "./alignment";
 
@@ -50,102 +51,158 @@ const childNameKey = (node: GoFishAST): string | undefined => {
   return isToken(n) ? n.__tag : n;
 };
 
-// ── Constraint space fold (PROTOTYPE, issue #475) ──────────────────────────
+// ── Spread-shape recognition: the operator image of layer constraints ───────
 //
-// Constraints are normally pure post-layout positioners. `spread`, by
-// contrast, also folds its children's underlying spaces into a composed claim
-// (a Monotonic sum + spacing on the stack axis, an alignment fold on the cross
-// axis) so a parent can invert that claim to auto-fit. This makes
-// `layer + align + distribute` carry that *same* claim for the simplest case:
-// exactly one `distribute` covering EVERY direct named child, optionally one
-// cross-axis `align` over the same set, and nothing else (no `position` /
-// z-order). Anything outside that shape returns undefined and the layer keeps
-// its existing `unionChildSpaces` behavior, so no existing constraint set —
-// including the heavily constraint-driven axis-elaboration layers — is touched.
+// Constraints are normally pure post-layout positioners. `spread`, by contrast,
+// also folds its children's underlying spaces into a composed claim (a Monotonic
+// sum + spacing on the stack axis via `distributeSpaceFold`, an alignment fold
+// on the cross axis via `alignSpaceFold`) so a parent can invert that claim to
+// auto-fit, and at layout time it *sizes* its children from a budget (the flex
+// fragment, `allocateSlices`). This recognizer detects when a layer's
+// constraints form that same operator image and reproduces both halves, so
+// `layer + align + distribute` is geometrically identical to `spread`.
+//
+// The recognized image: exactly ONE `distribute` (optionally `glue`), at most
+// one cross-axis `align` with a uniform string anchor, and nothing else (no
+// `position` / z-order). This is the same guard the prototype used minus the
+// "distribute covers every child" requirement: children NOT covered by the
+// distribute are unconstrained siblings that overlay (max-union with the
+// distribute's claim). The structural guards keep every existing constraint set
+// untouched — axis-elaboration layers carry `position` constraints, and the
+// legend layer carries two `align`s, so both fall out of the image and keep
+// their `unionChildSpaces` behavior. Anything beyond the image (multiple
+// distributes per axis, distribute + position on one axis) likewise falls back
+// to `unionChildSpaces`; the general max-plus composition that would handle it
+// is the residual in
+// apps/docs/docs/internals/design/constraints-as-core.md ("Composition and
+// conflict semantics").
 
-type ConstraintFold = {
-  /** Per-axis space overrides; undefined leaves the default union in place. */
-  spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined];
-  /** Distribute budget descriptor, consumed by `layout`. */
-  budget: {
-    dAxis: 0 | 1;
-    spacing: number;
-    /** Names of the distribute targets, in placement order. */
-    order: string[];
-    /** The folded SIZE Monotonic on the distribute axis, if SIZE — inverted
-     *  against the layer's allotted size to derive the child scale factor. */
-    sizeDomain?: Monotonic.Monotonic;
-  };
+/** Distribute budget descriptor, stashed by `resolveUnderlyingSpace` and
+ *  consumed by `layout` to solve a scale factor and propose per-child sizes. */
+type DistributeBudget = {
+  dAxis: 0 | 1;
+  /** Already glue-zeroed (see createDistributeConstraint). */
+  spacing: number;
+  /** Names of the distribute targets, in placement order. */
+  order: string[];
+  weights?: number[];
+  /** The folded SIZE Monotonic on the distribute axis, if the fold was SIZE —
+   *  inverted against the layer's allotted size to derive the child scale
+   *  factor (auto-fit). Absent for glue/POSITION/ORDINAL/UNDEFINED folds. */
+  sizeDomain?: Monotonic.Monotonic;
 };
 
-function resolveConstraintFold(
+type SpreadShape = {
+  /** Per-axis space overrides; undefined leaves the default union in place. */
+  spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined];
+  budget: DistributeBudget;
+};
+
+/** Build a per-axis Size carrying `space` on `axis` and UNDEFINED elsewhere, so
+ *  a single space can be fed to `unionChildSpaces` as a pseudo-child. */
+const axisSize = (
+  space: UnderlyingSpace,
+  axis: 0 | 1
+): Size<UnderlyingSpace> =>
+  axis === 0 ? [space, UNDEFINED] : [UNDEFINED, space];
+
+/** Max-union a folded claim with any unconstrained siblings' spaces on `axis`
+ *  (the distribute's claim and overlay siblings co-occupy the layer box, so
+ *  the extent is their union). With no siblings this returns `claim`
+ *  unchanged — preserving exact parity with spread for the covers-all image. */
+function maxUnionWith(
+  claim: UnderlyingSpace,
+  others: UnderlyingSpace[],
+  axis: 0 | 1
+): UnderlyingSpace {
+  if (others.length === 0) return claim;
+  return unionChildSpaces(
+    [axisSize(claim, axis), ...others.map((s) => axisSize(s, axis))],
+    axis
+  );
+}
+
+function resolveSpreadShape(
   constraints: ConstraintSpec[],
   childNodes: GoFishAST[],
   childSpaces: Size<UnderlyingSpace>[]
-): ConstraintFold | undefined {
+): SpreadShape | undefined {
   if (constraints.length === 0) return undefined;
   const distributes = constraints.filter((c) => c.type === "distribute");
   const aligns = constraints.filter((c) => c.type === "align");
-  // Only align/distribute may appear; a `position`/z-order constraint means a
-  // different layout regime that this fold does not model.
+  // Operator image: exactly one distribute, at most one align, nothing else.
+  // Any `position`/z-order constraint is a different layout regime.
   if (distributes.length !== 1) return undefined;
   if (aligns.length > 1) return undefined;
   if (distributes.length + aligns.length !== constraints.length) {
     return undefined;
   }
 
-  // Every direct child must be named (so "covers all named" == "covers all").
-  const names: string[] = [];
   const indexByName = new Map<string, number>();
   for (let i = 0; i < childNodes.length; i++) {
     const name = childNameKey(childNodes[i]);
-    if (name === undefined) return undefined;
-    names.push(name);
-    indexByName.set(name, i);
+    if (name !== undefined && !indexByName.has(name)) indexByName.set(name, i);
   }
-  const nameSet = new Set(names);
-  const coversAll = (refs: ReadonlyArray<{ name: string }>): boolean =>
-    refs.length === nameSet.size && refs.every((r) => nameSet.has(r.name));
+  const keyOf = (i: number): string | undefined =>
+    childNodes[i] instanceof GoFishNode
+      ? (childNodes[i] as GoFishNode).key
+      : undefined;
 
   const dist = distributes[0] as DistributeConstraint;
-  if (!coversAll(dist.children)) return undefined;
   const dAxis = axisIndex(dist.dir);
   const aAxis = (1 - dAxis) as 0 | 1;
 
   // Distribute targets in placement order (matches applyDistribute's `order`).
+  // Every target must be a direct child (so we can slice it); a ref into a
+  // nested tier has no slot here, so bail to the general union.
   const order = (
     dist.order === "reverse" ? [...dist.children].reverse() : dist.children
   ).map((r) => r.name);
+  if (!order.every((n) => indexByName.has(n))) return undefined;
   const dIdx = order.map((n) => indexByName.get(n)!);
-  const dTargetSpaces = dIdx.map((i) => childSpaces[i][dAxis]);
-  const dKeys = dIdx.map((i) =>
-    childNodes[i] instanceof GoFishNode
-      ? (childNodes[i] as GoFishNode).key
-      : undefined
+  const coveredSet = new Set(dIdx);
+
+  const foldD = distributeSpaceFold(
+    dIdx.map((i) => childSpaces[i][dAxis]),
+    dIdx.map(keyOf),
+    { spacing: dist.spacing, mode: dist.mode, glue: dist.glue }
   );
-  const foldD = distributeSpaceFold(dTargetSpaces, dist, dKeys);
+
+  // Unconstrained siblings (children outside the distribute) overlay the
+  // distribute's claim on both axes.
+  const otherSpaces = (axis: 0 | 1): UnderlyingSpace[] =>
+    childSpaces.filter((_, i) => !coveredSet.has(i)).map((c) => c[axis]);
 
   const spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined] = [
     undefined,
     undefined,
   ];
-  if (!isUNDEFINED(foldD)) spaces[dAxis] = foldD;
+  if (!isUNDEFINED(foldD)) {
+    spaces[dAxis] = maxUnionWith(foldD, otherSpaces(dAxis), dAxis);
+  }
 
-  // Optional cross-axis align over the same set: a single uniform anchor on the
-  // distribute's cross axis only (a per-child anchor array or a same-axis spec
-  // has no single spread equivalent).
+  // Optional cross-axis align: a single uniform anchor on the distribute's
+  // cross axis only (a per-child anchor array or a same-axis spec has no single
+  // spread equivalent). Folded over the children the align covers.
   if (aligns.length === 1) {
     const al = aligns[0] as AlignConstraint;
     const anchor = aAxis === 0 ? al.x : al.y;
     const distAxisSpec = dAxis === 0 ? al.x : al.y;
+    const aIdx = al.children
+      .map((r) => indexByName.get(r.name))
+      .filter((i): i is number => i !== undefined);
     if (
-      coversAll(al.children) &&
       typeof anchor === "string" &&
-      distAxisSpec === undefined
+      distAxisSpec === undefined &&
+      aIdx.length > 0
     ) {
-      const aTargetSpaces = dIdx.map((i) => childSpaces[i][aAxis]);
-      const foldA = alignSpaceFold(aTargetSpaces, anchor);
-      if (!isUNDEFINED(foldA)) spaces[aAxis] = foldA;
+      const foldA = alignSpaceFold(
+        aIdx.map((i) => childSpaces[i][aAxis]),
+        anchor
+      );
+      if (!isUNDEFINED(foldA)) {
+        spaces[aAxis] = maxUnionWith(foldA, otherSpaces(aAxis), aAxis);
+      }
     }
   }
 
@@ -155,6 +212,7 @@ function resolveConstraintFold(
       dAxis,
       spacing: dist.spacing,
       order,
+      weights: dist.weights,
       sizeDomain: isSIZE(foldD) ? foldD.domain : undefined,
     },
   };
@@ -360,10 +418,10 @@ export const layer = createNodeOperatorSequential(
       UnderlyingSpace | undefined,
     ] = [undefined, undefined];
 
-    // PROTOTYPE (#475): distribute budget descriptor from the constraint fold,
-    // stashed by `resolveUnderlyingSpace` and consumed by `layout` to invert
-    // the composed SIZE against the allotted size and propose per-child slices.
-    let constraintBudget: ConstraintFold["budget"] | undefined;
+    // Distribute budget descriptor from the recognized spread shape, stashed by
+    // `resolveUnderlyingSpace` and consumed by `layout` to invert the composed
+    // SIZE against the allotted size and propose per-child slices.
+    let constraintBudget: DistributeBudget | undefined;
 
     return new GoFishNode(
       {
@@ -414,21 +472,22 @@ export const layer = createNodeOperatorSequential(
             resolveAxis(1, scaleY, posDomains.y),
           ];
 
-          // PROTOTYPE (#475): a simple spread expressed as align + distribute.
-          // When the constraints match that shape, override the constrained
-          // axes with spread's own space folds (SIZE sum + spacing on the
-          // distribute axis, the alignment fold on the cross axis). Applied
-          // BEFORE the self-scaling stash below so an explicit-size layer
-          // builds its LOCAL scale from the folded space, exactly like spread.
-          const fold = resolveConstraintFold(
+          // A simple spread expressed as align + distribute. When the
+          // constraints match that operator image (see resolveSpreadShape),
+          // override the constrained axes with spread's own space folds (SIZE
+          // sum + spacing on the distribute axis, the alignment fold on the
+          // cross axis). Applied BEFORE the self-scaling stash below so an
+          // explicit-size layer builds its LOCAL scale from the folded space,
+          // exactly like spread.
+          const shape = resolveSpreadShape(
             constraints ?? [],
             _childNodes,
             children
           );
-          constraintBudget = fold?.budget;
-          if (fold) {
+          constraintBudget = shape?.budget;
+          if (shape) {
             for (const axis of [0, 1] as const) {
-              const s = fold.spaces[axis];
+              const s = shape.spaces[axis];
               if (s !== undefined) resolved[axis] = s;
             }
           }
@@ -490,42 +549,63 @@ export const layer = createNodeOperatorSequential(
             }
           }
 
-          // PROTOTYPE (#475): layer budget solve for a constraint fold. When
-          // the distribute fold composed a SIZE claim, invert it against this
+          // Layer budget solve for a recognized spread shape. When the
+          // distribute fold composed a SIZE claim, invert it against this
           // layer's resolved size on the distribute axis to derive the child
           // scale factor (the same Monotonic.inverse recipe as the selfScaled
           // path, but driven by the *allotted* size, not only an explicit
-          // w/h). Idempotent with the root's own inversion of the same SIZE.
+          // w/h, and passing `upperBoundGuess` like spread does). Idempotent
+          // with the root's own inversion of the same SIZE.
           if (
             constraintBudget?.sizeDomain &&
             Number.isFinite(size[constraintBudget.dAxis])
           ) {
-            const sf = constraintBudget.sizeDomain.inverse(
-              size[constraintBudget.dAxis]
-            );
-            if (sf !== undefined)
-              childScaleFactors[constraintBudget.dAxis] = sf;
+            const dAxis = constraintBudget.dAxis;
+            const sf = constraintBudget.sizeDomain.inverse(size[dAxis], {
+              upperBoundGuess: size[dAxis],
+            });
+            if (sf !== undefined) childScaleFactors[dAxis] = sf;
+            else
+              // A non-invertible fold-produced Monotonic would otherwise
+              // silently vanish the content (spread's `?? 0`); name the axis and
+              // budget so the failure is visible, then keep the inherited factor.
+              console.warn(
+                `layer: could not invert distribute SIZE claim on ${
+                  dAxis === 0 ? "x" : "y"
+                } axis for budget ${size[dAxis]}px; keeping inherited scale factor.`,
+                constraintBudget
+              );
           }
 
-          // Per-child proposed size for the constrained children: spread's
-          // equal-slice default — (size − spacing·(n−1))/n on the distribute
-          // axis, the full size on the cross axis. A child carrying its own
-          // explicit size ignores this (its size wins), matching spread.
-          const constrainedSet = constraintBudget
-            ? new Set(constraintBudget.order)
+          // Per-child proposed size for the distribute-covered children: the
+          // fill policy (`allocateSlices`) — equal slices by default, or
+          // weight-proportional — on the distribute axis, the full size on the
+          // cross axis. A child carrying its own explicit size ignores this (its
+          // size wins), matching spread; a claim-less child consumes the slice.
+          const sliceByName: Map<string, number> | undefined = constraintBudget
+            ? (() => {
+                const b = constraintBudget;
+                const slices = allocateSlices(
+                  size[b.dAxis],
+                  b.spacing,
+                  b.order.length,
+                  b.weights
+                );
+                const m = new Map<string, number>();
+                b.order.forEach((name, i) => m.set(name, slices[i]));
+                return m;
+              })()
             : undefined;
           const childSizeFor = (childName: string | undefined): Size => {
             if (
               !constraintBudget ||
               childName === undefined ||
-              !constrainedSet!.has(childName)
+              !sliceByName!.has(childName)
             ) {
               return size;
             }
-            const d = constraintBudget.dAxis;
-            const n = constraintBudget.order.length;
             const sliced: Size = [size[0], size[1]];
-            sliced[d] = (size[d] - constraintBudget.spacing * (n - 1)) / n;
+            sliced[constraintBudget.dAxis] = sliceByName!.get(childName)!;
             return sliced;
           };
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -13,6 +13,7 @@ import {
   UnderlyingSpace,
   isPOSITION,
   isSIZE,
+  isUNDEFINED,
   spaceMeasure,
 } from "../underlyingSpace";
 import * as Interval from "../../util/interval";
@@ -28,8 +29,15 @@ import {
   getPositioningConstraintRefs,
   isZOrderConstraint,
   type ConstraintPosScales,
+  type ConstraintSpec,
   type ZOrderConstraint,
 } from "../constraints";
+import {
+  distributeSpaceFold,
+  type DistributeConstraint,
+} from "../constraints/distribute";
+import { alignSpaceFold, type AlignConstraint } from "../constraints/align";
+import { axisIndex } from "../constraints/shared";
 import { unionChildSpaces } from "./alignment";
 
 /** Normalize a node's _name (string or Token) to the string used as a key in
@@ -41,6 +49,116 @@ const childNameKey = (node: GoFishAST): string | undefined => {
   if (n === undefined) return undefined;
   return isToken(n) ? n.__tag : n;
 };
+
+// ── Constraint space fold (PROTOTYPE, issue #475) ──────────────────────────
+//
+// Constraints are normally pure post-layout positioners. `spread`, by
+// contrast, also folds its children's underlying spaces into a composed claim
+// (a Monotonic sum + spacing on the stack axis, an alignment fold on the cross
+// axis) so a parent can invert that claim to auto-fit. This makes
+// `layer + align + distribute` carry that *same* claim for the simplest case:
+// exactly one `distribute` covering EVERY direct named child, optionally one
+// cross-axis `align` over the same set, and nothing else (no `position` /
+// z-order). Anything outside that shape returns undefined and the layer keeps
+// its existing `unionChildSpaces` behavior, so no existing constraint set —
+// including the heavily constraint-driven axis-elaboration layers — is touched.
+
+type ConstraintFold = {
+  /** Per-axis space overrides; undefined leaves the default union in place. */
+  spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined];
+  /** Distribute budget descriptor, consumed by `layout`. */
+  budget: {
+    dAxis: 0 | 1;
+    spacing: number;
+    /** Names of the distribute targets, in placement order. */
+    order: string[];
+    /** The folded SIZE Monotonic on the distribute axis, if SIZE — inverted
+     *  against the layer's allotted size to derive the child scale factor. */
+    sizeDomain?: Monotonic.Monotonic;
+  };
+};
+
+function resolveConstraintFold(
+  constraints: ConstraintSpec[],
+  childNodes: GoFishAST[],
+  childSpaces: Size<UnderlyingSpace>[]
+): ConstraintFold | undefined {
+  if (constraints.length === 0) return undefined;
+  const distributes = constraints.filter((c) => c.type === "distribute");
+  const aligns = constraints.filter((c) => c.type === "align");
+  // Only align/distribute may appear; a `position`/z-order constraint means a
+  // different layout regime that this fold does not model.
+  if (distributes.length !== 1) return undefined;
+  if (aligns.length > 1) return undefined;
+  if (distributes.length + aligns.length !== constraints.length) {
+    return undefined;
+  }
+
+  // Every direct child must be named (so "covers all named" == "covers all").
+  const names: string[] = [];
+  const indexByName = new Map<string, number>();
+  for (let i = 0; i < childNodes.length; i++) {
+    const name = childNameKey(childNodes[i]);
+    if (name === undefined) return undefined;
+    names.push(name);
+    indexByName.set(name, i);
+  }
+  const nameSet = new Set(names);
+  const coversAll = (refs: ReadonlyArray<{ name: string }>): boolean =>
+    refs.length === nameSet.size && refs.every((r) => nameSet.has(r.name));
+
+  const dist = distributes[0] as DistributeConstraint;
+  if (!coversAll(dist.children)) return undefined;
+  const dAxis = axisIndex(dist.dir);
+  const aAxis = (1 - dAxis) as 0 | 1;
+
+  // Distribute targets in placement order (matches applyDistribute's `order`).
+  const order = (
+    dist.order === "reverse" ? [...dist.children].reverse() : dist.children
+  ).map((r) => r.name);
+  const dIdx = order.map((n) => indexByName.get(n)!);
+  const dTargetSpaces = dIdx.map((i) => childSpaces[i][dAxis]);
+  const dKeys = dIdx.map((i) =>
+    childNodes[i] instanceof GoFishNode
+      ? (childNodes[i] as GoFishNode).key
+      : undefined
+  );
+  const foldD = distributeSpaceFold(dTargetSpaces, dist, dKeys);
+
+  const spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined] = [
+    undefined,
+    undefined,
+  ];
+  if (!isUNDEFINED(foldD)) spaces[dAxis] = foldD;
+
+  // Optional cross-axis align over the same set: a single uniform anchor on the
+  // distribute's cross axis only (a per-child anchor array or a same-axis spec
+  // has no single spread equivalent).
+  if (aligns.length === 1) {
+    const al = aligns[0] as AlignConstraint;
+    const anchor = aAxis === 0 ? al.x : al.y;
+    const distAxisSpec = dAxis === 0 ? al.x : al.y;
+    if (
+      coversAll(al.children) &&
+      typeof anchor === "string" &&
+      distAxisSpec === undefined
+    ) {
+      const aTargetSpaces = dIdx.map((i) => childSpaces[i][aAxis]);
+      const foldA = alignSpaceFold(aTargetSpaces, anchor);
+      if (!isUNDEFINED(foldA)) spaces[aAxis] = foldA;
+    }
+  }
+
+  return {
+    spaces,
+    budget: {
+      dAxis,
+      spacing: dist.spacing,
+      order,
+      sizeDomain: isSIZE(foldD) ? foldD.domain : undefined,
+    },
+  };
+}
 
 // ── Z-order resolution ────────────────────────────────────────────────────
 //
@@ -242,6 +360,11 @@ export const layer = createNodeOperatorSequential(
       UnderlyingSpace | undefined,
     ] = [undefined, undefined];
 
+    // PROTOTYPE (#475): distribute budget descriptor from the constraint fold,
+    // stashed by `resolveUnderlyingSpace` and consumed by `layout` to invert
+    // the composed SIZE against the allotted size and propose per-child slices.
+    let constraintBudget: ConstraintFold["budget"] | undefined;
+
     return new GoFishNode(
       {
         type: options.box === true ? "box" : "layer",
@@ -290,6 +413,25 @@ export const layer = createNodeOperatorSequential(
             resolveAxis(0, scaleX, posDomains.x),
             resolveAxis(1, scaleY, posDomains.y),
           ];
+
+          // PROTOTYPE (#475): a simple spread expressed as align + distribute.
+          // When the constraints match that shape, override the constrained
+          // axes with spread's own space folds (SIZE sum + spacing on the
+          // distribute axis, the alignment fold on the cross axis). Applied
+          // BEFORE the self-scaling stash below so an explicit-size layer
+          // builds its LOCAL scale from the folded space, exactly like spread.
+          const fold = resolveConstraintFold(
+            constraints ?? [],
+            _childNodes,
+            children
+          );
+          constraintBudget = fold?.budget;
+          if (fold) {
+            for (const axis of [0, 1] as const) {
+              const s = fold.spaces[axis];
+              if (s !== undefined) resolved[axis] = s;
+            }
+          }
 
           // Stash the absorbed POSITION/SIZE space and report UNDEFINED upward
           // for any dim with an explicit pixel size — self-scaling region; see
@@ -347,6 +489,45 @@ export const layer = createNodeOperatorSequential(
                 stashed.domain.inverse(size[dim]) ?? scaleFactors?.[dim];
             }
           }
+
+          // PROTOTYPE (#475): layer budget solve for a constraint fold. When
+          // the distribute fold composed a SIZE claim, invert it against this
+          // layer's resolved size on the distribute axis to derive the child
+          // scale factor (the same Monotonic.inverse recipe as the selfScaled
+          // path, but driven by the *allotted* size, not only an explicit
+          // w/h). Idempotent with the root's own inversion of the same SIZE.
+          if (
+            constraintBudget?.sizeDomain &&
+            Number.isFinite(size[constraintBudget.dAxis])
+          ) {
+            const sf = constraintBudget.sizeDomain.inverse(
+              size[constraintBudget.dAxis]
+            );
+            if (sf !== undefined)
+              childScaleFactors[constraintBudget.dAxis] = sf;
+          }
+
+          // Per-child proposed size for the constrained children: spread's
+          // equal-slice default — (size − spacing·(n−1))/n on the distribute
+          // axis, the full size on the cross axis. A child carrying its own
+          // explicit size ignores this (its size wins), matching spread.
+          const constrainedSet = constraintBudget
+            ? new Set(constraintBudget.order)
+            : undefined;
+          const childSizeFor = (childName: string | undefined): Size => {
+            if (
+              !constraintBudget ||
+              childName === undefined ||
+              !constrainedSet!.has(childName)
+            ) {
+              return size;
+            }
+            const d = constraintBudget.dAxis;
+            const n = constraintBudget.order.length;
+            const sliced: Size = [size[0], size[1]];
+            sliced[d] = (size[d] - constraintBudget.spacing * (n - 1)) / n;
+            return sliced;
+          };
 
           // `position` constraints with a datum coordinate contribute a data
           // domain on their axis (see collectPositionDomains); the union is what
@@ -437,7 +618,7 @@ export const layer = createNodeOperatorSequential(
                 ? positionTargetDims.get(childName)
                 : undefined;
             const childPlaceable = child.layout(
-              size,
+              childSizeFor(childName),
               childScaleFactors,
               childScalesFor(i, targetDims)
             );

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -281,13 +281,10 @@ export const Spread = createNodeOperator(
           // path doesn't share.
           applyDistribute(
             {
-              type: "distribute",
               dir: stackDir === 0 ? "x" : "y",
               spacing: effectiveSpacing,
               mode,
               order: "forward",
-              glue,
-              children: [],
             },
             childPlaceables,
             (expected, actual) =>

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -1,6 +1,6 @@
 import { GoFishNode, Placeable } from "../_node";
 import type { AxisOptions } from "../gofish";
-import { getMeasure, getValue, isValue, MaybeValue, Measure } from "../data";
+import { MaybeValue } from "../data";
 import {
   Direction,
   elaborateDims,
@@ -14,21 +14,20 @@ import { SplitBy, splitKeyFn } from "../datumProjection";
 import { computeAesthetic, computeSize, foldFinite } from "../../util";
 import { GoFishAST } from "../_ast";
 import { createNodeOperator } from "../withGoFish";
-import * as Monotonic from "../../util/monotonic";
 import {
-  ORDINAL,
-  POSITION,
-  SIZE,
   UNDEFINED,
   isDIFFERENCE,
   isPOSITION,
   isSIZE,
-  forgetAllMeasures,
-  spaceMeasure,
 } from "../underlyingSpace";
 import { UnderlyingSpace } from "../underlyingSpace";
 import * as Interval from "../../util/interval";
 import { Alignment, alignChildren, resolveAlignmentSpace } from "./alignment";
+import {
+  distributeSpaceFold,
+  applyDistribute,
+} from "../constraints/distribute";
+import { allocateSlices } from "../constraints/folds";
 import { createOperator } from "../marks/createOperator";
 import { Mark, Operator } from "../types";
 
@@ -113,118 +112,37 @@ export const Spread = createNodeOperator(
           children: Size<UnderlyingSpace>[],
           childNodes: GoFishAST[]
         ) => {
-          /* ALIGNMENT */
-          const alignSpaces = children.map((child) => child[alignDir]);
-          const alignResult = resolveAlignmentSpace(alignSpaces, alignment);
-          const alignSpace = alignResult.space;
+          // Cross axis: defer to the shared alignment fold. Keep the
+          // `fromSize` flag so layout still baseline-aligns SIZE-derived
+          // children even when a posScale is present.
+          const alignResult = resolveAlignmentSpace(
+            children.map((child) => child[alignDir]),
+            alignment
+          );
           alignFromSize = alignResult.fromSize;
 
-          /* STACK DIR */
-          const stackSpaces = children.map((child) => child[stackDir]);
+          // Stack axis: defer to the shared distribute fold. `namedKeys` is the
+          // compacted list of children's ordinal keys (drives the ORDINAL
+          // branch); distributeSpaceFold re-filters undefined, so the compacted
+          // form is equivalent to a positional one.
           const namedKeys = childNodes
             .filter((node): node is GoFishNode => node instanceof GoFishNode)
             .map((node) => node.key)
             .filter((key): key is string => key !== undefined);
-
-          // Forget-merge of the stacking children's measures. Stacking/
-          // spreading different fields is legitimate, so a conflict forgets to
-          // undefined rather than throwing.
-          const stackChildMeasure = (): Measure | undefined =>
-            forgetAllMeasures(stackSpaces.map((s) => spaceMeasure(s)));
-
-          // Explicit size on the spread overrides children-derived sizing.
-          if (isValue(dims[stackDir].size)) {
-            const explicit: Size<UnderlyingSpace> = [UNDEFINED, UNDEFINED];
-            explicit[stackDir] = SIZE(
-              Monotonic.linear(getValue(dims[stackDir].size!), 0),
-              getMeasure(dims[stackDir].size)
-            );
-            explicit[alignDir] = alignSpace;
-            return explicit;
-          }
-
-          let stackSpace: UnderlyingSpace = UNDEFINED;
-
-          if (glue) {
-            // STACK semantics: collapse children into a single POSITION at
-            // this level. Use children's intrinsic extent at scale=1.
-            if (children.every((c) => isPOSITION(c[stackDir]))) {
-              const totalWidth = children
-                .map((c) =>
-                  isPOSITION(c[stackDir])
-                    ? Interval.width(c[stackDir].domain)
-                    : 0
-                )
-                .reduce((a, b) => a + b, 0);
-              stackSpace = POSITION(
-                Interval.interval(0, totalWidth),
-                stackChildMeasure()
-              );
-            } else if (stackSpaces.every(isSIZE)) {
-              const totalSize = stackSpaces
-                .map((s) => (s as any).domain.run(1) as number)
-                .reduce((a, b) => a + b, 0);
-              stackSpace = POSITION(
-                Interval.interval(0, totalSize),
-                stackChildMeasure()
-              );
-            } else if (namedKeys.length > 0) {
-              stackSpace = ORDINAL(namedKeys);
+          const stackSpace = distributeSpaceFold(
+            children.map((child) => child[stackDir]),
+            namedKeys,
+            {
+              spacing: effectiveSpacing,
+              mode,
+              glue,
+              size: dims[stackDir].size,
             }
-          } else {
-            // SPREAD semantics:
-            //  - All-SIZE *and* data-driven (some non-constant Monotonic)
-            //    → keep SIZE composition so parents can solve scale
-            //    factors via Monotonic.inverse. Names don't override
-            //    because the visual size is data-driven, which dominates
-            //    over categorical labeling.
-            //  - All-SIZE constant + named → ORDINAL. Each slot is the
-            //    same size; categorical axis labels are the right thing.
-            //  - Named (any other shape) → ORDINAL.
-            //  - All-SIZE constant + unnamed → SIZE composition.
-            //  - All-POSITION → POSITION(union).
-            const allSize = stackSpaces.every(isSIZE);
-            const childDomains = allSize
-              ? stackSpaces.map((s) => (s as any).domain as Monotonic.Monotonic)
-              : [];
-            const dataDriven =
-              allSize && childDomains.some((d) => !Monotonic.isConstant(d));
-            const composeSize = () =>
-              mode === "edge"
-                ? Monotonic.adds(
-                    Monotonic.add(...childDomains),
-                    effectiveSpacing * (children.length - 1)
-                  )
-                : Monotonic.unknown(
-                    (scaleFactor: number) =>
-                      childDomains[0].run(scaleFactor) / 2 +
-                      effectiveSpacing * (children.length - 1) +
-                      childDomains[childDomains.length - 1].run(scaleFactor) / 2
-                  );
-            if (dataDriven) {
-              stackSpace = SIZE(composeSize(), stackChildMeasure());
-            } else if (namedKeys.length > 0) {
-              stackSpace = ORDINAL(namedKeys);
-            } else if (allSize) {
-              stackSpace = SIZE(composeSize(), stackChildMeasure());
-            } else if (children.every((c) => isPOSITION(c[stackDir]))) {
-              const totalWidth = children
-                .map((c) =>
-                  isPOSITION(c[stackDir])
-                    ? Interval.width(c[stackDir].domain)
-                    : 0
-                )
-                .reduce((a, b) => a + b, 0);
-              stackSpace = POSITION(
-                Interval.interval(0, totalWidth),
-                stackChildMeasure()
-              );
-            }
-          }
+          );
 
           const result: Size<UnderlyingSpace> = [UNDEFINED, UNDEFINED];
           result[stackDir] = stackSpace;
-          result[alignDir] = alignSpace;
+          result[alignDir] = alignResult.space;
           return result;
         },
         layout: (shared, size, scaleFactors, children, posScales, node) => {
@@ -301,23 +219,14 @@ export const Spread = createNodeOperator(
             scaleFactor: sfY,
           };
 
-          // Calculate available space for children in stacking direction after subtracting spacing
-          const totalSpacing = effectiveSpacing * (children.length - 1);
-          const availableStackSpace = size[stackDir] - totalSpacing;
-          const n = children.length;
-          const weightsOk =
-            stackWeights !== undefined &&
-            stackWeights.length === n &&
-            stackWeights.every((w) => Number.isFinite(w) && w >= 0);
-          const weightSum = weightsOk
-            ? stackWeights!.reduce((acc, w) => acc + Math.max(w, 0), 0)
-            : 0;
-          const useWeights = weightsOk && weightSum > 0;
-          const childStackSizes: number[] = useWeights
-            ? stackWeights!.map(
-                (w) => (Math.max(w, 0) / weightSum) * availableStackSpace
-              )
-            : Array.from({ length: n }, () => availableStackSpace / n);
+          // Divide the stack-axis budget into per-child slices (shared fill
+          // policy; weights split it in proportion, else an equal share).
+          const childStackSizes = allocateSlices(
+            size[stackDir],
+            effectiveSpacing,
+            children.length,
+            stackWeights
+          );
 
           const childPlaceables = children.map((child, i) => {
             const modifiedSize: Size = [0, 0];
@@ -364,65 +273,31 @@ export const Spread = createNodeOperator(
             alignFromSize
           );
 
-          /* distribute */
-          const firstFixedIdx = childPlaceables.findIndex(isFixed(stackDir));
-          let pos: number;
-          if (firstFixedIdx === -1) {
-            pos = 0;
-          } else {
-            const firstFixed = childPlaceables[firstFixedIdx];
-            const firstFixedMin = firstFixed.dims[stackDir].min as number;
-            const firstFixedMax = firstFixed.dims[stackDir].max as number;
-            const firstFixedCenter = (firstFixedMin + firstFixedMax) / 2;
-            if (mode === "edge") {
-              pos =
-                firstFixedMin -
-                firstFixedIdx * effectiveSpacing -
-                childPlaceables
-                  .slice(0, firstFixedIdx)
-                  .reduce((acc, c) => acc + c.dims[stackDir].size!, 0);
-            } else {
-              pos = firstFixedCenter - firstFixedIdx * effectiveSpacing;
-            }
-          }
-
-          if (mode === "edge") {
-            for (const child of childPlaceables) {
-              if (isFixed(stackDir)(child)) {
-                const childMin = child.dims[stackDir].min as number;
-                const childMax = child.dims[stackDir].max as number;
-                if (Math.abs(childMin - pos) > 1e-6) {
-                  console.warn(
-                    "Stack: fixed child stack-direction position inconsistent with layout order",
-                    { expected: pos, actual: childMin }
-                  );
-                }
-                pos = childMax + effectiveSpacing;
-              } else {
-                child.place(stackDir, pos, "min");
-                const sz = child.dims[stackDir].size ?? 0;
-                pos += sz + effectiveSpacing;
-              }
-            }
-          } else if (mode === "center") {
-            for (const child of childPlaceables) {
-              if (isFixed(stackDir)(child)) {
-                const childMin = child.dims[stackDir].min as number;
-                const childMax = child.dims[stackDir].max as number;
-                const childCenter = (childMin + childMax) / 2;
-                if (Math.abs(childCenter - pos) > 1e-6) {
-                  console.warn(
-                    "Stack: fixed child stack-direction position inconsistent (center-to-center)",
-                    { expected: pos, actual: childCenter }
-                  );
-                }
-                pos = childCenter + effectiveSpacing;
-              } else {
-                child.place(stackDir, pos, "center");
-                pos += effectiveSpacing;
-              }
-            }
-          }
+          // distribute: delegate to the shared walk. `reverse` was already
+          // applied to `children` above, so the placement order is fixed
+          // (order: "forward"). The reporter surfaces spread's historical
+          // inconsistency warning for fixed children whose position disagrees
+          // with the running layout — a console-only behavior the constraint
+          // path doesn't share.
+          applyDistribute(
+            {
+              type: "distribute",
+              dir: stackDir === 0 ? "x" : "y",
+              spacing: effectiveSpacing,
+              mode,
+              order: "forward",
+              glue,
+              children: [],
+            },
+            childPlaceables,
+            (expected, actual) =>
+              console.warn(
+                mode === "center"
+                  ? "Stack: fixed child stack-direction position inconsistent (center-to-center)"
+                  : "Stack: fixed child stack-direction position inconsistent with layout order",
+                { expected, actual }
+              )
+          );
 
           // A child the alignment step didn't place (no `alignment` given)
           // renders at its own origin (translate 0): nail it down there now so

--- a/packages/gofish-graphics/stories/lowlevel/ConstraintParity.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/ConstraintParity.stories.tsx
@@ -99,3 +99,163 @@ export const ConstraintFit: StoryObj<Args> = {
     return container;
   },
 };
+
+// ── Fill children: NO explicit size on the distribute axis ─────────────────
+// Each child has a fixed height but no width, so it must CONSUME its budget
+// slice on x. This exercises `allocateSlices` (equal split), which the
+// explicit-width pairs above never reach (their widths win over the slice).
+
+/** spread({ dir: "x" }) over fixed-height, width-less rects: equal slices. */
+export const SpreadFill: StoryObj<Args> = {
+  args: { w: 300, h: 80 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    spread(
+      { dir: "x", alignment: "start", spacing: 8 },
+      COLORS.map((c) => rect({ h: 40, fill: c }))
+    ).render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+/** Layer + align(y, start) + distribute(x) over the same width-less rects. */
+export const ConstraintFill: StoryObj<Args> = {
+  args: { w: 300, h: 80 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    layer(
+      COLORS.map((c, i) => rect({ h: 40, fill: c }).name(`r${i}`))
+    )
+      .constrain(({ r0, r1, r2 }) => [
+        Constraint.align({ y: "start" }, [r0, r1, r2]),
+        Constraint.distribute({ dir: "x", spacing: 8 }, [r0, r1, r2]),
+      ])
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+// ── Weighted fill children: budget split by weights, not equally ───────────
+
+const WEIGHTS = [1, 2, 3];
+
+/** spread({ stackWeights }) over width-less rects: proportional slices. */
+export const SpreadWeights: StoryObj<Args> = {
+  args: { w: 300, h: 80 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    spread(
+      { dir: "x", alignment: "start", spacing: 8, stackWeights: WEIGHTS },
+      COLORS.map((c) => rect({ h: 40, fill: c }))
+    ).render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+/** Layer + distribute({ weights }) over the same width-less rects. */
+export const ConstraintWeights: StoryObj<Args> = {
+  args: { w: 300, h: 80 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    layer(
+      COLORS.map((c, i) => rect({ h: 40, fill: c }).name(`r${i}`))
+    )
+      .constrain(({ r0, r1, r2 }) => [
+        Constraint.align({ y: "start" }, [r0, r1, r2]),
+        Constraint.distribute({ dir: "x", spacing: 8, weights: WEIGHTS }, [
+          r0,
+          r1,
+          r2,
+        ]),
+      ])
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+// ── Glue (stack): data-driven heights summed into a POSITION ───────────────
+// Stacked bars: equal-width rects with data-driven heights glued on y. The
+// glue fold sums the heights into POSITION([0, Σh]); children touch (spacing 0).
+
+const STACK_HEIGHTS = [30, 50, 20];
+
+/** spread({ dir: "y", glue: true }) over data-driven-height rects. */
+export const SpreadGlue: StoryObj<Args> = {
+  args: { w: 120, h: 200 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    spread(
+      { dir: "y", glue: true, alignment: "start" },
+      STACK_HEIGHTS.map((v, i) => rect({ w: 60, h: value(v), fill: COLORS[i] }))
+    ).render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+/** Layer + align(x, start) + distribute({ dir: "y", glue: true }). */
+export const ConstraintGlue: StoryObj<Args> = {
+  args: { w: 120, h: 200 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    layer(
+      STACK_HEIGHTS.map((v, i) =>
+        rect({ w: 60, h: value(v), fill: COLORS[i] }).name(`r${i}`)
+      )
+    )
+      .constrain(({ r0, r1, r2 }) => [
+        Constraint.align({ x: "start" }, [r0, r1, r2]),
+        Constraint.distribute({ dir: "y", glue: true }, [r0, r1, r2]),
+      ])
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+// ── End alignment: a PRINCIPLED DIVERGENCE, not a parity pair ───────────────
+// Unlike every pair above, this one renders DIFFERENTLY — by design. spread's
+// cross-axis alignment (alignChildren) and the align constraint use different
+// baseline POLICIES when no sibling is pre-placed (the AlignBaselinePolicy split
+// in constraints/align.ts):
+//   - spread's fallback is the data-scale origin `posScale(0)` (= 0 here),
+//     IRRESPECTIVE of the anchor — SIZE-derived bars align at the scale's zero,
+//     so the "end" (top) of every bar lands on the zero line and the bars hang
+//     into negative cross-coords (spread's SVG grows to reserve that overhang).
+//   - the constraint's fallback is the layer-box edge FOR that anchor —
+//     `end` → `size` (the box top) — so the bars sit flush at the top of the box.
+// For "start" both fallbacks are 0, so the start/bar/fit/fill/weights/glue pairs
+// above match exactly; for "end" (and "middle") they differ by the full box
+// extent. Both policies are load-bearing (axis-title elaboration needs the box
+// edge; spread needs the scale origin) and neither subsumes the other, so this
+// is reported as a genuine divergence — the policies are NOT reconciled.
+
+/** spread({ dir: "x", alignment: "end" }) over data-driven-height rects. */
+export const SpreadEnd: StoryObj<Args> = {
+  args: { w: 300, h: 200 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    spread(
+      { dir: "x", alignment: "end", spacing: 8 },
+      BAR_HEIGHTS.map((v, i) => rect({ w: 40, h: value(v), fill: COLORS[i] }))
+    ).render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+/** Layer + align(y, end) + distribute(x) over the same rects. */
+export const ConstraintEnd: StoryObj<Args> = {
+  args: { w: 300, h: 200 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    layer(
+      BAR_HEIGHTS.map((v, i) =>
+        rect({ w: 40, h: value(v), fill: COLORS[i] }).name(`r${i}`)
+      )
+    )
+      .constrain(({ r0, r1, r2 }) => [
+        Constraint.align({ y: "end" }, [r0, r1, r2]),
+        Constraint.distribute({ dir: "x", spacing: 8 }, [r0, r1, r2]),
+      ])
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};

--- a/packages/gofish-graphics/stories/lowlevel/ConstraintParity.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/ConstraintParity.stories.tsx
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import { Constraint, layer, rect, spread, value } from "../../src/lib";
+
+/**
+ * PROTOTYPE (issue #475): exact parity between `spread` and
+ * `layer + Constraint.align + Constraint.distribute`, INCLUDING the
+ * underlying-space / scale-solving work spread does (the composed SIZE claim,
+ * its inversion for auto-fit, and the cross-axis alignment fold). Each pair
+ * renders the same data at the same canvas size; their normalized DOM geometry
+ * should match exactly.
+ */
+const meta: Meta = {
+  title: "Low Level Syntax/Constraint Parity",
+};
+export default meta;
+
+type Args = { w: number; h: number };
+
+const COLORS = ["#e63946", "#457b9d", "#2a9d8f"];
+
+// ── Bar chart: data-driven heights, fixed widths ───────────────────────────
+// Stack axis (x) is fixed-size; cross axis (y) is data-driven, so it exercises
+// the ALIGN space fold (SIZE → POSITION) and the shared posScale path.
+
+const BAR_HEIGHTS = [30, 80, 50];
+
+/** spread({ dir: "x", alignment: "start" }) over data-driven-height rects. */
+export const SpreadBar: StoryObj<Args> = {
+  args: { w: 300, h: 200 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    spread(
+      { dir: "x", alignment: "start", spacing: 8 },
+      BAR_HEIGHTS.map((v, i) =>
+        rect({ w: 40, h: value(v), fill: COLORS[i] })
+      )
+    ).render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+/** Layer of named rects + align(y, start) + distribute(x). */
+export const ConstraintBar: StoryObj<Args> = {
+  args: { w: 300, h: 200 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    layer(
+      BAR_HEIGHTS.map((v, i) =>
+        rect({ w: 40, h: value(v), fill: COLORS[i] }).name(`r${i}`)
+      )
+    )
+      .constrain(({ r0, r1, r2 }) => [
+        Constraint.align({ y: "start" }, [r0, r1, r2]),
+        Constraint.distribute({ dir: "x", spacing: 8 }, [r0, r1, r2]),
+      ])
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+// ── Auto-fit: data-driven widths on the stack axis, canvas too small ───────
+// Natural content (120 + 200 + 90 + 2·8 = 426) is far wider than the 200px
+// canvas, so children must be scaled to fit. This exercises the SIZE sum +
+// spacing composition and its Monotonic inversion against the allotted size.
+
+const FIT_WIDTHS = [120, 200, 90];
+
+/** spread({ dir: "x" }) over data-driven-width rects, into a 200px canvas. */
+export const SpreadFit: StoryObj<Args> = {
+  args: { w: 200, h: 60 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    spread(
+      { dir: "x", alignment: "start", spacing: 8 },
+      FIT_WIDTHS.map((v, i) =>
+        rect({ w: value(v), h: 60, fill: COLORS[i] })
+      )
+    ).render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+/** Layer + align(y, start) + distribute(x), into the same 200px canvas. */
+export const ConstraintFit: StoryObj<Args> = {
+  args: { w: 200, h: 60 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    layer(
+      FIT_WIDTHS.map((v, i) =>
+        rect({ w: value(v), h: 60, fill: COLORS[i] }).name(`r${i}`)
+      )
+    )
+      .constrain(({ r0, r1, r2 }) => [
+        Constraint.align({ y: "start" }, [r0, r1, r2]),
+        Constraint.distribute({ dir: "x", spacing: 8 }, [r0, r1, r2]),
+      ])
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -164,6 +164,12 @@ export interface SpreadOperator extends BaseIRNode {
   sharedScale?: boolean;
   mode?: "edge" | "center";
   reverse?: boolean;
+  /** Stack semantics: glue children together (sizes sum into a position at
+   *  this level) instead of slicing a budget. Forces `spacing` to 0. */
+  glue?: boolean;
+  /** Flex weights aligned to placement order; splits the budget in proportion
+   *  to these instead of equally. */
+  stackWeights?: number[];
   axes?: AxesOptions;
 }
 

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -277,6 +277,8 @@ function walkOperator(node: unknown, path: string, ctx: Context): void {
       "sharedScale",
       "mode",
       "reverse",
+      "glue",
+      "stackWeights",
       "axes",
       "origin",
       "meta",
@@ -334,6 +336,16 @@ function walkOperator(node: unknown, path: string, ctx: Context): void {
           ctx.errors.push({
             path: p,
             message: `mode must be "edge" | "center"`,
+          });
+      });
+      // spread-only stack options (stack operator rejects these via its own
+      // knownFields list); optionalField no-ops when the field is absent.
+      optionalField(node, "glue", path, ctx, expectBoolean);
+      optionalField(node, "stackWeights", path, ctx, (v, p) => {
+        if (!Array.isArray(v) || !v.every((n) => typeof n === "number"))
+          ctx.errors.push({
+            path: p,
+            message: "stackWeights must be an array of numbers",
           });
       });
       optionalField(node, "axes", path, ctx, walkAxesOptions);

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -534,6 +534,8 @@ class Constraint:
         spacing: Optional[float] = None,
         mode: Optional[str] = None,
         order: Optional[str] = None,
+        glue: Optional[bool] = None,
+        weights: Optional[List[float]] = None,
     ) -> DistributeConstraint:
         """Distribute the given refs along an axis.
 
@@ -544,6 +546,12 @@ class Constraint:
             mode: "edge" (default) or "center" — edge-to-edge or
                 center-to-center spacing.
             order: "forward" (default) or "reverse" — distribute in reverse order.
+            glue: Stack semantics — glue the refs together (their sizes sum
+                into a position at the layer) instead of slicing a budget.
+                Forces `spacing` to 0. Mirrors spread's `glue`.
+            weights: Flex weights aligned to placement order (spread's
+                `stackWeights`); splits the budget in proportion to these
+                instead of equally.
         """
         options: Dict[str, Any] = {"dir": dir}
         if spacing is not None:
@@ -552,6 +560,10 @@ class Constraint:
             options["mode"] = mode
         if order is not None:
             options["order"] = order
+        if glue is not None:
+            options["glue"] = glue
+        if weights is not None:
+            options["weights"] = weights
         return DistributeConstraint(refs, options)
 
     @staticmethod

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -77,3 +77,14 @@ packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_Spaci
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadX_Spacing_AlignEnd
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadX_CenterToCenter
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_Reversed
+
+# ConstraintParity.stories.tsx (file-level) — JS-engine regression fixtures
+# from the operators/constraints unification (#543): each pair certifies that
+# the spread operator and its layer+constraints form produce byte-identical
+# geometry. A Python port would serialize through the same IR into the same
+# JS engine, re-testing nothing Python-specific; and the constraint-side
+# stories use distribute's `glue`/`weights`, which are not exposed to Python
+# (deliberately out of #543's scope — would need wrapper kwargs + the
+# three-encoding IR schema additions). Revisit if/when those options are
+# exposed (#550 program).
+packages/gofish-graphics/stories/lowlevel/ConstraintParity.stories.tsx

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -77,14 +77,3 @@ packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_Spaci
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadX_Spacing_AlignEnd
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadX_CenterToCenter
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_Reversed
-
-# ConstraintParity.stories.tsx (file-level) — JS-engine regression fixtures
-# from the operators/constraints unification (#543): each pair certifies that
-# the spread operator and its layer+constraints form produce byte-identical
-# geometry. A Python port would serialize through the same IR into the same
-# JS engine, re-testing nothing Python-specific; and the constraint-side
-# stories use distribute's `glue`/`weights`, which are not exposed to Python
-# (deliberately out of #543's scope — would need wrapper kwargs + the
-# three-encoding IR schema additions). Revisit if/when those options are
-# exposed (#550 program).
-packages/gofish-graphics/stories/lowlevel/ConstraintParity.stories.tsx

--- a/tests/python-stories/low-level-syntax/test_constraint_parity.py
+++ b/tests/python-stories/low-level-syntax/test_constraint_parity.py
@@ -1,0 +1,202 @@
+"""Equivalent of lowlevel/ConstraintParity.stories.tsx — Low Level Syntax/Constraint Parity.
+
+Ports the twelve single-chart stories that certify `spread` and its
+`layer + Constraint.align + Constraint.distribute` form produce identical
+geometry (issue #475 / the operators-constraints unification, #543). Each
+Spread*/Constraint* pair renders the same data at the same canvas size; their
+normalized DOM should match — except SpreadEnd/ConstraintEnd, a principled
+divergence (the cross-axis baseline policies differ when no sibling is
+pre-placed), which is documented in the JS story.
+
+`spread({...}, [children])` maps to the combinator form `spread([children], ...)`;
+`layer([...]).constrain(...)` maps to the same combinator form. Data-driven
+sizes use `datum(v)` (JS `value(v)`).
+"""
+
+from gofish import Constraint, datum, layer, rect, spread
+
+COLORS = ["#e63946", "#457b9d", "#2a9d8f"]
+
+# ── Bar chart: data-driven heights, fixed widths ───────────────────────────
+BAR_HEIGHTS = [30, 80, 50]
+
+
+def story_spread_bar():
+    return (
+        spread(
+            [
+                rect(w=40, h=datum(v), fill=COLORS[i])
+                for i, v in enumerate(BAR_HEIGHTS)
+            ],
+            dir="x",
+            alignment="start",
+            spacing=8,
+        ),
+        {"w": 300, "h": 200},
+    )
+
+
+def story_constraint_bar():
+    return (
+        layer([
+            rect(w=40, h=datum(v), fill=COLORS[i]).name(f"r{i}")
+            for i, v in enumerate(BAR_HEIGHTS)
+        ]).constrain(lambda r0, r1, r2: [
+            Constraint.align([r0, r1, r2], y="start"),
+            Constraint.distribute([r0, r1, r2], dir="x", spacing=8),
+        ]),
+        {"w": 300, "h": 200},
+    )
+
+
+# ── Auto-fit: data-driven widths on the stack axis, canvas too small ───────
+FIT_WIDTHS = [120, 200, 90]
+
+
+def story_spread_fit():
+    return (
+        spread(
+            [
+                rect(w=datum(v), h=60, fill=COLORS[i])
+                for i, v in enumerate(FIT_WIDTHS)
+            ],
+            dir="x",
+            alignment="start",
+            spacing=8,
+        ),
+        {"w": 200, "h": 60},
+    )
+
+
+def story_constraint_fit():
+    return (
+        layer([
+            rect(w=datum(v), h=60, fill=COLORS[i]).name(f"r{i}")
+            for i, v in enumerate(FIT_WIDTHS)
+        ]).constrain(lambda r0, r1, r2: [
+            Constraint.align([r0, r1, r2], y="start"),
+            Constraint.distribute([r0, r1, r2], dir="x", spacing=8),
+        ]),
+        {"w": 200, "h": 60},
+    )
+
+
+# ── Fill children: NO explicit size on the distribute axis ─────────────────
+
+
+def story_spread_fill():
+    return (
+        spread(
+            [rect(h=40, fill=c) for c in COLORS],
+            dir="x",
+            alignment="start",
+            spacing=8,
+        ),
+        {"w": 300, "h": 80},
+    )
+
+
+def story_constraint_fill():
+    return (
+        layer([
+            rect(h=40, fill=c).name(f"r{i}") for i, c in enumerate(COLORS)
+        ]).constrain(lambda r0, r1, r2: [
+            Constraint.align([r0, r1, r2], y="start"),
+            Constraint.distribute([r0, r1, r2], dir="x", spacing=8),
+        ]),
+        {"w": 300, "h": 80},
+    )
+
+
+# ── Weighted fill children: budget split by weights, not equally ───────────
+WEIGHTS = [1, 2, 3]
+
+
+def story_spread_weights():
+    return (
+        spread(
+            [rect(h=40, fill=c) for c in COLORS],
+            dir="x",
+            alignment="start",
+            spacing=8,
+            stackWeights=WEIGHTS,
+        ),
+        {"w": 300, "h": 80},
+    )
+
+
+def story_constraint_weights():
+    return (
+        layer([
+            rect(h=40, fill=c).name(f"r{i}") for i, c in enumerate(COLORS)
+        ]).constrain(lambda r0, r1, r2: [
+            Constraint.align([r0, r1, r2], y="start"),
+            Constraint.distribute(
+                [r0, r1, r2], dir="x", spacing=8, weights=WEIGHTS
+            ),
+        ]),
+        {"w": 300, "h": 80},
+    )
+
+
+# ── Glue (stack): data-driven heights summed into a position ───────────────
+STACK_HEIGHTS = [30, 50, 20]
+
+
+def story_spread_glue():
+    return (
+        spread(
+            [
+                rect(w=60, h=datum(v), fill=COLORS[i])
+                for i, v in enumerate(STACK_HEIGHTS)
+            ],
+            dir="y",
+            glue=True,
+            alignment="start",
+        ),
+        {"w": 120, "h": 200},
+    )
+
+
+def story_constraint_glue():
+    return (
+        layer([
+            rect(w=60, h=datum(v), fill=COLORS[i]).name(f"r{i}")
+            for i, v in enumerate(STACK_HEIGHTS)
+        ]).constrain(lambda r0, r1, r2: [
+            Constraint.align([r0, r1, r2], x="start"),
+            Constraint.distribute([r0, r1, r2], dir="y", glue=True),
+        ]),
+        {"w": 120, "h": 200},
+    )
+
+
+# ── End alignment: a principled divergence, not a parity pair ───────────────
+
+
+def story_spread_end():
+    return (
+        spread(
+            [
+                rect(w=40, h=datum(v), fill=COLORS[i])
+                for i, v in enumerate(BAR_HEIGHTS)
+            ],
+            dir="x",
+            alignment="end",
+            spacing=8,
+        ),
+        {"w": 300, "h": 200},
+    )
+
+
+def story_constraint_end():
+    return (
+        layer([
+            rect(w=40, h=datum(v), fill=COLORS[i]).name(f"r{i}")
+            for i, v in enumerate(BAR_HEIGHTS)
+        ]).constrain(lambda r0, r1, r2: [
+            Constraint.align([r0, r1, r2], y="end"),
+            Constraint.distribute([r0, r1, r2], dir="x", spacing=8),
+        ]),
+        {"w": 300, "h": 200},
+    )


### PR DESCRIPTION
## Why

Constraints and operators have been two parallel layout systems: `spread`/`stack` carried their own space-fold dispatch, slice arithmetic, align step, and distribute walk, while `Constraint.align`/`distribute` were near-duplicate post-layout positioners with **no participation in underlying-space resolution** — the auto-fit gap #475 documents. The feasibility analysis behind this PR (new internals essay, `apps/docs/docs/internals/design/constraints-as-core.md`) shows the operators' placement halves were *already* the constraint algorithms; the entire semantic surplus of `spread` is three mechanisms — the space fold, the budget solve, and the fill slice — all of which belong on the constraint/layer side.

## What

One machinery now exists for each mechanism, and the operators are thin bindings over it:

1. **Feasibility report + prototype checkpoint** — the essay (`internals/design/constraints-as-core.md`: Bluefish comparison, max-plus fold algebra, the budget solve as the fold's adjoint, the degrees-of-freedom rule, complexity analysis, residuals, staging) and the parity evidence: `layer + align + distribute` reproduces `spread` exactly, including Monotonic-inversion auto-fit.
2. **Align consolidation** — one placement walk, `alignTargets` + `AlignBaselinePolicy` (`constraints/align.ts`). The policy parameter makes the genuine divergence explicit: spread falls back to the data-scale origin (`posScale(0)`), the constraint path to the layer-box edge — both load-bearing, kept, documented.
3. **First-class folds + budget solve** — `distributeSpaceFold` (full spread dispatch: explicit-size override, `glue`/stack variant, ORDINAL fallback, measure forget-merge), `alignSpaceFold`, and `allocateSlices` (`constraints/folds.ts`). The layer composes folds per axis (uncovered children max-union in as overlay siblings), inverts fold-produced SIZE claims against its allotted size (warning before fallback when non-invertible), and proposes slices to fill children. Distribute constraints gain `glue` and `weights`.
4. **Delegation** — `spread`/`stack` call the shared fold, allocator, align walk, and distribute walk; the bespoke copies are deleted (`spread.tsx` −128 lines). `applyDistribute` takes `DistributeWalkOptions` (just the fields the walk reads) plus an optional inconsistency reporter so spread keeps its historic warnings. What remains in spread is exactly what has no shared home: `sharedScale` mutation, `scaleContext`, `reverse`, explicit-dims translate, `axisDir`, measure-and-report.

**User-visible change:** constraint-assembled layers now reach the operator expressive ceiling — a layer whose constraints form the spread shape auto-fits, including under a coord transform. Addresses the mechanism gap in #475; the gotree story that hand-budgets around it can drop its workaround.

## Verification

- `pnpm capture-diff main` on the final tree: **zero geometry changes** across every story (the 11 flagged are byte-identical outside image `href` filesystem paths — the known tool artifact; the 12 additions are the new parity stories).
- New `ConstraintParity` stories certify spread↔constraint equivalence pair-by-pair: bar, fit (auto-fit), fill (slice consumption), weights, glue (stack) — all geometrically exact. The `end` pair documents the intentional baseline-policy divergence instead of papering over it.
- `pnpm --filter gofish-graphics build` and `pnpm --filter docs check-backlinks` clean.

## Docs

- New essay `internals/design/constraints-as-core.md` (the feasibility report; records the staging status and the IR decision below).
- `internals/core/underlying-space.md`: constraint folds documented; `covers:` extended to the three constraint files (backlinks regenerated).
- `internals/design/operators-vs-constraints.md`: landed-status note.
- `js/api/constraints/constrain.md`: `glue`/`weights`, the auto-fit semantics, the now-exact spread-equivalences table (incl. `Stack` ↔ `glue`, `stackWeights` ↔ `weights`), and the `end`/`middle` fallback caveat.

## Deliberately out of scope — tracked in #550

- **Python / IR**: the high-level IR stays the bridge target (semantic information, accessibility); compilation to the constraint core happens JS-side after the bridge, and a serialized core IR is deferred until a consumer exists. The new *surface options* do cross the bridge per the parity rule (every pure gofish spec must be writable in Python): `glue`/`weights`/`stackWeights` are exposed as Python kwargs + typed IR fields, and all 12 `ConstraintParity` stories have byte-identical Python ports.
- The remaining program has a tracking issue with sub-issues: #545 size-setting constraints (the missing primitive: `contain`, width-alignment, scatter intervals, treemap slots), #546 scatter/position reduction, #541 treemap as a derived-constraint generator, #547 general per-axis composition algebra, #548 table as nested folds, #549 sharedScale → claim hoisting.

Related: #475, #354, #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
