### PR TITLE
Structure-preserving Monotonic (convex piecewise-linear claims)

### DIFF
--- a/apps/docs/docs/internals/core/monotonic.md
+++ b/apps/docs/docs/internals/core/monotonic.md
@@ -30,15 +30,15 @@ into other affine functions. The monotonic module captures exactly that structur
 keeps the closed form whenever it can, and falls back to a numeric function only when
 it must.
 
-## The two shapes
+## The three shapes
 
-Every monotonic value is one of two kinds. Both can be _run_ forwards and _inverted_;
+Every monotonic value is one of three kinds. All can be _run_ forwards and _inverted_;
 they differ in how much the engine knows about them.
 
 ```ts twoslash
 // The shared interface — every monotonic value can do this much.
 type Monotonic = {
-  kind: "linear" | "unknown";
+  kind: "linear" | "piecewise" | "unknown";
   run: (x: number) => number;
   inverse: (y: number) => number | undefined;
 };
@@ -48,6 +48,12 @@ interface Linear extends Monotonic {
   kind: "linear";
   slope: number;
   intercept: number;
+}
+
+// A PIECEWISE value is a convex envelope — the max of several lines...
+interface Piecewise extends Monotonic {
+  kind: "piecewise";
+  pieces: { slope: number; intercept: number }[];
 }
 
 // ...while an UNKNOWN value is just a numeric black box.
@@ -80,28 +86,44 @@ Plotted, a `Linear` is just a straight line:
 ::: gofish example:internal-monotonic-linear hidden
 :::
 
+A `Piecewise` carries a list of lines and represents their **upper envelope**,
+`max_i(slopeᵢ · x + interceptᵢ)`. Because the lines all rise (non-negative slopes), the
+envelope is a convex, increasing, bent function. `run` takes the max of the pieces;
+`inverse(y)` is still closed-form — the envelope first reaches `y` at the _smallest_ σ
+at which any rising piece does, `min_i (y − interceptᵢ)/slopeᵢ` (with a check that a
+constant floor isn't holding the value above `y`). A `Piecewise` is normalized on
+construction: dominated lines are pruned, and a lone survivor collapses back to `Linear`,
+so only genuinely bent envelopes carry `kind: "piecewise"`.
+
 An `Unknown` only has the numeric function. It can still be inverted, but inversion
 falls back to numeric root-finding (`findTargetMonotonic`) — correct, because the
 function is monotonic, but iterative.
 
 ## The algebra
 
-The point of the module is that the four combinators below are **closed over `Linear`**:
-combine linear inputs and you get a linear output, with its slope and intercept
-computed directly. Only when an `Unknown` enters the mix does the result degrade to
-`Unknown`.
+The point of the module is that the four combinators below are **closed over the
+piecewise-linear functions** (`Linear` ∪ `Piecewise`): combine PWL inputs and you get a
+PWL output, in closed form. Only when an `Unknown` enters the mix does the result degrade
+to `Unknown`. This is the convex piecewise-linear normal form of the (max, +) algebra —
+the same algebra the layout engine composes constraints in (see
+[Constraints as the core](/internals/design/constraints-as-core)).
 
-| Combinator   | Meaning               | Stays `Linear` when…                           |
-| ------------ | --------------------- | ---------------------------------------------- |
-| `add(...fs)` | sum of functions      | every argument is `Linear`                     |
-| `smul(k, f)` | scalar multiple       | `f` is `Linear`                                |
-| `adds(f, k)` | add a constant offset | `f` is `Linear`                                |
-| `max(...fs)` | pointwise maximum     | all args are `Linear` _and share an intercept_ |
+| Combinator   | Meaning               | Stays closed-form (PWL) when… |
+| ------------ | --------------------- | ----------------------------- |
+| `add(...fs)` | sum of functions      | no argument is `Unknown`      |
+| `smul(k, f)` | scalar multiple       | `f` is not `Unknown`          |
+| `adds(f, k)` | add a constant offset | `f` is not `Unknown`          |
+| `max(...fs)` | pointwise maximum     | no argument is `Unknown`      |
 
-`max` is the interesting one. The pointwise max of two lines is generally a bent
-piecewise function — _not_ linear. But if the lines share an intercept they fan out
-from a common point, so their max is just the steepest line. That is the only case
-`max` can keep in closed form; otherwise it returns an `Unknown`.
+`max` is the structural one: the pointwise max of lines is their envelope, so it simply
+**unions the pieces**. `add` stays closed because the sum of two envelopes is again an
+envelope — `(max_i aᵢ) + (max_j bⱼ) = max_{i,j}(aᵢ + bⱼ)` — i.e. the pairwise sums of the
+pieces. (When every argument is a single line, both fall back to the plain `Linear` fast
+path; the all-linear `add` is one slope-sum and one intercept-sum.)
+
+Because the structure is preserved, a composed claim can be **printed as the equation it
+represents** — `print` renders `40σ + 16`, or `max(160σ + 16, 90)` for an envelope —
+matching the forms in the [layout synthesis essay](/internals/design/layout-synthesis).
 
 ## Slope as a data-driven signal
 
@@ -114,11 +136,18 @@ interface Linear {
   slope: number;
   intercept: number;
 }
-type Monotonic = Linear | { kind: "unknown" };
+interface Piecewise {
+  kind: "piecewise";
+  pieces: { slope: number; intercept: number }[];
+}
+type Monotonic = Linear | Piecewise | { kind: "unknown" };
 declare const isLinear: (x: Monotonic) => x is Linear;
+declare const isPiecewise: (x: Monotonic) => x is Piecewise;
 // ---cut---
-// A constant subtree — slope 0 — does not depend on the data at all.
-const isConstant = (x: Monotonic): boolean => isLinear(x) && x.slope === 0;
+// A constant subtree — every slope 0 — does not depend on the data at all.
+const isConstant = (x: Monotonic): boolean =>
+  (isLinear(x) && x.slope === 0) ||
+  (isPiecewise(x) && x.pieces.every((p) => p.slope === 0));
 ```
 
 By monotonicity, slope can never decrease as contributions accumulate, so a total slope

