### PR TITLE
spread/stack → layer + align + distribute elaboration (incl. #549 de-mutation)

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -251,7 +251,15 @@ composes its targets' spaces into the layer's claim on that axis:
   layer enforces both at constraint-collection time (see [[size-claims]]).
 
 The layer composes these per axis — children not covered by a constraint
-max-union in as overlay siblings — and at layout time **solves the budget**:
+max-union in as overlay siblings. On an axis a constraint **does** cover, that
+fold is authoritative and overrides the layer's default `unionChildSpaces` —
+**even when the fold is UNDEFINED**. This matters for an `align` over ORDINAL
+cross-axis children: the alignment fold is UNDEFINED (no anchored axis), and if
+the default union were allowed to win it would resurrect an ORDINAL space and a
+spurious axis (a waffle's chunked-row index leaking a row "axis"). The
+covered-axis fold — UNDEFINED included — is what `composeConstraintSpaces`
+reports (`constraints/compose.ts`). At layout time the layer then **solves the
+budget**:
 a fold-produced SIZE claim is inverted against the layer's allotted size to
 derive a local scale factor, and distribute-covered fill children are
 proposed slices from the shared allocator (`allocateSlices`,
@@ -275,6 +283,21 @@ coordinate transform's children are pixel-pure by construction (posScales
 don't cross a nonlinear transform — children get scale _factors_ instead), so
 an `end`-aligned spread inside `coord` seats flush at the box edge rather
 than at a scale origin.
+
+The `posScale(0)` fallback is right only when the children are SIZE-derived
+(bars hanging from the zero line). When a `spread`'s cross-axis children
+**already hold their own data positions** — their pre-fold space is POSITION,
+not SIZE — a non-`middle` alignment must instead be a **no-op**: the children
+know where they belong, and forcing them to `posScale(0)` off a domain that
+doesn't straddle zero (e.g. faceted year panels over `[1955, 2010]`) flings
+them far off-canvas. The elaborated `align` constraint carries this as
+`guardDataPositioned` + a per-axis `fromSize` flag (`constraints/align.ts`):
+`spread.tsx` sets the flag, and the layer fills in `fromSize` from the
+**pre-fold** child spaces in `resolveUnderlyingSpace` (mirroring
+`resolveAlignmentSpace().fromSize` — the post-fold node space is wrong here,
+since a SIZE→POSITION fold has already erased the distinction). The guard is
+scoped to spread-emitted aligns; axis/legend/table aligns keep the
+unconditional fallback.
 
 Three patterns cover most operators:
 
@@ -400,8 +423,8 @@ gofish.tsx (root):
                                        to seed the root scale factor
   pass both downward as (scaleFactors, posScales)
 
-spread.layout (each spread/stack node):
-  if shared[axis]:
+layer.layout, on an axis the node scopes (node.shared[axis] — set by
+`spread`/`stack`'s `sharedScale`; default [false, false] is a no-op):
     if myUSpace[axis].kind === "size"       → space.domain.inverse(size[axis])
     if myUSpace[axis].kind === "position"   → size[axis] / Interval.width(domain)
     if myUSpace[axis].kind === "difference" → size[axis] / space.width
@@ -411,13 +434,18 @@ spread.layout (each spread/stack node):
 Leaf shapes never need to compute their own scale factors — they receive
 them via the `scaleFactors` parameter and apply them in `computeSize`.
 
-A `layer` whose constraints fold to a SIZE claim runs the same inversion
-as spread's first branch — `fold.inverse(size[axis])` against its allotted
-size — to derive a local scale factor for its constrained children (and
-warns before falling back when the fold isn't invertible at that budget).
-Unlike spread, the layer never mutates the inherited `scaleFactors`
-array; sibling scale sharing via mutation is a spread-only behavior
-(`sharedScale`).
+`spread`/`stack` no longer have their own `layout` — they **elaborate to
+`layer + align + distribute`** (`spread.tsx`), so the dispatch above lives
+entirely in `layer.layout`. A `layer` whose constraints fold to a SIZE claim
+inverts that fold against its allotted size (`fold.inverse(size[axis])`) to
+derive a local scale factor for its constrained children (warning before
+falling back when the fold isn't invertible at that budget); a `layer` that is
+a `sharedScale` scope runs the per-axis solve in the pseudocode above. Either
+way it writes into a **fresh `childScaleFactors` array** and hands that to
+descendants — **no node ever mutates the inherited `scaleFactors`**. That is
+the claim-hoisting form of `sharedScale` (#549): a scale solves at the lowest
+node where its measure stops being shared, and the result flows to descendants
+only, never leaking to siblings.
 
 This dispatch is the practical embodiment of the underlying-space-kind
 distinction. It also happens to make the rendering pipeline more readable:
@@ -725,7 +753,9 @@ companion thesis repo).
   `src/ast/constraints/{distribute,align,folds}.ts`.
 - The Monotonic algebra used by SIZE composition: `src/util/monotonic.ts`.
 - Layout consumption: `gofish.tsx`'s `layout()` for root-level dispatch;
-  `spread.tsx`'s `layout` for the per-node `computeScaleFactor`.
+  `layer.tsx`'s `layout` for the per-scope scale-factor solve and the
+  constraint budget inversion (`spread`/`stack` elaborate to `layer`, so they
+  have no `layout` of their own).
 - Companion factory docs:
   [The Mark Factory](/internals/frontend/mark-factory),
   [The Operator Factory](/internals/frontend/operator-factory).

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -82,6 +82,11 @@ export type Placeable = {
   place: (axis: FancyDirection, value: number, anchor?: Anchor) => void;
 };
 
+// `scaleFactors` is the σ (pixels-per-data-unit) handed down per axis. A node
+// MUST NOT mutate this array: to establish a local scale for its descendants
+// (the `shared` scoping annotation, below) it copies into a fresh array and
+// passes that down — never writing back to the parent's, so a solved σ can't
+// leak to the node's siblings (see spread.tsx / layer.tsx).
 export type Layout = (
   shared: Size<boolean>,
   size: Size,
@@ -143,6 +148,11 @@ export class GoFishNode {
   public children: GoFishAST[];
   public intrinsicDims?: Dimensions;
   public transform?: Transform;
+  /** Per-axis scope annotation: `true` = this node is a scale scope (it solves
+   *  σ from its own box and hands it to descendants via a fresh array — claim
+   *  hoisting, #549); `false` (default) = pass-through, inheriting σ from above.
+   *  It is NOT a mutation flag — no node writes back to the parent's
+   *  `scaleFactors`. Currently set only by `spread`/`stack` (`sharedScale`). */
   public shared: Size<boolean>;
   public renderData?: any;
   public coordinateTransform?: CoordinateTransform;

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -45,6 +45,18 @@ export interface AlignConstraint {
   x?: AlignAxisSpec;
   y?: AlignAxisSpec;
   children: ConstraintRef[];
+  /** Set by `spread`'s elaboration: apply the bespoke spread's data-positioned
+   *  guard — on a posScale axis whose target children are NOT all SIZE-derived
+   *  (`fromSize === false`), a non-`middle` anchor is a no-op (the children
+   *  already know where they belong; the scale's `posScale(0)` zero-line
+   *  fallback would fling a non-zero-origin axis off-canvas). Off (undefined) for
+   *  axis/legend/table aligns, which keep the unconditional align. */
+  guardDataPositioned?: boolean;
+  /** Per-axis "every target child's space on this axis is SIZE", computed from
+   *  the PRE-fold child spaces in the layer's `resolveUnderlyingSpace` (mirrors
+   *  bespoke `resolveAlignmentSpace().fromSize`). Only consulted when
+   *  `guardDataPositioned` is set. */
+  fromSize?: [boolean, boolean];
 }
 
 export interface AlignOptions {
@@ -171,8 +183,29 @@ function applyAlignAxis(
   axis: Axis,
   spec: AlignAxisSpec,
   targets: Placeable[],
-  env: AlignAxisEnv
+  env: AlignAxisEnv,
+  guardDataPositioned: boolean,
+  fromSize: boolean | undefined
 ): void {
+  // Data-positioned guard (mirrors bespoke spread's `alignChildren`:
+  // `posScale && !fromSize && alignment !== "middle"` → return). When the spread
+  // elaboration sets `guardDataPositioned` and the target children are NOT
+  // SIZE-derived on this axis (`fromSize === false`), a non-`middle` anchor on a
+  // posScale axis is a no-op: the children carry their own data positions, and
+  // the `alignFallbackBaseline` `posScale(0)` would otherwise fling a
+  // non-zero-origin axis (e.g. faceted year panels [1955,2010]) far off-canvas.
+  // Leaving them unplaced lets the layer's baseline placement keep them at the
+  // local origin. `middle` still centers (DIFFERENCE extent, no anchored origin).
+  if (
+    guardDataPositioned &&
+    fromSize === false &&
+    env.posScale !== undefined &&
+    !Array.isArray(spec) &&
+    spec !== "middle"
+  ) {
+    return;
+  }
+
   // Normalize to a per-child anchor array.
   let anchors: AlignAnchor[];
   if (Array.isArray(spec)) {
@@ -198,16 +231,25 @@ export function applyAlign(
   sizes: [number, number],
   posScales: ConstraintPosScales | undefined
 ): void {
+  const guard = constraint.guardDataPositioned ?? false;
   if (constraint.x !== undefined) {
-    applyAlignAxis("x", constraint.x, targets, {
-      size: sizes[0],
-      posScale: posScales?.[0],
-    });
+    applyAlignAxis(
+      "x",
+      constraint.x,
+      targets,
+      { size: sizes[0], posScale: posScales?.[0] },
+      guard,
+      constraint.fromSize?.[0]
+    );
   }
   if (constraint.y !== undefined) {
-    applyAlignAxis("y", constraint.y, targets, {
-      size: sizes[1],
-      posScale: posScales?.[1],
-    });
+    applyAlignAxis(
+      "y",
+      constraint.y,
+      targets,
+      { size: sizes[1], posScale: posScales?.[1] },
+      guard,
+      constraint.fromSize?.[1]
+    );
   }
 }

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -197,10 +197,16 @@ export function composeConstraintSpaces(
 
     const composed =
       fragments.length > 0 ? unionChildSpaces(fragments, axis) : UNDEFINED;
-    if (!isUNDEFINED(composed)) {
-      spaces[axis] = composed;
-      if (isSIZE(composed)) sizeDomain[axis] = composed.domain;
-    }
+    // This axis is covered by an align/distribute, so the FOLD is authoritative
+    // — set it even when UNDEFINED, to OVERRIDE (suppress) the layer's default
+    // `unionChildSpaces`. The bespoke spread always reported its cross-axis fold
+    // (`resolveAlignmentSpace`), and for ORDINAL children that fold is UNDEFINED
+    // (no axis). Letting the default union win instead resurrects an ORDINAL —
+    // e.g. the waffle's row index leaks a spurious "Lake B-N" y-axis. (axisSize
+    // pads the off-axis with UNDEFINED, so `spaces[axis]` only ever carries this
+    // axis's contribution.)
+    spaces[axis] = composed;
+    if (isSIZE(composed)) sizeDomain[axis] = composed.domain;
   }
 
   return {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -619,6 +619,23 @@ export const layer = createNodeOperatorSequential(
             }
           }
 
+          // Fill in each spread-guarded align's per-axis `fromSize` from the
+          // PRE-fold child spaces (mirrors bespoke `resolveAlignmentSpace()
+          // .fromSize`). Consumed by `applyAlign`'s data-positioned guard
+          // (align.ts) so a posScale cross axis whose children carry their own
+          // data positions isn't pulled to the scale's `posScale(0)` fallback.
+          const alignNameIdx = buildNameIndex(_childNodes);
+          for (const c of constraints ?? []) {
+            if (c.type !== "align" || !c.guardDataPositioned) continue;
+            const idxs = c.children
+              .map((r) => alignNameIdx.get(r.name))
+              .filter((i): i is number => i !== undefined);
+            const allSizeOn = (axis: 0 | 1): boolean =>
+              idxs.length > 0 &&
+              idxs.every((i) => isSIZE(effectiveChildren[i][axis]));
+            c.fromSize = [allSizeOn(0), allSizeOn(1)];
+          }
+
           // Stash the absorbed POSITION/SIZE space and report UNDEFINED upward
           // for any dim with an explicit pixel size — self-scaling region; see
           // selfScaledSpaces above. (last write wins — may run more than once.)

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -11,6 +11,7 @@ import {
   SIZE,
   UNDEFINED,
   UnderlyingSpace,
+  isDIFFERENCE,
   isPOSITION,
   isSIZE,
   spaceMeasure,
@@ -707,6 +708,32 @@ export const layer = createNodeOperatorSequential(
                   constraintBudget
                 );
             }
+          }
+
+          // `sharedScale` scale scope (claim hoisting, #549): on an axis this
+          // layer is a scope for (set by `spread`'s `sharedScale`; default
+          // [false,false] → no-op for every plain layer/table), solve σ locally
+          // from its composed claim against its own box and hand it to
+          // descendants via the FRESH array — the dispatch the bespoke spread
+          // used (computeScaleFactor): SIZE inverts, POSITION/DIFFERENCE divide
+          // by the domain/width.
+          for (const axis of [0, 1] as const) {
+            if (!shared[axis] || !Number.isFinite(size[axis])) continue;
+            const sp = selfScaledSpaces[axis] ?? node._underlyingSpace?.[axis];
+            if (sp === undefined) continue;
+            let sf: number | undefined;
+            if (isSIZE(sp)) {
+              sf =
+                sp.domain.inverse(size[axis], {
+                  upperBoundGuess: size[axis],
+                }) ?? 0;
+            } else if (isPOSITION(sp) && sp.domain) {
+              const w = Interval.width(sp.domain);
+              sf = w !== 0 ? size[axis] / w : 0;
+            } else if (isDIFFERENCE(sp)) {
+              sf = sp.width !== 0 ? size[axis] / sp.width : 0;
+            }
+            if (sf !== undefined) childScaleFactors[axis] = sf;
           }
 
           // Per-child proposed size for distribute-covered children: each

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -624,16 +624,25 @@ export const layer = createNodeOperatorSequential(
           // .fromSize`). Consumed by `applyAlign`'s data-positioned guard
           // (align.ts) so a posScale cross axis whose children carry their own
           // data positions isn't pulled to the scale's `posScale(0)` fallback.
-          const alignNameIdx = buildNameIndex(_childNodes);
-          for (const c of constraints ?? []) {
-            if (c.type !== "align" || !c.guardDataPositioned) continue;
-            const idxs = c.children
-              .map((r) => alignNameIdx.get(r.name))
-              .filter((i): i is number => i !== undefined);
-            const allSizeOn = (axis: 0 | 1): boolean =>
-              idxs.length > 0 &&
-              idxs.every((i) => isSIZE(effectiveChildren[i][axis]));
-            c.fromSize = [allSizeOn(0), allSizeOn(1)];
+          // Gated on a guarded align existing so the common case (every plain
+          // layer/table — `resolveUnderlyingSpace` is a hot path that can run
+          // more than once) skips the O(n) `buildNameIndex` build entirely.
+          if (
+            (constraints ?? []).some(
+              (c) => c.type === "align" && c.guardDataPositioned
+            )
+          ) {
+            const alignNameIdx = buildNameIndex(_childNodes);
+            for (const c of constraints ?? []) {
+              if (c.type !== "align" || !c.guardDataPositioned) continue;
+              const idxs = c.children
+                .map((r) => alignNameIdx.get(r.name))
+                .filter((i): i is number => i !== undefined);
+              const allSizeOn = (axis: 0 | 1): boolean =>
+                idxs.length > 0 &&
+                idxs.every((i) => isSIZE(effectiveChildren[i][axis]));
+              c.fromSize = [allSizeOn(0), allSizeOn(1)];
+            }
           }
 
           // Stash the absorbed POSITION/SIZE space and report UNDEFINED upward

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -81,18 +81,7 @@ export const Spread = createNodeOperator(
     // a GoFishNode — it carries `_name` too, so it must also be named or the
     // layer's `nameToPlaceable` won't have an entry for it and the constraint
     // silently drops it (the ref then never participates in align/distribute).
-    // `reverse` is handled by REVERSING the child array up front, then a plain
-    // forward distribute — exactly as the bespoke spread did (`if (reverse)
-    // children = children.reverse()`). This is NOT equivalent to a forward array
-    // with `order: "reverse"`: a reversed WALK keeps per-child positions but
-    // leaves the layer's child order, POSITION fold, and bbox/baseline forward,
-    // so a glued (stack) column's baseline (its local origin, which bubbles up to
-    // the parent's alignment) ends up flipped — the nested-mosaic regression.
-    // Reversing the array makes the fold, bbox, baseline, and walk all agree
-    // with bespoke. No-op for the common forward case.
-    const childList = reverse
-      ? [...(children as GoFishAST[])].reverse()
-      : (children as GoFishAST[]);
+    const childList = children as GoFishAST[];
     // Track names already claimed so a collision is disambiguated rather than
     // collapsing two children onto one slot. The bespoke spread placed children
     // POSITIONALLY, so same-named children were harmless; the layer addresses
@@ -152,8 +141,7 @@ export const Spread = createNodeOperator(
             spacing: glue ? 0 : spacing,
             mode,
             glue,
-            // Always forward — `reverse` already reordered `childList` above.
-            order: "forward",
+            order: reverse ? "reverse" : "forward",
           },
           refs
         ),

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -103,8 +103,15 @@ export const Spread = createNodeOperator(
     const used = new Set<string>();
     const names = childList.map((c, i) => {
       const existing = childNameKey(c);
+      // `||` (not `??`): an EMPTY-string name is as useless as a missing one and
+      // must be synthesized. An empty `childName` is falsy, so the layer's
+      // phase-1 guard `!childName` would baseline-place it even though it's a
+      // constraint target — then a `middle` align centers siblings on its
+      // (origin) center instead of the box center (the icicle/nested-waffle
+      // regression). A real Token name (`createName`) is a non-empty string, so
+      // `||` still preserves it.
       let nm =
-        existing ?? ((c instanceof GoFishNode && c.key) || `__spread_${i}`);
+        existing || (c instanceof GoFishNode && c.key) || `__spread_${i}`;
       if (used.has(nm)) nm = `${nm}__spread_${i}`;
       used.add(nm);
       // Write the name back ONLY when we assigned or disambiguated it, so the

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -120,8 +120,14 @@ export const Spread = createNodeOperator(
     )) as GoFishNode;
     node.constrain((ref) => {
       const refs = names.map((n) => ref[n] ?? { name: n });
+      // Carry the bespoke spread's data-positioned alignment guard: on a
+      // posScale cross axis whose children already hold their own data
+      // positions (not SIZE-derived), a non-`middle` align is a no-op. The
+      // layer fills in `fromSize` (from pre-fold child spaces) at resolve time.
+      const alignC = Constraint.align({ [alignAxis]: alignment }, refs);
+      alignC.guardDataPositioned = true;
       return [
-        Constraint.align({ [alignAxis]: alignment }, refs),
+        alignC,
         Constraint.distribute(
           {
             dir: stackAxis,

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -82,11 +82,32 @@ export const Spread = createNodeOperator(
     // layer's `nameToPlaceable` won't have an entry for it and the constraint
     // silently drops it (the ref then never participates in align/distribute).
     const childList = children as GoFishAST[];
+    // Track names already claimed so a collision is disambiguated rather than
+    // collapsing two children onto one slot. The bespoke spread placed children
+    // POSITIONALLY, so same-named children were harmless; the layer addresses
+    // them through `nameToPlaceable`, which keys by name — duplicates there map
+    // every constraint ref to a single placeable (e.g. cut returns N slices that
+    // all carry the source mark's name, so the distribute would place one slice
+    // and no-op the rest, collapsing them onto each other).
+    const used = new Set<string>();
     const names = childList.map((c, i) => {
       const existing = childNameKey(c);
-      if (existing !== undefined) return existing;
-      const nm = (c instanceof GoFishNode && c.key) || `__spread_${i}`;
-      if (c instanceof GoFishNode || c instanceof GoFishRef) c._name = nm;
+      let nm =
+        existing ?? ((c instanceof GoFishNode && c.key) || `__spread_${i}`);
+      if (used.has(nm)) nm = `${nm}__spread_${i}`;
+      used.add(nm);
+      // Write the name back ONLY when we assigned or disambiguated it, so the
+      // layer's `nameToPlaceable` keys match the constraint refs. A `ref` (e.g.
+      // an axis label's `ref(bar)`) is a GoFishRef proxy, not a GoFishNode, but
+      // carries `_name` too — name it as well or the constraint drops it. Leave
+      // an UNCHANGED existing name untouched: it may be a Token (created via
+      // `createName`), and overwriting it with a plain string would break
+      // token-based `ref`/`selectAll` resolution.
+      if (
+        nm !== existing &&
+        (c instanceof GoFishNode || c instanceof GoFishRef)
+      )
+        c._name = nm;
       return nm;
     });
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -81,7 +81,18 @@ export const Spread = createNodeOperator(
     // a GoFishNode — it carries `_name` too, so it must also be named or the
     // layer's `nameToPlaceable` won't have an entry for it and the constraint
     // silently drops it (the ref then never participates in align/distribute).
-    const childList = children as GoFishAST[];
+    // `reverse` is handled by REVERSING the child array up front, then a plain
+    // forward distribute — exactly as the bespoke spread did (`if (reverse)
+    // children = children.reverse()`). This is NOT equivalent to a forward array
+    // with `order: "reverse"`: a reversed WALK keeps per-child positions but
+    // leaves the layer's child order, POSITION fold, and bbox/baseline forward,
+    // so a glued (stack) column's baseline (its local origin, which bubbles up to
+    // the parent's alignment) ends up flipped — the nested-mosaic regression.
+    // Reversing the array makes the fold, bbox, baseline, and walk all agree
+    // with bespoke. No-op for the common forward case.
+    const childList = reverse
+      ? [...(children as GoFishAST[])].reverse()
+      : (children as GoFishAST[]);
     // Track names already claimed so a collision is disambiguated rather than
     // collapsing two children onto one slot. The bespoke spread placed children
     // POSITIONALLY, so same-named children were harmless; the layer addresses
@@ -134,7 +145,8 @@ export const Spread = createNodeOperator(
             spacing: glue ? 0 : spacing,
             mode,
             glue,
-            order: reverse ? "reverse" : "forward",
+            // Always forward — `reverse` already reordered `childList` above.
+            order: "forward",
           },
           refs
         ),

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -190,26 +190,25 @@ export const Spread = createNodeOperator(
             return undefined;
           };
 
+          // `sharedScale` makes this spread a scale SCOPE: it solves σ from its
+          // own box and hands it to its DESCENDANTS via a FRESH child array —
+          // it never mutates the parent's `scaleFactors`, so the solved σ does
+          // not leak to this node's siblings. This is the claim-hoisting form of
+          // `sharedScale` (#549): a scale solves at the lowest node where its
+          // measure stops being shared. `false` = pass-through, inheriting the σ
+          // handed down from above. (Mirrors `layer.tsx`'s fresh-array recipe.)
+          const childScaleFactors: Size<number | undefined> = [
+            scaleFactors[0],
+            scaleFactors[1],
+          ];
           if (shared[stackDir]) {
             const sf = computeScaleFactor(stackDir);
-            if (sf !== undefined) scaleFactors[stackDir] = sf;
+            if (sf !== undefined) childScaleFactors[stackDir] = sf;
           }
           if (shared[alignDir]) {
             const sf = computeScaleFactor(alignDir);
-            if (sf !== undefined) scaleFactors[alignDir] = sf;
+            if (sf !== undefined) childScaleFactors[alignDir] = sf;
           }
-
-          const scaleContext = node.getRenderSession().scaleContext;
-          const sfX = scaleFactors[0] ?? 1;
-          const sfY = scaleFactors[1] ?? 1;
-          scaleContext.x = {
-            domain: [0, size[0] / sfX],
-            scaleFactor: sfX,
-          };
-          scaleContext.y = {
-            domain: [0, size[1] / sfY],
-            scaleFactor: sfY,
-          };
 
           // Divide the stack-axis budget into equal per-child slices (the
           // shared fill policy).
@@ -223,7 +222,7 @@ export const Spread = createNodeOperator(
             const modifiedSize: Size = [0, 0];
             modifiedSize[stackDir] = childStackSizes[i] ?? 0;
             modifiedSize[alignDir] = size[alignDir];
-            return child.layout(modifiedSize, scaleFactors, posScales);
+            return child.layout(modifiedSize, childScaleFactors, posScales);
           });
 
           // Fixed-position children have dims already defined (e.g. Ref to another layer)

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -1,4 +1,5 @@
 import { GoFishNode } from "../_node";
+import { GoFishRef } from "../_ref";
 import type { AxisOptions } from "../gofish";
 import { MaybeValue } from "../data";
 import {
@@ -75,13 +76,17 @@ export const Spread = createNodeOperator(
     const stackAxis = stackDir === 0 ? "x" : "y";
 
     // Each child needs a name so the constraints can reference it; reuse its
-    // existing constraint name/key, else synthesize one.
+    // existing constraint name/key, else synthesize one. A child may be a
+    // `ref` (e.g. an axis label's `ref(bar)`), which is a GoFishRef proxy, not
+    // a GoFishNode — it carries `_name` too, so it must also be named or the
+    // layer's `nameToPlaceable` won't have an entry for it and the constraint
+    // silently drops it (the ref then never participates in align/distribute).
     const childList = children as GoFishAST[];
     const names = childList.map((c, i) => {
       const existing = childNameKey(c);
       if (existing !== undefined) return existing;
       const nm = (c instanceof GoFishNode && c.key) || `__spread_${i}`;
-      if (c instanceof GoFishNode) c._name = nm;
+      if (c instanceof GoFishNode || c instanceof GoFishRef) c._name = nm;
       return nm;
     });
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -1,33 +1,20 @@
-import { GoFishNode, Placeable } from "../_node";
+import { GoFishNode } from "../_node";
 import type { AxisOptions } from "../gofish";
 import { MaybeValue } from "../data";
 import {
   Direction,
-  elaborateDims,
   elaborateDirection,
   FancyDims,
   FancyDirection,
-  Size,
 } from "../dims";
 import { Collection } from "lodash";
 import { SplitBy, splitKeyFn } from "../datumProjection";
-import { computeAesthetic, computeSize, foldFinite } from "../../util";
 import { GoFishAST } from "../_ast";
 import { createNodeOperator } from "../withGoFish";
-import {
-  UNDEFINED,
-  isDIFFERENCE,
-  isPOSITION,
-  isSIZE,
-} from "../underlyingSpace";
-import { UnderlyingSpace } from "../underlyingSpace";
-import * as Interval from "../../util/interval";
-import { Alignment, alignChildren, resolveAlignmentSpace } from "./alignment";
-import {
-  distributeSpaceFold,
-  applyDistribute,
-} from "../constraints/distribute";
-import { allocateSlices } from "../constraints/folds";
+import { Alignment } from "./alignment";
+import { layer } from "./layer";
+import { Constraint } from "../constraints";
+import { childNameKey } from "../constraints/shared";
 import { createOperator } from "../marks/createOperator";
 import { Mark, Operator } from "../types";
 
@@ -39,8 +26,17 @@ const unwrapLodashArray = function <T>(value: T[] | Collection<T>): T[] {
   return value as T[];
 };
 
+/**
+ * `Spread` arranges its children along `dir` with spacing and aligns them on the
+ * cross axis. It **elaborates to `layer + distribute + align`**: #547 proved the
+ * space fold, budget, and auto-fit are identical to the bespoke spread, #549 made
+ * the scale handling match (fresh child array, no parent mutation), and the
+ * layer honors `sharedScale` as a scale scope (layer.tsx). `stack` is
+ * `spread({ glue: true })`; `spreadX`/`spreadY` fix `dir`. The IR keeps `spread`/
+ * `stack` (the v3 wrapper's `serialize` tag), so this elaboration is below the IR.
+ */
 export const Spread = createNodeOperator(
-  (
+  async (
     {
       name,
       key,
@@ -71,290 +67,55 @@ export const Spread = createNodeOperator(
     } & FancyDims<MaybeValue<number>>,
     children: GoFishAST[] | Collection<GoFishAST>
   ) => {
-    // Unwrap lodash wrapped children if needed
     children = unwrapLodashArray(children);
 
     const stackDir = elaborateDirection(dir);
     const alignDir = (1 - stackDir) as Direction;
-    // track whether align axis came from SIZE so we still perform baseline alignment even with posScales
-    let alignFromSize = false;
-    const dims = elaborateDims(fancyDims);
-    // Glue mode ignores spacing.
-    const effectiveSpacing = glue ? 0 : spacing;
+    const alignAxis = alignDir === 0 ? "x" : "y";
+    const stackAxis = stackDir === 0 ? "x" : "y";
 
-    const node = new GoFishNode(
-      {
-        type: "spread",
-        args: {
-          key,
-          name,
-          dir,
-          spacing,
-          alignment,
-          sharedScale,
-          mode,
-          reverse,
-          glue,
-          dims,
-        },
-        key,
-        name,
-        shared: [sharedScale, sharedScale],
-        resolveUnderlyingSpace: (
-          children: Size<UnderlyingSpace>[],
-          childNodes: GoFishAST[]
-        ) => {
-          // Cross axis: defer to the shared alignment fold. Keep the
-          // `fromSize` flag so layout still baseline-aligns SIZE-derived
-          // children even when a posScale is present.
-          const alignResult = resolveAlignmentSpace(
-            children.map((child) => child[alignDir]),
-            alignment
-          );
-          alignFromSize = alignResult.fromSize;
+    // Each child needs a name so the constraints can reference it; reuse its
+    // existing constraint name/key, else synthesize one.
+    const childList = children as GoFishAST[];
+    const names = childList.map((c, i) => {
+      const existing = childNameKey(c);
+      if (existing !== undefined) return existing;
+      const nm = (c instanceof GoFishNode && c.key) || `__spread_${i}`;
+      if (c instanceof GoFishNode) c._name = nm;
+      return nm;
+    });
 
-          // Stack axis: defer to the shared distribute fold. `namedKeys` is the
-          // compacted list of children's ordinal keys (drives the ORDINAL
-          // branch); distributeSpaceFold re-filters undefined, so the compacted
-          // form is equivalent to a positional one.
-          const namedKeys = childNodes
-            .filter((node): node is GoFishNode => node instanceof GoFishNode)
-            .map((node) => node.key)
-            .filter((key): key is string => key !== undefined);
-          const stackSpace = distributeSpaceFold(
-            children.map((child) => child[stackDir]),
-            namedKeys,
-            {
-              spacing: effectiveSpacing,
-              mode,
-              glue,
-              size: dims[stackDir].size,
-            }
-          );
+    // Elaborate to a layer carrying the cross-axis align + the stack distribute.
+    // `fancyDims` (explicit w/h) flow to the layer, whose self-scaling region
+    // handles an explicit size exactly as the bespoke spread did.
+    const node = (await layer(
+      { key, ...fancyDims } as any,
+      childList
+    )) as GoFishNode;
+    node.constrain((ref) => {
+      const refs = names.map((n) => ref[n] ?? { name: n });
+      return [
+        Constraint.align({ [alignAxis]: alignment }, refs),
+        Constraint.distribute(
+          {
+            dir: stackAxis,
+            spacing: glue ? 0 : spacing,
+            mode,
+            glue,
+            order: reverse ? "reverse" : "forward",
+          },
+          refs
+        ),
+      ];
+    });
 
-          const result: Size<UnderlyingSpace> = [UNDEFINED, UNDEFINED];
-          result[stackDir] = stackSpace;
-          result[alignDir] = alignResult.space;
-          return result;
-        },
-        layout: (shared, size, scaleFactors, children, posScales, node) => {
-          if (reverse) {
-            children = children.reverse();
-          }
-          const stackPos = computeAesthetic(
-            dims[stackDir].min,
-            posScales?.[stackDir]!,
-            undefined
-          );
-          const alignPos = computeAesthetic(
-            dims[alignDir].min,
-            posScales?.[alignDir]!,
-            undefined
-          );
-
-          const nextSize: Size = [0, 0];
-          nextSize[stackDir] = computeSize(
-            dims[stackDir].size,
-            scaleFactors?.[stackDir]!,
-            size[stackDir]
-          );
-          nextSize[alignDir] = computeSize(
-            dims[alignDir].size,
-            scaleFactors?.[alignDir]!,
-            size[alignDir]
-          );
-          size = nextSize;
-
-          // Compute scale factors at this level by dispatching on
-          // underlying-space kind: SIZE inverts the composed Monotonic;
-          // POSITION derives a linear factor from its domain extent;
-          // DIFFERENCE divides by its known pixel width (analogous to
-          // POSITION but with no anchored origin).
-          const myUSpace = node._underlyingSpace!;
-          const computeScaleFactor = (dir: Direction): number | undefined => {
-            const space = myUSpace[dir];
-            if (isSIZE(space)) {
-              return (
-                space.domain.inverse(size[dir], {
-                  upperBoundGuess: size[dir],
-                }) ?? 0
-              );
-            }
-            if (isPOSITION(space) && space.domain) {
-              const w = Interval.width(space.domain);
-              return w !== 0 ? size[dir] / w : 0;
-            }
-            if (isDIFFERENCE(space)) {
-              return space.width !== 0 ? size[dir] / space.width : 0;
-            }
-            return undefined;
-          };
-
-          // `sharedScale` makes this spread a scale SCOPE: it solves σ from its
-          // own box and hands it to its DESCENDANTS via a FRESH child array —
-          // it never mutates the parent's `scaleFactors`, so the solved σ does
-          // not leak to this node's siblings. This is the claim-hoisting form of
-          // `sharedScale` (#549): a scale solves at the lowest node where its
-          // measure stops being shared. `false` = pass-through, inheriting the σ
-          // handed down from above. (Mirrors `layer.tsx`'s fresh-array recipe.)
-          const childScaleFactors: Size<number | undefined> = [
-            scaleFactors[0],
-            scaleFactors[1],
-          ];
-          if (shared[stackDir]) {
-            const sf = computeScaleFactor(stackDir);
-            if (sf !== undefined) childScaleFactors[stackDir] = sf;
-          }
-          if (shared[alignDir]) {
-            const sf = computeScaleFactor(alignDir);
-            if (sf !== undefined) childScaleFactors[alignDir] = sf;
-          }
-
-          // Divide the stack-axis budget into equal per-child slices (the
-          // shared fill policy).
-          const childStackSizes = allocateSlices(
-            size[stackDir],
-            effectiveSpacing,
-            children.length
-          );
-
-          const childPlaceables = children.map((child, i) => {
-            const modifiedSize: Size = [0, 0];
-            modifiedSize[stackDir] = childStackSizes[i] ?? 0;
-            modifiedSize[alignDir] = size[alignDir];
-            return child.layout(modifiedSize, childScaleFactors, posScales);
-          });
-
-          // Fixed-position children have dims already defined (e.g. Ref to another layer)
-          const isFixed = (dir: Direction) => (child: Placeable) =>
-            child.dims[dir].min !== undefined;
-          const alignmentToDim = {
-            start: "min",
-            middle: "center",
-            end: "max",
-            baseline: "min",
-          } as const;
-          const getBaseline = (dir: Direction) => (child: Placeable) =>
-            child.dims[dir][alignmentToDim[alignment]!]!;
-          const isClose = (a: number, b: number) => Math.abs(a - b) < 1e-6;
-
-          // Align-direction consistency: check before placing (when >= 2 fixed)
-          const fixedChildren = childPlaceables.filter(isFixed(alignDir));
-          if (fixedChildren.length >= 2) {
-            const baselines = fixedChildren.map(getBaseline(alignDir));
-            const allSameBaseline = baselines.every((b) =>
-              isClose(b!, baselines[0]!)
-            );
-            if (!allSameBaseline) {
-              console.warn(
-                "Stack: fixed children have inconsistent align-direction positions",
-                { alignment, baselines }
-              );
-            }
-          }
-
-          /* align */
-          alignChildren(
-            childPlaceables,
-            alignDir,
-            alignment,
-            size[alignDir],
-            posScales?.[alignDir],
-            alignFromSize
-          );
-
-          // distribute: delegate to the shared walk. `reverse` was already
-          // applied to `children` above, so the placement order is fixed
-          // (order: "forward"). The reporter surfaces spread's historical
-          // inconsistency warning for fixed children whose position disagrees
-          // with the running layout — a console-only behavior the constraint
-          // path doesn't share.
-          applyDistribute(
-            {
-              dir: stackDir === 0 ? "x" : "y",
-              spacing: effectiveSpacing,
-              mode,
-              order: "forward",
-            },
-            childPlaceables,
-            (expected, actual) =>
-              console.warn(
-                mode === "center"
-                  ? "Stack: fixed child stack-direction position inconsistent (center-to-center)"
-                  : "Stack: fixed child stack-direction position inconsistent with layout order",
-                { expected, actual }
-              )
-          );
-
-          // A child the alignment step didn't place (no `alignment` given)
-          // renders at its own origin (translate 0): nail it down there now so
-          // the extents below measure the real box. Left unplaced, the child
-          // would be invisible to the measurement and the spread would report
-          // a zero cross extent — wrong whenever children's boxes overhang
-          // their origin (e.g. facets whose axis labels hang below baseline).
-          for (const child of childPlaceables) {
-            if (child.dims[alignDir].min === undefined) {
-              child.place(alignDir, 0, "baseline");
-            }
-          }
-
-          // Compute alignDir intrinsicDims from extents to account for negative
-          // bars (NaN-safe; see foldFinite for why undefined extents are
-          // skipped).
-          const reduceExtent = (
-            dir: Direction,
-            pick: (iv: { min?: number; max?: number }) => number | undefined,
-            f: (...n: number[]) => number
-          ): number =>
-            foldFinite(
-              childPlaceables.map((child) => pick(child.dims[dir])),
-              f
-            );
-          const alignMin = reduceExtent(alignDir, (iv) => iv.min, Math.min);
-          const alignMax = reduceExtent(alignDir, (iv) => iv.max, Math.max);
-          const stackMin = reduceExtent(stackDir, (iv) => iv.min, Math.min);
-          const stackMax = reduceExtent(stackDir, (iv) => iv.max, Math.max);
-          const alignSize = alignMax - alignMin;
-          const stackSize = stackMax - stackMin;
-          const translateAlign =
-            alignPos !== undefined ? alignPos - alignMin : undefined;
-
-          return {
-            intrinsicDims: {
-              [alignDir]: {
-                min: alignMin,
-                size: alignSize,
-                center: alignMin + alignSize / 2,
-                max: alignMax,
-              },
-              [stackDir]: {
-                min: stackMin,
-                size: stackSize,
-                center: stackMin + stackSize / 2,
-                max: stackMax,
-              },
-            },
-            transform: {
-              translate: {
-                [alignDir]: translateAlign,
-                [stackDir]:
-                  stackPos !== undefined ? stackPos - stackMin : undefined,
-              },
-            },
-          };
-        },
-        render: ({ transform }, children) => {
-          return (
-            <g
-              transform={`translate(${transform?.translate?.[0] ?? 0}, ${transform?.translate?.[1] ?? 0})`}
-            >
-              {children}
-            </g>
-          );
-        },
-      },
-      children
-    );
+    if (name !== undefined) node._name = name;
+    // `sharedScale` is a scale-scope annotation (claim hoisting, #549): the node
+    // solves σ locally and shares it with descendants. The layer honors this in
+    // `layout` (it self-solves per axis when `shared`, into a fresh array).
+    node.shared = [sharedScale, sharedScale];
+    // Tag with stack direction so coord can map axis overrides to polar dims.
+    node.axisDir = stackDir;
     if (axes !== undefined) {
       const toShow = (opt: AxisOptions | undefined): boolean | undefined =>
         opt === undefined ? undefined : opt === false ? false : true;
@@ -363,8 +124,6 @@ export const Spread = createNodeOperator(
           ? { x: axes, y: axes }
           : { x: toShow(axes.x), y: toShow(axes.y) };
     }
-    // Tag with stack direction so coord can map axis overrides to polar dimensions
-    node.axisDir = stackDir;
     return node;
   }
 );


### PR DESCRIPTION
## What

Make `spread`/`stack` (and `spreadX`/`spreadY`) **elaborate to `layer + align + distribute` constraints** instead of carrying their own bespoke `resolveUnderlyingSpace`/`layout`/render. Operators become sugar over the unified constraint core (like `table`→`grid` and `cut`), so there's one fold/allocator/placement path. The IR is unchanged — the v3 wrapper still serializes `{type:"spread"}`/`{type:"stack"}`; the elaboration lives below the IR, so Python/parity is unaffected.

This also includes the **#549 claim-hoisting de-mutation** that unblocked it (details at the bottom).

Closes #549. Advances #550 (constraints-as-core tracking).

**Gate: pixel equality vs the bespoke spread.** DOM reshuffles and identity `scale(1,1)` wrappers are accepted; only genuine geometry changes count. Final result: **0 real pixel diffs across all stories** (down from 83 → 42 → 37 over earlier passes → 0 here). Typecheck, eslint/prettier, and the 64 serialize round-trip tests are green.

## How the elaboration works

`Spread` builds `layer(children).constrain([Constraint.align({[crossAxis]: alignment}, refs), Constraint.distribute({dir: stackAxis, spacing, mode, glue, order}, refs)])`, carrying `name`/`axisDir`/`sharedScale`(`node.shared`)/axis overrides. `stack` is `spread({glue:true})`. The bespoke space/layout/render for spread are gone; the shared `distributeSpaceFold`/`alignSpaceFold`/`composeConstraintSpaces`/`allocateSlices`/`applyDistribute`/`alignTargets` do the work.

Reaching pixel-parity surfaced a cluster of latent fragilities — all rooted in one shift: the elaborated **layer addresses children by name and by underlying space**, whereas the bespoke spread placed them **positionally**. Fixes:

- **Data-positioned alignment guard.** Ported the bespoke spread's `posScale && !fromSize && alignment !== "middle"` → no-op. On a posScale cross axis whose children already hold their own data positions (not SIZE-derived), a non-`middle` align must not pull them to the `alignFallbackBaseline` `posScale(0)` — which, for a domain that doesn't straddle 0 (e.g. faceted year panels `[1955, 2010]`), flings them thousands of px off-canvas. The signal is the **pre-fold** child space (`fromSize`, computed in the layer's `resolveUnderlyingSpace`, mirroring `resolveAlignmentSpace().fromSize`), **not** the post-fold node space (a version keying on the latter regressed 61 stories, since pie/rose angles read as POSITION). Scoped to spread-emitted aligns via a `guardDataPositioned` flag so axis/legend/table aligns keep their unconditional behavior. *(Cleared: faceted scatter ×2, whisker ×2, waffle, the color legend.)*

- **Child naming robustness** (3 fixes). Name `ref` children (a `GoFishRef` proxy isn't a `GoFishNode` but still needs a `nameToPlaceable` entry, e.g. an axis label's `ref(bar)`); **disambiguate duplicate names** (`cut` returns N slices that all carry the source mark's name `"0"`, which otherwise collapse onto one placeable — distribute placed one slice and no-op'd the rest); and **synthesize a name for empty-string names** (`||` not `??`) — a falsy `""` name trips the layer's `!childName` phase-1 guard into baseline-placing a constraint target, after which a `middle` align centers its siblings on that child's origin instead of the box. *(Cleared: cut ×8, ribbon ×2, area/ridgeline/streamgraph, with-labels ×2, flower, icicle ×2, nested-mosaic, nested-waffle, ordinal-xaxis, planets ×5, and 3 python-tutor diagrams.)*

- **Fold is authoritative even when UNDEFINED** (`composeConstraintSpaces`). An axis covered by an align/distribute reports its fold, full stop — even `UNDEFINED` must override the layer's default `unionChildSpaces`. Otherwise ORDINAL cross-axis children resurrect a spurious axis (the waffle's chunked-row index leaked a "Lake B-N" y-axis). *(Cleared: waffle-chart.)*

- **`reverse` is a layout concern, not a structural one.** Keep distribute `order: "reverse"` (reverses only the placement walk); do **not** reverse `node.children`, which breaks positional ref navigation — `ref(heap).path(r, c)` in the python-tutor arrows resolved to the wrong node. *(Cleared: python-tutor.)*

## The enabling change — #549 claim hoisting (de-mutation)

`sharedScale: true` previously shared one scale factor by **mutating the parent's shared `scaleFactors` array**, so the value leaked to later siblings — order-dependent, imperative, and the reason `layer.tsx` refused to copy it (and thus the reason spread couldn't elaborate). Now `sharedScale` is a **scale scope**: spread/layer solve σ once against their own box and write it into a **fresh `childScaleFactors` array** handed to descendants, never mutating the parent.

- `sharedScale: true` = solve σ locally from own box, share with **descendants**.
- `false` (default) = pass-through, inherit σ from above (ultimately the root's solve against the canvas).
- `node.shared` is documented as a **scoping annotation**, not a mutation trigger.

The removed sibling-leak was inert in every `sharedScale` usage (sharing is always expressed by annotating the common-ancestor spread), confirmed by zero layout change across the suite at that step.

## Verification

- **Pixel gate:** `capture-diff` vs `main`, classified by the order-independent number multiset (stripping identity `scale(1,1)`): **REAL = 0**.
- Typecheck, eslint, prettier clean; `test:serialize` 64/64 (IR `{type:"spread"}`/`{type:"stack"}` unchanged).
- Python parity unaffected — the elaboration is below the IR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
