### PR TITLE
Unify the align baseline-fallback policies: dispatch on the axis's underlying space (#552)

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -235,6 +235,21 @@ the same expressive ceiling as the spread pipeline, auto-fit included
 back to `unionChildSpaces`; the general algebra is sketched in
 [[constraints-as-core]].
 
+Placement-time alignment dispatches on the same resolution. When an `align`
+(the constraint or spread's cross-axis alignment) finds **no pre-placed
+sibling**, its fallback baseline is computed from what the axis carries
+(`alignFallbackBaseline`, `constraints/align.ts`): a posScale-carrying
+POSITION axis falls back to the scale origin `posScale(0)` — SIZE-derived
+bars hang from the zero line — while a pixel-pure axis falls back to the
+layer-box edge for the anchor, so axis titles and chrome pin to the plot box.
+`middle` is the box center either way (it resolves to DIFFERENCE, an extent
+with no anchored origin). The fallback is a property of the axis's space, not
+of which API assembled the layer (#552). One consequence worth knowing: a
+coordinate transform's children are pixel-pure by construction (posScales
+don't cross a nonlinear transform — children get scale _factors_ instead), so
+an `end`-aligned spread inside `coord` seats flush at the box edge rather
+than at a scale origin.
+
 Three patterns cover most operators:
 
 **Leaf shapes** (`rect`, `ellipse`, `petal`, `text`, `image`) decide the

--- a/apps/docs/docs/internals/design/constraints-as-core.md
+++ b/apps/docs/docs/internals/design/constraints-as-core.md
@@ -258,14 +258,18 @@ Two findings sharpen the theory:
   move. In other words: the placement halves were already equivalent; the
   entire semantic content of "spread beyond align + distribute" lives in
   `resolveUnderlyingSpace`.
-- **One real divergence between the duplicate align implementations.**
-  Spread's `alignChildren` seats the cross-axis baseline at `posScale(0)`;
-  `applyAlign`'s fallback seats it on the layer box
-  (`{start: 0, middle: size/2, end: size}`). These coincide at `"start"` but
-  diverge for `"end"`/`"middle"` (the pre-existing `SpreadY_AlignMiddle` story
-  already hand-pins around this). Exact parity for those alignments requires
-  the consolidation in staging step 1 to teach the constraint fallback to
-  consult the posScale — a known, bounded fix, not a structural obstacle.
+- **The align-fallback divergence, now unified (#552).** Spread's
+  `alignChildren` and `applyAlign` once used different no-sibling fallbacks —
+  spread seated the cross-axis baseline at `posScale(0)`, the constraint on the
+  layer box (`{start: 0, middle: size/2, end: size}`) — coinciding at `"start"`
+  but diverging at `"end"`/`"middle"`. They now share one fallback that
+  dispatches on the axis's underlying-space kind, not the call site: a
+  posScale-carrying (POSITION) axis falls back to the scale origin `posScale(0)`,
+  a pixel-pure axis to the layer-box edge. Both callsites resolve the same
+  `alignSpaceFold` space and posScale, so spread/constraint pairs are now exact
+  at every anchor. The only remaining per-callsite difference is the
+  `readPlaced` reader for an already-placed sibling (the constraint reads real
+  extents/origin; spread pins baseline-reads to 0), which is out of scope.
 
 ## Operator-by-operator reduction
 
@@ -399,7 +403,8 @@ brittle in five identifiable ways, none of which needs a cleverer solver:
    record an owner per (node, axis) — O(1) per write — and report both
    writers, exactly Bluefish's `bboxOwners`.
 3. _Divergent align fallbacks_ — `posScale(0)` vs layer box (found by the
-   prototype). Fix: the consolidation in staging step 1.
+   prototype). Fixed (#552): a single space-kind-dispatched fallback —
+   posScale → scale origin, pixel-pure → box edge.
 4. _Underdetermination hidden_ — children the constraints never reach are
    silently nailed at origin. Fix: a diagnostic listing them.
 5. _Inversion failure modes_ — bisection's growth cap can fail and spread's
@@ -438,11 +443,12 @@ suggest it will not be needed.
 
 ## Suggested staging (refactor-first)
 
-1. ✅ **Consolidate the two align implementations** — done: `alignTargets` +
-   `AlignBaselinePolicy` (`constraints/align.ts`) is the single walk; both
-   callsites keep their policies. The end/middle fallback divergence turned
-   out to be a genuine two-policy fact (scale-origin vs box-edge), kept
-   explicit rather than reconciled.
+1. ✅ **Consolidate the two align implementations** — done: `alignTargets`
+   (`constraints/align.ts`) is the single walk. The end/middle fallback
+   divergence was then unified (#552): a single space-kind-dispatched
+   `alignFallbackBaseline` (posScale → scale origin, pixel-pure → box edge)
+   replaced the two policies, so the only remaining per-callsite difference is
+   the `readPlaced` reader for an already-placed sibling.
 2. ✅ **Constraint space folds + Layer budget solve** — done:
    `distributeSpaceFold` (full spread dispatch incl. glue/explicit-size),
    `alignSpaceFold`, `allocateSlices`, per-axis composition in the layer with

--- a/apps/docs/docs/internals/frontend/axes.md
+++ b/apps/docs/docs/internals/frontend/axes.md
@@ -35,14 +35,15 @@ root  = Layer([ inner.name("__axisInner"), ...ordinal labels ])
 The **inner tier** holds the constraint-pinned axes (continuous/difference); the
 **outer tier** holds the ordinal label rows, which need the inner tier fully laid
 out so they can seat past its bounding box. In each tier the wrapped child is
-pinned with `align({ x: "baseline", y: "baseline" })` — a _baseline_ (origin)
-pin, meaning "stay exactly where you were laid out". The pin exists because the
-content is referenced by `distribute` constraints, and a constraint-referenced
-child skips the layer's phase-1 baseline placement (placement is first-write-wins,
-so constraints must run against unplaced targets); the baseline pin re-states
-that phase-1 placement explicitly. It must be `baseline`, not `start`: `start`
-pins the _bounding-box_ corner, which slides the marks off the tick grid once
-the box overhangs the origin (nested facet labels, negative bars).
+pinned with `position({ x: 0, y: 0, anchor: "baseline" })` — a literal-pixel pin
+at the origin, meaning "stay exactly where you were laid out". The pin exists
+because the content is referenced by `distribute` constraints, and a
+constraint-referenced child skips the layer's phase-1 baseline placement
+(placement is first-write-wins, so constraints must run against unplaced
+targets); the origin pin re-states that phase-1 placement explicitly. The anchor
+must be `baseline`, not `start`: `start` pins the _bounding-box_ corner, which
+slides the marks off the tick grid once the box overhangs the origin (nested
+facet labels, negative bars).
 
 Everything else then seats around the stationary content in **negative gutter
 space** (into the SVG padding): the axis line distributes off the content's

--- a/apps/docs/docs/internals/frontend/legends.md
+++ b/apps/docs/docs/internals/frontend/legends.md
@@ -64,11 +64,12 @@ the top — matching the old bespoke order, which placed entry 0 at the top.
 The wrapper is wired with three constraints, and **the order matters** because
 the first one places the anchor the other two read:
 
-1. `align({ x: "baseline", y: "baseline" })` on the content — a _baseline_
-   (origin) pin meaning "stay exactly where you were laid out". The content is
-   referenced by the `distribute` below, and a constraint-referenced child skips
-   the layer's phase-1 baseline placement (placement is first-write-wins), so the
-   pin re-states that placement explicitly. It pins the **baseline**, not the
+1. `position({ x: 0, y: 0, anchor: "baseline" })` on the content — a
+   literal-pixel pin at the origin meaning "stay exactly where you were laid
+   out". The content is referenced by the `distribute` below, and a
+   constraint-referenced child skips the layer's phase-1 baseline placement
+   (placement is first-write-wins), so the pin re-states that placement
+   explicitly. It pins the **baseline** (the local 0 point), not the
    bounding-box corner, so the content never moves regardless of axis-label
    overhang.
 2. `distribute({ dir: "x", spacing: 20 }, [content, column])` — seats the column

--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -218,7 +218,7 @@ keys onto wrappers, the affected resolution passes (color, names, labels,
 underlying space, nice domains) rerun on the new tree.
 
 See [Axes](/internals/frontend/axes) for the full elaboration story (the
-two-tier structure, baseline pins, negative-space gutters, and the
+two-tier structure, origin pins, negative-space gutters, and the
 continuous/difference/ordinal kinds).
 
 **Axis-title elaboration** follows the axis block (after the nice-space capture)

--- a/apps/docs/docs/js/api/constraints/constrain.md
+++ b/apps/docs/docs/js/api/constraints/constrain.md
@@ -47,9 +47,9 @@ Constraint.align({ x?, y? }, [ref1, ref2, ...])
 | `x`    | `AlignAnchor \| AlignAnchor[]` | —       | Edge/center/origin to align on the x axis (omit to leave x untouched) |
 | `y`    | `AlignAnchor \| AlignAnchor[]` | —       | Edge/center/origin to align on the y axis (omit to leave y untouched) |
 
-`AlignAnchor` is `"start" \| "middle" \| "end" \| "baseline"`. The first three anchor a child by its bounding-box edge or center. `"baseline"` anchors a child by its **origin** (its local 0 point) instead of its box: `align({ y: "baseline" })` with no placed sibling pins the child's origin to the layer's origin — i.e. "stay where you were laid out" — regardless of how far its box overhangs the origin (a bar dipping below zero, axis labels hanging under a chart). Pass a single value to share one anchor across every child (the common case); pass an array to assign one anchor _per child_ positionally — the array length must equal the number of children.
+`AlignAnchor` is `"start" \| "middle" \| "end" \| "baseline"`. The first three anchor a child by its bounding-box edge or center. `"baseline"` anchors a child by its **origin** (its local 0 point) instead of its box. With no placed sibling the fallback is the **axis origin**: the scale's zero (`posScale(0)`) on a scaled axis, the layer's origin on a pixel-pure one. On a pixel-pure axis, `align({ y: "baseline" })` thus means "stay where you were laid out" — regardless of how far its box overhangs the origin (a bar dipping below zero, axis labels hanging under a chart). For an unconditional origin pin regardless of axis, use `Constraint.position({ x: 0, y: 0, anchor: "baseline" })`. Pass a single value to share one anchor across every child (the common case); pass an array to assign one anchor _per child_ positionally — the array length must equal the number of children.
 
-The first already-placed child in the list acts as the anchor on each specified axis (read at _that child's_ anchor). Unplaced children are moved to match it (placed at _their own_ anchor). If no child is placed yet, the layer's own edge is used as the fallback (`start` = 0, `middle` = midpoint, `end` = full extent, `baseline` = 0). When both `x` and `y` are given, x is resolved before y.
+The first already-placed child in the list acts as the anchor on each specified axis (read at _that child's_ anchor). Unplaced children are moved to match it (placed at _their own_ anchor). If no child is placed yet, the fallback depends on the axis's underlying space: a scaled axis uses the scale origin `posScale(0)`, a pixel-pure axis uses the layer's own edge (`start` = 0, `middle` = midpoint, `end` = full extent, `baseline` = layer origin). When both `x` and `y` are given, x is resolved before y.
 
 ### Per-child anchors
 
@@ -263,14 +263,12 @@ equivalent, **including** scale solving and auto-fit, not just placement:
 | `Stack({ dir: "y" }, items)`                                 | `distribute({ dir: "y", glue: true })`                          |
 | `Spread({ dir: "x", stackWeights: [2, 1] }, items)`          | `distribute({ dir: "x", weights: [2, 1] })`                     |
 
-One caveat: when **no child is pre-placed**, the cross-axis `align` fallback
-differs. `Spread` aligns to the data-scale origin (`posScale(0)`), while the
-`align` constraint falls back to the layer's box edge (`end` → the full
-extent). For `"start"` the two coincide; for `"end"`/`"middle"` they diverge
-by the box extent. Pre-place one child (or use `Constraint.position`) when you
-need spread-identical `end`/`middle` alignment. (Unifying the two fallbacks is
-tracked in
-[#552](https://github.com/gofish-graphics/gofish-graphics/issues/552).)
+When **no child is pre-placed**, the cross-axis alignment fallback depends on
+the **axis**, not the API — `Spread` and the `align` constraint resolve the
+same fallback, so the pairs above are exact. A scaled (POSITION) axis falls
+back to the scale origin `posScale(0)` (so SIZE-derived bars hang from the zero
+line); a pixel-pure axis falls back to the layer-box edge (`start` → 0,
+`middle` → midpoint, `end` → full extent).
 
 ## Partial placement
 

--- a/apps/docs/docs/python/api/constraints/constrain.md
+++ b/apps/docs/docs/python/api/constraints/constrain.md
@@ -45,11 +45,12 @@ Constraint.align(refs, *, x=None, y=None)
 
 The anchor is `"start" | "middle" | "end" | "baseline"`. The first three
 anchor a ref by its bounding-box edge or center. `"baseline"` anchors a ref by
-its **origin** (its local 0 point) instead of its box: `align([content],
-y="baseline")` with no placed sibling pins the ref's origin to the layer's
-origin — i.e. "stay where you were laid out" — regardless of how far its box
-overhangs the origin (a bar dipping below zero, axis labels hanging under a
-chart). Pass a single value to share one anchor across every ref; pass a list
+its **origin** (its local 0 point) instead of its box. With no placed sibling
+the fallback is the **axis origin**: the scale's zero (`posScale(0)`) on a
+scaled axis, the layer's origin on a pixel-pure one. On a pixel-pure axis,
+`align([content], y="baseline")` thus means "stay where you were laid out" —
+regardless of how far its box overhangs the origin (a bar dipping below zero,
+axis labels hanging under a chart). Pass a single value to share one anchor across every ref; pass a list
 to assign one anchor _per ref_ positionally (the list length must equal the
 number of refs) — e.g. `x=["middle", "start"]` aligns the first ref's center
 to the second ref's start. The first already-placed ref acts as the anchor;

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -524,19 +524,20 @@ export async function elaborateAxes(node: GoFishNode): Promise<{
   // axis tiers, then restore the identity onto the outermost wrapper.
   const root = await wrapPreservingIdentity(node, async (content) => {
     // Inner tier: content + constraint-based (continuous/difference) axes. The
-    // content is pinned at its own ORIGIN (baseline anchor, translate 0) so each
-    // axis grows into negative gutter space; this keeps the content on the
-    // posScale grid both axes' ticks use. The anchor must be `baseline`, not
-    // `start`: nested content (facets carrying their own ordinal labels) has a
-    // bbox extending past its origin, and pinning bbox-min would slide the marks
-    // off the tick grid by that overhang.
+    // content is pinned at its own ORIGIN (a literal-pixel position pin at the
+    // origin: x:0/y:0, translate 0) so each axis grows into negative gutter
+    // space; this keeps the content on the posScale grid both axes' ticks use.
+    // The anchor must be `baseline`, not `start`: nested content (facets
+    // carrying their own ordinal labels) has a bbox extending past its origin,
+    // and pinning bbox-min would slide the marks off the tick grid by that
+    // overhang.
     let inner: GoFishNode = content;
     if (constrained.length > 0) {
       content.name(CONTENT_NAME);
       const axisNodes = constrained.flatMap((e) => e.nodes);
       inner = (await (layer as any)([content, ...axisNodes])) as GoFishNode;
       inner.constrain((g) => [
-        Constraint.align({ x: "baseline", y: "baseline" } as any, [
+        Constraint.position({ x: 0, y: 0, anchor: "baseline" }, [
           g[CONTENT_NAME],
         ]),
         ...constrained.flatMap((e) => e.constraints(g)),
@@ -546,15 +547,16 @@ export async function elaborateAxes(node: GoFishNode): Promise<{
     // Outer tier: ref-based (ordinal) labels. The labels `distribute` against
     // `inner`, whose bbox includes any nested inner-facet labels — so an outer
     // label row stacks below the inner row. For that anchor to be "placed",
-    // `inner` is baseline-pinned: its 0 point stays the layer's 0 point, and the
-    // labels seat past its bbox edge in negative gutter space.
+    // `inner` is pinned at its origin (a literal-pixel position pin, x:0/y:0):
+    // its 0 point stays the layer's 0 point, and the labels seat past its bbox
+    // edge in negative gutter space.
     let outerRoot = inner;
     if (refBased.length > 0) {
       inner.name(INNER_REF_NAME);
       const labelNodes = refBased.flatMap((e) => e.nodes);
       outerRoot = (await (layer as any)([inner, ...labelNodes])) as GoFishNode;
       outerRoot.constrain((g) => [
-        Constraint.align({ x: "baseline", y: "baseline" } as any, [
+        Constraint.position({ x: 0, y: 0, anchor: "baseline" }, [
           g[INNER_REF_NAME],
         ]),
         ...refBased.flatMap((e) => e.constraints(g)),
@@ -674,9 +676,10 @@ export async function elaborateAxisTitles(
     // Constraint order matters; placement is first-write-wins.
     root.constrain((g) => {
       const cs: any[] = [
-        // Pin the content at its origin; it never moves. Everything else seats
-        // off the (already-placed) ref stand-ins and this content bbox.
-        Constraint.align({ x: "baseline", y: "baseline" }, [
+        // Pin the content at its origin (a literal-pixel position pin, x:0/y:0);
+        // it never moves. Everything else seats off the (already-placed) ref
+        // stand-ins and this content bbox.
+        Constraint.position({ x: 0, y: 0, anchor: "baseline" }, [
           g[TITLE_CONTENT_NAME],
         ]),
       ];

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -64,10 +64,10 @@ export const createAlignConstraint = (
   return { type: "align", x, y, children };
 };
 
-/** Per-axis environment threaded to a fallback policy: the layer's box size on
- *  this axis and the axis's data→pixel position scale (if any). The two
- *  fallback policies below each consume a different part of this env, so they
- *  can sit side by side as pure functions of `(anchor, size, posScale)`. */
+/** Per-axis environment threaded to the shared fallback: the layer's box size
+ *  on this axis and the axis's data→pixel position scale (if any).
+ *  `alignFallbackBaseline` dispatches on which of these the axis carries — a
+ *  posScale picks the scale origin, otherwise the box edge. */
 export interface AlignAxisEnv {
   size: number;
   posScale: ((v: number) => number) | undefined;
@@ -98,71 +98,47 @@ export const placeAtAnchor = (
 };
 
 /**
- * Where the enforced alignment coordinate (the "baseline") comes from. This is
- * the one genuine divergence between the two align callsites, so it is an
- * explicit parameter and each callsite supplies its own:
- *
- *  - `readPlaced` reads the baseline off the *first already-placed* target, at
- *    that target's anchor. The constraint path reads the target's real extent /
- *    origin (so a `"baseline"` anchor takes its actual `transform.translate`);
- *    spread pins a `"baseline"` anchor to 0 and tolerates missing extents.
- *  - `fallback` supplies the baseline when *nothing* is pre-placed. The
- *    constraint path returns the layer's own box edge (start→0, middle→size/2,
- *    end→size, baseline→0) — axis-title elaboration relies on a title pinning to
- *    the plot box. Spread instead returns the data scale's origin
- *    (`posScale(0)`, or `size/2` for middle, or 0 with no scale) so a
- *    SIZE-derived cross axis aligns at the scale's zero, not the box edge. Both
- *    are load-bearing; neither subsumes the other.
+ * Where the enforced alignment coordinate (the "baseline") comes from when a
+ * sibling *is* already placed. This `readPlaced` reader is the one remaining
+ * per-callsite difference between the two align callsites (and is out of scope
+ * for #552): the constraint path reads the target's real extent / origin (so a
+ * `"baseline"` anchor takes its actual `transform.translate`); spread pins a
+ * `"baseline"` anchor to 0 and tolerates missing extents. The no-sibling
+ * fallback is now SHARED and space-kind-dispatched (see
+ * `alignFallbackBaseline`), so it is no longer part of this policy.
  */
 export interface AlignBaselinePolicy {
   readPlaced: (target: Placeable, idx: 0 | 1, anchor: AlignAnchor) => number;
-  fallback: (anchor: AlignAnchor, env: AlignAxisEnv) => number;
 }
 
-/**
- * Fallback baseline for the `align` *constraint* path: the layer's own box
- * edge. start→0, middle→size/2, end→size, baseline→0 (the layer's origin).
- * Ignores `posScale` — axis-title elaboration relies on a title pinning to the
- * plot box, not the data scale. NOTE: an unsized axis carries a NaN `size`, so
- * middle/end yield NaN here exactly as the layer's literal `size/2` / `size`
- * would; no finite-guard is applied (behavior is bit-identical to the old
- * `fallbackFor` reading a `{start:0, middle:size/2, end:size}` literal).
- */
-export function constraintFallbackBaseline(
-  anchor: AlignAnchor,
-  size: number,
-  _posScale: ((v: number) => number) | undefined
-): number {
-  return anchor === "start"
-    ? 0
-    : anchor === "middle"
-      ? size / 2
-      : anchor === "baseline"
-        ? 0
-        : size;
-}
-
-/**
- * Fallback baseline for *spread*'s cross-axis alignment: the data scale's
- * origin. middle→size/2; otherwise `posScale(0)` (the scale's zero), or 0 with
- * no scale. A SIZE-derived cross axis thus aligns at the scale's zero, not the
- * box edge.
- */
-export function spreadFallbackBaseline(
+/** Fallback alignment baseline when no sibling is pre-placed on the axis.
+ *  Dispatches on the axis's underlying-space kind, not the call site: a
+ *  posScale-carrying (POSITION) axis falls back to the scale origin
+ *  `posScale(0)` (bars hang from the zero line); a pixel-pure axis falls back
+ *  to the layer-box edge for the anchor (axis titles and chrome pin to the
+ *  box). `middle` is box-center either way: it resolves to DIFFERENCE space —
+ *  an extent with no anchored origin — so a scale origin is meaningless for it.
+ *  The `end` box edge is finite-guarded: an unsized axis hands NaN down, and
+ *  the fallback must stay 0 there, not inject NaN translates. */
+export const alignFallbackBaseline = (
   anchor: AlignAnchor,
   size: number,
   posScale: ((v: number) => number) | undefined
-): number {
-  return anchor === "middle" ? size / 2 : posScale ? posScale(0) : 0;
-}
+): number => {
+  if (anchor === "middle") return size / 2;
+  if (posScale) return posScale(0);
+  if (anchor === "end") return Number.isFinite(size) ? size : 0;
+  return 0; // start | baseline → layer origin
+};
 
 /**
  * Place `targets` on one axis so each lands at a single shared baseline,
  * read at its own anchor. The baseline is taken from the first already-placed
- * target (via `policy.readPlaced`), or from `policy.fallback` when none is
- * placed; already-placed targets are left untouched. This is the single
- * placement walk shared by the `align` constraint and spread's cross-axis
- * alignment — only the baseline policy differs (see `AlignBaselinePolicy`).
+ * target (via `policy.readPlaced`), or from the shared space-kind-dispatched
+ * `alignFallbackBaseline` when none is placed; already-placed targets are left
+ * untouched. This is the single placement walk shared by the `align` constraint
+ * and spread's cross-axis alignment — only the `readPlaced` reader differs (see
+ * `AlignBaselinePolicy`).
  */
 export function alignTargets(
   targets: Placeable[],
@@ -182,7 +158,8 @@ export function alignTargets(
   }
   // Note: the fallback keys on `anchors[0]` (the first child's anchor), not the
   // per-child anchor — preserved from the original `as[0]` indexing.
-  if (baseline === undefined) baseline = policy.fallback(anchors[0], env);
+  if (baseline === undefined)
+    baseline = alignFallbackBaseline(anchors[0], env.size, env.posScale);
 
   for (let i = 0; i < targets.length; i++) {
     if (isPlacedOn(targets[i], idx)) continue;
@@ -209,19 +186,10 @@ function applyAlignAxis(
     anchors = new Array<AlignAnchor>(targets.length).fill(spec);
   }
 
-  // Layer-box policy: read a placed sibling's real extent/origin; with no
-  // placed sibling, fall back to the layer's own box baseline.
-  alignTargets(
-    targets,
-    axis,
-    anchors,
-    {
-      readPlaced: anchorValue,
-      fallback: (anchor, env) =>
-        constraintFallbackBaseline(anchor, env.size, env.posScale),
-    },
-    env
-  );
+  // Read a placed sibling's real extent/origin; with no placed sibling, the
+  // shared space-kind fallback decides (scale origin on a scaled axis, box edge
+  // on a pixel-pure one).
+  alignTargets(targets, axis, anchors, { readPlaced: anchorValue }, env);
 }
 
 export function applyAlign(

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -7,6 +7,7 @@ import {
   AlignAnchor,
   Axis,
   ConstraintRef,
+  ConstraintPosScales,
   axisIndex,
   isPlacedOn,
 } from "./shared";
@@ -63,10 +64,13 @@ export const createAlignConstraint = (
   return { type: "align", x, y, children };
 };
 
-export interface AlignFallbackBaseline {
-  start?: number;
-  middle?: number;
-  end?: number;
+/** Per-axis environment threaded to a fallback policy: the layer's box size on
+ *  this axis and the axis's data→pixel position scale (if any). The two
+ *  fallback policies below each consume a different part of this env, so they
+ *  can sit side by side as pure functions of `(anchor, size, posScale)`. */
+export interface AlignAxisEnv {
+  size: number;
+  posScale: ((v: number) => number) | undefined;
 }
 
 /** Read the coordinate of `target` along axis `idx` at anchor `a`. */
@@ -112,7 +116,44 @@ export const placeAtAnchor = (
  */
 export interface AlignBaselinePolicy {
   readPlaced: (target: Placeable, idx: 0 | 1, anchor: AlignAnchor) => number;
-  fallback: (anchors: AlignAnchor[], idx: 0 | 1) => number;
+  fallback: (anchor: AlignAnchor, env: AlignAxisEnv) => number;
+}
+
+/**
+ * Fallback baseline for the `align` *constraint* path: the layer's own box
+ * edge. start→0, middle→size/2, end→size, baseline→0 (the layer's origin).
+ * Ignores `posScale` — axis-title elaboration relies on a title pinning to the
+ * plot box, not the data scale. NOTE: an unsized axis carries a NaN `size`, so
+ * middle/end yield NaN here exactly as the layer's literal `size/2` / `size`
+ * would; no finite-guard is applied (behavior is bit-identical to the old
+ * `fallbackFor` reading a `{start:0, middle:size/2, end:size}` literal).
+ */
+export function constraintFallbackBaseline(
+  anchor: AlignAnchor,
+  size: number,
+  _posScale: ((v: number) => number) | undefined
+): number {
+  return anchor === "start"
+    ? 0
+    : anchor === "middle"
+      ? size / 2
+      : anchor === "baseline"
+        ? 0
+        : size;
+}
+
+/**
+ * Fallback baseline for *spread*'s cross-axis alignment: the data scale's
+ * origin. middle→size/2; otherwise `posScale(0)` (the scale's zero), or 0 with
+ * no scale. A SIZE-derived cross axis thus aligns at the scale's zero, not the
+ * box edge.
+ */
+export function spreadFallbackBaseline(
+  anchor: AlignAnchor,
+  size: number,
+  posScale: ((v: number) => number) | undefined
+): number {
+  return anchor === "middle" ? size / 2 : posScale ? posScale(0) : 0;
 }
 
 /**
@@ -127,7 +168,8 @@ export function alignTargets(
   targets: Placeable[],
   axis: Axis,
   anchors: AlignAnchor[],
-  policy: AlignBaselinePolicy
+  policy: AlignBaselinePolicy,
+  env: AlignAxisEnv
 ): void {
   const idx = axisIndex(axis);
 
@@ -138,7 +180,9 @@ export function alignTargets(
       break;
     }
   }
-  if (baseline === undefined) baseline = policy.fallback(anchors, idx);
+  // Note: the fallback keys on `anchors[0]` (the first child's anchor), not the
+  // per-child anchor — preserved from the original `as[0]` indexing.
+  if (baseline === undefined) baseline = policy.fallback(anchors[0], env);
 
   for (let i = 0; i < targets.length; i++) {
     if (isPlacedOn(targets[i], idx)) continue;
@@ -146,24 +190,11 @@ export function alignTargets(
   }
 }
 
-const fallbackFor = (
-  fallback: AlignFallbackBaseline | undefined,
-  a: AlignAnchor
-): number =>
-  (a === "start"
-    ? fallback?.start
-    : a === "middle"
-      ? fallback?.middle
-      : a === "baseline"
-        ? // Baseline-anchored targets pin their origin to the layer's origin.
-          0
-        : fallback?.end) ?? 0;
-
 function applyAlignAxis(
   axis: Axis,
   spec: AlignAxisSpec,
   targets: Placeable[],
-  fallback?: AlignFallbackBaseline
+  env: AlignAxisEnv
 ): void {
   // Normalize to a per-child anchor array.
   let anchors: AlignAnchor[];
@@ -180,21 +211,35 @@ function applyAlignAxis(
 
   // Layer-box policy: read a placed sibling's real extent/origin; with no
   // placed sibling, fall back to the layer's own box baseline.
-  alignTargets(targets, axis, anchors, {
-    readPlaced: anchorValue,
-    fallback: (as) => fallbackFor(fallback, as[0]),
-  });
+  alignTargets(
+    targets,
+    axis,
+    anchors,
+    {
+      readPlaced: anchorValue,
+      fallback: (anchor, env) =>
+        constraintFallbackBaseline(anchor, env.size, env.posScale),
+    },
+    env
+  );
 }
 
 export function applyAlign(
   constraint: AlignConstraint,
   targets: Placeable[],
-  fallback?: { x?: AlignFallbackBaseline; y?: AlignFallbackBaseline }
+  sizes: [number, number],
+  posScales: ConstraintPosScales | undefined
 ): void {
   if (constraint.x !== undefined) {
-    applyAlignAxis("x", constraint.x, targets, fallback?.x);
+    applyAlignAxis("x", constraint.x, targets, {
+      size: sizes[0],
+      posScale: posScales?.[0],
+    });
   }
   if (constraint.y !== undefined) {
-    applyAlignAxis("y", constraint.y, targets, fallback?.y);
+    applyAlignAxis("y", constraint.y, targets, {
+      size: sizes[1],
+      posScale: posScales?.[1],
+    });
   }
 }

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -164,16 +164,14 @@ export function collectPositionDomains(constraints: ConstraintSpec[]): {
  *
  * @param constraints - The constraint specs to apply in order
  * @param nameToPlaceable - Map from child name to its Placeable
- * @param fallbackBaselines - Layer box baselines for unanchored `align`s
+ * @param sizes - The layer's box size `[w, h]`, used to derive an unanchored
+ *   `align`'s fallback baseline (layer-box edge) per axis
  * @param posScales - Per-axis data→pixel scales for `position` constraints
  */
 export function applyConstraints(
   constraints: ConstraintSpec[],
   nameToPlaceable: Map<string, Placeable>,
-  fallbackBaselines?: {
-    x?: { start?: number; middle?: number; end?: number };
-    y?: { start?: number; middle?: number; end?: number };
-  },
+  sizes: [number, number],
   posScales?: ConstraintPosScales
 ): void {
   for (const constraint of constraints) {
@@ -186,7 +184,7 @@ export function applyConstraints(
     if (targets.length === 0) continue;
 
     if (constraint.type === "align") {
-      applyAlign(constraint, targets, fallbackBaselines);
+      applyAlign(constraint, targets, sizes, posScales);
     } else if (constraint.type === "position") {
       applyPosition(constraint, targets, posScales);
     } else {

--- a/packages/gofish-graphics/src/ast/constraints/shared.ts
+++ b/packages/gofish-graphics/src/ast/constraints/shared.ts
@@ -4,8 +4,10 @@ export type Axis = "x" | "y";
 export type Alignment = "start" | "middle" | "end";
 /** Anchor for align/position constraints. The bbox anchors (`Alignment`) place
  *  a target by its extent; `"baseline"` places the target's own ORIGIN (its
- *  local coordinate 0) at the value — i.e. `align({y: "baseline"})` with a
- *  fallback of 0 means "stay where you were laid out", regardless of how far
+ *  local coordinate 0) at the value. When no sibling is pre-placed the fallback
+ *  is the axis origin — the scale's zero (`posScale(0)`) on a scaled axis, the
+ *  layer origin on a pixel-pure one — so `align({y: "baseline"})` on a
+ *  pixel-pure axis means "stay where you were laid out", regardless of how far
  *  the target's bbox extends past its origin (e.g. axis labels hanging below
  *  a chart's zero line). */
 export type AlignAnchor = Alignment | "baseline";

--- a/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
@@ -22,7 +22,7 @@ import {
 } from "../underlyingSpace";
 import type { Measure } from "../data";
 import type { Size } from "../dims";
-import { alignTargets } from "../constraints/align";
+import { alignTargets, spreadFallbackBaseline } from "../constraints/align";
 import type { AlignAnchor } from "../constraints/shared";
 import * as Interval from "../../util/interval";
 import * as Monotonic from "../../util/monotonic";
@@ -204,16 +204,22 @@ export function alignChildren(
   if (posScale && !fromSize && alignment !== "middle") return;
 
   const anchors = new Array<AlignAnchor>(children.length).fill(alignment);
-  alignTargets(children, axis === 0 ? "x" : "y", anchors, {
-    readPlaced: (child, idx, a) =>
-      a === "baseline"
-        ? 0
-        : a === "start"
-          ? (child.dims[idx].min ?? 0)
-          : a === "middle"
-            ? (child.dims[idx].center ?? child.dims[idx].min ?? 0)
-            : (child.dims[idx].max ?? child.dims[idx].min ?? 0),
-    fallback: (as) =>
-      as[0] === "middle" ? size / 2 : posScale ? posScale(0) : 0,
-  });
+  alignTargets(
+    children,
+    axis === 0 ? "x" : "y",
+    anchors,
+    {
+      readPlaced: (child, idx, a) =>
+        a === "baseline"
+          ? 0
+          : a === "start"
+            ? (child.dims[idx].min ?? 0)
+            : a === "middle"
+              ? (child.dims[idx].center ?? child.dims[idx].min ?? 0)
+              : (child.dims[idx].max ?? child.dims[idx].min ?? 0),
+      fallback: (anchor, env) =>
+        spreadFallbackBaseline(anchor, env.size, env.posScale),
+    },
+    { size, posScale }
+  );
 }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
@@ -22,7 +22,7 @@ import {
 } from "../underlyingSpace";
 import type { Measure } from "../data";
 import type { Size } from "../dims";
-import { alignTargets, spreadFallbackBaseline } from "../constraints/align";
+import { alignTargets } from "../constraints/align";
 import type { AlignAnchor } from "../constraints/shared";
 import * as Interval from "../../util/interval";
 import * as Monotonic from "../../util/monotonic";
@@ -183,9 +183,11 @@ export function resolveAlignmentSpace(
 /**
  * Align children on a single axis using spread-style semantics. Thin wrapper
  * over the shared `alignTargets` walk (see `constraints/align.ts`) supplying
- * spread's baseline policy: a `"baseline"` anchor pins to 0, and an unplaced
- * fallback resolves to the data scale's origin (`posScale(0)`) rather than the
- * layer box.
+ * spread's `readPlaced` reader (a `"baseline"` anchor pins to 0 and missing
+ * extents are tolerated). The no-sibling fallback is the shared
+ * space-kind-dispatched rule (`alignFallbackBaseline`): a scaled (posScale)
+ * axis falls back to the scale origin `posScale(0)`, a pixel-pure axis to the
+ * layer-box edge.
  *
  * Guard: when children already have data-driven positions via posScale
  * (fromSize is false and alignment !== "middle"), skip — the children
@@ -217,8 +219,6 @@ export function alignChildren(
             : a === "middle"
               ? (child.dims[idx].center ?? child.dims[idx].min ?? 0)
               : (child.dims[idx].max ?? child.dims[idx].min ?? 0),
-      fallback: (anchor, env) =>
-        spreadFallbackBaseline(anchor, env.size, env.posScale),
     },
     { size, posScale }
   );

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -39,6 +39,7 @@ import {
 import { alignSpaceFold, type AlignConstraint } from "../constraints/align";
 import { allocateSlices } from "../constraints/folds";
 import { axisIndex } from "../constraints/shared";
+import { isValue } from "../data";
 import { unionChildSpaces } from "./alignment";
 
 /** Normalize a node's _name (string or Token) to the string used as a key in
@@ -647,8 +648,12 @@ export const layer = createNodeOperatorSequential(
               ? getPositioningConstraintRefs(node.constraints)
               : new Set<string>();
 
-          // Per-AXIS targets of `position` constraints (e.g. axis ticks pinned
-          // via `Constraint.position({ y: datum(v) })`). Tracked per axis, not
+          // Per-AXIS targets of *datum*-pinned `position` constraints (e.g. axis
+          // ticks pinned via `Constraint.position({ y: datum(v) })`). A datum pin
+          // consumes the scale, so the target must not also receive it; a literal
+          // *pixel* pin (`Constraint.position({ y: 0 })`) does not consume the
+          // scale, so it's deliberately NOT tracked here — content pinned at its
+          // raw pixel origin still needs its posScale. Tracked per axis, not
           // per child: a child pinned on one axis may still need the scale on
           // the other (an axis line position-seated on its cross axis resolves
           // its own-axis datum endpoints through the scale).
@@ -658,8 +663,8 @@ export const layer = createNodeOperatorSequential(
               for (const r of c.children) {
                 if (!r) continue;
                 const dims = positionTargetDims.get(r.name) ?? new Set();
-                if (c.x !== undefined) dims.add(0);
-                if (c.y !== undefined) dims.add(1);
+                if (c.x !== undefined && isValue(c.x)) dims.add(0);
+                if (c.y !== undefined && isValue(c.y)) dims.add(1);
                 positionTargetDims.set(r.name, dims);
               }
             }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -733,10 +733,7 @@ export const layer = createNodeOperatorSequential(
             applyConstraints(
               node.constraints,
               nameToPlaceable,
-              {
-                x: { start: 0, middle: size[0] / 2, end: size[0] },
-                y: { start: 0, middle: size[1] / 2, end: size[1] },
-              },
+              size,
               effectivePosScales
             );
 

--- a/packages/gofish-graphics/src/ast/legends/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/legends/elaborate.tsx
@@ -86,7 +86,9 @@ export async function elaborateLegend(
     // Constraint order matters: the content pin places the anchor the others read.
     root.constrain((g) => [
       // Pin the content at its origin; it never moves.
-      Constraint.align({ x: "baseline", y: "baseline" }, [g[CONTENT_NAME]]),
+      Constraint.position({ x: 0, y: 0, anchor: "baseline" }, [
+        g[CONTENT_NAME],
+      ]),
       // Seat the column just right of the full content bbox (incl. axis labels).
       Constraint.distribute({ dir: "x", spacing: LEGEND_CONTENT_GAP }, [
         g[CONTENT_NAME],

--- a/packages/gofish-graphics/stories/lowlevel/ConstraintParity.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/ConstraintParity.stories.tsx
@@ -211,22 +211,19 @@ export const ConstraintGlue: StoryObj<Args> = {
   },
 };
 
-// ── End alignment: a PRINCIPLED DIVERGENCE, not a parity pair ───────────────
-// Unlike every pair above, this one renders DIFFERENTLY — by design. spread's
-// cross-axis alignment (alignChildren) and the align constraint use different
-// baseline POLICIES when no sibling is pre-placed (the AlignBaselinePolicy split
-// in constraints/align.ts):
-//   - spread's fallback is the data-scale origin `posScale(0)` (= 0 here),
-//     IRRESPECTIVE of the anchor — SIZE-derived bars align at the scale's zero,
-//     so the "end" (top) of every bar lands on the zero line and the bars hang
-//     into negative cross-coords (spread's SVG grows to reserve that overhang).
-//   - the constraint's fallback is the layer-box edge FOR that anchor —
-//     `end` → `size` (the box top) — so the bars sit flush at the top of the box.
-// For "start" both fallbacks are 0, so the start/bar/fit/fill/weights/glue pairs
-// above match exactly; for "end" (and "middle") they differ by the full box
-// extent. Both policies are load-bearing (axis-title elaboration needs the box
-// edge; spread needs the scale origin) and neither subsumes the other, so this
-// is reported as a genuine divergence — the policies are NOT reconciled.
+// ── End alignment: EXACT PARITY, like every pair above (#552) ───────────────
+// This pair once rendered differently by design; since #552 it is exact parity.
+// The no-sibling alignment fallback now dispatches on the axis's UNDERLYING
+// SPACE, not the call site (the shared `alignFallbackBaseline` in
+// constraints/align.ts): a posScale-carrying (POSITION) axis falls back to the
+// scale origin `posScale(0)`, a pixel-pure axis to the layer-box edge.
+// Here both layers are SIZE-derived (data-driven-height rects), so both resolve
+// the SAME `alignSpaceFold` POSITION space and the SAME posScale. The "end"
+// (top) of every bar therefore lands on the scale's zero line in BOTH the
+// spread and the constraint layer, and the bars hang into negative cross-coords
+// (the SVG grows to reserve that overhang). Identical geometry — no divergence.
+// (The remaining per-callsite difference, the `readPlaced` reader for an
+// already-placed sibling, is out of scope for #552.)
 
 /** spread({ dir: "x", alignment: "end" }) over data-driven-height rects. */
 export const SpreadEnd: StoryObj<Args> = {

--- a/packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx
@@ -153,9 +153,10 @@ export const SpreadY_AlignEnd: StoryObj<Args> = {
  *
  * Three rects of different widths, stacked vertically, center-aligned.
  *
- * TODO: Revisit center baseline semantics so this equivalence does not
- * require pinning a child first. Today, spread middle defaults to viewport
- * center while constraint align-center defaults to 0 when no child is placed.
+ * Both spread-middle and constraint align-middle fall back to box-center
+ * (size/2) when no child is placed (since #543). This story still pins one
+ * child to the canvas center so the two panels share an explicit, obvious
+ * baseline, but the pin is illustrative rather than required for equivalence.
  */
 export const SpreadY_AlignMiddle: StoryObj<Args> = {
   args: { w: 300, h: 300 },

--- a/packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/html";
 import { initializeContainer } from "../helper";
-import { Constraint, layer, rect, spread } from "../../src/lib";
+import { Constraint, layer, rect, spread, value, wavy } from "../../src/lib";
 
 const meta: Meta = {
   title: "Low Level Syntax/Constraints",
@@ -192,6 +192,30 @@ export const SpreadY_AlignMiddle: StoryObj<Args> = {
           .render(container, { w: storyArgs.w, h: storyArgs.h });
       }
     ),
+};
+
+/**
+ * `end` alignment on a PIXEL-PURE axis: posScales don't cross a coordinate
+ * transform boundary (children of `coord` receive scale *factors* instead),
+ * so the cross-axis `end` fallback inside `wavy()` is the layer-box edge —
+ * the bar ends seat flush at the box top instead of hanging from a scale
+ * origin. Locks in the space-kind-dispatched fallback (#552): before the
+ * unification, spread's pixel-pure `end` fallback was 0 (a call-site quirk
+ * that seated the ends at the layer origin).
+ */
+export const SpreadEndUnderCoordTransform: StoryObj<Args> = {
+  args: { w: 300, h: 300 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    layer({ coord: wavy(), x: 0, y: 0 }, [
+      spread({ dir: "x", alignment: "end", spacing: 8 }, [
+        rect({ w: 40, h: value(30), fill: "#e63946" }),
+        rect({ w: 40, h: value(80), fill: "#457b9d" }),
+        rect({ w: 40, h: value(50), fill: "#2a9d8f" }),
+      ]),
+    ]).render(container, { w: args.w, h: args.h });
+    return container;
+  },
 };
 
 /**

--- a/packages/gofish-graphics/stories/seaborn/MarginalHistogram.stories.tsx
+++ b/packages/gofish-graphics/stories/seaborn/MarginalHistogram.stories.tsx
@@ -66,7 +66,7 @@ export const Default: StoryObj<Args> = {
       const GAP = 10;
       await layer([sc, topHist, rightHist])
         .constrain(({ scatter, topHist, rightHist }: any) => [
-          Constraint.align({ x: "baseline", y: "baseline" } as any, [scatter]),
+          Constraint.position({ x: 0, y: 0, anchor: "baseline" }, [scatter]),
           Constraint.align({ x: "baseline" } as any, [scatter, topHist]),
           Constraint.align({ y: "baseline" } as any, [scatter, rightHist]),
           Constraint.position({ y: args.h + GAP, anchor: "start" } as any, [topHist]),

--- a/tests/python-stories/low-level-syntax/test_constraint_parity.py
+++ b/tests/python-stories/low-level-syntax/test_constraint_parity.py
@@ -171,7 +171,12 @@ def story_constraint_glue():
     )
 
 
-# ── End alignment: a principled divergence, not a parity pair ───────────────
+# ── End alignment: exact parity, like every pair above (#552) ───────────────
+# Once a principled divergence; since #552 the no-sibling fallback dispatches on
+# the axis's underlying space (posScale -> scale origin; pixel-pure -> box edge).
+# Both layers here are SIZE-derived, so both resolve the same POSITION space and
+# posScale: the bars' "end" lands on the scale's zero line in both, hanging into
+# negative cross-coords. Identical geometry — an exact parity pair.
 
 
 def story_spread_end():

--- a/tests/python-stories/low-level-syntax/test_constraints.py
+++ b/tests/python-stories/low-level-syntax/test_constraints.py
@@ -1,12 +1,13 @@
 """Equivalent of lowlevel/Constraints.stories.tsx — Low Level Syntax/Constraints.
 
-Ports the six single-chart stories that demonstrate `layer + constrain`
-directly. The eight side-by-side equivalence stories (`SpreadY_*`,
-`SpreadX_*`) use a multi-panel DOM scaffold that doesn't fit the single-
-chart parity harness — those are per-export exempt.
+Ports the seven single-chart stories: the six that demonstrate
+`layer + constrain` directly, plus `SpreadEnd_UnderCoordTransform` (the
+pixel-pure `end` fallback canary, #552). The eight side-by-side equivalence
+stories (`SpreadY_*`, `SpreadX_*`) use a multi-panel DOM scaffold that
+doesn't fit the single-chart parity harness — those are per-export exempt.
 """
 
-from gofish import Constraint, layer, rect
+from gofish import Constraint, datum, layer, rect, spread, wavy
 
 
 # ─── partial placement ───────────────────────────────────────────────────────
@@ -86,6 +87,22 @@ def story_background_not_distributed():
 
 
 # ─── cross-axis ──────────────────────────────────────────────────────────────
+
+
+def story_spread_end_under_coord_transform():
+    # `end` alignment on a pixel-pure axis: posScales don't cross a coordinate
+    # transform boundary, so the cross-axis `end` fallback inside wavy() is the
+    # layer-box edge (#552) — the bar ends seat flush at the box top.
+    return (
+        layer([
+            spread([
+                rect(w=40, h=datum(30), fill="#e63946"),
+                rect(w=40, h=datum(80), fill="#457b9d"),
+                rect(w=40, h=datum(50), fill="#2a9d8f"),
+            ], dir="x", alignment="end", spacing=8),
+        ], coord=wavy(), x=0, y=0),
+        {"w": 300, "h": 300},
+    )
 
 
 def story_align_center_distribute_y():

--- a/tests/python-stories/seaborn/test_marginal_histogram.py
+++ b/tests/python-stories/seaborn/test_marginal_histogram.py
@@ -78,7 +78,7 @@ def story_default():
     return (
         Layer([sc, top_hist, right_hist]).constrain(
             lambda scatter, topHist, rightHist: [
-                Constraint.align([scatter], x="baseline", y="baseline"),
+                Constraint.position([scatter], x=0, y=0, anchor="baseline"),
                 Constraint.align([scatter, topHist], x="baseline"),
                 Constraint.align([scatter, rightHist], y="baseline"),
                 Constraint.position([topHist], y=h + GAP, anchor="start"),


### PR DESCRIPTION
Closes #552. Part of #550.

## What

When an `align` has no pre-placed sibling on an axis, the fallback baseline used to diverge by call site: **spread** fell back to the data-scale origin (`posScale(0)`), the **align constraint** to the layer-box edge per anchor. The same `align({y:"end"})` meant different things depending on which API assembled the layer.

The fallback now dispatches on the **axis's underlying-space kind**, not the call site:

- a posScale-carrying (POSITION) axis falls back to the scale origin `posScale(0)` — SIZE-derived bars hang from the zero line;
- a pixel-pure axis falls back to the box edge per anchor (`start`→0, `middle`→size/2, `end`→size) — axis titles and chrome keep pinning to the plot box;
- `middle` is box-center either way (it resolves to DIFFERENCE space, which has no anchored origin).

`AlignBaselinePolicy` shrinks to the `readPlaced` reader — the one remaining per-call-site difference, out of scope for #552 — and the `SpreadEnd`/`ConstraintEnd` ConstraintParity pair flips from documented-divergence to **exact parity** (verified: identical absolute leaf geometry, JS and Python).

## How (3 commits, refactor → easy change)

1. **`refactor: pin elaboration content via literal position constraints`** — zero-diff. The internal "pin content at its origin" idiom (axes/legends elaboration, MarginalHistogram) migrated from `align({baseline})` — which relied on the constraint fallback meaning "translate 0" — to `Constraint.position({x:0, y:0, anchor:"baseline"})`, which says raw pixel origin unconditionally. Enabling fix: `positionTargetDims` posScale suppression is now datum-only (a literal pixel pin doesn't consume the scale).
2. **`refactor: thread a per-axis env through the align fallback policies`** — zero-diff. `applyConstraints` takes `(sizes, posScales)` instead of a prebuilt box-baseline object; both fallback policies expressed side by side as pure functions of `(anchor, size, posScale)`.
3. **`align: dispatch the no-sibling fallback on the axis's underlying space`** — the semantic change: one `alignFallbackBaseline` replaces both policies. Stories + docs updated (the `constrain.md` caveat is replaced by the unified rule; `constraints-as-core.md` records the unification).

## Verification

- `capture-diff origin/main` per commit: commits 1–2 moved nothing; commit 3's movers are exactly the intended three — `ConstraintParity/ConstraintEnd` (bars move from box-top to zero-line-hanging, now byte-identical to the unchanged `SpreadEnd`) and the spread panels of `Constraints/SpreadY_AlignEnd` + `SpreadX_Spacing_AlignEnd` (pixel-pure `end`: 0 → box edge, making their "≡ constraint panel" claims literally true).
- **Flagged, verified visual no-ops**: the python-tutor diagrams (`global-frame`, `heap`, `python-tutor`) and `NestedWaffleChart` show normalized-DOM diffs that are pure translate redistribution between parent/child groups — flattening every transform to absolute leaf coordinates shows **zero** position changes in all four.
- Python parity: `ConstraintEnd` Python render matches the JS HEAD render exactly (same leaf coordinates); `validate-python-ir` passes (no IR changes — the migrated pins use the existing `position` constraint).
- `check-backlinks` passes; no `covers:` changes.
- **Visual baselines NOT regenerated** (Mac); CI should flag exactly `constraint-parity--constraint-end`, `constraints--spread-y_align-end`, `constraints--spread-x_spacing_align-end` as intended changes.

(The known-nondeterministic image-asset stories — `image-mixed-primitives--*`, `porter-duff-relations--*`, `bottle--default`, `image-marks--size-resolution` — diff against themselves HEAD-vs-HEAD and were excluded from the gates.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

`ConstraintEnd` — the one intended behavior change (an `end`-aligned constraint layer over SIZE-derived bars with no pre-placed sibling):

| Before (box-edge fallback) | After (scale-origin fallback) | `SpreadEnd` at HEAD (unchanged, now identical) |
| --- | --- | --- |
| ![before](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-557/before-constraint-end.png) | ![after](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-557/after-constraint-end.png) | ![spread-end](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-557/after-spread-end.png) |

Bars previously sat flush at the box top (`end` → box edge); they now hang from the scale's zero line, with the SVG growing to reserve the overhang — exactly what `spread({alignment: "end"})` has always done.

