### PR TITLE
#547: general per-axis constraint composition (max-plus fold)

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -11,6 +11,7 @@ covers:
   - packages/gofish-graphics/src/ast/channels.ts
   - packages/gofish-graphics/src/ast/data.ts
   - packages/gofish-graphics/src/ast/constraints/folds.ts
+  - packages/gofish-graphics/src/ast/constraints/compose.ts
   - packages/gofish-graphics/src/ast/constraints/distribute.ts
   - packages/gofish-graphics/src/ast/constraints/align.ts
   - packages/gofish-graphics/src/ast/constraints/nest.ts

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -2,36 +2,37 @@
 // @wiki Underlying Space — /internals/core/underlying-space
 // </gofish-wiki>
 
-// ── Per-axis constraint composition: the operator image of layer constraints ─
+// ── Per-axis constraint composition (the max-plus fold) ──────────────────────
 //
-// This module owns how a layer composes its constraints into a per-axis claim
-// (the *space fold*) plus a layout-time *budget* for sizing covered children.
-// It is the single seam the Layer (`layer.tsx`) calls; the general max-plus
-// composition algebra (issue #547) lands here as a body swap.
+// One rule, applied per axis, composes a layer's constraints into a claim the
+// parent can invert for auto-fit (and into a budget for sizing covered
+// children):
 //
-// Constraints are normally pure post-layout positioners. `spread`, by contrast,
-// also folds its children's underlying spaces into a composed claim (a Monotonic
-// sum + spacing on the stack axis via `distributeSpaceFold`, an alignment fold
-// on the cross axis via `alignSpaceFold`) so a parent can invert that claim to
-// auto-fit, and at layout time it *sizes* its children from a budget (the flex
-// fragment, `allocateSlices`). This module detects when a layer's constraints
-// form that same operator image and reproduces both halves, so
-// `layer + align + distribute` is geometrically identical to `spread`.
+//   claim(axis) = max-union over {
+//     each distribute(dir = axis):   its summed fold (Σ extent + spacing)   — series
+//     each align(spec on axis):      its overlay fold (alignSpaceFold)      — overlay
+//     each child covered by neither: its raw extent                        — overlay
+//   }
 //
-// The recognized image: exactly ONE `distribute` (optionally `glue`), at most
-// one cross-axis `align` with a uniform string anchor, and nothing else (no
-// `position` / z-order). This is the same guard the prototype used minus the
-// "distribute covers every child" requirement: children NOT covered by the
-// distribute are unconstrained siblings that overlay (max-union with the
-// distribute's claim). The structural guards keep every existing constraint set
-// untouched — axis-elaboration layers carry `position` constraints, and the
-// legend layer carries two `align`s, so both fall out of the image and keep
-// their `unionChildSpaces` behavior. Anything beyond the image (multiple
-// distributes per axis, distribute + position on one axis) likewise falls back
-// to `unionChildSpaces`; the general max-plus composition that would handle it
-// is the residual in
-// apps/docs/docs/internals/design/constraints-as-core.md ("Composition and
-// conflict semantics").
+// This is the (max, +) algebra from
+// apps/docs/docs/internals/design/layout-synthesis.md: a distribute is a series
+// (sum) on its axis, align/overlay is `max`, and any network of the two folds to
+// a single monotone claim — so the inversion (auto-fit) stays a one-unknown
+// solve. `spread` is the one-distribute + one-cross-axis-align instance; a grid
+// (`table`) is two cross-cutting distributes; SubsetSelection is two disjoint
+// distributes on one axis (their sub-sums overlay, hence `max`).
+//
+// The align fold is load-bearing, not cosmetic: in a bar chart (distribute on x,
+// bars aligned on y) it is `alignSpaceFold` that turns the bars' SIZE heights
+// into the y data-axis POSITION domain. Only the uniform-string anchor folds (a
+// per-child anchor array has no single overlay form); its children then fall to
+// the raw-extent path.
+//
+// Gated to layers with at least one distribute: a pure overlay (no series, e.g.
+// a legend) has nothing to compose, so it is left untouched (undefined) and the
+// layer's default union — which also merges `position` data domains — stands.
+// Distribute interleaved with a `position` pin (solve the sum relative to the
+// pin) is not yet modeled; the distribute claim wins on a shared axis for now.
 
 import * as Monotonic from "../../util/monotonic";
 import { GoFishNode } from "../_node";
@@ -47,26 +48,33 @@ import { unionChildSpaces } from "../graphicalOperators/alignment";
 import { type ConstraintSpec } from ".";
 import { distributeSpaceFold, type DistributeConstraint } from "./distribute";
 import { alignSpaceFold, type AlignConstraint } from "./align";
-import { axisIndex, childNameKey } from "./shared";
+import { axisIndex, childNameKey, type AlignAnchor } from "./shared";
 