--- a/packages/gofish-graphics/src/util/monotonic.ts
+++ b/packages/gofish-graphics/src/util/monotonic.ts
@@ -5,7 +5,7 @@
 import { findTargetMonotonic } from "../util";
 
 export type Monotonic = {
-  kind: "linear" | "unknown";
+  kind: "linear" | "piecewise" | "unknown";
   run: (x: number) => number;
   inverse: (
     x: number,
@@ -27,6 +27,25 @@ export interface Linear extends Monotonic {
   intercept: number;
 }
 
+/** A single line `slope·x + intercept`. */
+export interface Piece {
+  slope: number;
+  intercept: number;
+}
+
+/**
+ * A convex piecewise-linear function: the upper envelope `max_i(slope_i·x +
+ * intercept_i)` of its `pieces`. This is the normal form of the (max, +)
+ * algebra over linear claims — closed under `add` (pairwise sums of pieces),
+ * `max` (union of pieces), `smul`, and `adds` — so a composed claim keeps its
+ * structure (printable, exactly invertible) instead of collapsing to an opaque
+ * closure. See apps/docs/docs/internals/core/monotonic.md.
+ */
+export interface Piecewise extends Monotonic {
+  kind: "piecewise";
+  pieces: Piece[];
+}
+
 export interface Unknown extends Monotonic {
   kind: "unknown";
 }
@@ -41,14 +60,82 @@ export function linear(slope: number, intercept: number): Linear {
   };
 }
 
+/** Drop pieces dominated by another on x ≥ 0: line B is redundant when some
+ *  line A has `slope ≥` and `intercept ≥` B's (so A ≥ B everywhere on x ≥ 0).
+ *  Keeps the envelope small for printing and bounds `add`'s cartesian growth.
+ *  Exact dominance only — not a full convex-hull prune (non-binding interior
+ *  pieces may remain, which is harmless: `run`/`inverse` still take the max). */
+function pruneDominated(pieces: Piece[]): Piece[] {
+  const kept: Piece[] = [];
+  for (let i = 0; i < pieces.length; i++) {
+    const b = pieces[i];
+    const dominated = pieces.some((a, j) => {
+      if (j === i) return false;
+      const better = a.slope >= b.slope && a.intercept >= b.intercept;
+      const strict = a.slope > b.slope || a.intercept > b.intercept;
+      // On a tie (identical line) keep only the first occurrence.
+      return better && (strict || j < i);
+    });
+    if (!dominated) kept.push(b);
+  }
+  return kept;
+}
+
+/**
+ * Build a convex piecewise-linear Monotonic from `pieces` (interpreted as their
+ * max). Normalizes: prunes dominated pieces and collapses a single survivor back
+ * to `linear`, so the all-linear fast path and `.slope`/`.intercept` readers
+ * keep working and only genuinely multi-line envelopes carry `kind: "piecewise"`.
+ */
+export function piecewise(pieces: Piece[]): Linear | Piecewise {
+  const ps = pruneDominated(pieces);
+  if (ps.length === 1) return linear(ps[0].slope, ps[0].intercept);
+  return {
+    kind: "piecewise",
+    pieces: ps,
+    run: (x: number) => Math.max(...ps.map((p) => p.slope * x + p.intercept)),
+    inverse: (y: number, options) => {
+      // The envelope is increasing and convex, so it equals `y` at the SMALLEST
+      // σ at which any rising piece reaches `y` (past it the max overshoots).
+      let sigma = Infinity;
+      for (const p of ps) {
+        if (p.slope > 0) sigma = Math.min(sigma, (y - p.intercept) / p.slope);
+      }
+      if (!Number.isFinite(sigma)) return undefined; // all pieces constant
+      // Reject when a constant (or higher) piece dominates at σ, so the max
+      // never actually equals y (envelope(σ) > y).
+      const tol = options?.tolerance ?? 1e-6;
+      const at = Math.max(...ps.map((p) => p.slope * sigma + p.intercept));
+      return Math.abs(at - y) <= tol * Math.max(1, Math.abs(y))
+        ? sigma
+        : undefined;
+    },
+  };
+}
+
 export const isLinear = (x: Monotonic): x is Linear => {
   return x.kind === "linear";
 };
 
+export const isPiecewise = (x: Monotonic): x is Piecewise => {
+  return x.kind === "piecewise";
+};
+
+/** The line pieces of a linear/piecewise Monotonic, or undefined for `unknown`
+ *  (which has no closed-form envelope, so callers must fall back to a closure). */
+const piecesOf = (x: Monotonic): Piece[] | undefined =>
+  isLinear(x)
+    ? [{ slope: x.slope, intercept: x.intercept }]
+    : isPiecewise(x)
+      ? x.pieces
+      : undefined;
+
 /* TODO: if a function is constant, then the entire subtree isn't data-driven (by monotonicity, the
 slope can never decrease so all contributions to it must be zero) */
 export const isConstant = (x: Monotonic): boolean => {
-  return isLinear(x) && x.slope === 0;
+  if (isLinear(x)) return x.slope === 0;
+  if (isPiecewise(x)) return x.pieces.every((p) => p.slope === 0);
+  return false;
 };
 
 export const isZero = (x: Monotonic): boolean => {
@@ -81,39 +168,75 @@ export const add = (...args: Monotonic[]): Monotonic => {
       args.reduce((sum, arg) => sum + arg.slope, 0),
       args.reduce((sum, arg) => sum + arg.intercept, 0)
     );
-  } else {
-    return unknown((x: number) =>
-      args.reduce((sum, arg) => sum + arg.run(x), 0)
-    );
   }
+  // All linear/piecewise → the sum is the pairwise sum of envelopes:
+  // (max_i aᵢ) + (max_j bⱼ) = max_{i,j}(aᵢ + bⱼ). Still convex PWL.
+  const allPieces = args.map(piecesOf);
+  if (allPieces.every((p): p is Piece[] => p !== undefined)) {
+    let acc: Piece[] = [{ slope: 0, intercept: 0 }];
+    for (const ps of allPieces) {
+      acc = acc.flatMap((e) =>
+        ps.map((p) => ({
+          slope: e.slope + p.slope,
+          intercept: e.intercept + p.intercept,
+        }))
+      );
+    }
+    return piecewise(acc);
+  }
+  // An `unknown` operand has no envelope — fall back to a summing closure.
+  return unknown((x: number) => args.reduce((sum, arg) => sum + arg.run(x), 0));
 };
 
 export const smul = (scalar: number, fn: Monotonic): Monotonic => {
-  if (isLinear(fn)) {
-    return linear(scalar * fn.slope, scalar * fn.intercept);
-  } else {
-    return unknown((x: number) => scalar * fn.run(x));
-  }
+  if (isLinear(fn)) return linear(scalar * fn.slope, scalar * fn.intercept);
+  if (isPiecewise(fn))
+    return piecewise(
+      fn.pieces.map((p) => ({
+        slope: scalar * p.slope,
+        intercept: scalar * p.intercept,
+      }))
+    );
+  return unknown((x: number) => scalar * fn.run(x));
 };
 
 export const adds = (fn: Monotonic, scalar: number): Monotonic => {
-  if (isLinear(fn)) {
-    return linear(fn.slope, fn.intercept + scalar);
-  } else {
-    return unknown((x: number) => fn.run(x) + scalar);
-  }
+  if (isLinear(fn)) return linear(fn.slope, fn.intercept + scalar);
+  if (isPiecewise(fn))
+    return piecewise(
+      fn.pieces.map((p) => ({
+        slope: p.slope,
+        intercept: p.intercept + scalar,
+      }))
+    );
+  return unknown((x: number) => fn.run(x) + scalar);
 };
 
 export const max = (...args: Monotonic[]): Monotonic => {
   args = args.filter((arg) => !isZero(arg));
-  if (args.length === 0) {
-    return linear(0, 0);
-  } else if (
-    args.every(isLinear) &&
-    args.every((arg) => arg.intercept === args[0].intercept)
-  ) {
-    return linear(Math.max(...args.map((arg) => arg.slope)), args[0].intercept);
-  } else {
-    return unknown((x: number) => Math.max(...args.map((arg) => arg.run(x))));
+  if (args.length === 0) return linear(0, 0);
+  // All linear/piecewise → the max is the union of their pieces (one envelope).
+  const allPieces = args.map(piecesOf);
+  if (allPieces.every((p): p is Piece[] => p !== undefined)) {
+    return piecewise(allPieces.flat());
   }
+  // An `unknown` operand has no envelope — fall back to a max-of-runs closure.
+  return unknown((x: number) => Math.max(...args.map((arg) => arg.run(x))));
+};
+
+/** Pretty-print a Monotonic as the equation it represents — `40σ + 16`,
+ *  `max(40σ + 16, 90)`, or `f(σ)` for an opaque closure. Matches the forms in
+ *  the layout-synthesis essay; for debugging composed size claims. */
+export const print = (x: Monotonic): string => {
+  const line = (p: Piece): string => {
+    if (p.slope === 0) return `${p.intercept}`;
+    const term = `${p.slope}σ`;
+    if (p.intercept === 0) return term;
+    return p.intercept > 0
+      ? `${term} + ${p.intercept}`
+      : `${term} - ${-p.intercept}`;
+  };
+  if (isLinear(x)) return line(x);
+  if (isPiecewise(x)) return `max(${x.pieces.map(line).join(", ")})`;
+  return "f(σ)";
 };


### PR DESCRIPTION
## What

Makes the `Monotonic` algebra **structure-preserving** so composed size claims keep their closed form (and can be printed) instead of collapsing to an opaque closure.

Today `max` of two lines with different intercepts — e.g. a data-driven stack overlaid with a fixed legend — falls back to `unknown` (a numeric black box, inverted by bisection). After this change it stays a **convex piecewise-linear** envelope: the (max, +) normal form over linear claims.

## How

A new `piecewise` kind = the upper envelope `max_i(slopeᵢ·x + interceptᵢ)` of its line pieces:

- `max` unions the pieces; `add` takes their pairwise sums (`max_i aᵢ + max_j bⱼ = max_{i,j}(aᵢ+bⱼ)`); `smul`/`adds` map over them — all closed-form.
- `inverse` is closed-form (`min_i (y−bᵢ)/mᵢ` with a constant-floor check) — no bisection.
- Normalized on construction: dominated pieces pruned, a lone survivor collapses back to `linear`, so the **all-linear fast path and `.slope` readers are untouched** and only genuinely bent envelopes carry `kind: "piecewise"`. `unknown` still covers the non-PWL cases (center mode).

New `print()` renders the equation:

```
print(160σ + 16)               → "160σ + 16"
print(max(160σ + 16, 90))      → "max(160σ + 16, 90)"
inverse(300) on that envelope  → 1.775     // the layout-synthesis worked value
```

Matches the forms in `layout-synthesis.md`; the monotonic essay is updated (two shapes → three).

## Verification

`capture-diff` across all 189 stories: **one** story (`nest--auto-fit`) shifts by **0.0008px** — the closed-form PWL inverse is more precise than the old root-finding. Everything else byte-identical. Typecheck, eslint, prettier, back-links all clean.

Independent of #547 (this only touches `util/monotonic.ts` + its essay); it makes the claims that #547's composition produces visible/printable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)