### PR TITLE
docs: complete the Python API reference; document text/image/arrow (#449)

### DIFF
--- a/apps/docs/docs/.vitepress/config.mts
+++ b/apps/docs/docs/.vitepress/config.mts
@@ -357,6 +357,8 @@ export default defineConfig({
                 { text: "area", link: "/js/api/marks/area" },
                 { text: "blank", link: "/js/api/marks/blank" },
                 { text: "polygon", link: "/js/api/marks/polygon" },
+                { text: "text", link: "/js/api/marks/text" },
+                { text: "image", link: "/js/api/marks/image" },
                 { text: "ref", link: "/js/api/marks/ref" },
               ],
             },
@@ -369,8 +371,10 @@ export default defineConfig({
                 { text: "table", link: "/js/api/operators/table" },
                 { text: "scatter", link: "/js/api/operators/scatter" },
                 { text: "group", link: "/js/api/operators/group" },
+                { text: "treemap", link: "/js/api/operators/treemap" },
                 { text: "layer", link: "/js/api/operators/layer" },
                 { text: "connect", link: "/js/api/operators/connect" },
+                { text: "arrow", link: "/js/api/operators/arrow" },
                 {
                   text: "region compositing",
                   link: "/js/api/operators/region-compositing",
@@ -427,6 +431,22 @@ export default defineConfig({
           ],
         },
         {
+          text: "How To",
+          items: [
+            { text: "Create a chart", link: "/python/api/howto/create-chart" },
+            { text: "Create a glyph", link: "/python/api/howto/create-glyph" },
+            {
+              text: "Pick a layout operator",
+              link: "/python/api/howto/operators",
+            },
+            { text: "Use selection", link: "/python/api/howto/selection" },
+            {
+              text: "Name and scope",
+              link: "/python/api/howto/naming-and-scoping",
+            },
+          ],
+        },
+        {
           text: "API Reference",
           items: [
             {
@@ -450,6 +470,10 @@ export default defineConfig({
                 { text: "line", link: "/python/api/marks/line" },
                 { text: "area", link: "/python/api/marks/area" },
                 { text: "blank", link: "/python/api/marks/blank" },
+                { text: "polygon", link: "/python/api/marks/polygon" },
+                { text: "text", link: "/python/api/marks/text" },
+                { text: "image", link: "/python/api/marks/image" },
+                { text: "ref", link: "/python/api/marks/ref" },
               ],
             },
             {
@@ -461,6 +485,10 @@ export default defineConfig({
                 { text: "table", link: "/python/api/operators/table" },
                 { text: "scatter", link: "/python/api/operators/scatter" },
                 { text: "group", link: "/python/api/operators/group" },
+                { text: "treemap", link: "/python/api/operators/treemap" },
+                { text: "layer", link: "/python/api/operators/layer" },
+                { text: "connect", link: "/python/api/operators/connect" },
+                { text: "arrow", link: "/python/api/operators/arrow" },
                 { text: "derive", link: "/python/api/operators/derive" },
                 {
                   text: "region compositing",
@@ -497,6 +525,14 @@ export default defineConfig({
                   text: "ref / selectAll",
                   link: "/python/api/selection/ref",
                 },
+              ],
+            },
+            {
+              text: "Coordinates",
+              collapsed: true,
+              items: [
+                { text: "polar", link: "/python/api/coords/polar" },
+                { text: "clock", link: "/python/api/coords/clock" },
               ],
             },
           ],

--- a/apps/docs/docs/js/api/core/chart.md
+++ b/apps/docs/docs/js/api/core/chart.md
@@ -21,16 +21,41 @@ chart(data, options?)
 
 ## Parameters
 
-| Parameter       | Type                                    | Description                                                                                                                                                                  |
-| --------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `data`          | `T`                                     | The dataset to visualize                                                                                                                                                     |
-| `options.w`     | `number`                                | Width hint for the chart frame                                                                                                                                               |
-| `options.h`     | `number`                                | Height hint for the chart frame                                                                                                                                              |
-| `options.coord` | `CoordinateTransform`                   | Coordinate transform (e.g. `polar()`)                                                                                                                                        |
-| `options.color` | `ColorConfig`                           | Color scale applied to all marks in this chart. Use [`palette()`](/js/api/color/palette) for categorical data or [`gradient()`](/js/api/color/gradient) for continuous data. |
-| `options.axes`  | `boolean \| { x: boolean; y: boolean }` | Auto-generate axes, labels, and legends. Use an object to toggle x/y axes individually.                                                                                      |
+| Parameter       | Type                  | Description                                                                                                                                                                  |
+| --------------- | --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`          | `T`                   | The dataset to visualize                                                                                                                                                     |
+| `options.w`     | `number`              | Width hint for the chart frame                                                                                                                                               |
+| `options.h`     | `number`              | Height hint for the chart frame                                                                                                                                              |
+| `options.coord` | `CoordinateTransform` | Coordinate transform (e.g. `polar()`)                                                                                                                                        |
+| `options.color` | `ColorConfig`         | Color scale applied to all marks in this chart. Use [`palette()`](/js/api/color/palette) for categorical data or [`gradient()`](/js/api/color/gradient) for continuous data. |
+| `options.axes`  | `AxesOptions`         | Auto-generate axes, labels, and legends. See [Axes](#axes) below.                                                                                                            |
 
 Returns a `ChartBuilder<T>` with [`.flow()`](/js/api/core/flow), [`.mark()`](/js/api/core/mark), [`.render()`](/js/api/core/render), and [`.zOrder()`](#zorder) methods.
+
+## Axes
+
+`axes` accepts a boolean, a per-dimension object, or per-dimension title control:
+
+```ts
+chart(data, { axes: true }); // both axes, titles inferred
+chart(data, { axes: false }); // no axes (the default)
+chart(data, { axes: { x: true, y: false } }); // x only
+chart(data, { axes: { x: { title: "Year" }, y: true } }); // custom x title, inferred y title
+chart(data, { axes: { x: { title: false }, y: true } }); // suppress the inferred x title
+```
+
+The full type is:
+
+```ts
+type AxesOptions = boolean | { x?: AxisOptions; y?: AxisOptions };
+type AxisOptions = boolean | { title?: string | false };
+```
+
+Each axis title defaults to the field that dimension encodes (e.g. `count` for
+`rect({ h: "count" })`). Pass `{ title: "…" }` to override it, or `{ title: false }`
+to show the axis with no title. Manual `axis: true/false` overrides on individual
+operators within the chart are still respected when `axes: true`. See
+[render › Axes](/js/api/core/render#axes) for live examples.
 
 ## Example
 

--- a/apps/docs/docs/js/api/core/render.md
+++ b/apps/docs/docs/js/api/core/render.md
@@ -57,20 +57,33 @@ shared x/y axes.
 
 ## Axes
 
-The `axes` option controls per-axis visibility and titles:
+The `axes` option controls per-axis visibility and titles. It accepts a boolean, a
+per-dimension object, or per-dimension title control:
 
 ```ts
-chart(data, { axes: true })
-  .flow(spread({ by: "category", dir: "x" }))
-  .mark(rect({ h: "value" }))
-  .render(container, { w: 500, h: 300 });
+axes: true                                     // both axes, titles inferred
+axes: false                                    // no axes (the default)
+axes: { x: true, y: false }                    // x only
+axes: { x: { title: "Year" }, y: true }        // custom x title, inferred y title
+axes: { x: { title: false }, y: true }         // suppress the inferred x title
 ```
 
-```ts
-chart(data, { axes: { x: true, y: false } })
-  .flow(spread({ by: "category", dir: "x" }))
-  .mark(rect({ h: "value" }))
-  .render(container, { w: 500, h: 300 });
+`axes` is most naturally a `chart()`/`Chart()` option (e.g.
+`gf.Chart(data, { axes: true })`); it is also accepted directly on `.render()`, as
+the examples below show.
+
+### Axes with inferred titles
+
+When `axes: true` (or `{ title }` is omitted), each axis title is inferred from the
+field that dimension encodes — `lake` on x, `count` on y here.
+
+::: gofish
+
+```js
+gf.Chart(seafood)
+  .flow(gf.spread({ by: "lake", dir: "x" }))
+  .mark(gf.rect({ h: "count" }))
+  .render(root, { w: 400, h: 250, axes: true });
 ```
 
 :::

--- a/apps/docs/docs/js/api/marks/image.md
+++ b/apps/docs/docs/js/api/marks/image.md
@@ -1,0 +1,67 @@
+# image
+
+Draws a raster or SVG image for each data item. Use it for logos, icons, photo
+glyphs, or any artwork you want to place and size like a native mark.
+
+::: gofish
+
+```js
+gf.Chart([{ label: "badge" }])
+  .mark(
+    gf.image({
+      href: "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='96' height='64'%3E%3Crect width='96' height='64' rx='8' fill='%234e79a7'/%3E%3Ccircle cx='48' cy='32' r='18' fill='white'/%3E%3C/svg%3E",
+      w: 96,
+      h: 64,
+    })
+  )
+  .render(root, { w: 150, h: 120 });
+```
+
+:::
+
+## Signature
+
+```ts
+image({ href, w?, h?, x?, y?, opacity?, filter?, preserveAspectRatio?, name? })
+```
+
+## Parameters
+
+| Option                | Type               | Description                                                    |
+| --------------------- | ------------------ | -------------------------------------------------------------- |
+| `href`                | `string`           | Image source — a URL, asset import, or `data:` URI (required)  |
+| `w`                   | `number \| string` | Width — number for fixed pixels, field name to encode data     |
+| `h`                   | `number \| string` | Height — number for fixed pixels, field name to encode data    |
+| `x`, `y`              | `number \| string` | Explicit position accessors                                    |
+| `opacity`             | `number`           | Opacity, `0`–`1`                                               |
+| `filter`              | `string`           | SVG filter reference applied to the image                      |
+| `preserveAspectRatio` | `string`           | SVG `preserveAspectRatio` value (default `"xMidYMid meet"`)    |
+| `name`                | `string`           | Layer name for use with [`selectAll()`](/js/api/selection/ref) |
+
+## Sizing
+
+`href` is required. Width and height are resolved from the image's intrinsic
+dimensions when not given:
+
+- **`w` and `h`** — the image is drawn at exactly that size.
+- **`w` only** (or **`h` only**) — the missing dimension is derived from the
+  image's intrinsic aspect ratio, so the image scales proportionally.
+- **neither** — the image renders at its intrinsic pixel dimensions. GoFish
+  reads these by probing the loaded image (or parsing an SVG `data:` URI), so the
+  mark waits for the source to load before it produces a node.
+
+## Examples
+
+```ts
+// Fixed size
+.mark(image({ href: bottlePng, w: 193, h: 600 }))
+
+// Scale to a width, keep the aspect ratio
+.mark(image({ href: bottleJpg, w: 90 }))
+
+// Intrinsic size from a data URI
+.mark(image({ href: inlineBadgeSvg }))
+
+// Named for use with selectAll()
+.mark(image({ href: logoPng, w: 48 }).name("logos"))
+```

--- a/apps/docs/docs/js/api/marks/text.md
+++ b/apps/docs/docs/js/api/marks/text.md
@@ -1,0 +1,64 @@
+# text
+
+Draws a text label for each data item. Used for value labels on bars, point
+annotations, node names in diagrams, and axis titles.
+
+::: gofish
+
+```js
+gf.Chart([{ label: "GoFish" }])
+  .mark(gf.text({ text: "label", fontSize: 28, fill: "steelblue" }))
+  .render(root, { w: 240, h: 80 });
+```
+
+:::
+
+## Signature
+
+```ts
+text({ text, fill = "black", stroke?, strokeWidth = 0, fontSize = 12,
+       fontFamily = "system-ui, sans-serif", rotate = 0,
+       debugBoundingBox = false, x?, y?, w?, h? })
+```
+
+## Parameters
+
+| Option             | Type               | Description                                                                  |
+| ------------------ | ------------------ | ---------------------------------------------------------------------------- |
+| `text`             | `string \| number` | The string to render — a constant or a field name to read from data          |
+| `fill`             | `string`           | Fill color or field name for color encoding (default `"black"`)              |
+| `stroke`           | `string`           | Stroke color                                                                 |
+| `strokeWidth`      | `number`           | Stroke width (default `0`)                                                   |
+| `fontSize`         | `number`           | Font size in pixels (default `12`)                                           |
+| `fontFamily`       | `string`           | Font family (default `"system-ui, sans-serif"`)                              |
+| `rotate`           | `number`           | Rotation in degrees about the anchor; `90` reads bottom-to-top for a y-title |
+| `debugBoundingBox` | `boolean`          | Draw the text's bounding box (for layout debugging)                          |
+| `x`, `y`, `w`, `h` | `number \| string` | Explicit position / size accessors                                           |
+
+## Examples
+
+```ts
+// Static label
+.mark(text({ text: "Hello", fontSize: 24, fill: "steelblue" }))
+
+// Text content read from a data field
+.mark(text({ text: "name" }))
+
+// Value labels: layer text totals on top of bars
+layer([
+  Chart(seafood)
+    .flow(spread({ by: "lake", dir: "x" }))
+    .mark(rect({ h: "count" }).name("bars")),
+  Chart(selectAll("bars"))
+    .flow(group({ by: "datum.lake" }))
+    .mark((d) =>
+      spread({ dir: "y", alignment: "middle", spacing: 10 }, [
+        d[0],
+        text({ text: String(sumBy(d[0].datum, "count")) }),
+      ])
+    ),
+]);
+
+// Rotated y-axis title (reads bottom-to-top)
+.mark(text({ text: "count", rotate: 90, fontSize: 13 }))
+```

--- a/apps/docs/docs/js/api/operators/arrow.md
+++ b/apps/docs/docs/js/api/operators/arrow.md
@@ -1,0 +1,103 @@
+# arrow
+
+Draws a curved, arrowheaded connector from the first child to the second.
+Like [`connect`](/js/api/operators/connect), `arrow` links elements that have
+already been placed by another layer or constraint — but it renders a directed,
+gently bowed arrow (powered by
+[perfect-arrows](https://github.com/steveruizok/perfect-arrows)) instead of a
+plain line. Reach for it in diagrams: callouts, pointer/heap edges, and labeled
+annotations.
+
+::: gofish
+
+```js
+gf.Layer([
+  gf
+    .Layer([
+      gf.rect({ w: 70, h: 40, fill: gf.color.blue[2] }).name("a"),
+      gf.rect({ w: 70, h: 40, fill: gf.color.red[2] }).name("b"),
+    ])
+    .constrain(({ a, b }) => [
+      gf.Constraint.distribute({ dir: "x", spacing: 120 }, [a, b]),
+      gf.Constraint.align({ y: "middle" }, [a, b]),
+    ]),
+  gf.Arrow({ stroke: "#333", strokeWidth: 3 }, [gf.ref("a"), gf.ref("b")]),
+]).render(root, { w: 320, h: 100 });
+```
+
+:::
+
+## Signature
+
+```ts
+arrow({
+  // visual
+  stroke?, strokeWidth?, start?,
+  // curve shape (perfect-arrows)
+  bow?, stretch?, stretchMin?, stretchMax?,
+  padStart?, padEnd?, flip?, straights?,
+}, [from, to])
+```
+
+`Arrow` is the v2 alias for the same factory. The children are usually two
+[`ref(...)`](/js/api/selection/ref) calls (or datum-level sub-refs) pointing at
+named elements placed by an earlier tier: the arrow runs **from the first child
+to the second**. Fewer than two children renders nothing.
+
+## Visual props
+
+| Option        | Type      | Default   | Description                                                                        |
+| ------------- | --------- | --------- | ---------------------------------------------------------------------------------- |
+| `stroke`      | `string`  | `"black"` | Color of the arrow's line and head (and start dot, if shown)                       |
+| `strokeWidth` | `number`  | `3`       | Line width; also scales the arrowhead and the start dot                            |
+| `start`       | `boolean` | `false`   | Draw a filled dot at the start (source) point — useful for pointer/reference edges |
+
+## Curve shape
+
+The arrow's path is a quadratic bezier whose bow and routing come straight from
+[perfect-arrows](https://github.com/steveruizok/perfect-arrows)'
+`getBoxToBoxArrow`. These options are passed through unchanged:
+
+| Option       | Type      | Default | Description                                                                                           |
+| ------------ | --------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `bow`        | `number`  | `0.2`   | Baseline curvature. `0` is a straight line; higher values bow the arc further from center.            |
+| `stretch`    | `number`  | `0.5`   | How much the bow grows as the endpoints get closer (and shrinks as they get farther apart).           |
+| `stretchMin` | `number`  | `40`    | Distance (px) below which `stretch` has its full effect.                                              |
+| `stretchMax` | `number`  | `420`   | Distance (px) above which `stretch` has no effect.                                                    |
+| `padStart`   | `number`  | `5`     | Gap (px) between the source box and the start of the line.                                            |
+| `padEnd`     | `number`  | `20`    | Gap (px) between the end of the line and the target box — leave room for the arrowhead.               |
+| `flip`       | `boolean` | `false` | Flip which side the arrow bows toward.                                                                |
+| `straights`  | `boolean` | `true`  | Allow perfectly straight lines when the endpoints are axis-aligned (instead of forcing a slight bow). |
+
+## Examples
+
+```ts
+// Labeled callout: a text label pointing at a named shape (gently bowed default)
+Arrow({}, [ref("label"), ref("Mercury")]);
+
+// Pointer edge: straight, with a dot at the source (e.g. a heap/stack reference)
+Arrow({ bow: 0, stretch: 0, padStart: 0, stroke: "#1A5683", start: true }, [
+  ref("stackSlot"),
+  ref("heapCell"),
+]);
+
+// Datum-level endpoints: arrow into a specific selected sub-element
+Arrow({ bow: 0, padEnd: 25, padStart: 0, stroke: "#1A5683", start: true }, [
+  ref("heap").path(0, 1).val,
+  ref("heap").path(0, 2).elmTuples[0],
+]);
+```
+
+## Notes
+
+- The arrow's bbox is the union of the resolved endpoints' boxes — like
+  `connect`, it does not contribute its own space.
+- `ref(name)` resolves names declared via `.name(...)`. With `createName()`
+  tokens, the name is global; with plain strings, it is layer-scoped.
+- Use [`connect`](/js/api/operators/connect) instead when you want an
+  _undirected_ line (or a multi-stop polyline) with explicit bbox-anchor
+  control; use `arrow` when you want a _directed_ arrowhead and automatic curved
+  routing.
+- Pair the operator with z-order constraints
+  ([`Constraint.zAbove` / `zBelow`](/js/api/constraints/constrain#constraint-zabove-constraint-zbelow))
+  when an arrow needs to sit between two elements in paint order.

--- a/apps/docs/docs/python/api/constraints/constrain.md
+++ b/apps/docs/docs/python/api/constraints/constrain.md
@@ -50,11 +50,34 @@ the fallback is the **axis origin**: the scale's zero (`posScale(0)`) on a
 scaled axis, the layer's origin on a pixel-pure one. On a pixel-pure axis,
 `align([content], y="baseline")` thus means "stay where you were laid out" —
 regardless of how far its box overhangs the origin (a bar dipping below zero,
-axis labels hanging under a chart). Pass a single value to share one anchor across every ref; pass a list
+axis labels hanging under a chart). For an unconditional origin pin regardless
+of axis, use `Constraint.position([ref], x=0, y=0, anchor="baseline")` instead.
+Pass a single value to share one anchor across every ref; pass a list
 to assign one anchor _per ref_ positionally (the list length must equal the
 number of refs) — e.g. `x=["middle", "start"]` aligns the first ref's center
 to the second ref's start. The first already-placed ref acts as the anchor;
-unplaced refs move to match it.
+unplaced refs move to match it. When both `x` and `y` are given, `x` is
+resolved before `y`.
+
+When no ref is placed yet, the fallback depends on the axis's underlying space:
+a scaled axis uses the scale origin `posScale(0)`, a pixel-pure axis uses the
+layer's own edge (`start` = 0, `middle` = midpoint, `end` = full extent,
+`baseline` = layer origin).
+
+### Per-ref anchors
+
+The list form of `x` / `y` expresses "edges share" relations directly — the
+per-ref generalization of the single-anchor form, instead of going through a
+`distribute` with a negative `spacing`:
+
+```python
+# "A's center aligns with B's start" — shared-edge layouts where two refs
+# overlap by a known fraction of their bbox.
+Constraint.align([a, b], x=["middle", "start"])
+
+# "B's end touches C's start" — adjacent placement.
+Constraint.align([b, c], x=["end", "start"])
+```
 
 ## Constraint.distribute
 
@@ -187,7 +210,66 @@ Constraint.z_below(a, b)  # a paints behind b (under in z)
 
 `z_below(a, b)` is equivalent to `z_above(b, a)`; both are provided so the spec
 reads naturally either way. When a `layer` carries any z-order constraint, the
-render flattens the subtree and topologically sorts it; a cycle raises an error.
+render flattens the (non-component) subtree into a single paint list and
+**topologically sorts** it. Within the order the constraints don't pin, the
+existing default order is preserved (`.z_order(n)` hints first, then declaration
+order); a cycle (`z_above(a, b)` + `z_above(b, a)`) raises an error at render
+time.
+
+```python
+layer([
+    rect(w=80, h=40, fill="lightgray").name("bg"),
+    rect(w=60, h=60, fill="steelblue").name("box"),
+    text(text="label", fontSize=14).name("label"),
+]).constrain(
+    lambda bg, box, label: [
+        # box paints over bg; label paints over both.
+        Constraint.z_above(box, bg),
+        Constraint.z_above(label, box),
+    ]
+)
+```
+
+### Cross-tier references
+
+Z-order refs can reach into the layer's _direct_ children and into any
+**plain (non-component) nested `layer`** below — the same descent rule `ref()`
+uses inside `mark` composites. This makes patterns like "rope on the outer
+layer slots in z between two pulleys in the inner layer" expressible without
+restructuring the AST.
+
+### When to use this vs `.z_order(n)`
+
+- Use `.z_order(n)` when you want a _global tier_ (e.g. "all ropes go behind
+  all wheels").
+- Use `Constraint.z_above` / `z_below` when you want a _relational_ exception
+  (e.g. "this specific rope sits between these two specific wheels").
+
+The two compose: `.z_order(n)` sets the default order; z-order constraints
+override it for the pairs they name.
+
+## spread equivalences
+
+Constraints are the primitive `spread` and `stack` are built on — literally:
+the operators delegate their space resolution, budget slicing, and placement
+walks to the same machinery the constraint path uses. These pairs are
+equivalent, **including** scale solving and auto-fit, not just placement:
+
+| spread                                                | Constraint equivalent                                |
+| ----------------------------------------------------- | ---------------------------------------------------- |
+| `spread(items, dir="y", alignment="start")`           | `align(x="start")` + `distribute(dir="y")`           |
+| `spread(items, dir="x", alignment="end", spacing=10)` | `align(y="end")` + `distribute(dir="x", spacing=10)` |
+| `spread(items, dir="x", spacing=60, mode="center")`   | `distribute(dir="x", spacing=60, mode="center")`     |
+| `spread(items, dir="y", reverse=True)`                | `distribute(dir="y", order="reverse")`               |
+| `stack(items, dir="y")`                               | `distribute(dir="y", glue=True)`                     |
+| `spread(items, dir="x", stackWeights=[2, 1])`         | `distribute(dir="x", weights=[2, 1])`                |
+
+When **no ref is pre-placed**, the cross-axis alignment fallback depends on the
+**axis**, not the API — `spread` and the `align` constraint resolve the same
+fallback, so the pairs above are exact. A scaled (POSITION) axis falls back to
+the scale origin `posScale(0)` (so SIZE-derived bars hang from the zero line); a
+pixel-pure axis falls back to the layer-box edge (`start` → 0, `middle` →
+midpoint, `end` → full extent).
 
 ## Partial placement
 

--- a/apps/docs/docs/python/api/coords/clock.md
+++ b/apps/docs/docs/python/api/coords/clock.md
@@ -1,0 +1,73 @@
+# clock
+
+A polar coordinate system oriented like a clock face. 0° is at 12 o'clock (top) and angles increase clockwise. Ideal for pie charts, donut charts, and radial visualizations.
+
+::: gofish example:pie-chart hidden
+:::
+
+```python
+from gofish import chart, stack, rect, clock
+
+chart(seafood, coord=clock()) \
+    .flow(stack(by="species", dir="x")) \
+    .mark(rect(w="count", fill="species")) \
+    .render(w=400, h=300)
+```
+
+## Signature
+
+```python
+clock() -> Coord
+```
+
+## Parameters
+
+None. The clock transform has no configuration options.
+
+## Usage
+
+Pass the coordinate transform to [`chart`](/python/api/core/chart) via the
+`coord` keyword:
+
+```python
+chart(data, coord=clock()) \
+    .flow(...) \
+    .mark(...) \
+    .render(w=400, h=300)
+```
+
+`coord` may also be passed as a positional options dict —
+`chart(data, {"coord": clock()})` — but the keyword form above is preferred in
+Python.
+
+## Coordinate Mapping
+
+| Cartesian | Clock                               |
+| --------- | ----------------------------------- |
+| x         | angle (theta), 0° at top, clockwise |
+| y         | radius from center                  |
+
+## Examples
+
+```python
+import math
+
+# Pie chart
+chart(data, coord=clock()) \
+    .flow(stack(by="category", dir="x")) \
+    .mark(rect(w="value", fill="category"))
+
+# Donut chart (with inner radius)
+chart(data, coord=clock()) \
+    .flow(stack(by="category", dir="x", y=50, h=50)) \
+    .mark(rect(w="value", fill="category"))
+
+# Rose chart (radial bar chart)
+chart(data, coord=clock()) \
+    .flow(stack(by="month", dir="x")) \
+    .mark(rect(w=(math.pi * 2) / 12, emX=True, h="value"))
+```
+
+## See Also
+
+- [polar](/python/api/coords/polar) — Standard polar coordinates with 0° at right

--- a/apps/docs/docs/python/api/coords/polar.md
+++ b/apps/docs/docs/python/api/coords/polar.md
@@ -1,0 +1,66 @@
+# polar
+
+Transforms Cartesian coordinates into a polar coordinate system. The x-axis maps to angle (theta) and the y-axis maps to radius.
+
+::: gofish example:polar-ribbon-chart hidden
+:::
+
+```python
+from gofish import chart, stack, rect, polar
+
+chart(seafood, coord=polar()) \
+    .flow(stack(by="species", dir="x")) \
+    .mark(rect(w="count", fill="species")) \
+    .render(w=400, h=300)
+```
+
+## Signature
+
+```python
+polar() -> Coord
+```
+
+## Parameters
+
+None. The polar transform has no configuration options.
+
+## Usage
+
+Pass the coordinate transform to [`chart`](/python/api/core/chart) via the
+`coord` keyword:
+
+```python
+chart(data, coord=polar()) \
+    .flow(...) \
+    .mark(...) \
+    .render(w=400, h=300)
+```
+
+`coord` may also be passed as a positional options dict —
+`chart(data, {"coord": polar()})` — but the keyword form above is preferred in
+Python.
+
+## Coordinate Mapping
+
+| Cartesian | Polar                  |
+| --------- | ---------------------- |
+| x         | angle (theta), 0 to 2π |
+| y         | radius from center     |
+
+## Examples
+
+```python
+# Basic polar chart
+chart(data, coord=polar()) \
+    .flow(stack(by="category", dir="x")) \
+    .mark(rect(w="value"))
+
+# Polar with spread for radial segments
+chart(data, coord=polar()) \
+    .flow(spread(by="month", dir="x")) \
+    .mark(rect(w=1, h="value"))
+```
+
+## See Also
+
+- [clock](/python/api/coords/clock) — Similar to polar but with 0° at 12 o'clock

--- a/apps/docs/docs/python/api/howto/create-chart.md
+++ b/apps/docs/docs/python/api/howto/create-chart.md
@@ -1,0 +1,192 @@
+# How to create a chart
+
+GoFish uses a builder pattern to create charts. You chain four methods together:
+[`chart`](/python/api/core/chart), [`flow`](/python/api/core/flow),
+[`mark`](/python/api/core/mark), and [`render`](/python/api/core/render).
+
+## Basic pattern
+
+```python
+chart(data) \
+    .flow(operators...) \
+    .mark(visual_mark) \
+    .render(w=..., h=...)
+```
+
+Each method has a specific role:
+
+| Method         | Purpose                                   |
+| -------------- | ----------------------------------------- |
+| `chart(data)`  | Creates a builder with your dataset       |
+| `.flow(...)`   | Applies layout operators to position data |
+| `.mark(...)`   | Sets the visual representation            |
+| `.render(...)` | Renders the chart to a widget             |
+
+## Step 1: chart
+
+`chart(data)` creates a `ChartBuilder` with your dataset. The data can be any
+list of dicts (or a pandas `DataFrame`):
+
+```python
+data = [
+    {"category": "A", "value": 30},
+    {"category": "B", "value": 50},
+    {"category": "C", "value": 20},
+]
+
+chart(data)
+```
+
+Chart-level options are passed as **keyword arguments** — including `axes`
+(see [Step 4](#step-4-render)), a color scale, or a coordinate transform such as
+polar coordinates for pie charts:
+
+```python
+chart(data, coord=clock())
+```
+
+## Step 2: flow
+
+`.flow()` accepts one or more **operators** that determine how data is laid out
+spatially. The main operators are:
+
+- [`spread(by=..., dir=...)`](/python/api/operators/spread) — divides space into
+  separate regions for each group
+- [`stack(by=..., dir=...)`](/python/api/operators/stack) — stacks items
+  edge-to-edge along a shared scale
+- [`scatter(by=..., x=..., y=...)`](/python/api/operators/scatter) — positions
+  items by x/y coordinates
+
+```python
+.flow(spread(by="category", dir="x"))
+```
+
+The `dir` option specifies the direction: `"x"` for horizontal, `"y"` for
+vertical.
+
+See [How to pick a layout operator](/python/api/howto/operators) for guidance on
+choosing between them.
+
+## Step 3: mark
+
+`.mark()` specifies how each data item should appear visually. Common marks
+include:
+
+- [`rect()`](/python/api/marks/rect) — rectangles (bars)
+- [`circle()`](/python/api/marks/circle) — circles
+- [`line()`](/python/api/marks/line) — connecting line
+- [`area()`](/python/api/marks/area) — filled area
+
+Mark options can use fixed values or reference data fields:
+
+```python
+.mark(rect(h="value", fill="category"))
+```
+
+Here `h="value"` means the rectangle height comes from each item's `value`
+field, and `fill="category"` maps the fill color to the `category` field.
+
+## Step 4: render
+
+`.render()` renders the chart, returning a widget that auto-displays in a
+notebook:
+
+```python
+.render(w=400, h=300)
+```
+
+Render options:
+
+- `w` — width in pixels
+- `h` — height in pixels
+
+::: tip
+**Axes are a `chart()` option in Python, not a render option** (mirroring the JS
+`Chart(data, { axes: true })`). Pass `axes=...` to `chart(...)`:
+
+```python
+chart(data, axes=True)                      # both axes, titles inferred
+chart(data, axes=False)                     # no axes
+chart(data, axes={"x": True, "y": False})   # x only
+```
+
+Only **size** (`w`/`h`) goes on `.render()`. See
+[`chart`](/python/api/core/chart#axes) for the full `axes` shape.
+:::
+
+## Composing operators
+
+You can pass multiple operators to `.flow()` to create nested layouts. Operators
+apply in order — the first groups and positions the data, then subsequent
+operators work within those groups.
+
+**Example: Stacked bar chart**
+
+To create a stacked bar chart, use `spread` to separate categories horizontally,
+then `stack` to stack items within each category:
+
+::: gofish example:stacked-bar-chart hidden
+:::
+
+```python
+from gofish import chart, spread, stack, rect
+
+chart(seafood, axes=True).flow(
+    spread(by="lake", dir="x"),
+    stack(by="species", dir="y"),
+).mark(rect(h="count", fill="species")).render(w=400, h=300)
+```
+
+The first operator (`spread`) creates separate regions for each lake along the
+x-axis. The second operator (`stack`) stacks the species vertically within each
+region.
+
+## Complete examples
+
+### Basic bar chart
+
+A simple bar chart with one bar per category:
+
+::: gofish example:bar-chart hidden
+:::
+
+```python
+from gofish import chart, spread, rect
+
+chart(seafood, axes=True).flow(spread(by="lake", dir="x")).mark(
+    rect(h="count")
+).render(w=400, h=300)
+```
+
+### Grouped bar chart
+
+To group bars side-by-side instead of stacking, use `spread` for both levels
+(same direction):
+
+::: gofish example:grouped-bar-chart hidden
+:::
+
+```python
+from gofish import chart, spread, rect
+
+chart(seafood, axes=True).flow(
+    spread(by="lake", dir="x"),
+    spread(by="species", dir="x", spacing=0),
+).mark(rect(h="count", fill="species")).render(w=400, h=300)
+```
+
+### Stacked bar chart
+
+To stack bars, use `spread` then `stack` (perpendicular directions):
+
+::: gofish example:stacked-bar-chart hidden
+:::
+
+```python
+from gofish import chart, spread, stack, rect
+
+chart(seafood, axes=True).flow(
+    spread(by="lake", dir="x"),
+    stack(by="species", dir="y"),
+).mark(rect(h="count", fill="species")).render(w=400, h=300)
+```

--- a/apps/docs/docs/python/api/howto/create-glyph.md
+++ b/apps/docs/docs/python/api/howto/create-glyph.md
@@ -1,0 +1,134 @@
+# How to create a glyph
+
+A **glyph** is a composite visual element built from multiple shapes. Instead of
+using a single mark like `rect()` or `circle()`, you can layer shapes together to
+create custom visualizations.
+
+## Basic pattern
+
+Use `layer()` to compose multiple shapes at the same position:
+
+```python
+layer([shape1, shape2, shape3])
+```
+
+All children are placed at position `(0, 0)` relative to the layer. The layer's
+size is computed as the union of all children's bounding boxes.
+
+## Creating a simple glyph
+
+Here's a simple "badge" glyph with a rounded rectangle and a dot:
+
+```python
+from gofish import layer, rect, ellipse
+
+layer([
+    rect(cx=0, cy=0, w=50, h=30, rx=8, fill="steelblue"),
+    ellipse(cx=-15, cy=0, w=10, h=10, fill="white"),
+]).render(w=100, h=100)
+```
+
+The shapes are rendered in order, so later shapes appear on top of earlier ones.
+
+## Making glyphs reusable
+
+Wrap your glyph in a function to make it reusable with different parameters:
+
+```python
+def badge(w=50, h=30, fill="steelblue"):
+    return layer([
+        rect(cx=0, cy=0, w=w, h=h, rx=8, fill=fill),
+        ellipse(cx=-w / 2 + 10, cy=0, w=10, h=10, fill="white"),
+    ])
+```
+
+Now you can create badges of different sizes and colors, laid out with the
+[`spread`](/python/api/operators/spread) combinator (a positional list of marks):
+
+```python
+from gofish import spread
+
+spread([
+    badge(w=40, h=24, fill="steelblue"),
+    badge(w=60, h=36, fill="coral"),
+    badge(w=50, h=30, fill="seagreen"),
+], dir="x", spacing=20).render(w=250, h=100)
+```
+
+For hygienic naming of a glyph's inner nodes (so they don't collide across
+instances), promote the function to a component with the
+[`@mark`](/python/api/howto/naming-and-scoping#scope-roots-with-mark) decorator.
+
+## Using glyphs as chart marks
+
+Build the glyph from shapes whose channels reference data **fields**, then pass
+it to `.mark()`. Each shape's field channel resolves per row, so the glyph is
+drawn once per data item:
+
+```python
+from gofish import chart, scatter, layer, ellipse, rect
+
+def pin():
+    return layer([
+        ellipse(cx=0, cy=-8, w=16, h=16, fill="color"),
+        ellipse(cx=0, cy=-10, w=6, h=6, fill="white"),
+        rect(cx=0, cy=0, w=3, h=10, fill="color"),
+    ])
+
+locations = [
+    {"id": "A", "x": 50, "y": 150, "color": "tomato"},
+    {"id": "B", "x": 150, "y": 80, "color": "steelblue"},
+    {"id": "C", "x": 280, "y": 120, "color": "seagreen"},
+]
+
+chart(locations).flow(scatter(by="id", x="x", y="y")).mark(pin()).render(
+    w=350, h=200
+)
+```
+
+Here `fill="color"` reads each row's `color` field, so every pin picks up its
+own color.
+
+::: tip
+This differs from the JavaScript `.mark((d) => Pin({ fill: d[0].color }))`
+per-datum function form. In Python a `.mark()` callable is the
+**mark-as-function** pattern (it receives a data slice and returns a new
+`ChartBuilder`), so for ordinary glyphs prefer **field channels** like
+`fill="color"` to vary appearance per row.
+:::
+
+## Building complex glyphs
+
+You can combine any shapes: rectangles, ellipses, text, and more. Here's a
+labeled data point glyph that positions its parts with the `spread` combinator:
+
+```python
+from gofish import chart, scatter, spread, ellipse, text
+
+def data_point():
+    return spread([
+        ellipse(cx=0, cy=0, w=12, h=12, fill="steelblue"),
+        text(text="value", fontSize=10),
+    ], dir="y", spacing=4, alignment="middle")
+
+points = [
+    {"id": 1, "x": 50, "y": 40, "value": 42},
+    {"id": 2, "x": 150, "y": 120, "value": 87},
+    {"id": 3, "x": 250, "y": 80, "value": 63},
+]
+
+chart(points).flow(scatter(by="id", x="x", y="y")).mark(data_point()).render(
+    w=350, h=200
+)
+```
+
+Passing `text="value"` makes the text read each row's `value` field.
+
+## Summary
+
+| Task              | Approach                                   |
+| ----------------- | ------------------------------------------ |
+| Compose shapes    | `layer([shape1, shape2, ...])`             |
+| Make reusable     | Wrap in a function with parameters         |
+| Use in chart      | Pass the glyph to `.mark()`, encode fields |
+| Position elements | Use the `spread([...])` combinator         |

--- a/apps/docs/docs/python/api/howto/naming-and-scoping.md
+++ b/apps/docs/docs/python/api/howto/naming-and-scoping.md
@@ -1,0 +1,165 @@
+# How to name and scope
+
+When you build composable components — a `stack_slot` that itself contains a
+`box` and a `value` text; a `heap_object` that contains many `elm_tuple`s — the
+names you give to inner nodes have to _not_ collide across instances. GoFish has
+two complementary mechanisms for this:
+
+1. **Strings** are **layer-local**. Use them for constraint callbacks.
+2. **`createName(tag)`** tokens are **externally addressable**. Use them for
+   cross-component references.
+
+## Strings: layer-local names
+
+`.name("x")` on a child of a [`layer`](/python/api/constraints/constrain) makes
+`x` available inside that layer's `.constrain()` callback. Strings never cross
+component boundaries, never register globally, and never show up as path
+segments.
+
+```python
+from gofish import layer, rect, text, Constraint
+
+layer([
+    rect(w=200, h=150, fill="#eee").name("bg"),
+    text(text="Title").name("label"),
+]).constrain(lambda bg, label: [
+    Constraint.align([label, bg], x="middle", y="end"),
+])
+```
+
+This is the workhorse mechanism. Reach for strings first; strings are simpler and
+enforce composition by default.
+
+## createName
+
+```python
+from gofish import createName
+
+my_name = createName("tag")
+```
+
+`createName(tag)` returns a `Token` — a unique value carrying a string tag. Each
+call produces a fresh token; two `createName("value")` calls from two component
+instances are _different_ tokens even though they share the tag. That's what
+makes this hygienic.
+
+When you attach a token to a node with `.name(token)`:
+
+- The node registers **globally** in the token context, so `ref(token)` looks it
+  up from anywhere.
+- The node registers in the **nearest enclosing scope root**'s scope map under
+  the token's tag, so a path like `ref(parent_token).tag` can find it.
+- The tag still works as a constraint-callback key inside the enclosing layer.
+
+```python
+from gofish import layer, rect, text, createName, Constraint
+
+value_name = createName("value")
+
+layer([
+    rect(w=40, h=40).name("box"),
+    text(text="5").name(value_name),
+]).constrain(lambda box, value: [
+    Constraint.align([box, value], x="middle", y="middle"),
+])
+```
+
+## Scope roots with @mark {#scope-roots-with-mark}
+
+A _scope root_ is a node whose tagged descendants form a named scope. Every
+component built with the `@mark` decorator is automatically a scope root — `@mark`
+flags its output as a scope boundary. Built-in marks (`rect`, `text`, …) are
+leaves so the scope is inert there; user-defined component-style marks (a
+`(**props) -> Mark` function) get hygienic naming for free:
+
+```python
+from gofish import mark, layer, spread, rect, text, createName, Constraint
+
+@mark
+def stack_slot(variable, value):
+    box_tag = createName("box")
+    value_tag = createName("value")
+    return spread([
+        text(text=variable).name("variable"),
+        layer([
+            rect(w=40, h=40).name(box_tag),
+            text(text=value).name(value_tag),
+        ]).constrain(lambda box, value: [
+            Constraint.align([box, value], x="middle", y="middle"),
+        ]),
+    ], dir="x", spacing=5)
+```
+
+- The component's output (the `spread` here) is the scope root.
+- `value_tag` and `box_tag` are Tokens: they register in `stack_slot`'s scope
+  under tags `"value"` and `"box"`.
+- `"variable"` (the left-side text) is a plain string: layer-local only, not
+  path-addressable from outside.
+
+The decorator is imported as `mark` (`from gofish import mark`) and applied as
+`@mark`; it is the Python mirror of JS `createMark`.
+
+## Paths
+
+Arrows and cross-component refs use **paths** to descend through scopes.
+`ref(token)` returns a chainable proxy:
+
+```python
+ref(parent_token).tag1[i].tag2
+```
+
+- The token is the root (global lookup).
+- Attribute access (`.tag1`) walks the current scope map by tag.
+- Index access (`[i]`) picks the positional child.
+- For variadic dynamic segments, use `.path(...)`:
+  `ref(token).path(*segs).next`.
+
+Because scopes are per-instance, you can have many `stack_slot`s with inner tag
+`"value"` and there's no ambiguity — the path always names the specific instance
+before descending.
+
+### Example: arrows between composed components
+
+```python
+from gofish import layer, spread, arrow, ref, createName
+
+global_frame_name = createName("global_frame")
+heap_name = createName("heap")
+
+layer([
+    spread([
+        global_frame(stack=stack).name(global_frame_name),
+        heap(heap=heap, heap_arrangement=heap_arrangement).name(heap_name),
+    ], dir="x", spacing=100),
+    arrow([
+        # "value" text of the 0th stack slot inside global_frame's "variables"
+        ref(global_frame_name).variables[0].value,
+        # "elm-0" of the heap cell at row 0, col 0
+        ref(heap_name)[0][0].elm_tuples[0],
+    ], stroke="#1A5683"),
+])
+```
+
+## Decision table
+
+| I want to…                                                   | Use                                                    |
+| ------------------------------------------------------------ | ------------------------------------------------------ |
+| Reference a sibling by name in a layer's `.constrain()`      | `.name("x")` string                                    |
+| Make an inner node reachable from outside the component      | `createName("tag")` + `.name(token)`                   |
+| Give a component instance a global handle the caller can use | Caller calls `createName("foo")`, then `.name(handle)` |
+| Reach deep into another component                            | Path: `ref(token).tag[i]...`                           |
+| Avoid dynamic string suffixes like `f"item-{i}"`             | Use integer positional indices in the path             |
+
+## Gotchas
+
+- **Strings are not path-addressable.** If you want a name to appear in a
+  `ref(token)....` path, use `createName`.
+- **Scopes are per-node, not per-file.** Every `@mark` invocation produces a
+  fresh scope at runtime, so each component instance has its own.
+- **The first path segment must be a Token.** Paths don't start from strings
+  because strings have no global identity.
+- **Reserved names.** A handful of attribute names (`name`, `label`, `render`,
+  `to_dict`, `to_ir`, `constrain`, `multiplicity`, and any leading-underscore
+  name) pass through to the underlying ref proxy instead of becoming path
+  segments. Use `ref(token).path("name")` to reach a child whose tag collides
+  with one of these.

--- a/apps/docs/docs/python/api/howto/operators.md
+++ b/apps/docs/docs/python/api/howto/operators.md
@@ -1,0 +1,142 @@
+# How to pick a layout operator
+
+GoFish provides three layout operators for positioning marks:
+[**spread**](/python/api/operators/spread),
+[**stack**](/python/api/operators/stack), and
+[**scatter**](/python/api/operators/scatter). Each serves a different purpose.
+
+## Quick reference
+
+| Operator  | Use when...                                            | Typical charts                                 |
+| --------- | ------------------------------------------------------ | ---------------------------------------------- |
+| `spread`  | Items are independent and need their own regions       | Grouped bars, faceted layouts, small multiples |
+| `stack`   | Items are parts of a whole, sharing a continuous scale | Stacked bars, stacked areas, streamgraphs      |
+| `scatter` | Marks need x/y coordinate positioning                  | Scatterplots, bubble charts                    |
+
+## Decision guide
+
+```
+Do you need to position marks at specific x/y coordinates?
+  └─ Yes → scatter
+  └─ No  → Are items parts of a whole (additive)?
+             └─ Yes → stack
+             └─ No  → spread
+```
+
+## spread vs stack: the key difference
+
+Both operators divide space along an axis, but they treat that space
+differently. Consider this data for a single stacked bar with three segments:
+
+```python
+segments = [
+    {"category": "A", "value": 30},
+    {"category": "B", "value": 50},
+    {"category": "C", "value": 20},
+]
+```
+
+**Wrong: Using spread** — each segment gets its own independent region:
+
+```python
+from gofish import chart, spread, rect
+
+chart(segments, axes=True).flow(
+    spread(by="category", dir="y", spacing=1)
+).mark(rect(h="value", fill="category")).render(w=100, h=200)
+```
+
+This is **not** a stacked bar. The three rectangles are placed in separate
+slots — each has its own scale. A value of 30 in slot A doesn't relate to a value
+of 50 in slot B; they're just arranged vertically like small multiples.
+
+**Correct: Using stack** — segments share a continuous scale:
+
+```python
+from gofish import chart, stack, rect
+
+chart(segments, axes=True).flow(
+    stack(by="category", dir="y")
+).mark(rect(h="value", fill="category")).render(w=100, h=200)
+```
+
+Now the rectangles stack on top of each other: A starts at 0, B starts at 30, C
+starts at 80. The total height represents the sum (100). This is the correct way
+to show part-to-whole relationships.
+
+## spread
+
+Divides space into separate regions for each group, with optional gaps between
+them.
+
+```python
+.flow(spread(by="category", dir="x", spacing=8))
+```
+
+Use `spread` when groups are independent and shouldn't share a scale. The
+`spacing` parameter controls the gap size (default is 8).
+
+**Example: Grouped bar chart**
+
+```python
+chart(data).flow(
+    spread(by="category", dir="x", spacing=24),
+    spread(by="group", dir="x", spacing=0),
+).mark(rect(h="value", fill="group"))
+```
+
+## stack
+
+Arranges items along a continuous shared scale, with each item starting where
+the previous one ended.
+
+```python
+.flow(stack(by="weather", dir="y"))
+```
+
+Use `stack` when building part-to-whole visualizations where values should add
+up.
+
+**Example: Stacked bar chart**
+
+```python
+chart(data).flow(
+    spread(by="month", dir="x"),
+    stack(by="category", dir="y"),
+).mark(rect(fill="category"))
+```
+
+## scatter
+
+Groups data by a field and positions each group at the mean x/y coordinates of
+its members.
+
+```python
+.flow(scatter(by="species", x="bill_length", y="flipper_length"))
+```
+
+Use `scatter` when your data has numeric x and y fields and you want marks
+positioned by those values.
+
+**Example: Scatterplot**
+
+```python
+chart(penguins).flow(
+    scatter(by="species", x="bill_length", y="flipper_length")
+).mark(circle(r=4, fill="species"))
+```
+
+## Combining operators
+
+You can chain multiple operators in `.flow()` to create nested layouts:
+
+```python
+# First spread by category (with gaps), then stack within each category
+.flow(
+    spread(by="category", dir="x", spacing=16),
+    stack(by="subcategory", dir="y"),
+)
+```
+
+The operators apply in order: the first groups and lays out the data, then
+subsequent operators work within those groups.

--- a/apps/docs/docs/python/api/howto/selection.md
+++ b/apps/docs/docs/python/api/howto/selection.md
@@ -1,0 +1,155 @@
+# How to use selection
+
+Selection lets you connect marks across charts — for example, drawing a line
+through scatterplot points or filling the area between stacked bars. It works in
+two steps:
+
+1. **Name a mark** using `.name("layerName")` to register its nodes
+2. **Reference those nodes** using `selectAll("layerName")` (an array of
+   [`ref`](/python/api/selection/ref)s) or `ref("layerName")` (a single ref) as
+   data for another chart
+
+`selectAll` is the `querySelectorAll` of GoFish — one ref per named node, never
+flattened. `ref(name)` as data is the singular `querySelector`: it returns one
+ref and raises if the layer matched zero or more than one node.
+
+## Basic pattern
+
+```python
+Layer([
+    # Chart 1: create marks and name them
+    chart(data)
+        .flow(spread(by="category", dir="x"))
+        .mark(rect(h="value").name("bars")),
+
+    # Chart 2: selectAll those marks as data for a connector
+    chart(selectAll("bars")).mark(line()),
+])
+```
+
+The `Layer` function renders both charts in the same coordinate space, allowing
+the second chart to overlay the first.
+
+::: tip
+For the common case of threading a connector through a chart's **own** marks,
+[`.connect()`](/python/api/core/connect) is shorter sugar for this two-layer
+recipe. Reach for the explicit `Layer([...])` + `selectAll` form when connecting
+a _different_ chart's marks or when you need a custom paint order.
+:::
+
+## Example: Connected scatterplot
+
+[`line`](/python/api/marks/line) and [`area`](/python/api/marks/area) take an
+array of refs directly and read placed geometry off them, so feed them
+`selectAll`:
+
+::: gofish example:connected-scatter-plot hidden
+:::
+
+```python
+from gofish import Layer, chart, scatter, circle, line, selectAll
+
+Layer([
+    chart(driving_shifts)
+        .flow(scatter(by="year", x="miles", y="gas"))
+        .mark(circle(r=4, fill="white", stroke="black", strokeWidth=2).name("points")),
+    chart(selectAll("points")).mark(line(stroke="black", strokeWidth=2)),
+]).render(w=400, h=250, axes=True)
+```
+
+The `line` mark connects all selected points in order.
+
+## Example: Invisible blank with line
+
+Sometimes you want a connecting line without visible points. Use
+[`blank()`](/python/api/marks/blank) to create invisible anchor points:
+
+::: gofish example:line-chart hidden
+:::
+
+```python
+from gofish import Layer, chart, scatter, blank, line, selectAll
+
+Layer([
+    chart(catch_locations)
+        .flow(scatter(by="lake", x="x", y="y"))
+        .mark(blank().name("points")),
+    chart(selectAll("points")).mark(line(stroke="steelblue", strokeWidth=2)),
+]).render(w=400, h=250, axes=True)
+```
+
+## Example: Re-encoding a selection by its data
+
+Connectors often need to re-partition the selected nodes — a ribbon/stream chart
+draws one area **per species** through bars that were laid out **per lake**.
+Because the selected stream is now refs (not raw records), you re-encode by the
+**datum path**: `group(by="datum.species")` rather than `group(by="species")`.
+
+::: gofish example:highlighted-ribbon-chart hidden
+:::
+
+```python
+from gofish import Layer, chart, spread, stack, derive, group, rect, area, selectAll
+
+Layer([
+    chart(seafood)
+        .flow(
+            spread(by="lake", dir="x", spacing=64),
+            derive(lambda d: sorted(d, key=lambda r: r["count"], reverse=True)),
+            stack(by="species", dir="y", label=False),
+        )
+        .mark(rect(h="count", fill="species").name("bars")),
+    chart(selectAll("bars"))
+        .flow(group(by="datum.species"))
+        .mark(area(opacity=0.8)),
+]).render(w=500, h=300, axes=True)
+```
+
+Here each bar is a single species row, so `datum.species` collapses cleanly to
+one value. A `datum.field` path resolves only when every row in the ref's bag
+agrees on that field (homogeneity collapse); if it is multi-valued the path is
+`None` and you must disaggregate first. `by` also accepts a callable escape
+hatch: `group(by=lambda r: r.datum.species)`. Note the asymmetry: `by` reads the
+**selection stream** (refs, so `datum.` paths), while a mark's channel like
+`rect(h="count")` reads the **raw record** and is _not_ path-prefixed. See
+[path-aware `by`](/python/api/operators/spread#path-aware-by).
+
+## Example: A single-node reference
+
+When a layer holds exactly one node, `ref(name)` as **chart data** returns that
+one ref — handy for diagrammatic annotations. It raises if the layer matched
+more than one node, which catches mistakes early:
+
+```python
+from gofish import Layer, chart, scatter, blank, text, ref, selectAll
+
+Layer([
+    chart(data).flow(scatter(by="id", x="x", y="y")).mark(blank().name("origin")),
+    # ref("origin") returns one ref; errors if "origin" matched 0 or >1 nodes
+    chart(ref("origin")).mark(text(text="start")),
+])
+```
+
+## How it works
+
+When you call `.name("layerName")` on a mark, each node it produces is registered
+in a shared layer context during rendering. `selectAll("layerName")` returns a
+lazy selector that resolves, when the second chart renders, to one
+[`ref`](/python/api/selection/ref) per registered node; `ref("layerName")` as
+data resolves to the single ref (erroring otherwise).
+
+Each ref:
+
+- Points at the placed node, so overlay marks position themselves relative to it
+- Exposes the bound datum via `ref.datum` — the raw bag of rows behind the node
+  (a 1-row list if fully split, all the partition's rows if it is an auto-summed
+  aggregate)
+
+## Common use cases
+
+| Goal                | Pattern                                                                              |
+| ------------------- | ------------------------------------------------------------------------------------ |
+| Line through points | `circle().name("points")` → `selectAll("points")` + `line()`                         |
+| Area under line     | `blank().name("points")` → `selectAll("points")` + `area()`                          |
+| Ribbon / stream     | `rect().name("bars")` → `selectAll("bars")` + `group(by="datum.species")` + `area()` |
+| Single annotation   | Name one mark → `chart(ref("name"))` borrows that one node                           |

--- a/apps/docs/docs/python/api/marks/image.md
+++ b/apps/docs/docs/python/api/marks/image.md
@@ -1,0 +1,54 @@
+# image
+
+Draws a raster or SVG image for each data item. Use it for logos, icons, photo
+glyphs, or any artwork you want to place and size like a native mark.
+
+```python
+from gofish import chart, image
+
+chart([{"label": "badge"}]).mark(
+    image(href="https://example.com/badge.svg", w=96, h=64)
+).render(w=150, h=120)
+```
+
+## Signature
+
+```python
+image(href=None, w=None, h=None, x=None, y=None, debug=None) -> Mark
+```
+
+## Parameters
+
+| Parameter | Type           | Description                                                  |
+| --------- | -------------- | ------------------------------------------------------------ |
+| `href`    | `str`          | Image source — a URL or `data:` URI (required)               |
+| `w`       | `int` \| `str` | Width — a constant in pixels or a field name to encode data  |
+| `h`       | `int` \| `str` | Height — a constant in pixels or a field name to encode data |
+| `x`, `y`  | `int` \| `str` | Explicit position accessors                                  |
+| `debug`   | `bool`         | Log debug info to the console                                |
+
+Returns a `Mark` for use in [`.mark()`](/python/api/core/mark).
+
+## Sizing
+
+`href` is required. Width and height are resolved from the image's intrinsic
+dimensions when not given:
+
+- **`w` and `h`** — the image is drawn at exactly that size.
+- **`w` only** (or **`h` only**) — the missing dimension is derived from the
+  image's intrinsic aspect ratio, so the image scales proportionally.
+- **neither** — the image renders at its intrinsic pixel dimensions. GoFish
+  reads these by probing the loaded image (or parsing an SVG `data:` URI).
+
+## Examples
+
+```python
+# Fixed size
+chart(data).mark(image(href=bottle_png, w=193, h=600))
+
+# Scale to a width, keep the aspect ratio
+chart(data).mark(image(href=bottle_jpg, w=90))
+
+# Intrinsic size from a data URI
+chart(data).mark(image(href=inline_badge_svg))
+```

--- a/apps/docs/docs/python/api/marks/polygon.md
+++ b/apps/docs/docs/python/api/marks/polygon.md
@@ -1,0 +1,97 @@
+# polygon
+
+Draws a closed polygon from explicit local-coordinate points. Useful for
+non-rectangular glyphs (trapezoids, arrows, custom shapes) that can't be
+expressed by the standard shape primitives.
+
+```python
+from gofish import chart, polygon
+
+chart([{}]).mark(
+    polygon(
+        points=[
+            [0, 0],
+            [60, 0],
+            [50, 40],
+            [10, 40],
+        ],
+        fill="steelblue",
+    )
+).render(w=100, h=60)
+```
+
+## Signature
+
+```python
+polygon(points, fill=None, stroke=None, strokeWidth=None) -> Mark
+```
+
+## Parameters
+
+| Parameter     | Type                | Default   | Description                                                                |
+| ------------- | ------------------- | --------- | -------------------------------------------------------------------------- |
+| `points`      | `list[list[float]]` | —         | Vertices in local coordinates. GoFish is y-up: `[0, 0]` is the bottom-left |
+| `fill`        | `str`               | `"black"` | Fill color                                                                 |
+| `stroke`      | `str`               | `fill`    | Stroke color (defaults to `fill`)                                          |
+| `strokeWidth` | `int`               | `0`       | Stroke width                                                               |
+
+Returns a `Mark` for use in [`.mark()`](/python/api/core/mark). Call
+[`.name()`](/python/api/core/mark) on the result to make it referenceable via
+[`ref`](/python/api/marks/ref) / [`selectAll`](/python/api/selection/ref) or a
+constraint.
+
+## Coordinates
+
+Points are interpreted in the local coordinate system of whatever places the
+polygon — typically a `Layer` or a constraint. The polygon's bounding box is
+the axis-aligned extent of its points; the parent placement system translates
+the whole polygon to position it.
+
+GoFish is y-up internally, so a trapezoid whose wide edge sits at the bottom
+and narrow edge at the top is written:
+
+```python
+polygon(
+    points=[
+        [0, 0],            # bottom-left (the wider edge)
+        [width, 0],        # bottom-right
+        [width - 10, h],   # top-right  (inset)
+        [10, h],           # top-left   (inset)
+    ],
+)
+```
+
+## Examples
+
+```python
+# Trapezoidal weight glyph (from the pulley diagram)
+polygon(
+    points=[
+        [0, 0],
+        [width, 0],
+        [width - 10, height],
+        [10, height],
+    ],
+    fill="#545454",
+).name("body")
+
+# Triangle with stroke
+polygon(
+    points=[
+        [0, 0],
+        [40, 0],
+        [20, 30],
+    ],
+    fill="transparent",
+    stroke="black",
+    strokeWidth=2,
+)
+```
+
+## Notes
+
+- The polygon is always closed — the last point connects back to the first
+  automatically.
+- Points are literals, not channel-bound. If you need a polygon whose shape
+  depends on data, compose multiple polygons or use a derived mark
+  ([`@mark`](/python/api/core/mark)).

--- a/apps/docs/docs/python/api/marks/ref.md
+++ b/apps/docs/docs/python/api/marks/ref.md
@@ -1,0 +1,122 @@
+# ref
+
+References another node so later marks can reuse its position or bounding box — the basis for overlays, connectors, and arrows.
+
+`ref` is the single reference noun, usable in two positions:
+
+- **Inline in a layout** (this page): `arrow([ref("a"), ref("b")])`,
+  `ref(token).row[2]` — resolved at layout time against the name tree.
+- **As chart data**: `chart(ref("maxBar")).mark(text(text="peak"))` — resolved at
+  build time against the named-layer registry, where it must match **exactly one**
+  node (use [`selectAll`](/python/api/selection/ref) for many). See
+  [ref / selectAll](/python/api/selection/ref) for the chart-data role and node-unit
+  selection.
+
+See also [hygienic scoping](/python/api/selection/ref#hygienic-scoping) for when a name is visible and when to reach for a `createName` token.
+
+## Signature
+
+```python
+ref(target: str | Token) -> Ref
+```
+
+`Token` is the hygienic name returned by `createName(tag)`. A `Ref` is chainable:
+`ref(token).foo[i].bar` accumulates a selection path (see [Path](#path) below).
+
+## Forms
+
+### String — layer-local
+
+`ref("x")` walks up the parent chain to the nearest `Layer` and picks the direct child named `.name("x")`. Strings do **not** cross component boundaries.
+
+```python
+from gofish import Layer, rect, ref
+
+Layer([
+    rect(w=80, h=40).name("bg"),
+    ref("bg"),  # resolves to the rect above
+])
+```
+
+### Token — globally addressable
+
+A `Token` (from `createName`) is a unique value. `.name(token)` registers the node in a global token context; `ref(token)` retrieves it.
+
+```python
+from gofish import Layer, rect, ref, createName
+
+target_name = createName("target")
+
+Layer([
+    rect(w=80, h=40).name(target_name),
+    # ...somewhere in a sibling subtree:
+    ref(target_name),
+])
+```
+
+### Path — step through scopes + positional children {#path}
+
+A path starts at a `Token` and descends one step per segment. Tag strings resolve against the current node's scope map (populated by `createName`-tagged children inside a scope root). Numbers pick the positional child at that index.
+
+```python
+# Chained (proxy) — preferred for static paths
+ref(global_frame_name).variables[2].value
+```
+
+The chained form is a proxy that wraps the underlying `Ref`; it stays a ref, so it can go anywhere a ref is expected.
+
+For variadic dynamic segments (e.g. spreading a `[row, col]` tuple into the path), use `.path(*segs)`:
+
+```python
+cell = addr_pos[addr]  # [row, col]
+ref(heap_name).path(*cell).elmTuples[0]
+```
+
+::: info Array form is JavaScript only
+JS also accepts a literal path array — `ref([token, "variables", 2, "value"])`.
+The Python `ref(...)` takes only a string or a `Token`, so build dynamic paths
+with the chained form or the variadic `.path(*segs)` escape hatch shown above.
+:::
+
+**Reserved names.** Children registered with one of the `Ref`'s own attribute names (`name`, `label`, `render`, `constrain`, `to_dict`, `to_ir`, `multiplicity`, …) or any name starting with `_` are not reachable via dotted access — normal Python attribute lookup wins. Use `ref(token).path("name")` for those.
+
+## Parameters
+
+| Parameter | Type           | Description                                                                                                             |
+| --------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `target`  | `str \| Token` | What to reference — a string (layer-local) or a `Token` (global). Extend with `.attr` / `[i]` / `.path(...)` for paths. |
+
+## `ref.datum` {#datum}
+
+A ref exposes the datum bound to the node it points at via its `.datum` path:
+
+```python
+bars = selectAll("bars")  # list of refs
+bars[0].datum             # the raw row-bag behind the first bar
+```
+
+`ref.datum` is the **raw bag of rows** that flowed into the referenced node — a
+**list** of records. A fully-split leaf (one datum per node) is a **1-row
+list**; an aggregate — for example a bar produced by `rect(h="count")` over a
+partition, whose height auto-sums several rows — holds all the rows of its
+partition.
+
+Because it is the raw, un-collapsed bag, you can aggregate over it directly:
+
+```python
+sum(row["count"] for row in bars[0].datum)  # total count across the bar's rows
+```
+
+Operators read this same bag when you re-encode a selection by a datum path,
+e.g. `group(by="datum.species")`, but with **homogeneity collapse** applied: the
+path resolves to a scalar only if every row in the bag agrees on the field — see
+[path-aware `by`](/python/api/operators/spread#path-aware-by). Enumerating
+_every_ distinct value at a path instead is the JS-only `pluck`; see the
+[note on `pluck`](/python/api/selection/ref#path-aware-by-after-a-selection) on
+the selection page.
+
+## Notes
+
+- Refs participate in layout: the referenced node's placement determines the ref's bounding box, and `arrow`, `connect`, etc. use that to draw geometry between nodes.
+- Cross-subtree refs resolve correctly: the ref traverses to the least common ancestor and accumulates coordinate transforms along the way, so you can ref a node inside one component from inside another.
+- Errors name the scope: if a path segment misses, the error lists the tags or indices available at that level.

--- a/apps/docs/docs/python/api/marks/text.md
+++ b/apps/docs/docs/python/api/marks/text.md
@@ -1,0 +1,67 @@
+# text
+
+Draws a text label for each data item. Used for value labels on bars, point
+annotations, node names in diagrams, and axis titles.
+
+```python
+from gofish import chart, text
+
+chart([{"label": "GoFish"}]).mark(
+    text(text="label", fontSize=28, fill="steelblue")
+).render(w=240, h=80)
+```
+
+## Signature
+
+```python
+text(text=None, fill=None, fontSize=None, fontWeight=None, fontFamily=None,
+     debugBoundingBox=None, label=None) -> Mark
+```
+
+## Parameters
+
+| Parameter          | Type            | Description                                                                   |
+| ------------------ | --------------- | ----------------------------------------------------------------------------- |
+| `text`             | `str` \| `int`  | The string to render — a constant, a field name, or a `(row) -> str` callable |
+| `fill`             | `str`           | Fill color — a constant or a field name                                       |
+| `fontSize`         | `int` \| `str`  | Font size in pixels                                                           |
+| `fontWeight`       | `int` \| `str`  | Font weight                                                                   |
+| `fontFamily`       | `str`           | Font family                                                                   |
+| `debugBoundingBox` | `bool`          | Draw the text's bounding box (for layout debugging)                           |
+| `label`            | `bool` \| `str` | Auto value-label flag (distinct from `text` content)                          |
+
+Returns a `Mark` for use in [`.mark()`](/python/api/core/mark).
+
+## Encoding
+
+The `text` option takes a **constant**, a **field name** (a string column in
+your data), or a **callable** `(row) -> str` evaluated per row:
+
+```python
+text(text="Hello")               # constant string
+text(text="name")                # content from a field
+text(text=lambda row: f"{row['amount']}%")  # computed per row
+```
+
+## Examples
+
+```python
+# Static label
+chart([{"label": "GoFish"}]).mark(text(text="label", fontSize=24, fill="steelblue"))
+
+# Value labels: layer text totals on top of bars
+layer([
+    chart(seafood)
+        .flow(spread(by="lake", dir="x"))
+        .mark(rect(h="count").name("bars")),
+    chart(selectAll("bars"))
+        .flow(group(by="datum.lake"))
+        .mark(lambda d: spread(
+            [d[0], text(text=str(sum(r["count"] for r in d[0].datum)))],
+            dir="y", alignment="middle", spacing=10,
+        )),
+])
+
+# Computed per-row label
+chart(bottles).mark(text(text=lambda d: f"{d['amount']}%", fontSize=35, fill="#666"))
+```

--- a/apps/docs/docs/python/api/operators/arrow.md
+++ b/apps/docs/docs/python/api/operators/arrow.md
@@ -1,0 +1,98 @@
+# arrow
+
+Draws a curved, arrowheaded connector from the first child to the second.
+Like [`connect`](/python/api/operators/connect), `arrow` links elements that
+have already been placed by another layer or constraint — but it renders a
+directed, gently bowed arrow (powered by
+[perfect-arrows](https://github.com/steveruizok/perfect-arrows)) instead of a
+plain line. Reach for it in diagrams: callouts, pointer/heap edges, and labeled
+annotations.
+
+```python
+from gofish import layer, arrow, rect, ref, Constraint
+
+layer([
+    layer([
+        rect(w=70, h=40, fill="#9ecae1").name("a"),
+        rect(w=70, h=40, fill="#fcae91").name("b"),
+    ]).constrain(lambda a, b: [
+        Constraint.distribute([a, b], dir="x", spacing=120),
+        Constraint.align([a, b], y="middle"),
+    ]),
+    arrow([ref("a"), ref("b")], stroke="#333", strokeWidth=3),
+]).render(w=320, h=100)
+```
+
+## Signature
+
+```python
+arrow(children, *,
+      # visual
+      stroke=None, strokeWidth=None, start=None,
+      # curve shape (perfect-arrows)
+      bow=None, stretch=None, stretchMin=None, stretchMax=None,
+      padStart=None, padEnd=None, flip=None, straights=None) -> Mark
+```
+
+`Arrow` is the capitalized alias for the same factory. The children are usually
+two [`ref(...)`](/python/api/selection/ref) calls (or datum-level sub-refs)
+pointing at named elements placed by an earlier tier: the arrow runs **from the
+first child to the second**. Fewer than two children renders nothing.
+
+## Visual props
+
+| Option        | Type    | Default   | Description                                                                        |
+| ------------- | ------- | --------- | ---------------------------------------------------------------------------------- |
+| `stroke`      | `str`   | `"black"` | Color of the arrow's line and head (and start dot, if shown)                       |
+| `strokeWidth` | `float` | `3`       | Line width; also scales the arrowhead and the start dot                            |
+| `start`       | `bool`  | `False`   | Draw a filled dot at the start (source) point — useful for pointer/reference edges |
+
+## Curve shape
+
+The arrow's path is a quadratic bezier whose bow and routing come straight from
+[perfect-arrows](https://github.com/steveruizok/perfect-arrows)'
+`getBoxToBoxArrow`. These options are passed through unchanged:
+
+| Option       | Type    | Default | Description                                                                                           |
+| ------------ | ------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `bow`        | `float` | `0.2`   | Baseline curvature. `0` is a straight line; higher values bow the arc further from center.            |
+| `stretch`    | `float` | `0.5`   | How much the bow grows as the endpoints get closer (and shrinks as they get farther apart).           |
+| `stretchMin` | `float` | `40`    | Distance (px) below which `stretch` has its full effect.                                              |
+| `stretchMax` | `float` | `420`   | Distance (px) above which `stretch` has no effect.                                                    |
+| `padStart`   | `float` | `5`     | Gap (px) between the source box and the start of the line.                                            |
+| `padEnd`     | `float` | `20`    | Gap (px) between the end of the line and the target box — leave room for the arrowhead.               |
+| `flip`       | `bool`  | `False` | Flip which side the arrow bows toward.                                                                |
+| `straights`  | `bool`  | `True`  | Allow perfectly straight lines when the endpoints are axis-aligned (instead of forcing a slight bow). |
+
+## Examples
+
+```python
+# Labeled callout: a text label pointing at a named shape (gently bowed default)
+arrow([ref("label"), ref("Mercury")])
+
+# Pointer edge: straight, with a dot at the source (e.g. a heap/stack reference)
+arrow(
+    [ref("stackSlot"), ref("heapCell")],
+    bow=0, stretch=0, padStart=0, stroke="#1A5683", start=True,
+)
+
+# Datum-level endpoints: arrow into a specific selected sub-element
+arrow(
+    [ref("heap").path(0, 1).val, ref("heap").path(0, 2).elmTuples[0]],
+    bow=0, padEnd=25, padStart=0, stroke="#1A5683", start=True,
+)
+```
+
+## Notes
+
+- The arrow's bbox is the union of the resolved endpoints' boxes — like
+  `connect`, it does not contribute its own space.
+- `ref(name)` resolves names declared via `.name(...)`. With `createName()`
+  tokens, the name is global; with plain strings, it is layer-scoped.
+- Use [`connect`](/python/api/operators/connect) instead when you want an
+  _undirected_ line (or a multi-stop polyline) with explicit bbox-anchor
+  control; use `arrow` when you want a _directed_ arrowhead and automatic curved
+  routing.
+- Pair the operator with z-order constraints
+  ([`Constraint.z_above` / `z_below`](/python/api/constraints/constrain#constraintz_above--constraintz_below))
+  when an arrow needs to sit between two elements in paint order.

--- a/apps/docs/docs/python/api/operators/connect.md
+++ b/apps/docs/docs/python/api/operators/connect.md
@@ -1,0 +1,160 @@
+# connect
+
+Draws a connector (line) between each consecutive pair of children. Used for
+linking elements that have already been placed by another layer or
+constraint — most commonly inside a [nested-tier](/internals/design/principles)
+layout where the inner tier places the shapes and the outer tier draws the
+connections.
+
+```python
+from gofish import layer, connect, rect, ref, Constraint
+
+layer([
+    layer([
+        rect(w=60, h=40, fill="#9ecae1").name("a"),
+        rect(w=60, h=40, fill="#fcae91").name("b"),
+    ]).constrain(lambda a, b: [
+        Constraint.distribute([a, b], dir="x", spacing=80),
+        Constraint.align([a, b], y="middle"),
+    ]),
+    connect(
+        [ref("a"), ref("b")],
+        stroke="black",
+        strokeWidth=2,
+        source=["end", "middle"],
+        target=["start", "middle"],
+    ),
+]).render(w=240, h=80)
+```
+
+## Signature
+
+```python
+connect(children, *, source=None, target=None,
+        stroke=None, strokeWidth=None, fill=None, opacity=None,
+        mixBlendMode=None, interpolation=None,
+        # for non-anchor (edge) mode:
+        direction=None, mode=None) -> Mark
+```
+
+`Connect` is the capitalized alias for the same factory. The children are
+usually [`ref(...)`](/python/api/selection/ref) calls that point at named
+elements placed by an earlier tier.
+
+## Anchor mode (recommended)
+
+When `source` or `target` is provided, `connect` runs a straight line between
+the _anchored points_ on each consecutive pair of children's bounding boxes —
+ignoring `direction` and `mode`. The anchor is a normalized fraction of the
+bbox: `[0, 0]` = bottom-left, `[1, 1]` = top-right, `[0.5, 0.5]` = center.
+(GoFish is y-up.)
+
+Anchors accept three forms — pick the one that reads clearest at the call
+site:
+
+```python
+# Single keyword: both axes share the alignment
+source="middle"              # = [0.5, 0.5]
+
+# Per-axis list: each axis can be a keyword or a number
+source=["start", "middle"]   # = [0,   0.5]
+source=[0.5, "end"]          # = [0.5, 1]
+
+# Axis-keyed dict: only set the axes you care about; omitted = 0.5
+source={"x": "start"}        # = [0,   0.5]
+source={"y": 0.25}           # = [0.5, 0.25]
+```
+
+Where `start` → `0`, `middle` → `0.5`, `end` → `1`.
+
+### One anchor or two?
+
+|                                  | Behavior                                                                                                                                                                                     |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Both `source` and `target` given | Line runs directly between the two anchored points.                                                                                                                                          |
+| Only one given                   | The line's other endpoint is the specified point **clamped onto the opposite bbox** per axis. Produces an axis-aligned line when the specified point lies inside the other bbox on one axis. |
+| Neither (and `direction` set)    | See "Edge mode" below.                                                                                                                                                                       |
+
+```python
+# Both anchors: literal line between two corners
+connect([ref("a"), ref("b")], source="end", target="start")
+
+# One anchor: target endpoint is clamped onto B's bbox
+connect([ref("A"), ref("B")], source=["end", "middle"])
+# -> straight horizontal line from A's right-middle to B's left edge at the same y
+
+# Center-to-center is the most common: just use "middle"
+connect([ref("A"), ref("B")], source="middle", target="middle")
+```
+
+## Edge mode (no anchors)
+
+When neither `source` nor `target` is given, `connect` falls back to
+edge mode: it routes between the children's facing edges along
+`direction`. This is the legacy path; most diagrams should prefer anchor
+mode.
+
+| Option      | Type                                         | Default  | Description                           |
+| ----------- | -------------------------------------------- | -------- | ------------------------------------- |
+| `direction` | `"horizontal"` \| `"vertical"` \| `0` \| `1` | `0`      | Axis the connector runs along         |
+| `mode`      | `"edge"` \| `"center"`                       | `"edge"` | Where the line attaches on each child |
+
+## Visual props
+
+| Option          | Type                       | Default                                                   | Description                                                                                                             |
+| --------------- | -------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `stroke`        | `str`                      | `fill`                                                    | Stroke color                                                                                                            |
+| `strokeWidth`   | `float`                    | `0`                                                       | Stroke width                                                                                                            |
+| `fill`          | `str` \| `Value`           | `"black"`                                                 | Fill (for closed paths; channel-bindable)                                                                               |
+| `opacity`       | `float`                    | `1`                                                       | Element opacity                                                                                                         |
+| `mixBlendMode`  | `"multiply"` \| `"normal"` | `"multiply"` in edge mode / `"normal"` in `mode="center"` | Blend mode of the rendered path. Override to `"normal"` for opaque strokes that don't darken under colored backgrounds. |
+| `interpolation` | `"linear"` \| `"bezier"`   | `"linear"`                                                | Path interpolation between consecutive children                                                                         |
+
+## Examples
+
+```python
+# Center-to-center, opaque
+connect(
+    [ref("A"), ref("B")],
+    stroke="#774e32",
+    strokeWidth=3,
+    mixBlendMode="normal",
+    source="middle",
+)
+
+# Bottom-to-top vertical link (e.g. ceiling -> hanging weight)
+connect(
+    [ref("ceiling"), ref("weight")],
+    source=["middle", "start"],
+    target=["middle", "end"],
+)
+
+# One-sided clamp: A's right-middle straight across to B
+connect([ref("A"), ref("B")], source=["end", "middle"])
+
+# Multi-stop polyline: each consecutive pair gets its own segment
+connect([ref("A"), ref("B"), ref("C")], source="middle")
+```
+
+## Notes
+
+- This is the **low-level layout operator**, distinct from the builder method
+  [`ChartBuilder.connect()`](/python/api/core/connect). The builder
+  `.connect(line())` is the canonical spelling for simple line/area charts: it
+  threads a ref-consuming _mark_ through a chart's own marks. This operator
+  connects explicitly-listed `ref(...)` children inside a layout — reach for it
+  only for cross-chart or hand-placed diagrams.
+- The high-level [`line`](/python/api/marks/line) and
+  [`area`](/python/api/marks/area) marks are thin wrappers over `connect`: they
+  take the array of refs from [`selectAll(...)`](/python/api/selection/ref) and
+  connect them. To re-partition a selection before connecting (e.g. one area per
+  species), run it through a path-aware operator first —
+  `group(by="datum.species")`; see
+  [`spread` -> path-aware `by`](/python/api/operators/spread#path-aware-by).
+- `ref(name)` resolves names declared via `.name(...)`. With `createName()`
+  tokens, the name is global; with plain strings, it is layer-scoped.
+- The connector's bbox is the union of the resolved endpoints — it does
+  not contribute its own space.
+- Pair the operator with z-order constraints
+  ([`Constraint.z_above` / `z_below`](/python/api/constraints/constrain#constraintz_above--constraintz_below))
+  when a connector needs to sit _between_ two elements in paint order.

--- a/apps/docs/docs/python/api/operators/layer.md
+++ b/apps/docs/docs/python/api/operators/layer.md
@@ -1,0 +1,68 @@
+# layer
+
+Overlays multiple children in the same coordinate space without any layout offset.
+
+```python
+from gofish import layer, rect, ellipse
+
+layer([
+    rect(w=100, h=80, fill="#9ecae1"),
+    ellipse(w=60, h=60, fill="#fcae91"),
+]).render(w=200, h=150)
+```
+
+Both shapes occupy the same space. The ellipse is drawn on top of the rectangle
+because it appears second in the list.
+
+## Signature
+
+```python
+layer(children, **options) -> Mark
+```
+
+The children are a positional list of marks; layout options are passed as
+kwargs. Children typically carry `.name(...)` tags so they can be referenced
+from a [`.constrain(...)`](/python/api/constraints/constrain) callback or by a
+sibling [`connect`](/python/api/operators/connect) / `ref`.
+
+## Parameters
+
+| Option              | Type      | Description                         |
+| ------------------- | --------- | ----------------------------------- |
+| `coord`             | transform | Coordinate transform for this layer |
+| `w`                 | `float`   | Override width                      |
+| `h`                 | `float`   | Override height                     |
+| `transform.scale.x` | `float`   | Scale factor for x axis             |
+| `transform.scale.y` | `float`   | Scale factor for y axis             |
+
+## Z-ordering
+
+By default, children are drawn in the order they appear in the list — later
+children appear on top. You can override this with `.z_order(n)` on any child.
+Children are sorted by z-order value before rendering; lower values are drawn
+first (underneath). Children with the same z-order value keep their original
+list order.
+
+```python
+from gofish import layer, rect, ellipse
+
+layer([
+    ellipse(w=60, h=60, fill="#fcae91").z_order(1),  # forced on top
+    rect(w=100, h=80, fill="#9ecae1").z_order(0),     # forced underneath
+])
+```
+
+`.z_order()` is available on every `Mark`. The capitalized
+[`Layer`](/python/api/core/chart) (which overlays whole charts) exposes the
+same control on a `ChartBuilder` as `.zOrder()`.
+
+## Notes
+
+- This is the **low-level combinator-form** `layer`, which wraps an explicit list
+  of marks and renders directly. To overlay whole charts — for example to draw
+  one chart's marks on top of another and relate them with cross-chart
+  constraints — use the capitalized [`Layer([chart1, chart2])`](/python/api/core/chart)
+  builder, which composes `ChartBuilder` instances and accepts `.constrain(...)`.
+- Naming a child (`rect(...).name("a")`) makes it addressable from a
+  `.constrain(...)` callback and from a sibling
+  [`connect`](/python/api/operators/connect) drawn over the same layer.

--- a/apps/docs/docs/python/api/operators/treemap.md
+++ b/apps/docs/docs/python/api/operators/treemap.md
@@ -1,0 +1,71 @@
+# treemap
+
+Lays children out into a treemap: a 2D tiling of rectangles (or circles) whose
+**areas are proportional to a weight**.
+
+GoFish exposes two spellings:
+
+- **`treemap(...)`** — an operator for use inside
+  [`.flow()`](/python/api/core/flow); it tiles the partitioned data of a chart.
+- **`Treemap(children, ...)`** — the low-level **combinator** form: it takes an
+  explicit list of pre-data-bound marks and assigns each one its `(x, y, w, h)`.
+
+The two share the same options below.
+
+::: gofish example:circle-treemap hidden
+:::
+
+```python
+from gofish import Treemap, circle, datum
+
+# Movie worldwide gross summed per major genre -> [(genre, gross), ...]
+nodes = [
+    circle(fill=datum(genre), stroke="gray", strokeWidth=1, label=True)
+        .bind_data({"worldwideGross": gross}, genre)
+    for genre, gross in genres
+]
+
+# Each child gets its own circle; Treemap assigns its (x, y, w, h).
+# `valueField` reads weights from each child's bound datum.
+Treemap(
+    nodes,
+    valueField="worldwideGross",
+    paddingInner=2,
+    paddingOuter=2,
+    round=True,
+).render(w=700, h=420)
+```
+
+## Signature
+
+```python
+# Operator form (inside .flow())
+treemap(**options) -> Operator
+
+# Combinator form (explicit children)
+Treemap(children, **options) -> Mark
+```
+
+## Parameters
+
+| Option                     | Type                                                                                       | Description                                                                                                                                                                                                                                                                                                                                                               |
+| -------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `valueField`               | `str`                                                                                      | Reads weights from each child's bound datum (`bind_data`); sums if the datum is a list.                                                                                                                                                                                                                                                                                   |
+| `value`                    | `Callable`                                                                                 | Custom weight accessor (overrides `valueField`).                                                                                                                                                                                                                                                                                                                          |
+| `paddingInner`             | `float`                                                                                    | Padding between sibling rectangles.                                                                                                                                                                                                                                                                                                                                       |
+| `paddingOuter`             | `float`                                                                                    | Padding around the outer edge of the treemap.                                                                                                                                                                                                                                                                                                                             |
+| `round`                    | `bool`                                                                                     | Round pixel positions/sizes.                                                                                                                                                                                                                                                                                                                                              |
+| `tile`                     | `"squarify"` \| `"slice"` \| `"dice"` \| `"binary"` \| `"slicedice"` \| `"squarifyCircle"` | Tiling strategy (`"squarify"` default).                                                                                                                                                                                                                                                                                                                                   |
+| `sort`                     | `"asc"` \| `"desc"` \| `"none"`                                                            | Sort leaves by weight before layout (`"desc"` default).                                                                                                                                                                                                                                                                                                                   |
+| `flipY`                    | `bool`                                                                                     | When `True`, mirror the layout top-to-bottom inside the treemap box (default `False`).                                                                                                                                                                                                                                                                                    |
+| `leafIntrinsicRadiusField` | `str`                                                                                      | Optional datum key for **radius** (pixels in treemap space): each leaf is laid out in a square `min(leafW, leafH, 2*radius)` so the same value can match across separate treemaps.                                                                                                                                                                                        |
+| `x`, `y`                   | `float` \| `Value`                                                                         | Optional position offset for the treemap container.                                                                                                                                                                                                                                                                                                                       |
+| `w`, `h`                   | `float` \| `Value`                                                                         | Optional size for the treemap container (the box tiled into). A `float` is an explicit pixel size; a `Value` (e.g. a data-driven `size` channel that sums a field) scales the box through the layout's scale system — and when several treemaps are faceted side by side, they share one scale so their boxes are proportional. When omitted, the treemap fills its slot. |
+
+## Notes
+
+- A treemap accepts a **flat list of children**; for multi-level treemaps,
+  compose by nesting `Treemap(...)` calls (or add a higher-level wrapper).
+- In the combinator form, each child is bound to its row with
+  `mark.bind_data(d, key)` and a `datum(...)` channel (e.g.
+  `fill=datum(genre)`) makes the built-in label show the key.


### PR DESCRIPTION
Closes #449.

Brings the **Python API reference to structural parity with JavaScript**, and fills the remaining gaps in *both* languages. Each Python page is grounded in the actual wrapper signatures (`packages/gofish-python/gofish/ast.py`) and translated to Python conventions (kwargs options, `from gofish import …`, Figma compositing names). The two sidebars in `.vitepress/config.mts` are updated and kept parallel.

### New Python pages (matching JS)
- **How To**: create a chart, create a glyph, pick a layout operator, use selection, name & scope
- **Marks**: `polygon`, `ref`
- **Operators**: `layer`, `connect`, `treemap`
- **Coordinates**: `polar`, `clock`
- **Constraints**: rounded out `constrain.md` (spread equivalences, z-order detail, per-ref anchors) to match the JS page; `selection/ref.md` confirmed already covering `selectAll` + cross-chart `Layer`

### Newly documented in both languages
- **Marks**: `text`, `image`
- **Operators**: `arrow`

### Notes
- `petal` is intentionally left **undocumented** for now (per request).
- The stale checklist in #449 listed `over`/`inside`/`xor`/`out`/`atop` Porter-Duff names and a non-existent `select` function — compositing is already documented as Figma-style (`paint`/`intersect`/`subtract`/`exclude`/`mask`/`over`) on the existing region-compositing page, and selection is `ref` + `selectAll` (no `select`), so those are covered/superseded rather than added verbatim.
- The text/image surfaces have genuinely **diverged** between JS and Python (e.g. Python `text` adds `fontWeight`/`label` but lacks `rotate`/`stroke`; Python `image` lacks `opacity`/`filter`/`preserveAspectRatio`). Each page documents the actual per-language surface and the tables differ accordingly — worth a follow-up if parity of the *API* (not just docs) is desired.
- `pnpm docs:build` passes (dead-link + unknown-`example:`-id checks are clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)