-/** Distribute budget descriptor, stashed by `resolveUnderlyingSpace` and
- *  consumed by `layout` to solve a scale factor and propose per-child sizes. */
-export type DistributeBudget = {
+/** One distribute's slice of the layout budget: equal shares of the axis size
+ *  among its covered children (consumed by `layer.tsx`'s `layout`). */
+export type DistributeSegment = {
   dAxis: 0 | 1;
   /** Already glue-zeroed (see createDistributeConstraint). */
   spacing: number;
-  /** Names of the distribute targets, in placement order. */
+  /** Covered child names, in placement order. */
   order: string[];
-  /** The folded SIZE Monotonic on the distribute axis, if the fold was SIZE —
-   *  inverted against the layer's allotted size to derive the child scale
-   *  factor (auto-fit). Absent for glue/POSITION/ORDINAL/UNDEFINED folds. */
-  sizeDomain?: Monotonic.Monotonic;
 };
 
-export type SpreadShape = {
-  /** Per-axis space overrides; undefined leaves the default union in place. */
+export type ComposeBudget = {
+  segments: DistributeSegment[];
+  /** Per-axis composed SIZE claim (the max-plus longest path) to invert against
+   *  the allotted size for auto-fit. Undefined when the axis claim isn't SIZE. */
+  sizeDomain: [
+    Monotonic.Monotonic | undefined,
+    Monotonic.Monotonic | undefined,
+  ];
+};
+
+export type ComposedSpaces = {
+  /** Per-axis space overrides; undefined leaves the default union in place
+   *  (no distribute or align on that axis). */
   spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined];
-  budget: DistributeBudget;
+  budget: ComposeBudget;
 };
 
 /** Build a per-axis Size carrying `space` on `axis` and UNDEFINED elsewhere, so
@@ -77,37 +85,25 @@ const axisSize = (
 ): Size<UnderlyingSpace> =>
   axis === 0 ? [space, UNDEFINED] : [UNDEFINED, space];
 
-/** Max-union a folded claim with any unconstrained siblings' spaces on `axis`
- *  (the distribute's claim and overlay siblings co-occupy the layer box, so
- *  the extent is their union). With no siblings this returns `claim`
- *  unchanged — preserving exact parity with spread for the covers-all image. */
-function maxUnionWith(
-  claim: UnderlyingSpace,
-  others: UnderlyingSpace[],
-  axis: 0 | 1
-): UnderlyingSpace {
-  if (others.length === 0) return claim;
-  return unionChildSpaces(
-    [axisSize(claim, axis), ...others.map((s) => axisSize(s, axis))],
-    axis
-  );
-}
-
 export function composeConstraintSpaces(
   constraints: ConstraintSpec[],
   childNodes: GoFishAST[],
   childSpaces: Size<UnderlyingSpace>[]
-): SpreadShape | undefined {
-  if (constraints.length === 0) return undefined;
-  const distributes = constraints.filter((c) => c.type === "distribute");
-  const aligns = constraints.filter((c) => c.type === "align");
-  // Operator image: exactly one distribute, at most one align, nothing else.
-  // Any `position`/z-order constraint is a different layout regime.
-  if (distributes.length !== 1) return undefined;
-  if (aligns.length > 1) return undefined;
-  if (distributes.length + aligns.length !== constraints.length) {
+): ComposedSpaces | undefined {
+  const distributes = constraints.filter(
+    (c): c is DistributeConstraint => c.type === "distribute"
+  );
+  const aligns = constraints.filter(
+    (c): c is AlignConstraint => c.type === "align"
+  );
+  // Compose only layers that are PURELY distributes + aligns. A `position` pin
+  // (or z-order) puts the layer in a different regime — the distribute-relative-
+  // to-a-pin solve is deferred (layout-synthesis.md) — so leave it to the
+  // layer's default union, which already merges position data domains.
+  if (distributes.length + aligns.length !== constraints.length)
     return undefined;
-  }
+  // No series → the layer is a pure overlay; its default union already says it.
+  if (distributes.length === 0) return undefined;
 
   const indexByName = new Map<string, number>();
   for (let i = 0; i < childNodes.length; i++) {
@@ -118,72 +114,103 @@ export function composeConstraintSpaces(
     childNodes[i] instanceof GoFishNode
       ? (childNodes[i] as GoFishNode).key
       : undefined;
+  const idxOf = (refs: { name: string }[]): number[] | undefined => {
+    const out = refs.map((r) => indexByName.get(r.name));
+    return out.every((i): i is number => i !== undefined) ? out : undefined;
+  };
 
-  const dist = distributes[0] as DistributeConstraint;
-  const dAxis = axisIndex(dist.dir);
-  const aAxis = (1 - dAxis) as 0 | 1;
+  // Resolve each distribute to its covered child indices in placement order.
+  // A target that isn't a direct child (a ref into a nested tier) has no slot
+  // here, so bail to the layer's default union.
+  type Seg = DistributeSegment & {
+    idx: number[];
+    mode: "edge" | "center";
+    glue: boolean;
+  };
+  const segments: Seg[] = [];
+  for (const d of distributes) {
+    const ordered =
+      d.order === "reverse" ? [...d.children].reverse() : d.children;
+    const idx = idxOf(ordered);
+    if (idx === undefined) return undefined;
+    segments.push({
+      dAxis: axisIndex(d.dir),
+      spacing: d.spacing,
+      order: ordered.map((r) => r.name),
+      idx,
+      mode: d.mode,
+      glue: d.glue,
+    });
+  }
 
-  // Distribute targets in placement order (matches applyDistribute's `order`).
-  // Every target must be a direct child (so we can slice it); a ref into a
-  // nested tier has no slot here, so bail to the general union.
-  const order = (
-    dist.order === "reverse" ? [...dist.children].reverse() : dist.children
-  ).map((r) => r.name);
-  if (!order.every((n) => indexByName.has(n))) return undefined;
-  const dIdx = order.map((n) => indexByName.get(n)!);
-  const coveredSet = new Set(dIdx);
-
-  const foldD = distributeSpaceFold(
-    dIdx.map((i) => childSpaces[i][dAxis]),
-    dIdx.map(keyOf),
-    { spacing: dist.spacing, mode: dist.mode, glue: dist.glue }
-  );
-
-  // Unconstrained siblings (children outside the distribute) overlay the
-  // distribute's claim on both axes.
-  const otherSpaces = (axis: 0 | 1): UnderlyingSpace[] =>
-    childSpaces.filter((_, i) => !coveredSet.has(i)).map((c) => c[axis]);
+  // Each align contributes an overlay fold on the axis it specifies, but only
+  // for a uniform string anchor (a per-child array has no single fold form).
+  type Al = { axis: 0 | 1; anchor: string; idx: number[] };
+  const alignFolds: Al[] = [];
+  for (const a of aligns) {
+    const idx = idxOf(a.children);
+    if (idx === undefined) continue;
+    for (const axis of [0, 1] as const) {
+      const spec = axis === 0 ? a.x : a.y;
+      if (typeof spec === "string")
+        alignFolds.push({ axis, anchor: spec, idx });
+    }
+  }
 
   const spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined] = [
     undefined,
     undefined,
   ];
-  if (!isUNDEFINED(foldD)) {
-    spaces[dAxis] = maxUnionWith(foldD, otherSpaces(dAxis), dAxis);
-  }
+  const sizeDomain: [
+    Monotonic.Monotonic | undefined,
+    Monotonic.Monotonic | undefined,
+  ] = [undefined, undefined];
 
-  // Optional cross-axis align: a single uniform anchor on the distribute's
-  // cross axis only (a per-child anchor array or a same-axis spec has no single
-  // spread equivalent). Folded over the children the align covers.
-  if (aligns.length === 1) {
-    const al = aligns[0] as AlignConstraint;
-    const anchor = aAxis === 0 ? al.x : al.y;
-    const distAxisSpec = dAxis === 0 ? al.x : al.y;
-    const aIdx = al.children
-      .map((r) => indexByName.get(r.name))
-      .filter((i): i is number => i !== undefined);
-    if (
-      typeof anchor === "string" &&
-      distAxisSpec === undefined &&
-      aIdx.length > 0
-    ) {
-      const foldA = alignSpaceFold(
-        aIdx.map((i) => childSpaces[i][aAxis]),
-        anchor
+  for (const axis of [0, 1] as const) {
+    const dists = segments.filter((s) => s.dAxis === axis);
+    const als = alignFolds.filter((a) => a.axis === axis);
+    if (dists.length === 0 && als.length === 0) continue; // keep default union
+
+    const fragments: Size<UnderlyingSpace>[] = [];
+    const covered = new Set<number>();
+    for (const s of dists) {
+      s.idx.forEach((i) => covered.add(i));
+      const fold = distributeSpaceFold(
+        s.idx.map((i) => childSpaces[i][axis]),
+        s.idx.map(keyOf),
+        { spacing: s.spacing, mode: s.mode, glue: s.glue }
       );
-      if (!isUNDEFINED(foldA)) {
-        spaces[aAxis] = maxUnionWith(foldA, otherSpaces(aAxis), aAxis);
-      }
+      if (!isUNDEFINED(fold)) fragments.push(axisSize(fold, axis));
+    }
+    for (const a of als) {
+      a.idx.forEach((i) => covered.add(i));
+      const fold = alignSpaceFold(
+        a.idx.map((i) => childSpaces[i][axis]),
+        a.anchor as never
+      );
+      if (!isUNDEFINED(fold)) fragments.push(axisSize(fold, axis));
+    }
+    for (let i = 0; i < childSpaces.length; i++) {
+      if (!covered.has(i)) fragments.push(axisSize(childSpaces[i][axis], axis));
+    }
+
+    const composed =
+      fragments.length > 0 ? unionChildSpaces(fragments, axis) : UNDEFINED;
+    if (!isUNDEFINED(composed)) {
+      spaces[axis] = composed;
+      if (isSIZE(composed)) sizeDomain[axis] = composed.domain;
     }
   }
 
   return {
     spaces,
     budget: {
-      dAxis,
-      spacing: dist.spacing,
-      order,
-      sizeDomain: isSIZE(foldD) ? foldD.domain : undefined,
+      segments: segments.map(({ dAxis, spacing, order }) => ({
+        dAxis,
+        spacing,
+        order,
+      })),
+      sizeDomain,
     },
   };
 }

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -1,0 +1,189 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
+// ── Per-axis constraint composition: the operator image of layer constraints ─
+//
+// This module owns how a layer composes its constraints into a per-axis claim
+// (the *space fold*) plus a layout-time *budget* for sizing covered children.
+// It is the single seam the Layer (`layer.tsx`) calls; the general max-plus
+// composition algebra (issue #547) lands here as a body swap.
+//
+// Constraints are normally pure post-layout positioners. `spread`, by contrast,
+// also folds its children's underlying spaces into a composed claim (a Monotonic
+// sum + spacing on the stack axis via `distributeSpaceFold`, an alignment fold
+// on the cross axis via `alignSpaceFold`) so a parent can invert that claim to
+// auto-fit, and at layout time it *sizes* its children from a budget (the flex
+// fragment, `allocateSlices`). This module detects when a layer's constraints
+// form that same operator image and reproduces both halves, so
+// `layer + align + distribute` is geometrically identical to `spread`.
+//
+// The recognized image: exactly ONE `distribute` (optionally `glue`), at most
+// one cross-axis `align` with a uniform string anchor, and nothing else (no
+// `position` / z-order). This is the same guard the prototype used minus the
+// "distribute covers every child" requirement: children NOT covered by the
+// distribute are unconstrained siblings that overlay (max-union with the
+// distribute's claim). The structural guards keep every existing constraint set
+// untouched — axis-elaboration layers carry `position` constraints, and the
+// legend layer carries two `align`s, so both fall out of the image and keep
+// their `unionChildSpaces` behavior. Anything beyond the image (multiple
+// distributes per axis, distribute + position on one axis) likewise falls back
+// to `unionChildSpaces`; the general max-plus composition that would handle it
+// is the residual in
+// apps/docs/docs/internals/design/constraints-as-core.md ("Composition and
+// conflict semantics").
+
+import * as Monotonic from "../../util/monotonic";
+import { GoFishNode } from "../_node";
+import { GoFishAST } from "../_ast";
+import { Size } from "../dims";
+import {
+  UNDEFINED,
+  UnderlyingSpace,
+  isSIZE,
+  isUNDEFINED,
+} from "../underlyingSpace";
+import { unionChildSpaces } from "../graphicalOperators/alignment";
+import { type ConstraintSpec } from ".";
+import { distributeSpaceFold, type DistributeConstraint } from "./distribute";
+import { alignSpaceFold, type AlignConstraint } from "./align";
+import { axisIndex, childNameKey } from "./shared";
+
+/** Distribute budget descriptor, stashed by `resolveUnderlyingSpace` and
+ *  consumed by `layout` to solve a scale factor and propose per-child sizes. */
+export type DistributeBudget = {
+  dAxis: 0 | 1;
+  /** Already glue-zeroed (see createDistributeConstraint). */
+  spacing: number;
+  /** Names of the distribute targets, in placement order. */
+  order: string[];
+  /** The folded SIZE Monotonic on the distribute axis, if the fold was SIZE —
+   *  inverted against the layer's allotted size to derive the child scale
+   *  factor (auto-fit). Absent for glue/POSITION/ORDINAL/UNDEFINED folds. */
+  sizeDomain?: Monotonic.Monotonic;
+};
+
+export type SpreadShape = {
+  /** Per-axis space overrides; undefined leaves the default union in place. */
+  spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined];
+  budget: DistributeBudget;
+};
+
+/** Build a per-axis Size carrying `space` on `axis` and UNDEFINED elsewhere, so
+ *  a single space can be fed to `unionChildSpaces` as a pseudo-child. */
+const axisSize = (
+  space: UnderlyingSpace,
+  axis: 0 | 1
+): Size<UnderlyingSpace> =>
+  axis === 0 ? [space, UNDEFINED] : [UNDEFINED, space];
+
+/** Max-union a folded claim with any unconstrained siblings' spaces on `axis`
+ *  (the distribute's claim and overlay siblings co-occupy the layer box, so
+ *  the extent is their union). With no siblings this returns `claim`
+ *  unchanged — preserving exact parity with spread for the covers-all image. */
+function maxUnionWith(
+  claim: UnderlyingSpace,
+  others: UnderlyingSpace[],
+  axis: 0 | 1
+): UnderlyingSpace {
+  if (others.length === 0) return claim;
+  return unionChildSpaces(
+    [axisSize(claim, axis), ...others.map((s) => axisSize(s, axis))],
+    axis
+  );
+}
+
+export function composeConstraintSpaces(
+  constraints: ConstraintSpec[],
+  childNodes: GoFishAST[],
+  childSpaces: Size<UnderlyingSpace>[]
+): SpreadShape | undefined {
+  if (constraints.length === 0) return undefined;
+  const distributes = constraints.filter((c) => c.type === "distribute");
+  const aligns = constraints.filter((c) => c.type === "align");
+  // Operator image: exactly one distribute, at most one align, nothing else.
+  // Any `position`/z-order constraint is a different layout regime.
+  if (distributes.length !== 1) return undefined;
+  if (aligns.length > 1) return undefined;
+  if (distributes.length + aligns.length !== constraints.length) {
+    return undefined;
+  }
+
+  const indexByName = new Map<string, number>();
+  for (let i = 0; i < childNodes.length; i++) {
+    const name = childNameKey(childNodes[i]);
+    if (name !== undefined && !indexByName.has(name)) indexByName.set(name, i);
+  }
+  const keyOf = (i: number): string | undefined =>
+    childNodes[i] instanceof GoFishNode
+      ? (childNodes[i] as GoFishNode).key
+      : undefined;
+
+  const dist = distributes[0] as DistributeConstraint;
+  const dAxis = axisIndex(dist.dir);
+  const aAxis = (1 - dAxis) as 0 | 1;
+
+  // Distribute targets in placement order (matches applyDistribute's `order`).
+  // Every target must be a direct child (so we can slice it); a ref into a
+  // nested tier has no slot here, so bail to the general union.
+  const order = (
+    dist.order === "reverse" ? [...dist.children].reverse() : dist.children
+  ).map((r) => r.name);
+  if (!order.every((n) => indexByName.has(n))) return undefined;
+  const dIdx = order.map((n) => indexByName.get(n)!);
+  const coveredSet = new Set(dIdx);
+
+  const foldD = distributeSpaceFold(
+    dIdx.map((i) => childSpaces[i][dAxis]),
+    dIdx.map(keyOf),
+    { spacing: dist.spacing, mode: dist.mode, glue: dist.glue }
+  );
+
+  // Unconstrained siblings (children outside the distribute) overlay the
+  // distribute's claim on both axes.
+  const otherSpaces = (axis: 0 | 1): UnderlyingSpace[] =>
+    childSpaces.filter((_, i) => !coveredSet.has(i)).map((c) => c[axis]);
+
+  const spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined] = [
+    undefined,
+    undefined,
+  ];
+  if (!isUNDEFINED(foldD)) {
+    spaces[dAxis] = maxUnionWith(foldD, otherSpaces(dAxis), dAxis);
+  }
+
+  // Optional cross-axis align: a single uniform anchor on the distribute's
+  // cross axis only (a per-child anchor array or a same-axis spec has no single
+  // spread equivalent). Folded over the children the align covers.
+  if (aligns.length === 1) {
+    const al = aligns[0] as AlignConstraint;
+    const anchor = aAxis === 0 ? al.x : al.y;
+    const distAxisSpec = dAxis === 0 ? al.x : al.y;
+    const aIdx = al.children
+      .map((r) => indexByName.get(r.name))
+      .filter((i): i is number => i !== undefined);
+    if (
+      typeof anchor === "string" &&
+      distAxisSpec === undefined &&
+      aIdx.length > 0
+    ) {
+      const foldA = alignSpaceFold(
+        aIdx.map((i) => childSpaces[i][aAxis]),
+        anchor
+      );
+      if (!isUNDEFINED(foldA)) {
+        spaces[aAxis] = maxUnionWith(foldA, otherSpaces(aAxis), aAxis);
+      }
+    }
+  }
+
+  return {
+    spaces,
+    budget: {
+      dAxis,
+      spacing: dist.spacing,
+      order,
+      sizeDomain: isSIZE(foldD) ? foldD.domain : undefined,
+    },
+  };
+}

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -48,7 +48,7 @@ import { unionChildSpaces } from "../graphicalOperators/alignment";
 import { type ConstraintSpec } from ".";
 import { distributeSpaceFold, type DistributeConstraint } from "./distribute";
 import { alignSpaceFold, type AlignConstraint } from "./align";
-import { axisIndex, childNameKey, type AlignAnchor } from "./shared";
+import { axisIndex, buildNameIndex, type AlignAnchor } from "./shared";
 
 /** One distribute's slice of the layout budget: equal shares of the axis size
  *  among its covered children (consumed by `layer.tsx`'s `layout`). */
@@ -102,14 +102,14 @@ export function composeConstraintSpaces(
   // layer's default union, which already merges position data domains.
   if (distributes.length + aligns.length !== constraints.length)
     return undefined;
-  // No series → the layer is a pure overlay; its default union already says it.
+  // No series → a pure overlay. Align-only composition WOULD fold (alignSpaceFold
+  // converts SIZE→POSITION), but for a pure overlay that conversion only changes
+  // the layer's reported space (e.g. a legend's), so defer it: fall to the
+  // default union. (The per-axis loop already handles align-only axes when a
+  // distribute exists on the other axis.)
   if (distributes.length === 0) return undefined;
 
-  const indexByName = new Map<string, number>();
-  for (let i = 0; i < childNodes.length; i++) {
-    const name = childNameKey(childNodes[i]);
-    if (name !== undefined && !indexByName.has(name)) indexByName.set(name, i);
-  }
+  const indexByName = buildNameIndex(childNodes);
   const keyOf = (i: number): string | undefined =>
     childNodes[i] instanceof GoFishNode
       ? (childNodes[i] as GoFishNode).key
@@ -145,7 +145,7 @@ export function composeConstraintSpaces(
 
   // Each align contributes an overlay fold on the axis it specifies, but only
   // for a uniform string anchor (a per-child array has no single fold form).
-  type Al = { axis: 0 | 1; anchor: string; idx: number[] };
+  type Al = { axis: 0 | 1; anchor: AlignAnchor; idx: number[] };
   const alignFolds: Al[] = [];
   for (const a of aligns) {
     const idx = idxOf(a.children);
@@ -186,7 +186,7 @@ export function composeConstraintSpaces(
       a.idx.forEach((i) => covered.add(i));
       const fold = alignSpaceFold(
         a.idx.map((i) => childSpaces[i][axis]),
-        a.anchor as never
+        a.anchor
       );
       if (!isUNDEFINED(fold)) fragments.push(axisSize(fold, axis));
     }

--- a/packages/gofish-graphics/src/ast/constraints/shared.ts
+++ b/packages/gofish-graphics/src/ast/constraints/shared.ts
@@ -1,4 +1,6 @@
-import type { Placeable } from "../_node";
+import { GoFishNode, type Placeable } from "../_node";
+import type { GoFishAST } from "../_ast";
+import { isToken } from "../createName";
 
 export type Axis = "x" | "y";
 export type Alignment = "start" | "middle" | "end";
@@ -29,3 +31,13 @@ export const axisIndex = (axis: Axis): 0 | 1 => (axis === "x" ? 0 : 1);
 /** Check if a placeable has been placed on a given axis */
 export const isPlacedOn = (p: Placeable, axisIdx: 0 | 1): boolean =>
   p.dims[axisIdx].min !== undefined;
+
+/** Normalize a node's _name (string or Token) to the string used as a key in
+ * the Layer's nameToPlaceable and constraint refs. Tokens contribute their
+ * `__tag`. */
+export const childNameKey = (node: GoFishAST): string | undefined => {
+  if (!("_name" in node)) return undefined;
+  const n = (node as GoFishNode)._name;
+  if (n === undefined) return undefined;
+  return isToken(n) ? n.__tag : n;
+};

--- a/packages/gofish-graphics/src/ast/constraints/shared.ts
+++ b/packages/gofish-graphics/src/ast/constraints/shared.ts
@@ -41,3 +41,17 @@ export const childNameKey = (node: GoFishAST): string | undefined => {
   if (n === undefined) return undefined;
   return isToken(n) ? n.__tag : n;
 };
+
+/** Map each direct child's name (`childNameKey`) to its index; first occurrence
+ *  wins. Shared by the layer's constraint passes (nest plan, composition) to
+ *  resolve `ConstraintRef`s against child positions. */
+export const buildNameIndex = (
+  childNodes: GoFishAST[]
+): Map<string, number> => {
+  const m = new Map<string, number>();
+  for (let i = 0; i < childNodes.length; i++) {
+    const name = childNameKey(childNodes[i]);
+    if (name !== undefined && !m.has(name)) m.set(name, i);
+  }
+  return m;
+};

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -35,25 +35,14 @@ import {
   type NestConstraint,
   type ZOrderConstraint,
 } from "../constraints";
-import {
-  distributeSpaceFold,
-  type DistributeConstraint,
-} from "../constraints/distribute";
-import { alignSpaceFold, type AlignConstraint } from "../constraints/align";
 import { allocateSlices } from "../constraints/folds";
-import { axisIndex } from "../constraints/shared";
+import { childNameKey } from "../constraints/shared";
+import {
+  composeConstraintSpaces,
+  type DistributeBudget,
+} from "../constraints/compose";
 import { isValue } from "../data";
 import { unionChildSpaces } from "./alignment";
-
-/** Normalize a node's _name (string or Token) to the string used as a key in
- * the Layer's nameToPlaceable and constraint refs. Tokens contribute their
- * `__tag`. */
-const childNameKey = (node: GoFishAST): string | undefined => {
-  if (!("_name" in node)) return undefined;
-  const n = (node as GoFishNode)._name;
-  if (n === undefined) return undefined;
-  return isToken(n) ? n.__tag : n;
-};
 
 // ── Nest pre-pass ───────────────────────────────────────────────────────────
 //
@@ -311,171 +300,6 @@ function buildNestPlan(
   for (let i = 0; i < childNodes.length; i++) visit(i, []);
 
   return { byDerived, order };
-}
-
-// ── Spread-shape recognition: the operator image of layer constraints ───────
-//
-// Constraints are normally pure post-layout positioners. `spread`, by contrast,
-// also folds its children's underlying spaces into a composed claim (a Monotonic
-// sum + spacing on the stack axis via `distributeSpaceFold`, an alignment fold
-// on the cross axis via `alignSpaceFold`) so a parent can invert that claim to
-// auto-fit, and at layout time it *sizes* its children from a budget (the flex
-// fragment, `allocateSlices`). This recognizer detects when a layer's
-// constraints form that same operator image and reproduces both halves, so
-// `layer + align + distribute` is geometrically identical to `spread`.
-//
-// The recognized image: exactly ONE `distribute` (optionally `glue`), at most
-// one cross-axis `align` with a uniform string anchor, and nothing else (no
-// `position` / z-order). This is the same guard the prototype used minus the
-// "distribute covers every child" requirement: children NOT covered by the
-// distribute are unconstrained siblings that overlay (max-union with the
-// distribute's claim). The structural guards keep every existing constraint set
-// untouched — axis-elaboration layers carry `position` constraints, and the
-// legend layer carries two `align`s, so both fall out of the image and keep
-// their `unionChildSpaces` behavior. Anything beyond the image (multiple
-// distributes per axis, distribute + position on one axis) likewise falls back
-// to `unionChildSpaces`; the general max-plus composition that would handle it
-// is the residual in
-// apps/docs/docs/internals/design/constraints-as-core.md ("Composition and
-// conflict semantics").
-
-/** Distribute budget descriptor, stashed by `resolveUnderlyingSpace` and
- *  consumed by `layout` to solve a scale factor and propose per-child sizes. */
-type DistributeBudget = {
-  dAxis: 0 | 1;
-  /** Already glue-zeroed (see createDistributeConstraint). */
-  spacing: number;
-  /** Names of the distribute targets, in placement order. */
-  order: string[];
-  /** The folded SIZE Monotonic on the distribute axis, if the fold was SIZE —
-   *  inverted against the layer's allotted size to derive the child scale
-   *  factor (auto-fit). Absent for glue/POSITION/ORDINAL/UNDEFINED folds. */
-  sizeDomain?: Monotonic.Monotonic;
-};
-
-type SpreadShape = {
-  /** Per-axis space overrides; undefined leaves the default union in place. */
-  spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined];
-  budget: DistributeBudget;
-};
-
-/** Build a per-axis Size carrying `space` on `axis` and UNDEFINED elsewhere, so
- *  a single space can be fed to `unionChildSpaces` as a pseudo-child. */
-const axisSize = (
-  space: UnderlyingSpace,
-  axis: 0 | 1
-): Size<UnderlyingSpace> =>
-  axis === 0 ? [space, UNDEFINED] : [UNDEFINED, space];
-
-/** Max-union a folded claim with any unconstrained siblings' spaces on `axis`
- *  (the distribute's claim and overlay siblings co-occupy the layer box, so
- *  the extent is their union). With no siblings this returns `claim`
- *  unchanged — preserving exact parity with spread for the covers-all image. */
-function maxUnionWith(
-  claim: UnderlyingSpace,
-  others: UnderlyingSpace[],
-  axis: 0 | 1
-): UnderlyingSpace {
-  if (others.length === 0) return claim;
-  return unionChildSpaces(
-    [axisSize(claim, axis), ...others.map((s) => axisSize(s, axis))],
-    axis
-  );
-}
-
-function resolveSpreadShape(
-  constraints: ConstraintSpec[],
-  childNodes: GoFishAST[],
-  childSpaces: Size<UnderlyingSpace>[]
-): SpreadShape | undefined {
-  if (constraints.length === 0) return undefined;
-  const distributes = constraints.filter((c) => c.type === "distribute");
-  const aligns = constraints.filter((c) => c.type === "align");
-  // Operator image: exactly one distribute, at most one align, nothing else.
-  // Any `position`/z-order constraint is a different layout regime.
-  if (distributes.length !== 1) return undefined;
-  if (aligns.length > 1) return undefined;
-  if (distributes.length + aligns.length !== constraints.length) {
-    return undefined;
-  }
-
-  const indexByName = new Map<string, number>();
-  for (let i = 0; i < childNodes.length; i++) {
-    const name = childNameKey(childNodes[i]);
-    if (name !== undefined && !indexByName.has(name)) indexByName.set(name, i);
-  }
-  const keyOf = (i: number): string | undefined =>
-    childNodes[i] instanceof GoFishNode
-      ? (childNodes[i] as GoFishNode).key
-      : undefined;
-
-  const dist = distributes[0] as DistributeConstraint;
-  const dAxis = axisIndex(dist.dir);
-  const aAxis = (1 - dAxis) as 0 | 1;
-
-  // Distribute targets in placement order (matches applyDistribute's `order`).
-  // Every target must be a direct child (so we can slice it); a ref into a
-  // nested tier has no slot here, so bail to the general union.
-  const order = (
-    dist.order === "reverse" ? [...dist.children].reverse() : dist.children
-  ).map((r) => r.name);
-  if (!order.every((n) => indexByName.has(n))) return undefined;
-  const dIdx = order.map((n) => indexByName.get(n)!);
-  const coveredSet = new Set(dIdx);
-
-  const foldD = distributeSpaceFold(
-    dIdx.map((i) => childSpaces[i][dAxis]),
-    dIdx.map(keyOf),
-    { spacing: dist.spacing, mode: dist.mode, glue: dist.glue }
-  );
-
-  // Unconstrained siblings (children outside the distribute) overlay the
-  // distribute's claim on both axes.
-  const otherSpaces = (axis: 0 | 1): UnderlyingSpace[] =>
-    childSpaces.filter((_, i) => !coveredSet.has(i)).map((c) => c[axis]);
-
-  const spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined] = [
-    undefined,
-    undefined,
-  ];
-  if (!isUNDEFINED(foldD)) {
-    spaces[dAxis] = maxUnionWith(foldD, otherSpaces(dAxis), dAxis);
-  }
-
-  // Optional cross-axis align: a single uniform anchor on the distribute's
-  // cross axis only (a per-child anchor array or a same-axis spec has no single
-  // spread equivalent). Folded over the children the align covers.
-  if (aligns.length === 1) {
-    const al = aligns[0] as AlignConstraint;
-    const anchor = aAxis === 0 ? al.x : al.y;
-    const distAxisSpec = dAxis === 0 ? al.x : al.y;
-    const aIdx = al.children
-      .map((r) => indexByName.get(r.name))
-      .filter((i): i is number => i !== undefined);
-    if (
-      typeof anchor === "string" &&
-      distAxisSpec === undefined &&
-      aIdx.length > 0
-    ) {
-      const foldA = alignSpaceFold(
-        aIdx.map((i) => childSpaces[i][aAxis]),
-        anchor
-      );
-      if (!isUNDEFINED(foldA)) {
-        spaces[aAxis] = maxUnionWith(foldA, otherSpaces(aAxis), aAxis);
-      }
-    }
-  }
-
-  return {
-    spaces,
-    budget: {
-      dAxis,
-      spacing: dist.spacing,
-      order,
-      sizeDomain: isSIZE(foldD) ? foldD.domain : undefined,
-    },
-  };
 }
 
 // ── Z-order resolution ────────────────────────────────────────────────────
@@ -771,13 +595,13 @@ export const layer = createNodeOperatorSequential(
           ];
 
           // A simple spread expressed as align + distribute. When the
-          // constraints match that operator image (see resolveSpreadShape),
+          // constraints match that operator image (see composeConstraintSpaces),
           // override the constrained axes with spread's own space folds (SIZE
           // sum + spacing on the distribute axis, the alignment fold on the
           // cross axis). Applied BEFORE the self-scaling stash below so an
           // explicit-size layer builds its LOCAL scale from the folded space,
           // exactly like spread.
-          const shape = resolveSpreadShape(
+          const shape = composeConstraintSpaces(
             constraints ?? [],
             _childNodes,
             effectiveChildren

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -36,7 +36,7 @@ import {
   type ZOrderConstraint,
 } from "../constraints";
 import { allocateSlices } from "../constraints/folds";
-import { childNameKey } from "../constraints/shared";
+import { childNameKey, buildNameIndex } from "../constraints/shared";
 import {
   composeConstraintSpaces,
   type ComposeBudget,
@@ -107,11 +107,7 @@ function buildNestPlan(
   if (!constraints.some(isNestConstraint)) return undefined;
   const nests = constraints.filter(isNestConstraint);
 
-  const indexByName = new Map<string, number>();
-  for (let i = 0; i < childNodes.length; i++) {
-    const name = childNameKey(childNodes[i]);
-    if (name !== undefined && !indexByName.has(name)) indexByName.set(name, i);
-  }
+  const indexByName = buildNameIndex(childNodes);
 
   type ResolvedNest = {
     c: NestConstraint;

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -13,7 +13,6 @@ import {
   UnderlyingSpace,
   isPOSITION,
   isSIZE,
-  isUNDEFINED,
   spaceMeasure,
 } from "../underlyingSpace";
 import * as Interval from "../../util/interval";

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -39,7 +39,7 @@ import { allocateSlices } from "../constraints/folds";
 import { childNameKey } from "../constraints/shared";
 import {
   composeConstraintSpaces,
-  type DistributeBudget,
+  type ComposeBudget,
 } from "../constraints/compose";
 import { isValue } from "../data";
 import { unionChildSpaces } from "./alignment";
@@ -505,7 +505,7 @@ export const layer = createNodeOperatorSequential(
     // Distribute budget descriptor from the recognized spread shape, stashed by
     // `resolveUnderlyingSpace` and consumed by `layout` to invert the composed
     // SIZE against the allotted size and propose per-child slices.
-    let constraintBudget: DistributeBudget | undefined;
+    let constraintBudget: ComposeBudget | undefined;
 
     return new GoFishNode(
       {
@@ -671,63 +671,67 @@ export const layer = createNodeOperatorSequential(
             }
           }
 
-          // Layer budget solve for a recognized spread shape. When the
-          // distribute fold composed a SIZE claim, invert it against this
-          // layer's resolved size on the distribute axis to derive the child
-          // scale factor (the same Monotonic.inverse recipe as the selfScaled
-          // path, but driven by the *allotted* size, not only an explicit
-          // w/h, and passing `upperBoundGuess` like spread does). Idempotent
-          // with the root's own inversion of the same SIZE.
-          if (
-            constraintBudget?.sizeDomain &&
-            Number.isFinite(size[constraintBudget.dAxis])
-          ) {
-            const dAxis = constraintBudget.dAxis;
-            const sf = constraintBudget.sizeDomain.inverse(size[dAxis], {
-              upperBoundGuess: size[dAxis],
-            });
-            if (sf !== undefined) childScaleFactors[dAxis] = sf;
-            else
-              // A non-invertible fold-produced Monotonic would otherwise
-              // silently vanish the content (spread's `?? 0`); name the axis and
-              // budget so the failure is visible, then keep the inherited factor.
-              console.warn(
-                `layer: could not invert distribute SIZE claim on ${
-                  dAxis === 0 ? "x" : "y"
-                } axis for budget ${size[dAxis]}px; keeping inherited scale factor.`,
-                constraintBudget
-              );
+          // Layer budget solve. For each axis whose composed claim is SIZE
+          // (the max-plus longest path), invert it against this layer's resolved
+          // size to derive the child scale factor (the same Monotonic.inverse
+          // recipe as the selfScaled path, but driven by the *allotted* size,
+          // not only an explicit w/h, and passing `upperBoundGuess` like spread
+          // does). Idempotent with the root's own inversion of the same SIZE.
+          if (constraintBudget) {
+            for (const axis of [0, 1] as const) {
+              const dom = constraintBudget.sizeDomain[axis];
+              if (dom === undefined || !Number.isFinite(size[axis])) continue;
+              const sf = dom.inverse(size[axis], {
+                upperBoundGuess: size[axis],
+              });
+              if (sf !== undefined) childScaleFactors[axis] = sf;
+              else
+                // A non-invertible fold-produced Monotonic would otherwise
+                // silently vanish the content (spread's `?? 0`); name the axis
+                // and budget so the failure is visible, then keep the inherited
+                // factor.
+                console.warn(
+                  `layer: could not invert distribute SIZE claim on ${
+                    axis === 0 ? "x" : "y"
+                  } axis for budget ${size[axis]}px; keeping inherited scale factor.`,
+                  constraintBudget
+                );
+            }
           }
 
-          // Per-child proposed size for the distribute-covered children: the
-          // fill policy (`allocateSlices`) — an equal slice each — on the
-          // distribute axis, the full size on the cross axis. A child carrying
-          // its own explicit size ignores this (its size wins), matching
-          // spread; a claim-less child consumes the slice.
-          const sliceByName: Map<string, number> | undefined = constraintBudget
+          // Per-child proposed size for distribute-covered children: each
+          // distribute segment slices its axis size equally (`allocateSlices`)
+          // among its covered children; a child covered on both axes (a table
+          // cell) draws an x-slice and a y-slice. Uncovered axes get the full
+          // size. A child carrying its own explicit size ignores this (its size
+          // wins), matching spread; a claim-less child consumes the slice.
+          const sliceByName: Map<string, Size> | undefined = constraintBudget
             ? (() => {
-                const b = constraintBudget;
-                const slices = allocateSlices(
-                  size[b.dAxis],
-                  b.spacing,
-                  b.order.length
-                );
-                const m = new Map<string, number>();
-                b.order.forEach((name, i) => m.set(name, slices[i]));
+                const m = new Map<string, Size>();
+                for (const seg of constraintBudget.segments) {
+                  const slices = allocateSlices(
+                    size[seg.dAxis],
+                    seg.spacing,
+                    seg.order.length
+                  );
+                  seg.order.forEach((name, i) => {
+                    const cur = m.get(name) ?? ([size[0], size[1]] as Size);
+                    cur[seg.dAxis] = slices[i];
+                    m.set(name, cur);
+                  });
+                }
                 return m;
               })()
             : undefined;
           const childSizeFor = (childName: string | undefined): Size => {
             if (
-              !constraintBudget ||
+              sliceByName === undefined ||
               childName === undefined ||
-              !sliceByName!.has(childName)
+              !sliceByName.has(childName)
             ) {
               return size;
             }
-            const sliced: Size = [size[0], size[1]];
-            sliced[constraintBudget.dAxis] = sliceByName!.get(childName)!;
-            return sliced;
+            return sliceByName.get(childName)!;
           };
 
           // `position` constraints with a datum coordinate contribute a data


### PR DESCRIPTION
## What

Continues the *constraints as the core language* epic (#550). Replaces the single-distribute "operator image" recognizer (`resolveSpreadShape`) with **one unified per-axis composition rule** — the (max, +) algebra from [`layout-synthesis.md`](apps/docs/docs/internals/design/layout-synthesis.md):

```
claim(axis) = max-union over {
  each distribute(dir = axis):   its summed fold (Σ extent + spacing)   — series
  each align(spec on axis):      its overlay fold (alignSpaceFold)      — overlay
  each child covered by neither:  its raw extent                        — overlay
}
```

A distribute is a series (sum) on its axis; align/overlay is `max`; any network of the two folds to a single monotone claim per axis, inverted once for auto-fit. `spread` is the one-distribute + one-cross-axis-align instance; `SubsetSelection` is two disjoint distributes on one axis (sub-sums overlay → `max`); a grid (`table`, #548) is two cross-cutting distributes. The old recognizer could only handle the single-distribute image and **bailed to a plain union for anything richer** — losing the composed claim and auto-fit.

## How

- **`refactor` commit** — extract the composition seam (`resolveSpreadShape` & friends) verbatim out of `layer.tsx` into a new `constraints/compose.ts`, behind one entry point. Zero geometry change. `childNameKey` moved to `constraints/shared.ts` to avoid an import cycle.
- **`#547` commit** — replace the recognizer body with the general fold: `composeConstraintSpaces` composes N distributes + N aligns per axis via `unionChildSpaces` over the fragment list. The budget generalizes from one distribute to **N segments** (each slices its axis independently; a child covered on both axes draws an x- and a y-slice — the prerequisite for `table`/#548). Auto-fit inversion loops both axes over the composed SIZE claims.
- **`simplify` commit** — dedup the name→index build into `buildNameIndex`, type the align anchor (drop an `as never`), clarify a gate comment.

### Scope boundaries (deliberate)
- Composition fires only for layers that are **purely distributes + aligns**. A `position` pin or z-order puts the layer in a different regime — the *distribute-relative-to-a-pin* solve is deferred (per the design doc) — so it falls to the layer's default union, which preserves every chart's axis layers exactly.
- Pure overlays (no distribute, e.g. legends) keep the union; folding their aligns to POSITION would change their reported space.

## Verification

`pnpm capture-diff` (normalized-geometry, baseline-free) vs the refactor commit: **only 3 bluefish constraint diagrams** (pulley, python-tutor, global-frame) restructure their DOM, and **all three render visually identical** (verified by screenshot). Every chart, spread, and low-level parity story is byte-identical. `SubsetSelection`'s two disjoint y-distributes now genuinely compose (previously bailed to union). Typecheck clean.

| before (squished — earlier WIP regression, now fixed) | after |
| --- | --- |
| n/a | bar charts, scatter, pulley, python-tutor all unchanged |

## Follow-ups (not in this PR)
- **#548** — migrate `table` onto the shared grouped-distribute machinery (the real demonstration of multi-distribute composition).
- **Printable equations** — make `Monotonic` structure-preserving so `max(160σ + 16, 90)` (the `layout-synthesis.md` form) can be pretty-printed; today `max` of incompatible linears collapses to an opaque closure.
- **Docs** — mark residual 4 in `constraints-as-core.md` done; fix the `layout-synthesis.md` line that mislabels the marginal-histogram acceptance test as #547 (it belongs to the measure-scoping round, #549).

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)
