### PR TITLE
docs: axis titles (fix malformed Axes section, JS↔Python parity)

### DIFF
--- a/apps/docs/docs/js/api/core/chart.md
+++ b/apps/docs/docs/js/api/core/chart.md
@@ -21,16 +21,41 @@ chart(data, options?)
 
 ## Parameters
 
-| Parameter       | Type                                    | Description                                                                                                                                                                  |
-| --------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data`          | `T`                                     | The dataset to visualize                                                                                                                                                     |
-| `options.w`     | `number`                                | Width hint for the chart frame                                                                                                                                               |
-| `options.h`     | `number`                                | Height hint for the chart frame                                                                                                                                              |
-| `options.coord` | `CoordinateTransform`                   | Coordinate transform (e.g. `polar()`)                                                                                                                                        |
-| `options.color` | `ColorConfig`                           | Color scale applied to all marks in this chart. Use [`palette()`](/js/api/color/palette) for categorical data or [`gradient()`](/js/api/color/gradient) for continuous data. |
-| `options.axes`  | `boolean \| { x: boolean; y: boolean }` | Auto-generate axes, labels, and legends. Use an object to toggle x/y axes individually.                                                                                      |
+| Parameter       | Type                  | Description                                                                                                                                                                  |
+| --------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`          | `T`                   | The dataset to visualize                                                                                                                                                     |
+| `options.w`     | `number`              | Width hint for the chart frame                                                                                                                                               |
+| `options.h`     | `number`              | Height hint for the chart frame                                                                                                                                              |
+| `options.coord` | `CoordinateTransform` | Coordinate transform (e.g. `polar()`)                                                                                                                                        |
+| `options.color` | `ColorConfig`         | Color scale applied to all marks in this chart. Use [`palette()`](/js/api/color/palette) for categorical data or [`gradient()`](/js/api/color/gradient) for continuous data. |
+| `options.axes`  | `AxesOptions`         | Auto-generate axes, labels, and legends. See [Axes](#axes) below.                                                                                                            |
 
 Returns a `ChartBuilder<T>` with [`.flow()`](/js/api/core/flow), [`.mark()`](/js/api/core/mark), [`.render()`](/js/api/core/render), and [`.zOrder()`](#zorder) methods.
+
+## Axes
+
+`axes` accepts a boolean, a per-dimension object, or per-dimension title control:
+
+```ts
+chart(data, { axes: true }); // both axes, titles inferred
+chart(data, { axes: false }); // no axes (the default)
+chart(data, { axes: { x: true, y: false } }); // x only
+chart(data, { axes: { x: { title: "Year" }, y: true } }); // custom x title, inferred y title
+chart(data, { axes: { x: { title: false }, y: true } }); // suppress the inferred x title
+```
+
+The full type is:
+
+```ts
+type AxesOptions = boolean | { x?: AxisOptions; y?: AxisOptions };
+type AxisOptions = boolean | { title?: string | false };
+```
+
+Each axis title defaults to the field that dimension encodes (e.g. `count` for
+`rect({ h: "count" })`). Pass `{ title: "…" }` to override it, or `{ title: false }`
+to show the axis with no title. Manual `axis: true/false` overrides on individual
+operators within the chart are still respected when `axes: true`. See
+[render › Axes](/js/api/core/render#axes) for live examples.
 
 ## Example
 

--- a/apps/docs/docs/js/api/core/render.md
+++ b/apps/docs/docs/js/api/core/render.md
@@ -57,20 +57,33 @@ shared x/y axes.
 
 ## Axes
 
-The `axes` option controls per-axis visibility and titles:
+The `axes` option controls per-axis visibility and titles. It accepts a boolean, a
+per-dimension object, or per-dimension title control:
 
 ```ts
-chart(data, { axes: true })
-  .flow(spread({ by: "category", dir: "x" }))
-  .mark(rect({ h: "value" }))
-  .render(container, { w: 500, h: 300 });
+axes: true                                     // both axes, titles inferred
+axes: false                                    // no axes (the default)
+axes: { x: true, y: false }                    // x only
+axes: { x: { title: "Year" }, y: true }        // custom x title, inferred y title
+axes: { x: { title: false }, y: true }         // suppress the inferred x title
 ```
 
-```ts
-chart(data, { axes: { x: true, y: false } })
-  .flow(spread({ by: "category", dir: "x" }))
-  .mark(rect({ h: "value" }))
-  .render(container, { w: 500, h: 300 });
+`axes` is most naturally a `chart()`/`Chart()` option (e.g.
+`gf.Chart(data, { axes: true })`); it is also accepted directly on `.render()`, as
+the examples below show.
+
+### Axes with inferred titles
+
+When `axes: true` (or `{ title }` is omitted), each axis title is inferred from the
+field that dimension encodes — `lake` on x, `count` on y here.
+
+::: gofish
+
+```js
+gf.Chart(seafood)
+  .flow(gf.spread({ by: "lake", dir: "x" }))
+  .mark(gf.rect({ h: "count" }))
+  .render(root, { w: 400, h: 250, axes: true });
 ```
 
 :::


### PR DESCRIPTION
Closes #391.

**Short answer to the issue:** we *do* have axis-title docs now — they shipped with the node-based axis rendering in #411 (after this issue was filed). But the docs had drifted and one section was broken, so this PR cleans them up rather than just closing.

## What was wrong

- **`js/api/core/render.md` "Axes" section was malformed**: a stray orphan `:::` and two dead static ` ```ts ` fences sitting where live examples should be. The orphan `:::` produced broken markup on the page.
- **`js/api/core/chart.md` was stale**: `options.axes` was typed `boolean | { x: boolean; y: boolean }` — omitting the `{ title }` shape entirely — and the page had no Axes section, even though the Python `chart` page already documents the full `axes`/title shape.

## Changes

- **render.md**: replace the two dead fences + orphan `:::` with a documented title-control summary and one live `::: gofish` inferred-title example. The existing custom-title and suppress-title live examples below already cover those cases.
- **chart.md**: update the type to `AxesOptions`, add an Axes section documenting the bool / per-dimension / `{ title }` forms and the `AxesOptions`/`AxisOptions` types — mirroring the Python `chart` page so the JS and Python doc trees stay structurally parallel.

No source/API changes — documentation only. `pnpm docs:build` passes.