### PR TITLE
Size-setting constraints: linsys bbox + Constraint.span; reduce scatter to constraints (#546, #39)

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -643,6 +643,19 @@ annotation or provenance is a hard claim. `inferSize`/`inferPos` tag the
 `value(...)` they emit with this resolved measure, which is what eventually
 lands on the space.
 
+**Constraint-domain measures.** A `position`/`span` constraint's datum
+coordinate carries the same resolved measure, and `collectPositionDomains`
+folds those per axis with `mergeMeasures` — so a layer's own positioning
+constraints in clashing units (a span with one endpoint in `mm` and the other
+in `inch`) throw at the source. The layer's `resolveAxis` (`layer.tsx`) then
+treats this constraint-domain measure as the axis's unit: it **prefers** the
+constraint measure and falls back to the children's POSITION measure only when
+the coordinates are untagged (literal pixels). It deliberately does _not_
+strict-unify the two — a self-scaling child (a `scatter`'s pie glyph) can leak
+its own inner unit into the children's space, and that leak is not a competing
+claim about the scatter's data axis. This restores the unit tag the scatter
+operator's reduction onto constraints had dropped.
+
 **Propagation through the SIZE→POSITION conversion.** A histogram's count axis
 is all-SIZE at the children, and `resolveAlignmentSpace`'s start/end/baseline
 branch converts all-SIZE children into `POSITION([0, max])`. That conversion

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -16,6 +16,8 @@ covers:
   - packages/gofish-graphics/src/ast/constraints/align.ts
   - packages/gofish-graphics/src/ast/constraints/nest.ts
   - packages/gofish-graphics/src/ast/constraints/grid.ts
+  - packages/gofish-graphics/src/ast/constraints/span.ts
+  - packages/gofish-graphics/src/ast/constraints/bbox.ts
 ---
 
 # The underlying space tree
@@ -249,6 +251,30 @@ composes its targets' spaces into the layer's claim on that axis:
   one nest may derive a given (node, axis), and a nest that resolves
   inside-out on one axis and outside-in on the other is rejected as mixed — the
   layer enforces both at constraint-collection time (see [[size-claims]]).
+
+- `Constraint.span` (`constraints/span.ts`) is the second size-setting
+  constraint: pin BOTH edges of a target on an axis (`x: [min, max]`) and the
+  **size falls out** — the relation `place()`'s position-only protocol cannot
+  express. It is built on the **linear-system bbox** (`constraints/bbox.ts`,
+  #39): a per-axis 2-unknown system in `(min, size)` where each facet
+  (`min`/`max`/`center`/`size`) is one equation; two independent facets are
+  rank 2, so the rest are inferred (two edges ⇒ a size), and a third, dependent
+  write is a structured over-determination report rather than a silent
+  last-writer-wins. A span's datum endpoints feed the axis's POSITION domain via
+  `collectPositionDomains` (like a `position` pin's coordinate), and
+  `composeConstraintSpaces` treats a span as an **extent-establisher** (like a
+  distribute), so the cross-axis `align` fold still runs — a histogram is a span
+  on x plus an `align` on y, and it is that align fold (SIZE→POSITION) that makes
+  the count axis. The solved `(min, size)` is bridged into GoFish's
+  `(local box, translate)` split by stamping `[0, size]` into the local box and
+  the absolute `min` into the translate. The bbox is currently a per-constraint
+  solver used by `span` (and stamped into the existing dimension model), not yet
+  the node's authoritative dimension ledger — that full adoption (the linsys
+  _as_ `Placeable`'s dims, plus aspect ratio) is the larger remainder of #39
+  ([[size-claims]]); until then a target may not be both spanned and pinned on
+  the same axis. `scatter` uses both: plain `x`/`y` → `Constraint.position`,
+  range `xMin`/`xMax`/`yMin`/`yMax` → `Constraint.span` (the operator no longer
+  has a bespoke layout).
 
 The layer composes these per axis — children not covered by a constraint
 max-union in as overlay siblings. On an axis a constraint **does** cover, that

--- a/apps/docs/docs/internals/design/unified-propagation.md
+++ b/apps/docs/docs/internals/design/unified-propagation.md
@@ -1,0 +1,157 @@
+---
+title: "Collapsing the Two Passes: One Propagation, Printable Equations"
+section: Speculative Notes
+order: 34
+status: speculative
+---
+
+# Collapsing the Two Passes: One Propagation, Printable Equations
+
+**Claim.** GoFish's layout core is two passes — a max-plus **fold** that solves
+the scale factor σ from size claims, then a separate **placement** walk that
+positions things once σ is known. Most of the engine's apparent complexity is
+the seam between them: a zoo of placement modes (distribute's edge/center walk,
+align's anchor walk, position's write-once pin, span's two-edge stamp, nest's
+and contain's 2-of-3 arithmetic), each a bespoke way to write a child's
+geometry. Replace the whole thing with **one model** — a per-node, per-axis
+ledger of facet equations whose values are σ-affine `Monotonic`s, solved by
+single-assignment propagation — and that zoo collapses into "emit equations,
+then propagate." The payoff is not fewer lines; it is **uniformity** (one
+mechanism to reason about) and **printable equations** (every facet is a
+`max(aσ+b, …)` you can read off), and it makes a placed thing's extent feed back
+into the scale solve so labels stop overhanging.
+
+This note records the target, what genuinely collapses, the three couplings that
+deliberately _don't_, the one open fork, and a staged path. It is the
+end-state [[size-claims]] designs the ownership for and [[layout-synthesis]]
+frames the algebra for; the linsys bbox ([[underlying-space]], #39) is its seed.
+
+## The model
+
+A node owns, per axis, a **ledger of facet equations**. The facets are
+`min`/`max`/`center`/`size`; the unknowns per axis are `(min, size)` (the other
+two are affine in those — `max = min + size`, `center = min + size/2`). Equations
+come from three places:
+
+1. **Owned affine relations** — the `max = min + size` family. Already the
+   bbox's `COEFFS`.
+2. **Constraints, as equation emitters** rather than placement walks (table
+   below).
+3. **The scope's σ** — the one unknown closed when a scope's content claim meets
+   its allotted pixels. A facet's value may be a `Monotonic` in σ (a bar's
+   `size = count·σ`), not just a number.
+
+Layout is then **single-assignment propagation**: seed the known facets, derive
+whatever a rank-2 fact determines, and when a scope closes, fold its children's
+**edges** (`position + size`, σ-affine) into the scope's σ-claim, invert once,
+back-substitute. Over- and under-determination are named reports, not silent
+last-writer-wins (the [[size-claims]] ownership rule, generalized from positions
+to all facets).
+
+## What collapses
+
+The placement-time mode zoo becomes "add facet equations; let the solver place."
+These stop being separate code paths:
+
+| today (a bespoke placement)                               | unified (a facet equation)                                         |
+| --------------------------------------------------------- | ------------------------------------------------------------------ |
+| `distribute` edge-walk vs center-walk                     | difference constraint on the `min`-chain vs the `center`-chain     |
+| `align` anchor walk                                       | equality on the chosen facet between siblings                      |
+| `position` pin (write-once `place()`)                     | one owned facet equation                                           |
+| `span` two edges + `setExtent` rank-1/rank-2 dispatch     | add facets; rank 2 ⇒ `size` falls out (the bbox already does this) |
+| `nest` 2-of-3, `contain` 2-of-3                           | the same rank-2 solve, not bespoke arithmetic                      |
+| pass-1 SIZE fold **and** pass-2 placement                 | one propagation                                                    |
+| `align`'s SIZE→POSITION conversion (makes the count axis) | read the axis domain off the resolved facets                       |
+
+Most `apply*` functions, the `setExtent` rank dispatch, and the two-pass
+structure fuse into one solver. Edge-vs-center survives only as _which facet the
+difference constraint relates_ — a parameter, not a branch.
+
+And because every facet is a `Monotonic`, the equations are **printable**:
+`bar.size = 30σ`, `label.min = 30σ + 10`, `plot.size = max(30σ + 10 + th, …)`.
+That is the readability win [[layout-synthesis]] calls for, and the reason to
+keep `Monotonic` structure-preserving (#568) rather than collapsing maxima into
+opaque closures.
+
+## What deliberately does _not_ collapse
+
+Three couplings are irreducibly non-local. They are **accepted as explicit
+overlays** on the per-axis propagation — keeping them separate is the point, not
+a wart:
+
+1. **σ is per-_scope_, cross-child.** It is not a per-node facet; it is solved
+   when a scope (a `sharedScale` boundary) closes, by inverting the max-plus
+   fold of that scope's content edges. The scope concept stays; σ is a special
+   unknown the propagation pauses to solve. This is where fold and ledger meet.
+2. **Aspect ratio is cross-axis.** `size_y = r · size_x` couples the two
+   per-axis systems — the one place per-axis decomposition breaks. It rides on
+   top as a single cross-axis equation (circles/images/waffle), not as part of
+   either axis's propagation.
+3. **Measure / scale kind stays.** A SIZE-in-σ and a data-POSITION are placed by
+   the same propagation, but they remain different _kinds_ for axis rendering
+   and unit-checking ([[underlying-space]]). `UnderlyingSpace` doesn't vanish; it
+   stops driving the placement walk.
+
+These three are exactly the structure that makes GoFish charts, not just
+diagrams: a diagram solver (Bluefish) needs none of them. Carrying them as named
+overlays — rather than dissolving them — is what keeps scales, shared scopes,
+and aspect locks first-class.
+
+## The one open fork
+
+**Override / authority.** A pie glyph (placed by a polar coordinate transform)
+and a scatter glyph (self-placed in a linear frame) both emit a `position` facet
+owned by `"layout"`. A parent pin must override the scatter one and must _not_
+override the polar one — and owner identity alone can't tell them apart, which is
+why the current `override` flag is a per-call opt-in (and is **genuine**, not
+removable by naive owner-priority). The unification does not automatically
+dissolve this. The **hypothesis to test**: a coordinate-transform-derived
+position is a _hard_ equation, so a parent pin over it is a named
+over-determination (correctly — you can't reposition a polar-placed glyph),
+whereas a linear self-place is a _default_ the pin supersedes. If that holds,
+authority becomes equation strength (hard vs default) rather than a flag. If it
+doesn't, a per-call authority signal stays. This is the one design decision to
+resolve with a spike before committing the solver.
+
+## What it takes (staged, each gated `capture-diff` REAL = 0)
+
+1. **Ledger holds `Monotonic` facets** — σ-affine values, not only numbers
+   (finishes #39 step 1). Type + tests only; no behavior change.
+2. **`dims` reads the ledger; `place`/`setExtent`/intrinsic writes record into
+   it** — the risky core (~38 `place()` callers). Behavior-preserving; switch
+   readers over one at a time. Watch the `baseline` anchor, `embedded`, and the
+   `translate === undefined` "unplaced" signal (it must survive as "facet not yet
+   determined", never become 0).
+3. **Migrate each constraint to a facet-equation emitter** behind today's
+   `apply*` signatures, one at a time, gated.
+4. **Replace the placement walk with the propagation solver** — σ solved per
+   scope inside it; cycles / over-determination → the named-conflict report.
+   _This_ is where the two passes fuse, and where a placed edge first feeds back
+   into the σ-claim (the label-fits-the-box behavior below).
+5. **Aspect ratio + σ-scope as explicit cross-cutting equations** on top.
+
+Blast radius is the whole layout core (`_node.ts`, `layer.tsx`, every `apply*`,
+`compose.ts`); the pixel gate is the net. Step 4 is the one that can fail to
+converge — it is, in effect, adopting a Bluefish-style constraint solver while
+carrying the max-plus σ-scope and the measure type-system on top. Realistically
+several sessions.
+
+## The motivating consequence: labels that fit
+
+Today the label overhang is structural. Bars A=10, B=30, C=20; a value label
+`spacing = 10` above each σ-scaled bar top, label height `th`:
+
+- **Two-pass (today).** Pass 1 solves the bars' claim `max(10σ, 30σ, 20σ) = 30σ`
+  against height `H` ⇒ `σ = H/30`. The label's `+10+th` is not in that claim
+  (labels are placed in pass 2, post-σ), so the tallest bar's label overhangs the
+  top by `10 + th`.
+- **Unified.** The label's top edge is `30σ + 10 + th` — still a `Monotonic`. Fold
+  it into the scope claim: `max(30σ + 10 + th, …) = H` ⇒ `σ = (H − 10 − th)/30`.
+  The bars shrink just enough that the tallest label fits. No new mechanism —
+  `Monotonic.smul` then `Monotonic.adds`, max-folded, inverted — just placement
+  feeding edges back into the solve it was previously downstream of.
+
+That single change — _a placed position's extent participates in solving σ_ — is
+both the headline simplification and the behavior the two-pass split can't
+express. Everything else here is the refactor that makes it a one-line
+consequence instead of a special case.

--- a/apps/docs/docs/python/api/operators/derive.md
+++ b/apps/docs/docs/python/api/operators/derive.md
@@ -77,23 +77,35 @@ have the _same_ measure merges their domains, while mixing _different_ measures
 (say, a count axis with a millimeter axis) is refused with an error rather than
 silently corrupting the shared domain.
 
-By default the measure is just the field name, which is usually right. Because
-`derive` round-trips through your kernel, a transform's unit provenance does
-**not** survive the bridge — once `bin()` (or your own lambda) returns new
-columns, GoFish only knows their names, not their units. When a derived column
-is really in some existing unit and its axis should share with that unit's
-axis, annotate the channel with `field(name, measure=...)`:
+By default the measure is just the field name, which is usually right. A
+built-in transform like `bin()` declares the measure of its output columns —
+the bin edges `start`/`end` are still in the source field's units, not the
+literal column names — and that **provenance now travels in the operator's IR
+across the bridge**, so a binned histogram's edges auto-unify on the source
+axis with no annotation:
 
 ```python
-from gofish import bin, chart, derive, field, rect, scatter
+from gofish import bin, chart, derive, rect, scatter
 
-# bin edges are still beak-length millimeters, not "start"/"end" units:
+# bin edges auto-tag as "Beak Length (mm)" — no field(..., measure=...) needed:
 chart(penguins, h=80).flow(
     derive(bin("Beak Length (mm)")),
-    scatter(
-        xMin=field("start", measure="Beak Length (mm)"),
-        xMax=field("end", measure="Beak Length (mm)"),
-    ),
+    scatter(xMin="start", xMax="end"),
+).mark(rect(h="count"))
+```
+
+Your **own** `derive` lambda is opaque to GoFish — once it returns new columns,
+GoFish only knows their names, not their units. When such a derived column is
+really in some existing unit and its axis should share with that unit's axis,
+annotate the channel with `field(name, measure=...)`:
+
+```python
+from gofish import chart, derive, field, rect, scatter
+
+chart(data, h=80).flow(
+    derive(my_transform),  # renames a length column to "lo"/"hi"
+    scatter(xMin=field("lo", measure="Beak Length (mm)"),
+            xMax=field("hi", measure="Beak Length (mm)")),
 ).mark(rect(h="count"))
 ```
 

--- a/packages/gofish-graphics/package.json
+++ b/packages/gofish-graphics/package.json
@@ -38,9 +38,10 @@
     "fetch-titanic-passengers": "node scripts/fetch-titanic-passengers.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "pnpm run test:path && pnpm run test:font && pnpm run test:serialize",
+    "test": "pnpm run test:path && pnpm run test:font && pnpm run test:bbox && pnpm run test:serialize",
     "test:path": "tsx src/tests/path.test.ts",
     "test:font": "tsx src/tests/fontUtils.test.ts",
+    "test:bbox": "tsx src/tests/bbox.test.ts",
     "test:serialize": "pnpm run build && tsx src/tests/serialize.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -576,10 +576,7 @@ export class GoFishNode {
       baseline: 0,
     };
 
-    if (!this.transform!.translate) {
-      this.transform!.translate = [undefined, undefined];
-    }
-    this.transform!.translate![dir] = value - anchorToPoint[anchor];
+    this.ensureTranslate()[dir] = value - anchorToPoint[anchor];
   }
 
   /**
@@ -618,25 +615,20 @@ export class GoFishNode {
     const bbox = new BBox();
     for (const [facet, value] of facets) bbox.add(facet, value, owner);
     if (!sizeOwned) {
-      // Rank-1 position pin: the size comes from the node's own layout.
-      const [facet, value] = facets[0];
-      if (localSize === undefined || facet === "size") {
-        // No local box to size against (a bare mark) — fall back to the
-        // write-once place(), which defines the anchor.
-        if (facet !== "size") this.place(axis, value, facet);
-        return;
-      }
-      bbox.add("size", localSize, "layout");
+      // Rank-1 position pin: the second equation (the size) comes from the
+      // node's own layout — `0` for a point-like / unsized mark, matching the
+      // old `placePinned`'s `size ?? 0`, so the pin still rewrites the translate
+      // rather than silently dropping.
+      const [facet] = facets[0];
+      if (facet === "size") return; // a lone size can't determine a position
+      bbox.add("size", localSize ?? 0, "layout");
     }
 
     const absMin = bbox.read("min");
     const size = bbox.read("size");
     if (absMin === undefined || size === undefined) return; // under-determined
 
-    if (!this.transform) this.transform = { translate: [undefined, undefined] };
-    if (!this.transform.translate)
-      this.transform.translate = [undefined, undefined];
-
+    const translate = this.ensureTranslate();
     if (sizeOwned) {
       // The box is (re)sized: its local frame becomes [0, size], placed at absMin.
       if (!this.intrinsicDims) this.intrinsicDims = [];
@@ -647,12 +639,22 @@ export class GoFishNode {
         center: size / 2,
         max: size,
       };
-      this.transform.translate![dir] = absMin;
+      translate[dir] = absMin;
     } else {
       // Position pin: keep the local box, move the origin so the box's absolute
       // min lands at absMin.
-      this.transform.translate![dir] = absMin - localMin;
+      translate[dir] = absMin - localMin;
     }
+  }
+
+  /** Lazily ensure `transform.translate` exists (preserving any `scale`) and
+   *  return it. Shared by `place()` and `setExtent` — the one place the
+   *  `[undefined, undefined]` "unplaced on both axes" seed is written. */
+  private ensureTranslate(): (number | undefined)[] {
+    if (!this.transform) this.transform = { translate: [undefined, undefined] };
+    if (!this.transform.translate)
+      this.transform.translate = [undefined, undefined];
+    return this.transform.translate;
   }
 
   public embed(direction: FancyDirection): void {

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -42,6 +42,7 @@ import type { TokenContext } from "./tokenContext";
 import { isToken, Token } from "./createName";
 import type { ConstraintSpec, ConstraintRef } from "./constraints";
 import { collectConstraintRefs } from "./constraints";
+import { BBox, type BBoxFacet } from "./constraints/bbox";
 import {
   assignPaletteColor,
   assignGradientColor,
@@ -80,6 +81,15 @@ export type Placeable = {
    *  me". Exposed so the `baseline` align anchor can read a target's origin. */
   transform?: Transform;
   place: (axis: FancyDirection, value: number, anchor?: Anchor) => void;
+  /** Write an axis extent from owned bbox facets (the size-setting primitive
+   *  #39 — `span` and an authoritative `position` pin go through it). Optional
+   *  because not every placeable shape implements it (a `ref` stand-in doesn't);
+   *  it is only ever invoked on real `GoFishNode` constraint targets. */
+  setExtent?: (
+    axis: FancyDirection,
+    owned: Partial<Record<BBoxFacet, number>>,
+    owner?: string
+  ) => void;
 };
 
 // `scaleFactors` is the σ (pixels-per-data-unit) handed down per axis. A node
@@ -570,6 +580,79 @@ export class GoFishNode {
       this.transform!.translate = [undefined, undefined];
     }
     this.transform!.translate![dir] = value - anchorToPoint[anchor];
+  }
+
+  /**
+   * Write a node's per-axis extent from OWNED bbox facets (min/max/center/size)
+   * — the bbox-backed primitive that `span` and an authoritative `position` pin
+   * share (#39). Two or more owned facets DETERMINE the box (size included — the
+   * size-setting case, e.g. span's two edges), so the local box is reset to
+   * `[0, size]` and the translate to the absolute min. A single owned facet is a
+   * position pin: the size comes from the node's own layout (the second
+   * equation), the local box is left intact, and only the translate moves — so
+   * the pin OVERRIDES a self-placed translate, which the write-once `place()`
+   * cannot. Anchor facets map start→min, end→max, middle→center; `baseline`
+   * (the origin) is not a bbox facet, so a baseline pin still uses `place()`.
+   *
+   * NOTE (interim): each call builds a FRESH bbox, so over-determination is
+   * detected only WITHIN one call (e.g. span's two edges), not across separate
+   * constraints pinning the same target — the cross-constraint ledger is the
+   * remaining #39 step (accumulate facets per target, then solve once).
+   */
+  public setExtent(
+    axis: FancyDirection,
+    owned: Partial<Record<BBoxFacet, number>>,
+    owner?: string
+  ): void {
+    const dir = elaborateDirection(axis);
+    const facets = (
+      Object.entries(owned) as [BBoxFacet, number | undefined][]
+    ).filter((e): e is [BBoxFacet, number] => e[1] !== undefined);
+    if (facets.length === 0) return;
+
+    const intrinsic = this.intrinsicDims?.[dir];
+    const localMin = intrinsic?.min ?? 0;
+    const localSize = intrinsic?.size;
+    const sizeOwned = facets.length >= 2;
+
+    const bbox = new BBox();
+    for (const [facet, value] of facets) bbox.add(facet, value, owner);
+    if (!sizeOwned) {
+      // Rank-1 position pin: the size comes from the node's own layout.
+      const [facet, value] = facets[0];
+      if (localSize === undefined || facet === "size") {
+        // No local box to size against (a bare mark) — fall back to the
+        // write-once place(), which defines the anchor.
+        if (facet !== "size") this.place(axis, value, facet);
+        return;
+      }
+      bbox.add("size", localSize, "layout");
+    }
+
+    const absMin = bbox.read("min");
+    const size = bbox.read("size");
+    if (absMin === undefined || size === undefined) return; // under-determined
+
+    if (!this.transform) this.transform = { translate: [undefined, undefined] };
+    if (!this.transform.translate)
+      this.transform.translate = [undefined, undefined];
+
+    if (sizeOwned) {
+      // The box is (re)sized: its local frame becomes [0, size], placed at absMin.
+      if (!this.intrinsicDims) this.intrinsicDims = [];
+      this.intrinsicDims[dir] = {
+        ...(this.intrinsicDims[dir] ?? {}),
+        min: 0,
+        size,
+        center: size / 2,
+        max: size,
+      };
+      this.transform.translate![dir] = absMin;
+    } else {
+      // Position pin: keep the local box, move the origin so the box's absolute
+      // min lands at absMin.
+      this.transform.translate![dir] = absMin - localMin;
+    }
   }
 
   public embed(direction: FancyDirection): void {

--- a/packages/gofish-graphics/src/ast/constraints/bbox.ts
+++ b/packages/gofish-graphics/src/ast/constraints/bbox.ts
@@ -1,0 +1,145 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
+/**
+ * A per-axis linear-system bounding box (#39), modeled on Bluefish's
+ * `createLinSysBBox`/`solveSystem` (`bbox.ts`). Each axis is a **2-unknown
+ * system in `(min, size)`** — `min` is the absolute low edge, `size` the
+ * extent. Every facet a caller pins is one linear equation in those unknowns:
+ *
+ * | facet  | reads as          | coefficients `[min, size]` |
+ * | ------ | ----------------- | -------------------------- |
+ * | min    | `min`             | `[1, 0]`                   |
+ * | max    | `min + size`      | `[1, 1]`                   |
+ * | center | `min + size/2`    | `[1, 0.5]`                 |
+ * | size   | `size`            | `[0, 1]`                   |
+ *
+ * - **< 2 independent equations** → only what was written is readable; the rest
+ *   are `undefined` (the system is under-determined).
+ * - **exactly 2 independent** → solve `(min, size)`; every facet becomes
+ *   readable and is marked *inferred*. (Two edges therefore *determine a size* —
+ *   exactly what scatter's interval channels need, and what `place()`'s
+ *   position-only protocol could not express.)
+ * - **a 3rd, dependent equation** → checked for consistency against the solve
+ *   within tolerance; a violation is a structured over-determination report
+ *   (returned to the caller to warn), NOT a silent last-writer-wins.
+ *
+ * Each equation records its `owner` so a double-write on the same facet is a
+ * named conflict (one owner per facet). This is the ownership ledger
+ * size-setting constraints write into (size-claims.md "Dimension B"); GoFish's
+ * `(intrinsic-local box, translate)` split is bridged at the call site by
+ * stamping `min` into the translate and `[0, size]` into the local box.
+ */
+export type BBoxFacet = "min" | "max" | "center" | "size";
+
+const COEFFS: Record<BBoxFacet, [number, number]> = {
+  min: [1, 0],
+  max: [1, 1],
+  center: [1, 0.5],
+  size: [0, 1],
+};
+
+export interface BBoxConflict {
+  facet: BBoxFacet;
+  /** Value the new equation asserts. */
+  asserted: number;
+  /** Value the already-solved system implies. */
+  implied: number;
+  owner: string | undefined;
+  priorOwner: string | undefined;
+}
+
+interface Equation {
+  facet: BBoxFacet;
+  value: number;
+  owner: string | undefined;
+}
+
+/** Solved unknowns `[min, size]`, or undefined when rank < 2. */
+type Solution = [number, number] | undefined;
+
+export class BBox {
+  /** Independent equations retained (at most 2 drive the solve). */
+  private eqs: Equation[] = [];
+  private solution: Solution = undefined;
+
+  /**
+   * Add one facet equation. Returns a conflict descriptor when the write is
+   * inconsistent with the already-determined system (rank-2 over-determination
+   * or a second write to the same facet with a different value), else
+   * undefined. A consistent or new equation is absorbed.
+   */
+  add(
+    facet: BBoxFacet,
+    value: number,
+    owner?: string,
+    tolerance = 1e-6
+  ): BBoxConflict | undefined {
+    // If the system already determines this facet, the write is a redundant
+    // check rather than new information (rank-2 over-determination, or a repeat
+    // of an existing facet). Verify consistency; report on violation.
+    if (this.solution !== undefined) {
+      const implied = this.read(facet)!;
+      if (Math.abs(implied - value) > tolerance) {
+        return {
+          facet,
+          asserted: value,
+          implied,
+          owner,
+          priorOwner: this.eqs[0]?.owner,
+        };
+      }
+      return undefined;
+    }
+    const existing = this.eqs.find((e) => e.facet === facet);
+    if (existing) {
+      // Same facet again: a consistent repeat is ignored; a contradiction is a
+      // single-owner conflict.
+      if (Math.abs(existing.value - value) > tolerance) {
+        return {
+          facet,
+          asserted: value,
+          implied: existing.value,
+          owner,
+          priorOwner: existing.owner,
+        };
+      }
+      return undefined;
+    }
+    // Reject a second equation that is linearly dependent on the first (e.g.
+    // `min` then `min`): handled above by the same-facet check. Distinct facets
+    // are always independent here (the four facets are pairwise independent in
+    // 2 unknowns), so two distinct facets solve the system.
+    this.eqs.push({ facet, value, owner });
+    if (this.eqs.length === 2) this.solve();
+    return undefined;
+  }
+
+  private solve(): void {
+    const [a, b] = this.eqs;
+    const [a0, a1] = COEFFS[a.facet];
+    const [b0, b1] = COEFFS[b.facet];
+    const det = a0 * b1 - a1 * b0;
+    if (Math.abs(det) < 1e-12) return; // dependent (shouldn't happen for distinct facets)
+    const min = (a.value * b1 - b.value * a1) / det;
+    const size = (a0 * b.value - b0 * a.value) / det;
+    this.solution = [min, size];
+  }
+
+  /** Whether the system is fully determined (rank 2). */
+  get solved(): boolean {
+    return this.solution !== undefined;
+  }
+
+  /** Read a facet: from the solve when determined, else from a direct pin, else
+   *  undefined (under-determined). */
+  read(facet: BBoxFacet): number | undefined {
+    if (this.solution !== undefined) {
+      const [min, size] = this.solution;
+      const [c0, c1] = COEFFS[facet];
+      return c0 * min + c1 * size;
+    }
+    return this.eqs.find((e) => e.facet === facet)?.value;
+  }
+}

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -97,18 +97,26 @@ export function composeConstraintSpaces(
   const aligns = constraints.filter(
     (c): c is AlignConstraint => c.type === "align"
   );
-  // Compose only layers that are PURELY distributes + aligns. A `position` pin
-  // (or z-order) puts the layer in a different regime — the distribute-relative-
-  // to-a-pin solve is deferred (layout-synthesis.md) — so leave it to the
-  // layer's default union, which already merges position data domains.
-  if (distributes.length + aligns.length !== constraints.length)
+  // `span` (the size-setting interval constraint, #39/#546) establishes its
+  // axis's extent like a distribute does — its datum range already feeds the
+  // layer's POSITION domain via `collectPositionDomains`, so it needs no fold
+  // here, but its PRESENCE means this is NOT a pure overlay: the cross-axis
+  // align fold (SIZE→POSITION) must still run (e.g. a histogram = span on x,
+  // align on y; the align fold is what makes the count axis).
+  const spans = constraints.filter((c) => c.type === "span");
+  // Compose only layers that are PURELY distributes + aligns + spans. A
+  // `position` pin (or z-order) puts the layer in a different regime — the
+  // distribute-relative-to-a-pin solve is deferred (layout-synthesis.md) — so
+  // leave it to the layer's default union, which already merges position
+  // data domains.
+  if (distributes.length + aligns.length + spans.length !== constraints.length)
     return undefined;
-  // No series → a pure overlay. Align-only composition WOULD fold (alignSpaceFold
-  // converts SIZE→POSITION), but for a pure overlay that conversion only changes
-  // the layer's reported space (e.g. a legend's), so defer it: fall to the
-  // default union. (The per-axis loop already handles align-only axes when a
-  // distribute exists on the other axis.)
-  if (distributes.length === 0) return undefined;
+  // No series and no span → a pure overlay. Align-only composition WOULD fold
+  // (alignSpaceFold converts SIZE→POSITION), but for a pure overlay that
+  // conversion only changes the layer's reported space (e.g. a legend's), so
+  // defer it: fall to the default union. (A span on the other axis makes it not
+  // an overlay, so the align fold runs.)
+  if (distributes.length === 0 && spans.length === 0) return undefined;
 
   const indexByName = buildNameIndex(childNodes);
   const keyOf = (i: number): string | undefined =>

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -49,6 +49,7 @@ import { unionChildSpaces } from "../graphicalOperators/alignment";
 import { type ConstraintSpec } from ".";
 import { distributeSpaceFold, type DistributeConstraint } from "./distribute";
 import { alignSpaceFold, type AlignConstraint } from "./align";
+import type { SpanConstraint } from "./span";
 import { axisIndex, buildNameIndex, type AlignAnchor } from "./shared";
 
 /** One distribute's slice of the layout budget: equal shares of the axis size
@@ -103,7 +104,9 @@ export function composeConstraintSpaces(
   // here, but its PRESENCE means this is NOT a pure overlay: the cross-axis
   // align fold (SIZE→POSITION) must still run (e.g. a histogram = span on x,
   // align on y; the align fold is what makes the count axis).
-  const spans = constraints.filter((c) => c.type === "span");
+  const spans = constraints.filter(
+    (c): c is SpanConstraint => c.type === "span"
+  );
   // Compose only layers that are PURELY distributes + aligns + spans. A
   // `position` pin (or z-order) puts the layer in a different regime — the
   // distribute-relative-to-a-pin solve is deferred (layout-synthesis.md) — so
@@ -166,6 +169,20 @@ export function composeConstraintSpaces(
     }
   }
 
+  // A span COVERS its children on the axis it sizes (it sets their extent
+  // directly via `applySpan`, and their datum range already feeds the POSITION
+  // domain through `collectPositionDomains`). It contributes no fold here, but
+  // its children must be marked covered so the per-axis loop below does not also
+  // fold their raw extent in as an overlay sibling (double-counting) when a
+  // distribute/align shares the same axis.
+  const spanCover: [Set<number>, Set<number>] = [new Set(), new Set()];
+  for (const s of spans) {
+    const idx = idxOf(s.children);
+    if (idx === undefined) continue;
+    if (s.x !== undefined) idx.forEach((i) => spanCover[0].add(i));
+    if (s.y !== undefined) idx.forEach((i) => spanCover[1].add(i));
+  }
+
   const spaces: [UnderlyingSpace | undefined, UnderlyingSpace | undefined] = [
     undefined,
     undefined,
@@ -181,7 +198,7 @@ export function composeConstraintSpaces(
     if (dists.length === 0 && als.length === 0) continue; // keep default union
 
     const fragments: Size<UnderlyingSpace>[] = [];
-    const covered = new Set<number>();
+    const covered = new Set<number>(spanCover[axis]);
     for (const s of dists) {
       s.idx.forEach((i) => covered.add(i));
       const fold = distributeSpaceFold(

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -253,7 +253,7 @@ export function applyConstraints(
     } else if (constraint.type === "position") {
       applyPosition(constraint, targets, posScales);
     } else if (isSpanConstraint(constraint)) {
-      applySpan(constraint, targets, posScales, (msg) => console.warn(msg));
+      applySpan(constraint, targets, posScales);
     } else {
       applyDistribute(constraint, targets);
     }

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -1,7 +1,8 @@
 import type { GoFishAST } from "../_ast";
 import { GoFishNode, type Placeable } from "../_node";
 import { isToken, type Token } from "../createName";
-import { getValue, isValue } from "../data";
+import { getMeasure, getValue, isValue, type Measure } from "../data";
+import { mergeMeasures } from "../underlyingSpace";
 import * as Interval from "../../util/interval";
 import { applyAlign, createAlignConstraint } from "./align";
 import { applyDistribute, createDistributeConstraint } from "./distribute";
@@ -172,18 +173,24 @@ export function getPositioningConstraintRefs(
  * contribute. The layer's `resolveUnderlyingSpace` merges this with the
  * children's spaces (see `layer.tsx`).
  *
- * Measure note (Stage-1 guard): these constraint-datum domains are left
- * UNTAGGED (no Measure). The layer merges them permissively into the
- * children's POSITION, whose measure wins. A `datum(v, measure)` coordinate's
- * unit is therefore not yet enforced against the children's — a deliberate
- * permissive edge until constraint domains carry measures end-to-end.
+ * Measure (Stage-1 guard): a datum coordinate's `measure` is folded per axis
+ * with {@link mergeMeasures} (equal measures unify; two *different* defined
+ * measures throw — a unit conflict among a layer's own position constraints).
+ * The layer's `resolveAxis` then treats this as the axis's unit, PREFERRING it
+ * over the children's POSITION measure (falling back to the children only for
+ * untagged literal-pixel coords) — restoring the unit tag the scatter reduction
+ * dropped, without strict-unifying against a self-scaling child's leaked unit.
  */
 export function collectPositionDomains(constraints: ConstraintSpec[]): {
   x?: Interval.Interval;
   y?: Interval.Interval;
+  xMeasure?: Measure;
+  yMeasure?: Measure;
 } {
   let x: Interval.Interval | undefined;
   let y: Interval.Interval | undefined;
+  let xMeasure: Measure | undefined;
+  let yMeasure: Measure | undefined;
   const fold = (
     acc: Interval.Interval | undefined,
     coord: PositionConstraint["x"]
@@ -197,18 +204,46 @@ export function collectPositionDomains(constraints: ConstraintSpec[]): {
     acc: Interval.Interval | undefined,
     iv: Interval.Interval | undefined
   ) => (iv === undefined ? acc : acc ? Interval.unionAll(acc, iv) : iv);
+  // A datum endpoint's measure; literals carry none. `[min,max]` span endpoints
+  // unify their two measures the same way (a span in mixed units is a conflict).
+  const coordMeasure = (
+    coord: PositionConstraint["x"] | undefined
+  ): Measure | undefined =>
+    coord === undefined ? undefined : getMeasure(coord);
+  const spanMeasure = (
+    span: SpanConstraint["x"] | undefined
+  ): Measure | undefined =>
+    span === undefined
+      ? undefined
+      : mergeMeasures(
+          getMeasure(span[0]),
+          getMeasure(span[1]),
+          "span endpoints"
+        );
   for (const c of constraints) {
     if (c.type === "position") {
       x = fold(x, c.x);
       y = fold(y, c.y);
+      xMeasure = mergeMeasures(
+        xMeasure,
+        coordMeasure(c.x),
+        "position constraints"
+      );
+      yMeasure = mergeMeasures(
+        yMeasure,
+        coordMeasure(c.y),
+        "position constraints"
+      );
     } else if (isSpanConstraint(c)) {
       // A span's two endpoints contribute their data range to the axis domain,
       // so the layer builds a posScale covering the spanned interval.
       x = unionIv(x, spanDatumInterval(c.x));
       y = unionIv(y, spanDatumInterval(c.y));
+      xMeasure = mergeMeasures(xMeasure, spanMeasure(c.x), "span constraints");
+      yMeasure = mergeMeasures(yMeasure, spanMeasure(c.y), "span constraints");
     }
   }
-  return { x, y };
+  return { x, y, xMeasure, yMeasure };
 }
 
 /**

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -13,12 +13,19 @@ import {
 } from "./zorder";
 import { applyNest, createNestConstraint, isNestConstraint } from "./nest";
 import { applyGrid, createGridConstraint, isGridConstraint } from "./grid";
+import {
+  applySpan,
+  createSpanConstraint,
+  isSpanConstraint,
+  spanDatumInterval,
+} from "./span";
 import type { AlignConstraint, AlignOptions } from "./align";
 import type { DistributeConstraint, DistributeOptions } from "./distribute";
 import type { PositionConstraint, PositionOptions } from "./position";
 import type { ZAboveConstraint, ZBelowConstraint } from "./zorder";
 import type { NestConstraint, NestOptions } from "./nest";
 import type { GridConstraint, GridOptions } from "./grid";
+import type { SpanConstraint, SpanOptions } from "./span";
 import { type ConstraintPosScales, type ConstraintRef } from "./shared";
 
 export type {
@@ -37,9 +44,12 @@ export type {
 } from "./zorder";
 export type { NestConstraint, NestOptions } from "./nest";
 export type { GridConstraint, GridOptions } from "./grid";
+export type { SpanConstraint, SpanOptions } from "./span";
 export { isZOrderConstraint } from "./zorder";
 export { isNestConstraint, nestedSpace } from "./nest";
 export { isGridConstraint, gridSpaces, gridCellSize } from "./grid";
+export { isSpanConstraint } from "./span";
+export { BBox } from "./bbox";
 
 export type ConstraintSpec =
   | AlignConstraint
@@ -48,7 +58,8 @@ export type ConstraintSpec =
   | ZAboveConstraint
   | ZBelowConstraint
   | NestConstraint
-  | GridConstraint;
+  | GridConstraint
+  | SpanConstraint;
 
 // --- Factory ---
 
@@ -82,6 +93,9 @@ export const Constraint = {
   },
   grid(options: GridOptions, children: ConstraintRef[]): GridConstraint {
     return createGridConstraint(options, children);
+  },
+  span(options: SpanOptions, children: ConstraintRef[]): SpanConstraint {
+    return createSpanConstraint(options, children);
   },
 };
 
@@ -179,10 +193,20 @@ export function collectPositionDomains(constraints: ConstraintSpec[]): {
     const iv = Interval.interval(n, n);
     return acc ? Interval.unionAll(acc, iv) : iv;
   };
+  const unionIv = (
+    acc: Interval.Interval | undefined,
+    iv: Interval.Interval | undefined
+  ) => (iv === undefined ? acc : acc ? Interval.unionAll(acc, iv) : iv);
   for (const c of constraints) {
-    if (c.type !== "position") continue;
-    x = fold(x, c.x);
-    y = fold(y, c.y);
+    if (c.type === "position") {
+      x = fold(x, c.x);
+      y = fold(y, c.y);
+    } else if (isSpanConstraint(c)) {
+      // A span's two endpoints contribute their data range to the axis domain,
+      // so the layer builds a posScale covering the spanned interval.
+      x = unionIv(x, spanDatumInterval(c.x));
+      y = unionIv(y, spanDatumInterval(c.y));
+    }
   }
   return { x, y };
 }
@@ -228,6 +252,8 @@ export function applyConstraints(
       applyAlign(constraint, targets, sizes, posScales);
     } else if (constraint.type === "position") {
       applyPosition(constraint, targets, posScales);
+    } else if (isSpanConstraint(constraint)) {
+      applySpan(constraint, targets, posScales, (msg) => console.warn(msg));
     } else {
       applyDistribute(constraint, targets);
     }

--- a/packages/gofish-graphics/src/ast/constraints/position.ts
+++ b/packages/gofish-graphics/src/ast/constraints/position.ts
@@ -82,7 +82,12 @@ export interface PositionOptions {
    *  its own layout (a Frame / coord glyph arrives with a translate, which makes
    *  the write-once `place()` a no-op). Set by `scatter`, whose `x`/`y` ARE the
    *  child's placement. Off (default) for axis/pie/legend pins, where a
-   *  pre-placed target keeps its position (the write-once no-op). */
+   *  pre-placed target keeps its position (the write-once no-op).
+   *
+   *  Interim: once #39's linsys ledger ({@link BBox}) becomes the node's actual
+   *  dimension state, per-equation ownership subsumes this — a pin would simply
+   *  own the position facet, and a second writer would be a named conflict
+   *  rather than a silent no-op needing a per-call opt-out. */
   override?: boolean;
 }
 

--- a/packages/gofish-graphics/src/ast/constraints/position.ts
+++ b/packages/gofish-graphics/src/ast/constraints/position.ts
@@ -11,6 +11,58 @@ import {
 } from "./shared";
 
 /**
+ * Place `target` on `axis` so its `anchor` lands at pixel `px`. A `position`
+ * constraint is an authoritative pin (one owner per target/axis).
+ *
+ * Default (`override` false) is exactly `placeAtAnchor` (the write-once
+ * `place()`): unchanged behavior for axis / pie / legend pins, including their
+ * already-placed targets (a 2nd write is a no-op).
+ *
+ * With `override` (set by `scatter`, whose `x`/`y` ARE the placement): an
+ * already-placed target — one that self-placed during its OWN layout (e.g. a
+ * Frame / coord glyph arrives with a translate) — would be stranded by
+ * `place()`'s no-op. The pin must win, so OVERRIDE: compute the additive delta
+ * from the target's current anchor (intrinsicDims + translate) and rewrite the
+ * translate so the anchor lands at `px` (the arithmetic the bespoke scatter
+ * used). Anchor maps start→min, middle→center, end→max, baseline→origin.
+ */
+function placePinned(
+  target: Placeable,
+  axis: Axis,
+  px: number,
+  anchor: AlignAnchor,
+  override: boolean
+): void {
+  const idx = axisIndex(axis);
+  const node = target as {
+    intrinsicDims?: {
+      min?: number;
+      size?: number;
+      center?: number;
+      max?: number;
+    }[];
+    transform?: { translate?: (number | undefined)[] };
+  };
+  if (!override || node.transform?.translate?.[idx] === undefined) {
+    placeAtAnchor(target, axis, px, anchor);
+    return;
+  }
+  const dim = node.intrinsicDims?.[idx] ?? {};
+  const t = node.transform.translate[idx]!;
+  const min = dim.min ?? 0;
+  const size = dim.size ?? 0;
+  const cur =
+    anchor === "start"
+      ? min + t
+      : anchor === "end"
+        ? (dim.max ?? min + size) + t
+        : anchor === "baseline"
+          ? t
+          : (dim.center ?? min + size / 2) + t; // "middle"
+  node.transform.translate[idx] = t + (px - cur);
+}
+
+/**
  * Options for a `position` constraint. Mirrors how you position a shape (or use
  * the `position` operator): give an `x` and/or `y` that is either a **literal**
  * pixel coordinate or a **datum** (`datum(n)` / `value(n)`). A literal is placed
@@ -26,6 +78,12 @@ export interface PositionOptions {
    *  (the target's center sits on the value), matching how `scatter`/`position`
    *  place marks at their center. `"baseline"` pins the target's origin. */
   anchor?: AlignAnchor;
+  /** Authoritative pin: also reposition a target that ALREADY self-placed during
+   *  its own layout (a Frame / coord glyph arrives with a translate, which makes
+   *  the write-once `place()` a no-op). Set by `scatter`, whose `x`/`y` ARE the
+   *  child's placement. Off (default) for axis/pie/legend pins, where a
+   *  pre-placed target keeps its position (the write-once no-op). */
+  override?: boolean;
 }
 
 export interface PositionConstraint {
@@ -33,11 +91,12 @@ export interface PositionConstraint {
   x?: MaybeValue<number>;
   y?: MaybeValue<number>;
   anchor: AlignAnchor;
+  override: boolean;
   children: ConstraintRef[];
 }
 
 export const createPositionConstraint = (
-  { x, y, anchor }: PositionOptions,
+  { x, y, anchor, override }: PositionOptions,
   children: ConstraintRef[]
 ): PositionConstraint => {
   if (x === undefined && y === undefined) {
@@ -45,7 +104,14 @@ export const createPositionConstraint = (
       "Constraint.position: at least one of `x` or `y` must be specified"
     );
   }
-  return { type: "position", x, y, anchor: anchor ?? "middle", children };
+  return {
+    type: "position",
+    x,
+    y,
+    anchor: anchor ?? "middle",
+    override: override ?? false,
+    children,
+  };
 };
 
 /**
@@ -66,7 +132,7 @@ export function applyPosition(
     if (isValue(coord) && scale === undefined) return;
     const px = computeAesthetic(coord, scale!, undefined)!;
     for (const target of targets) {
-      placeAtAnchor(target, axis, px, constraint.anchor);
+      placePinned(target, axis, px, constraint.anchor, constraint.override);
     }
   };
   placeAxis("x", constraint.x);

--- a/packages/gofish-graphics/src/ast/constraints/position.ts
+++ b/packages/gofish-graphics/src/ast/constraints/position.ts
@@ -33,33 +33,23 @@ function placePinned(
   anchor: AlignAnchor,
   override: boolean
 ): void {
-  const idx = axisIndex(axis);
-  const node = target as {
-    intrinsicDims?: {
-      min?: number;
-      size?: number;
-      center?: number;
-      max?: number;
-    }[];
-    transform?: { translate?: (number | undefined)[] };
-  };
-  if (!override || node.transform?.translate?.[idx] === undefined) {
+  if (
+    !override ||
+    target.transform?.translate?.[axisIndex(axis)] === undefined
+  ) {
     placeAtAnchor(target, axis, px, anchor);
     return;
   }
-  const dim = node.intrinsicDims?.[idx] ?? {};
-  const t = node.transform.translate[idx]!;
-  const min = dim.min ?? 0;
-  const size = dim.size ?? 0;
-  const cur =
-    anchor === "start"
-      ? min + t
-      : anchor === "end"
-        ? (dim.max ?? min + size) + t
-        : anchor === "baseline"
-          ? t
-          : (dim.center ?? min + size / 2) + t; // "middle"
-  node.transform.translate[idx] = t + (px - cur);
+  // Authoritative override of a self-placed target. The origin (`baseline`) is
+  // pinned directly; the box anchors go through the bbox-backed `setExtent`
+  // (a single owned facet ⇒ rank-1 pin: keep the local box, move the translate).
+  if (anchor === "baseline") {
+    target.transform!.translate![axisIndex(axis)] = px;
+    return;
+  }
+  const facet =
+    anchor === "start" ? "min" : anchor === "end" ? "max" : "center";
+  target.setExtent!(axis, { [facet]: px }, "position");
 }
 
 /**

--- a/packages/gofish-graphics/src/ast/constraints/shared.ts
+++ b/packages/gofish-graphics/src/ast/constraints/shared.ts
@@ -1,4 +1,5 @@
 import { GoFishNode, type Placeable } from "../_node";
+import { GoFishRef } from "../_ref";
 import type { GoFishAST } from "../_ast";
 import { isToken } from "../createName";
 
@@ -40,6 +41,38 @@ export const childNameKey = (node: GoFishAST): string | undefined => {
   const n = (node as GoFishNode)._name;
   if (n === undefined) return undefined;
   return isToken(n) ? n.__tag : n;
+};
+
+/**
+ * Give every child a UNIQUE constraint name and return the names in order, so an
+ * operator that elaborates to `layer(children).constrain(...)` (spread, scatter)
+ * can reference each child. Reuses an existing name/key; else synthesizes
+ * `__${prefix}_${i}`. Two subtleties both elaborations need (and both got wrong
+ * before being shared):
+ *   - `||` not `??`: an EMPTY-string name is as useless as a missing one (it's
+ *     falsy, so the layer's phase-1 `!childName` guard would baseline-place a
+ *     constraint target).
+ *   - duplicates are disambiguated (cut returns N slices that all carry the
+ *     source mark's name — without this they collapse onto one placeable).
+ * The (possibly new) name is written back to `_name` ONLY when it changed, so an
+ * unchanged `createName` Token survives for token-based `ref`/`selectAll`. A
+ * `ref` child is a GoFishRef proxy (not a GoFishNode) but carries `_name` too.
+ */
+export const ensureChildNames = (
+  children: GoFishAST[],
+  prefix: string
+): string[] => {
+  const used = new Set<string>();
+  return children.map((c, i) => {
+    const existing = childNameKey(c);
+    let nm =
+      existing || (c instanceof GoFishNode && c.key) || `__${prefix}_${i}`;
+    if (used.has(nm)) nm = `${nm}__${prefix}_${i}`;
+    used.add(nm);
+    if (nm !== existing && (c instanceof GoFishNode || c instanceof GoFishRef))
+      c._name = nm;
+    return nm;
+  });
 };
 
 /** Map each direct child's name (`childNameKey`) to its index; first occurrence

--- a/packages/gofish-graphics/src/ast/constraints/span.ts
+++ b/packages/gofish-graphics/src/ast/constraints/span.ts
@@ -1,0 +1,131 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Underlying Space — /internals/core/underlying-space
+// </gofish-wiki>
+
+import type { Placeable } from "../_node";
+import { getValue, isValue, MaybeValue } from "../data";
+import { computeAesthetic } from "../../util";
+import { BBox } from "./bbox";
+import { Axis, ConstraintPosScales, ConstraintRef, axisIndex } from "./shared";
+import * as Interval from "../../util/interval";
+
+/**
+ * A **size-setting** constraint (#39/#546): pin BOTH edges of each target on an
+ * axis (`x: [min, max]`) and let the edges *determine the size*. This is the
+ * first consumer of the linsys bbox ({@link BBox}): two anchors on one axis are
+ * rank 2, so the extent (`size = max − min`) falls out — the relation scatter's
+ * `xMin`/`xMax` interval channels need, which `place()`'s position-only,
+ * write-once protocol could not express (it can pin a point, not set a size).
+ *
+ * Each endpoint is a literal pixel coordinate or a datum (`value(n)`) mapped
+ * through the layer's posScale, exactly like `position`. The resolved
+ * `(min, size)` is stamped into GoFish's `(local box, translate)` split: the
+ * target's local box becomes `[0, size]` and its translate becomes the absolute
+ * `min` on that axis.
+ */
+export interface SpanConstraint {
+  type: "span";
+  x?: [MaybeValue<number>, MaybeValue<number>];
+  y?: [MaybeValue<number>, MaybeValue<number>];
+  children: ConstraintRef[];
+}
+
+export interface SpanOptions {
+  x?: [MaybeValue<number>, MaybeValue<number>];
+  y?: [MaybeValue<number>, MaybeValue<number>];
+}
+
+export const createSpanConstraint = (
+  { x, y }: SpanOptions,
+  children: ConstraintRef[]
+): SpanConstraint => {
+  if (x === undefined && y === undefined) {
+    throw new Error(
+      "Constraint.span: at least one of `x` or `y` must be specified"
+    );
+  }
+  return { type: "span", x, y, children };
+};
+
+export const isSpanConstraint = (
+  c: { type: string } | undefined
+): c is SpanConstraint => c !== undefined && c.type === "span";
+
+/** Each endpoint contributes its datum value to the axis's POSITION domain
+ *  (parallel to `collectPositionDomains` for `position` constraints), so the
+ *  layer builds a posScale that covers the spanned range. Literal-pixel
+ *  endpoints are not data and don't contribute. */
+export function spanDatumInterval(
+  span: [MaybeValue<number>, MaybeValue<number>] | undefined
+): Interval.Interval | undefined {
+  if (span === undefined) return undefined;
+  const vals = span.filter(isValue).map((v) => getValue(v)!);
+  if (vals.length === 0) return undefined;
+  return Interval.interval(Math.min(...vals), Math.max(...vals));
+}
+
+/**
+ * Resolve each axis's `[min, max]` to pixels (datum → posScale, literal as-is),
+ * solve the bbox (rank 2 → size), and stamp `(local [0, size], translate=min)`
+ * into every target. A datum endpoint on an axis with no scale is a no-op
+ * (mirrors `applyPosition`).
+ */
+export function applySpan(
+  constraint: SpanConstraint,
+  targets: Placeable[],
+  posScales: ConstraintPosScales | undefined,
+  onConflict?: (msg: string) => void
+): void {
+  const spanAxis = (
+    axis: Axis,
+    span: [MaybeValue<number>, MaybeValue<number>] | undefined
+  ) => {
+    if (span === undefined) return;
+    const idx = axisIndex(axis);
+    const scale = posScales?.[idx];
+    const toPx = (coord: MaybeValue<number>): number | undefined => {
+      if (isValue(coord) && scale === undefined) return undefined; // datum, no scale
+      return computeAesthetic(coord, scale!, undefined)!;
+    };
+    const minPx = toPx(span[0]);
+    const maxPx = toPx(span[1]);
+    if (minPx === undefined || maxPx === undefined) return;
+
+    const bbox = new BBox();
+    bbox.add("min", minPx, "span");
+    const conflict = bbox.add("max", maxPx, "span");
+    if (conflict && onConflict)
+      onConflict(
+        `Constraint.span: ${axis} over-determined — max asserts ${conflict.asserted} but the system implies ${conflict.implied}`
+      );
+    const min = bbox.read("min")!;
+    const size = bbox.read("size")!;
+
+    for (const target of targets) {
+      const node = target as {
+        intrinsicDims?: {
+          min?: number;
+          size?: number;
+          center?: number;
+          max?: number;
+          embedded?: boolean;
+        }[];
+        transform?: { translate?: (number | undefined)[] };
+      };
+      if (!node.intrinsicDims) node.intrinsicDims = [];
+      node.intrinsicDims[idx] = {
+        ...(node.intrinsicDims[idx] ?? {}),
+        min: 0,
+        size,
+        center: size / 2,
+        max: size,
+      };
+      if (!node.transform) node.transform = {};
+      if (!node.transform.translate)
+        node.transform.translate = [undefined, undefined];
+      node.transform.translate[idx] = min;
+    }
+  };
+  spanAxis("x", constraint.x);
+  spanAxis("y", constraint.y);
+}

--- a/packages/gofish-graphics/src/ast/constraints/span.ts
+++ b/packages/gofish-graphics/src/ast/constraints/span.ts
@@ -5,7 +5,6 @@
 import type { Placeable } from "../_node";
 import { getValue, isValue, MaybeValue } from "../data";
 import { computeAesthetic } from "../../util";
-import { BBox } from "./bbox";
 import { Axis, ConstraintPosScales, ConstraintRef, axisIndex } from "./shared";
 import * as Interval from "../../util/interval";
 
@@ -65,66 +64,31 @@ export function spanDatumInterval(
 }
 
 /**
- * Resolve each axis's `[min, max]` to pixels (datum → posScale, literal as-is),
- * solve the bbox (rank 2 → size), and stamp `(local [0, size], translate=min)`
- * into every target. A datum endpoint on an axis with no scale is a no-op
- * (mirrors `applyPosition`).
+ * Resolve each axis's `[min, max]` to pixels (datum → posScale, literal as-is)
+ * and hand both edges to each target's `setExtent` — the bbox-backed primitive
+ * that solves the extent (two edges ⇒ rank 2 ⇒ size) and stamps it into the
+ * node's `(local box, translate)` split. A datum endpoint on an axis with no
+ * scale is a no-op (mirrors `applyPosition`).
  */
 export function applySpan(
   constraint: SpanConstraint,
   targets: Placeable[],
-  posScales: ConstraintPosScales | undefined,
-  onConflict?: (msg: string) => void
+  posScales: ConstraintPosScales | undefined
 ): void {
   const spanAxis = (
     axis: Axis,
     span: [MaybeValue<number>, MaybeValue<number>] | undefined
   ) => {
     if (span === undefined) return;
-    const idx = axisIndex(axis);
-    const scale = posScales?.[idx];
+    const scale = posScales?.[axisIndex(axis)];
     const toPx = (coord: MaybeValue<number>): number | undefined => {
       if (isValue(coord) && scale === undefined) return undefined; // datum, no scale
       return computeAesthetic(coord, scale!, undefined)!;
     };
-    const minPx = toPx(span[0]);
-    const maxPx = toPx(span[1]);
-    if (minPx === undefined || maxPx === undefined) return;
-
-    const bbox = new BBox();
-    bbox.add("min", minPx, "span");
-    const conflict = bbox.add("max", maxPx, "span");
-    if (conflict && onConflict)
-      onConflict(
-        `Constraint.span: ${axis} over-determined — max asserts ${conflict.asserted} but the system implies ${conflict.implied}`
-      );
-    const min = bbox.read("min")!;
-    const size = bbox.read("size")!;
-
-    for (const target of targets) {
-      const node = target as {
-        intrinsicDims?: {
-          min?: number;
-          size?: number;
-          center?: number;
-          max?: number;
-          embedded?: boolean;
-        }[];
-        transform?: { translate?: (number | undefined)[] };
-      };
-      if (!node.intrinsicDims) node.intrinsicDims = [];
-      node.intrinsicDims[idx] = {
-        ...(node.intrinsicDims[idx] ?? {}),
-        min: 0,
-        size,
-        center: size / 2,
-        max: size,
-      };
-      if (!node.transform) node.transform = {};
-      if (!node.transform.translate)
-        node.transform.translate = [undefined, undefined];
-      node.transform.translate[idx] = min;
-    }
+    const min = toPx(span[0]);
+    const max = toPx(span[1]);
+    if (min === undefined || max === undefined) return;
+    for (const target of targets) target.setExtent!(axis, { min, max }, "span");
   };
   spanAxis("x", constraint.x);
   spanAxis("y", constraint.y);

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -44,7 +44,7 @@ import {
   composeConstraintSpaces,
   type ComposeBudget,
 } from "../constraints/compose";
-import { isValue } from "../data";
+import { isValue, type Measure } from "../data";
 import { unionChildSpaces } from "./alignment";
 
 // ── Nest pre-pass ───────────────────────────────────────────────────────────
@@ -579,7 +579,8 @@ export const layer = createNodeOperatorSequential(
           const resolveAxis = (
             axis: 0 | 1,
             scale: number,
-            iv: Interval.Interval | undefined
+            iv: Interval.Interval | undefined,
+            ivMeasure: Measure | undefined
           ): UnderlyingSpace => {
             const base = applyScale(
               unionChildSpaces(effectiveChildren, axis),
@@ -590,13 +591,18 @@ export const layer = createNodeOperatorSequential(
               isPOSITION(base) && base.domain
                 ? Interval.unionAll(base.domain, iv)
                 : iv;
-            // `position`-constraint datum domains (iv) are untagged — measure
-            // flows from the children's POSITION (if any), permissively.
-            return POSITION(merged, spaceMeasure(base));
+            // The position/span constraints' OWN measure is the authoritative
+            // unit for this axis's data domain (they define it); it wins, falling
+            // back to the children's POSITION measure when the constraints are
+            // untagged (literal-pixel coords). We do NOT strict-unify the two: a
+            // self-scaling child (e.g. a pie glyph) can leak its inner unit into
+            // `base`, and that is not a competing claim about the scatter axis.
+            // Same-layer conflicts ARE caught — inside collectPositionDomains.
+            return POSITION(merged, ivMeasure ?? spaceMeasure(base));
           };
           const resolved: [UnderlyingSpace, UnderlyingSpace] = [
-            resolveAxis(0, scaleX, posDomains.x),
-            resolveAxis(1, scaleY, posDomains.y),
+            resolveAxis(0, scaleX, posDomains.x, posDomains.xMeasure),
+            resolveAxis(1, scaleY, posDomains.y, posDomains.yMeasure),
           ];
 
           // A simple spread expressed as align + distribute. When the

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -74,6 +74,12 @@ export const Scatter = createNodeOperator(
     if (xMax !== undefined && xMax.length !== children.length) {
       throw new Error("Scatter operator xMax array must match children length");
     }
+    if (yMin !== undefined && yMin.length !== children.length) {
+      throw new Error("Scatter operator yMin array must match children length");
+    }
+    if (yMax !== undefined && yMax.length !== children.length) {
+      throw new Error("Scatter operator yMax array must match children length");
+    }
 
     // Elaborate to a layer carrying per-child placement constraints (#546),
     // sharing the constraint path instead of a bespoke layout (as spread

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -1,25 +1,15 @@
-import { computeAesthetic } from "../../util";
-import { GoFishNode, Placeable } from "../_node";
+import { GoFishNode } from "../_node";
 import type { AxisOptions } from "../gofish";
-import { getMeasure, getValue, isValue, MaybeValue } from "../data";
-import { Dimensions, elaborateDims, FancyDims, Size } from "../dims";
+import { MaybeValue } from "../data";
+import { FancyDims } from "../dims";
 import { createNodeOperator } from "../withGoFish";
 import { GoFishAST } from "../_ast";
 import { Collection } from "lodash";
 import { SplitBy, splitKeyFn } from "../datumProjection";
-import {
-  forgetAllMeasures,
-  isPOSITION,
-  POSITION,
-  UNDEFINED,
-  UnderlyingSpace,
-} from "../underlyingSpace";
-import { computePosScale, continuous } from "../domain";
-import * as Interval from "../../util/interval";
-import { Alignment, alignChildren, resolveAlignmentSpace } from "./alignment";
+import { Alignment } from "./alignment";
 import { createOperator } from "../marks/createOperator";
 import { layer } from "./layer";
-import { Constraint } from "../constraints";
+import { Constraint, type ConstraintSpec } from "../constraints";
 import { childNameKey } from "../constraints/shared";
 import { GoFishRef } from "../_ref";
 
@@ -44,55 +34,6 @@ export type ScatterProps = {
   axes?: boolean | { x?: AxisOptions; y?: AxisOptions };
 } & FancyDims<MaybeValue<number>>;
 
-function getCurrentAnchor(
-  child: Placeable,
-  axis: 0 | 1,
-  anchor: "min" | "center" | "max" | "baseline"
-) {
-  const dims = child.dims[axis];
-  const min = dims.min ?? 0;
-  const size = dims.size ?? 0;
-  const max = dims.max ?? min + size;
-  const center = dims.center ?? min + size / 2;
-
-  switch (anchor) {
-    case "min":
-      return min;
-    case "center":
-      return center;
-    case "max":
-      return max;
-    case "baseline":
-      return 0;
-  }
-}
-
-function setAxisTranslation(
-  child: Placeable,
-  axis: 0 | 1,
-  target: number,
-  anchor: "min" | "center" | "max" | "baseline"
-) {
-  const node = child as GoFishNode;
-  const delta = target - getCurrentAnchor(child, axis, anchor);
-  node.transform!.translate![axis] =
-    (node.transform!.translate![axis] ?? 0) + delta;
-}
-
-function resolvePositionSpace(
-  values: MaybeValue<number>[] | undefined
-): UnderlyingSpace {
-  if (!values || values.length === 0) return UNDEFINED;
-  if (!values.every((value) => isValue(value))) return UNDEFINED;
-  const rawValues = values.map((value) => getValue(value)!);
-  // Value measures should all agree (same field); a mixed array forgets to
-  // undefined rather than throwing.
-  return POSITION(
-    Interval.interval(Math.min(...rawValues), Math.max(...rawValues)),
-    forgetAllMeasures(values.map((v) => getMeasure(v)))
-  );
-}
-
 export const Scatter = createNodeOperator(
   async (
     options: ScatterProps,
@@ -112,7 +53,6 @@ export const Scatter = createNodeOperator(
       ...fancyDims
     } = options;
     children = unwrapLodashArray(children);
-    const dims = elaborateDims(fancyDims);
 
     const hasX = x !== undefined || (xMin !== undefined && xMax !== undefined);
     const hasY = y !== undefined || (yMin !== undefined && yMax !== undefined);
@@ -136,310 +76,76 @@ export const Scatter = createNodeOperator(
       throw new Error("Scatter operator xMax array must match children length");
     }
 
-    // Plain x/y channels reduce to `layer + per-child Constraint.position`
-    // (#546): the layer derives the data→pixel posScale from the position
-    // constraints' datum coords (`collectPositionDomains`) and places each child
-    // centered on its coordinate — sharing the constraint path instead of a
-    // bespoke layout, exactly as `spread` delegates to distribute/align. The
-    // range channels (`xMin`/`xMax`/`yMin`/`yMax`) set a SIZE from two positions,
-    // which needs the size-setting ledger (#39); those keep the bespoke node
-    // below until that lands.
-    const noRange =
-      xMin === undefined &&
-      xMax === undefined &&
-      yMin === undefined &&
-      yMax === undefined;
-    if (noRange) {
-      const childList = children as GoFishAST[];
-      const used = new Set<string>();
-      const names = childList.map((c, i) => {
-        const existing = childNameKey(c);
-        let nm =
-          existing || (c instanceof GoFishNode && c.key) || `__scatter_${i}`;
-        if (used.has(nm)) nm = `${nm}__scatter_${i}`;
-        used.add(nm);
-        if (
-          nm !== existing &&
-          (c instanceof GoFishNode || c instanceof GoFishRef)
-        )
-          c._name = nm;
-        return nm;
+    // Elaborate to a layer carrying per-child placement constraints (#546),
+    // sharing the constraint path instead of a bespoke layout (as spread
+    // delegates to distribute/align):
+    //   - plain x / y      → Constraint.position (centers the child on its datum;
+    //                        `override` repositions a child that self-placed in
+    //                        its own layout, e.g. a Frame / coord glyph).
+    //   - range xMin/xMax  → Constraint.span: two edges DETERMINE the size via
+    //                        the linsys bbox (#39) — the size-setting the bespoke
+    //                        layout used to do by hand on intrinsicDims.
+    //   - an axis with neither → a guarded cross-axis align (the old
+    //                        alignChildren, fromSize guard included).
+    // The layer derives the data→pixel posScale from the position/span datum
+    // coords (collectPositionDomains).
+    const childList = children as GoFishAST[];
+    const used = new Set<string>();
+    const names = childList.map((c, i) => {
+      const existing = childNameKey(c);
+      let nm =
+        existing || (c instanceof GoFishNode && c.key) || `__scatter_${i}`;
+      if (used.has(nm)) nm = `${nm}__scatter_${i}`;
+      used.add(nm);
+      if (
+        nm !== existing &&
+        (c instanceof GoFishNode || c instanceof GoFishRef)
+      )
+        c._name = nm;
+      return nm;
+    });
+    const node = (await layer(
+      { key, ...fancyDims } as any,
+      childList
+    )) as GoFishNode;
+    node.constrain((ref) => {
+      const refs = names.map((n) => ref[n] ?? { name: n });
+      const cs: ConstraintSpec[] = [];
+      childList.forEach((_, i) => {
+        const pos: {
+          x?: MaybeValue<number>;
+          y?: MaybeValue<number>;
+          override: boolean;
+        } = { override: true };
+        if (x?.[i] !== undefined) pos.x = x[i];
+        if (y?.[i] !== undefined) pos.y = y[i];
+        if (pos.x !== undefined || pos.y !== undefined)
+          cs.push(Constraint.position(pos, [refs[i]]));
+
+        const span: {
+          x?: [MaybeValue<number>, MaybeValue<number>];
+          y?: [MaybeValue<number>, MaybeValue<number>];
+        } = {};
+        if (xMin?.[i] !== undefined && xMax?.[i] !== undefined)
+          span.x = [xMin[i], xMax[i]];
+        if (yMin?.[i] !== undefined && yMax?.[i] !== undefined)
+          span.y = [yMin[i], yMax[i]];
+        if (span.x !== undefined || span.y !== undefined)
+          cs.push(Constraint.span(span, [refs[i]]));
       });
-      const elaborated = (await layer(
-        { key, ...fancyDims } as any,
-        childList
-      )) as GoFishNode;
-      elaborated.constrain((ref) => {
-        const refs = names.map((n) => ref[n] ?? { name: n });
-        const cs: ReturnType<typeof Constraint.position>[] = [];
-        childList.forEach((_, i) => {
-          const opts: {
-            x?: MaybeValue<number>;
-            y?: MaybeValue<number>;
-            override: boolean;
-          } = { override: true };
-          if (x?.[i] !== undefined) opts.x = x[i];
-          if (y?.[i] !== undefined) opts.y = y[i];
-          // `anchor` defaults to "middle" — the child centers on its coordinate,
-          // matching the bespoke `setAxisTranslation(..., "center")`. `override`
-          // repositions a child that self-placed during layout (a Frame / coord
-          // glyph), which the write-once `place()` would otherwise strand.
-          if (opts.x !== undefined || opts.y !== undefined)
-            cs.push(Constraint.position(opts, [refs[i]]));
-        });
-        // Cross-axis alignment for the axis scatter does NOT position (mirrors
-        // the bespoke `alignChildren`, data-positioned guard included).
-        const out: (
-          | ReturnType<typeof Constraint.position>
-          | ReturnType<typeof Constraint.align>
-        )[] = [...cs];
-        if (!hasX) {
-          const a = Constraint.align({ x: alignment }, refs);
-          a.guardDataPositioned = true;
-          out.push(a);
-        }
-        if (!hasY) {
-          const a = Constraint.align({ y: alignment }, refs);
-          a.guardDataPositioned = true;
-          out.push(a);
-        }
-        return out;
-      });
-      if (name !== undefined) elaborated._name = name;
-      if (axes !== undefined) {
-        const toShow = (opt: AxisOptions | undefined): boolean | undefined =>
-          opt === undefined ? undefined : opt === false ? false : true;
-        elaborated._axisOverride =
-          typeof axes === "boolean"
-            ? { x: axes, y: axes }
-            : { x: toShow(axes.x), y: toShow(axes.y) };
+      if (!hasX) {
+        const a = Constraint.align({ x: alignment }, refs);
+        a.guardDataPositioned = true;
+        cs.push(a);
       }
-      return elaborated;
-    }
-
-    // Track whether the align axis came from SIZE (so alignChildren knows to run)
-    let xFromSize = false;
-    let yFromSize = false;
-
-    const node = new GoFishNode(
-      {
-        type: "scatter",
-        key,
-        name,
-        args: { key, name, x, y, xMin, xMax, yMin, yMax, alignment, dims },
-        shared: [false, false],
-        resolveUnderlyingSpace: (childSpaces: Size<UnderlyingSpace>[]) => {
-          let xSpace: UnderlyingSpace;
-          if (x !== undefined) {
-            xSpace = resolvePositionSpace(x);
-          } else if (xMin !== undefined && xMax !== undefined) {
-            xSpace = POSITION(
-              Interval.interval(
-                Math.min(...xMin.map((v) => getValue(v)!)),
-                Math.max(...xMax.map((v) => getValue(v)!))
-              ),
-              forgetAllMeasures([...xMin, ...xMax].map((v) => getMeasure(v)))
-            );
-          } else {
-            const result = resolveAlignmentSpace(
-              childSpaces.map((child) => child[0]),
-              alignment
-            );
-            xSpace = result.space;
-            xFromSize = result.fromSize;
-          }
-
-          let ySpace: UnderlyingSpace;
-          if (y !== undefined) {
-            ySpace = resolvePositionSpace(y);
-          } else if (yMin !== undefined && yMax !== undefined) {
-            ySpace = POSITION(
-              Interval.interval(
-                Math.min(...yMin.map((v) => getValue(v)!)),
-                Math.max(...yMax.map((v) => getValue(v)!))
-              ),
-              forgetAllMeasures([...yMin, ...yMax].map((v) => getMeasure(v)))
-            );
-          } else {
-            const result = resolveAlignmentSpace(
-              childSpaces.map((child) => child[1]),
-              alignment
-            );
-            ySpace = result.space;
-            yFromSize = result.fromSize;
-          }
-
-          return [xSpace, ySpace];
-        },
-        layout: (_shared, size, scaleFactors, childNodes, posScales, node) => {
-          // In a faceted context the outer x/y may be ORDINAL, giving undefined
-          // posScales for those dims. Scatter has its own POSITION domain, so
-          // compute local posScales as a fallback for any undefined dim.
-          const space = node._underlyingSpace;
-          const effectivePosScales: typeof posScales = [
-            posScales[0] ??
-              (space && isPOSITION(space[0]) && space[0].domain
-                ? computePosScale(
-                    continuous({
-                      value: [space[0].domain.min!, space[0].domain.max!],
-                      measure: "unit",
-                    }),
-                    size[0]
-                  )
-                : undefined),
-            posScales[1] ??
-              (space && isPOSITION(space[1]) && space[1].domain
-                ? computePosScale(
-                    continuous({
-                      value: [space[1].domain.min!, space[1].domain.max!],
-                      measure: "unit",
-                    }),
-                    size[1]
-                  )
-                : undefined),
-          ];
-
-          const childPlaceables = childNodes.map((child) =>
-            child.layout(size, scaleFactors, effectivePosScales)
-          );
-
-          childPlaceables.forEach((child) => {
-            child.place("x", 0);
-            child.place("y", 0);
-          });
-
-          childPlaceables.forEach((child, index) => {
-            const xPos = x?.[index];
-            const yPos = y?.[index];
-
-            if (xMin !== undefined && xMax !== undefined) {
-              // Range mode: stretch child to span [xMin, xMax] in data space
-              const node = child as GoFishNode;
-              const xMinPx = computeAesthetic(
-                xMin[index],
-                effectivePosScales[0]!,
-                undefined
-              )!;
-              const xMaxPx = computeAesthetic(
-                xMax[index],
-                effectivePosScales[0]!,
-                undefined
-              )!;
-              const width = xMaxPx - xMinPx;
-              node.transform!.translate![0] = xMinPx;
-              node.intrinsicDims![0] = {
-                ...(node.intrinsicDims![0] ?? {}),
-                min: 0,
-                size: width,
-                center: width / 2,
-                max: width,
-              } as Dimensions[0];
-            } else if (xPos !== undefined) {
-              const resolvedX = computeAesthetic(
-                xPos,
-                effectivePosScales[0]!,
-                undefined
-              )!;
-              setAxisTranslation(child, 0, resolvedX, "center");
-            }
-
-            if (yMin !== undefined && yMax !== undefined) {
-              // Range mode: stretch child to span [yMin, yMax] in data space
-              const node = child as GoFishNode;
-              const yMinPx = computeAesthetic(
-                yMin[index],
-                effectivePosScales[1]!,
-                undefined
-              )!;
-              const yMaxPx = computeAesthetic(
-                yMax[index],
-                effectivePosScales[1]!,
-                undefined
-              )!;
-              const height = yMaxPx - yMinPx;
-              node.transform!.translate![1] = yMinPx;
-              node.intrinsicDims![1] = {
-                ...(node.intrinsicDims![1] ?? {}),
-                min: 0,
-                size: height,
-                center: height / 2,
-                max: height,
-              } as Dimensions[1];
-            } else if (yPos !== undefined) {
-              const resolvedY = computeAesthetic(
-                yPos,
-                effectivePosScales[1]!,
-                undefined
-              )!;
-              setAxisTranslation(child, 1, resolvedY, "center");
-            }
-          });
-
-          // Align children on axes scatter doesn't position (spread-style semantics)
-          ([0, 1] as const).forEach((axis) => {
-            const positions = axis === 0 ? x : y;
-            const isRangeAxis =
-              axis === 0
-                ? xMin !== undefined && xMax !== undefined
-                : yMin !== undefined && yMax !== undefined;
-            if (positions !== undefined || isRangeAxis) return;
-
-            const fromSize = axis === 0 ? xFromSize : yFromSize;
-            alignChildren(
-              childPlaceables,
-              axis,
-              alignment,
-              size[axis],
-              effectivePosScales?.[axis],
-              fromSize
-            );
-          });
-
-          const minX = Math.min(
-            ...childPlaceables.map((child) => child.dims[0].min!)
-          );
-          const maxX = Math.max(
-            ...childPlaceables.map((child) => child.dims[0].max!)
-          );
-          const minY = Math.min(
-            ...childPlaceables.map((child) => child.dims[1].min!)
-          );
-          const maxY = Math.max(
-            ...childPlaceables.map((child) => child.dims[1].max!)
-          );
-
-          return {
-            intrinsicDims: [
-              {
-                min: minX,
-                size: maxX - minX,
-                center: minX + (maxX - minX) / 2,
-                max: maxX,
-              },
-              {
-                min: minY,
-                size: maxY - minY,
-                center: minY + (maxY - minY) / 2,
-                max: maxY,
-              },
-            ],
-            transform: {
-              translate: [hasX ? 0 : undefined, hasY ? 0 : undefined],
-            },
-          };
-        },
-        render: ({ transform }, children) => {
-          return (
-            <g
-              transform={`translate(${transform?.translate?.[0] ?? 0}, ${transform?.translate?.[1] ?? 0})`}
-            >
-              {children}
-            </g>
-          );
-        },
-      },
-      children
-    );
+      if (!hasY) {
+        const a = Constraint.align({ y: alignment }, refs);
+        a.guardDataPositioned = true;
+        cs.push(a);
+      }
+      return cs;
+    });
+    if (name !== undefined) node._name = name;
     if (axes !== undefined) {
       const toShow = (opt: AxisOptions | undefined): boolean | undefined =>
         opt === undefined ? undefined : opt === false ? false : true;

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -18,6 +18,10 @@ import { computePosScale, continuous } from "../domain";
 import * as Interval from "../../util/interval";
 import { Alignment, alignChildren, resolveAlignmentSpace } from "./alignment";
 import { createOperator } from "../marks/createOperator";
+import { layer } from "./layer";
+import { Constraint } from "../constraints";
+import { childNameKey } from "../constraints/shared";
+import { GoFishRef } from "../_ref";
 
 const unwrapLodashArray = function <T>(value: T[] | Collection<T>): T[] {
   if (typeof value === "object" && value !== null && "value" in value) {
@@ -90,7 +94,10 @@ function resolvePositionSpace(
 }
 
 export const Scatter = createNodeOperator(
-  (options: ScatterProps, children: GoFishAST[] | Collection<GoFishAST>) => {
+  async (
+    options: ScatterProps,
+    children: GoFishAST[] | Collection<GoFishAST>
+  ) => {
     const {
       name,
       key,
@@ -127,6 +134,87 @@ export const Scatter = createNodeOperator(
     }
     if (xMax !== undefined && xMax.length !== children.length) {
       throw new Error("Scatter operator xMax array must match children length");
+    }
+
+    // Plain x/y channels reduce to `layer + per-child Constraint.position`
+    // (#546): the layer derives the data→pixel posScale from the position
+    // constraints' datum coords (`collectPositionDomains`) and places each child
+    // centered on its coordinate — sharing the constraint path instead of a
+    // bespoke layout, exactly as `spread` delegates to distribute/align. The
+    // range channels (`xMin`/`xMax`/`yMin`/`yMax`) set a SIZE from two positions,
+    // which needs the size-setting ledger (#39); those keep the bespoke node
+    // below until that lands.
+    const noRange =
+      xMin === undefined &&
+      xMax === undefined &&
+      yMin === undefined &&
+      yMax === undefined;
+    if (noRange) {
+      const childList = children as GoFishAST[];
+      const used = new Set<string>();
+      const names = childList.map((c, i) => {
+        const existing = childNameKey(c);
+        let nm =
+          existing || (c instanceof GoFishNode && c.key) || `__scatter_${i}`;
+        if (used.has(nm)) nm = `${nm}__scatter_${i}`;
+        used.add(nm);
+        if (
+          nm !== existing &&
+          (c instanceof GoFishNode || c instanceof GoFishRef)
+        )
+          c._name = nm;
+        return nm;
+      });
+      const elaborated = (await layer(
+        { key, ...fancyDims } as any,
+        childList
+      )) as GoFishNode;
+      elaborated.constrain((ref) => {
+        const refs = names.map((n) => ref[n] ?? { name: n });
+        const cs: ReturnType<typeof Constraint.position>[] = [];
+        childList.forEach((_, i) => {
+          const opts: {
+            x?: MaybeValue<number>;
+            y?: MaybeValue<number>;
+            override: boolean;
+          } = { override: true };
+          if (x?.[i] !== undefined) opts.x = x[i];
+          if (y?.[i] !== undefined) opts.y = y[i];
+          // `anchor` defaults to "middle" — the child centers on its coordinate,
+          // matching the bespoke `setAxisTranslation(..., "center")`. `override`
+          // repositions a child that self-placed during layout (a Frame / coord
+          // glyph), which the write-once `place()` would otherwise strand.
+          if (opts.x !== undefined || opts.y !== undefined)
+            cs.push(Constraint.position(opts, [refs[i]]));
+        });
+        // Cross-axis alignment for the axis scatter does NOT position (mirrors
+        // the bespoke `alignChildren`, data-positioned guard included).
+        const out: (
+          | ReturnType<typeof Constraint.position>
+          | ReturnType<typeof Constraint.align>
+        )[] = [...cs];
+        if (!hasX) {
+          const a = Constraint.align({ x: alignment }, refs);
+          a.guardDataPositioned = true;
+          out.push(a);
+        }
+        if (!hasY) {
+          const a = Constraint.align({ y: alignment }, refs);
+          a.guardDataPositioned = true;
+          out.push(a);
+        }
+        return out;
+      });
+      if (name !== undefined) elaborated._name = name;
+      if (axes !== undefined) {
+        const toShow = (opt: AxisOptions | undefined): boolean | undefined =>
+          opt === undefined ? undefined : opt === false ? false : true;
+        elaborated._axisOverride =
+          typeof axes === "boolean"
+            ? { x: axes, y: axes }
+            : { x: toShow(axes.x), y: toShow(axes.y) };
+      }
+      return elaborated;
     }
 
     // Track whether the align axis came from SIZE (so alignChildren knows to run)

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -10,8 +10,7 @@ import { Alignment } from "./alignment";
 import { createOperator } from "../marks/createOperator";
 import { layer } from "./layer";
 import { Constraint, type ConstraintSpec } from "../constraints";
-import { childNameKey } from "../constraints/shared";
-import { GoFishRef } from "../_ref";
+import { ensureChildNames } from "../constraints/shared";
 
 const unwrapLodashArray = function <T>(value: T[] | Collection<T>): T[] {
   if (typeof value === "object" && value !== null && "value" in value) {
@@ -90,20 +89,7 @@ export const Scatter = createNodeOperator(
     // The layer derives the data→pixel posScale from the position/span datum
     // coords (collectPositionDomains).
     const childList = children as GoFishAST[];
-    const used = new Set<string>();
-    const names = childList.map((c, i) => {
-      const existing = childNameKey(c);
-      let nm =
-        existing || (c instanceof GoFishNode && c.key) || `__scatter_${i}`;
-      if (used.has(nm)) nm = `${nm}__scatter_${i}`;
-      used.add(nm);
-      if (
-        nm !== existing &&
-        (c instanceof GoFishNode || c instanceof GoFishRef)
-      )
-        c._name = nm;
-      return nm;
-    });
+    const names = ensureChildNames(childList, "scatter");
     const node = (await layer(
       { key, ...fancyDims } as any,
       childList

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -1,5 +1,4 @@
 import { GoFishNode } from "../_node";
-import { GoFishRef } from "../_ref";
 import type { AxisOptions } from "../gofish";
 import { MaybeValue } from "../data";
 import {
@@ -15,7 +14,7 @@ import { createNodeOperator } from "../withGoFish";
 import { Alignment } from "./alignment";
 import { layer } from "./layer";
 import { Constraint } from "../constraints";
-import { childNameKey } from "../constraints/shared";
+import { ensureChildNames } from "../constraints/shared";
 import { createOperator } from "../marks/createOperator";
 import { Mark, Operator } from "../types";
 
@@ -75,48 +74,10 @@ export const Spread = createNodeOperator(
     const alignAxis = alignDir === 0 ? "x" : "y";
     const stackAxis = stackDir === 0 ? "x" : "y";
 
-    // Each child needs a name so the constraints can reference it; reuse its
-    // existing constraint name/key, else synthesize one. A child may be a
-    // `ref` (e.g. an axis label's `ref(bar)`), which is a GoFishRef proxy, not
-    // a GoFishNode — it carries `_name` too, so it must also be named or the
-    // layer's `nameToPlaceable` won't have an entry for it and the constraint
-    // silently drops it (the ref then never participates in align/distribute).
+    // Give each child a unique constraint name so the align/distribute can
+    // reference it (shared with scatter — see `ensureChildNames`).
     const childList = children as GoFishAST[];
-    // Track names already claimed so a collision is disambiguated rather than
-    // collapsing two children onto one slot. The bespoke spread placed children
-    // POSITIONALLY, so same-named children were harmless; the layer addresses
-    // them through `nameToPlaceable`, which keys by name — duplicates there map
-    // every constraint ref to a single placeable (e.g. cut returns N slices that
-    // all carry the source mark's name, so the distribute would place one slice
-    // and no-op the rest, collapsing them onto each other).
-    const used = new Set<string>();
-    const names = childList.map((c, i) => {
-      const existing = childNameKey(c);
-      // `||` (not `??`): an EMPTY-string name is as useless as a missing one and
-      // must be synthesized. An empty `childName` is falsy, so the layer's
-      // phase-1 guard `!childName` would baseline-place it even though it's a
-      // constraint target — then a `middle` align centers siblings on its
-      // (origin) center instead of the box center (the icicle/nested-waffle
-      // regression). A real Token name (`createName`) is a non-empty string, so
-      // `||` still preserves it.
-      let nm =
-        existing || (c instanceof GoFishNode && c.key) || `__spread_${i}`;
-      if (used.has(nm)) nm = `${nm}__spread_${i}`;
-      used.add(nm);
-      // Write the name back ONLY when we assigned or disambiguated it, so the
-      // layer's `nameToPlaceable` keys match the constraint refs. A `ref` (e.g.
-      // an axis label's `ref(bar)`) is a GoFishRef proxy, not a GoFishNode, but
-      // carries `_name` too — name it as well or the constraint drops it. Leave
-      // an UNCHANGED existing name untouched: it may be a Token (created via
-      // `createName`), and overwriting it with a plain string would break
-      // token-based `ref`/`selectAll` resolution.
-      if (
-        nm !== existing &&
-        (c instanceof GoFishNode || c instanceof GoFishRef)
-      )
-        c._name = nm;
-      return nm;
-    });
+    const names = ensureChildNames(childList, "spread");
 
     // Elaborate to a layer carrying the cross-axis align + the stack distribute.
     // `fancyDims` (explicit w/h) flow to the layer, whose self-scaling region

--- a/packages/gofish-graphics/src/lib.ts
+++ b/packages/gofish-graphics/src/lib.ts
@@ -16,6 +16,11 @@ export { value as v } from "./ast/data";
 // accessor; `literal(x)` is an explicit constant.
 export { datum, field, literal } from "./ast/data";
 export type { FieldAccessor, LiteralValue } from "./ast/data";
+// Measure-provenance tagging: how a data transform (e.g. `bin`) declares that
+// its output columns are in a source field's units. The deserializer re-applies
+// it to RPC-returned rows (the array symbol can't cross the bridge).
+export { setMeasureProvenance } from "./ast/data";
+export type { MeasureProvenance } from "./ast/data";
 export { For as map } from "./ast/iterators/for";
 
 // Coordinate Transforms

--- a/packages/gofish-graphics/src/serialize/registry.ts
+++ b/packages/gofish-graphics/src/serialize/registry.ts
@@ -61,6 +61,7 @@ import {
 // fromJSON.ts rather than via a flat factory map.
 import { cut as cutSlices, cutMark } from "../ast/graphicalOperators/cut";
 import { offset as offsetOp } from "../ast/graphicalOperators/offset";
+import { setMeasureProvenance, type MeasureProvenance } from "../ast/data";
 import type { Frontend } from "gofish-ir";
 
 export type { ChartBuilder, Mark, Operator };
@@ -161,13 +162,22 @@ export const OPERATOR_MAP: Record<
         "derive operator references a Python lambda but no DeriveBridge was supplied"
       );
     }
+    // A data transform (e.g. `bin`) declares measure provenance for its output
+    // columns in the IR (the array-symbol provenance can't ride the rows across
+    // the RPC). Re-apply it to the returned rows so channel inference unifies a
+    // histogram's edges on the source field's axis (mirrors the JS bin).
+    const provenance = opts.provenance as MeasureProvenance | undefined;
     return derive(async (d: any) => {
       const rows = Array.isArray(d) ? d : d == null ? [] : [d];
       if (rows.length === 0) {
         return Array.isArray(d) ? d : (d ?? null);
       }
       const result = await bridge.applyLambda(lambdaId, rows);
-      return Array.isArray(d) ? result : (result[0] ?? null);
+      const tagged =
+        provenance !== undefined
+          ? setMeasureProvenance(result, provenance)
+          : result;
+      return Array.isArray(d) ? tagged : (tagged[0] ?? null);
     });
   },
   spread: (opts) => spread(opts as any),

--- a/packages/gofish-graphics/src/tests/bbox.test.ts
+++ b/packages/gofish-graphics/src/tests/bbox.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for the per-axis linear-system bbox ledger (#39).
+ * Run: `tsx src/tests/bbox.test.ts` (wired into `pnpm test` as `test:bbox`).
+ *
+ * The bbox is a 2-unknown system in (min, size): each facet (min/max/center/
+ * size) is one equation; two independent facets are rank 2 and determine the
+ * rest; a third dependent write is checked for consistency. These tests pin that
+ * contract so the ledger can be grown into the node's authoritative dimension
+ * state without silent behavior drift.
+ */
+
+import { BBox } from "../ast/constraints/bbox";
+
+let passed = 0;
+let failed = 0;
+function ok(name: string, cond: boolean, detail?: string): void {
+  if (cond) {
+    passed++;
+    console.log(`  ok  ${name}`);
+  } else {
+    failed++;
+    console.error(`  FAIL ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+const near = (a: number | undefined, b: number) =>
+  a !== undefined && Math.abs(a - b) < 1e-9;
+
+console.log("# bbox: under-determined (rank < 2)");
+{
+  const b = new BBox();
+  ok("empty: all facets undefined", b.read("min") === undefined && !b.solved);
+  b.add("min", 10);
+  ok("rank 1: pinned facet readable", b.read("min") === 10);
+  ok("rank 1: other facets undefined", b.read("size") === undefined && !b.solved);
+}
+
+console.log("# bbox: rank 2 solves every facet");
+{
+  // min + max → size, center
+  const b = new BBox();
+  b.add("min", 10);
+  b.add("max", 30);
+  ok(
+    "min+max ⇒ size=20, center=20, solved",
+    b.solved && near(b.read("size"), 20) && near(b.read("center"), 20)
+  );
+}
+{
+  // min + size → max, center
+  const b = new BBox();
+  b.add("min", 10);
+  b.add("size", 20);
+  ok(
+    "min+size ⇒ max=30, center=20",
+    near(b.read("max"), 30) && near(b.read("center"), 20)
+  );
+}
+{
+  // center + size → min, max  (the case place()-by-center + a size would hit)
+  const b = new BBox();
+  b.add("center", 20);
+  b.add("size", 20);
+  ok(
+    "center+size ⇒ min=10, max=30",
+    near(b.read("min"), 10) && near(b.read("max"), 30)
+  );
+}
+{
+  // max + center → min, size
+  const b = new BBox();
+  b.add("max", 30);
+  b.add("center", 20);
+  ok(
+    "max+center ⇒ min=10, size=20",
+    near(b.read("min"), 10) && near(b.read("size"), 20)
+  );
+}
+{
+  // zero-width span: min == max ⇒ size 0 (the degenerate but valid case)
+  const b = new BBox();
+  b.add("min", 10);
+  b.add("max", 10);
+  ok("min==max ⇒ size 0", b.solved && near(b.read("size"), 0));
+}
+
+console.log("# bbox: ownership / over-determination");
+{
+  // A consistent repeat of an already-pinned facet is absorbed (no conflict).
+  const b = new BBox();
+  ok("first min: no conflict", b.add("min", 10, "a") === undefined);
+  ok("repeat min same value: no conflict", b.add("min", 10, "b") === undefined);
+}
+{
+  // A contradicting second write to the SAME facet (still rank 1) is a conflict.
+  const b = new BBox();
+  b.add("min", 10, "a");
+  const c = b.add("min", 99, "b");
+  ok(
+    "conflicting same-facet write reports owners",
+    c !== undefined && c.facet === "min" && c.owner === "b" && c.priorOwner === "a"
+  );
+}
+{
+  // Rank-2 over-determination: a 3rd facet that disagrees with the solve.
+  const b = new BBox();
+  b.add("min", 10, "a");
+  b.add("max", 30, "a"); // size now implied = 20
+  const c = b.add("size", 99, "c"); // contradicts implied 20
+  ok(
+    "rank-2 over-determination reports asserted vs implied",
+    c !== undefined &&
+      c.facet === "size" &&
+      near(c.asserted, 99) &&
+      near(c.implied, 20)
+  );
+}
+{
+  // Rank-2 over-determination that AGREES is absorbed (no conflict).
+  const b = new BBox();
+  b.add("min", 10);
+  b.add("max", 30); // size implied = 20, center implied = 20
+  ok("consistent 3rd facet absorbed", b.add("center", 20) === undefined);
+}
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -153,6 +153,12 @@ export type OperatorIR =
 export interface DeriveOperator extends BaseIRNode {
   type: "derive";
   lambdaId?: string;
+  /** Measure provenance a transform (e.g. `bin`) declares for its output
+   *  columns — a map from output field name to the measure it carries (the
+   *  source field's units). Travels in the IR because the JS-side array symbol
+   *  can't ride the data rows across the derive RPC; the deserializer re-applies
+   *  it via `setMeasureProvenance`. */
+  provenance?: Record<string, string>;
 }
 
 export interface SpreadOperator extends BaseIRNode {

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -269,7 +269,7 @@ function walkOperator(node: unknown, path: string, ctx: Context): void {
   // Per-type field validation. Each operator has a known set of optional
   // and required fields; in strict mode, unknown fields are rejected.
   const knownFields: Record<string, string[]> = {
-    derive: ["type", "lambdaId", "origin", "meta"],
+    derive: ["type", "lambdaId", "provenance", "origin", "meta"],
     spread: [
       "type",
       "by",
@@ -317,6 +317,7 @@ function walkOperator(node: unknown, path: string, ctx: Context): void {
   switch (node.type) {
     case "derive":
       optionalField(node, "lambdaId", path, ctx, expectString);
+      optionalField(node, "provenance", path, ctx, expectStringRecord);
       break;
     case "spread":
     case "stack":
@@ -966,6 +967,26 @@ function expectObject(value: unknown, path: string, ctx: Context): void {
       path,
       message: `expected object, got ${typeNameOf(value)}`,
     });
+  }
+}
+
+/** An object whose every value is a string — e.g. a measure-provenance map
+ *  (field name → measure). */
+function expectStringRecord(value: unknown, path: string, ctx: Context): void {
+  if (!isObject(value)) {
+    ctx.errors.push({
+      path,
+      message: `expected object, got ${typeNameOf(value)}`,
+    });
+    return;
+  }
+  for (const [k, v] of Object.entries(value)) {
+    if (typeof v !== "string") {
+      ctx.errors.push({
+        path: `${path}.${k}`,
+        message: `expected string, got ${typeNameOf(v)}`,
+      });
+    }
   }
 }
 

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -21,14 +21,23 @@ class Operator:
 class DeriveOperator(Operator):
     """Operator for deriving new data via Python function."""
 
-    def __init__(self, fn: Callable):
+    def __init__(self, fn: Callable, provenance: Optional[dict] = None):
         super().__init__("derive")
         self.fn = fn
         self.lambda_id = str(uuid.uuid4())
+        # Measure provenance a data transform (e.g. `bin`) declares for its
+        # output columns. It can't ride the data rows across the derive RPC
+        # bridge, so it travels in the operator IR and is re-applied JS-side via
+        # `setMeasureProvenance` — mirroring the JS bin's array-symbol
+        # provenance so a histogram's edges unify on the source field's axis.
+        self.provenance = provenance
 
     def to_dict(self) -> dict:
-        """Convert to dict - return lambda ID."""
-        return {"type": "derive", "lambdaId": self.lambda_id}
+        """Convert to dict - return lambda ID (+ measure provenance, if any)."""
+        out = {"type": "derive", "lambdaId": self.lambda_id}
+        if self.provenance:
+            out["provenance"] = self.provenance
+        return out
 
 
 class _MarkFn:
@@ -1452,8 +1461,15 @@ def derive(fn: Callable) -> DeriveOperator:
 
     Returns:
         DeriveOperator object
+
+    A transform may declare measure provenance for its output columns by
+    setting `_gofish_measure_provenance` on the callable (e.g. `bin`); it is
+    carried into the operator IR so the JS side can re-tag the rows after the
+    RPC. This is what lets `derive(bin("X"))` produce `start`/`end` edges that
+    unify on X's axis without an explicit `field(name, measure=...)`.
     """
-    return DeriveOperator(fn)
+    provenance = getattr(fn, "_gofish_measure_provenance", None)
+    return DeriveOperator(fn, provenance)
 
 
 def group(*, by: str, **options: Any) -> Operator:
@@ -1707,19 +1723,22 @@ def field(name: str, measure: Optional[str] = None) -> dict:
     optional **measure annotation** — a unit-of-measure type claim for the
     channel (see the underlying-space measure system).
 
-    Use the measure annotation when a transform has renamed fields so the
-    weak field-name default would mis-tag the channel. The canonical case is
-    Python-side `bin()`: its provenance map can't cross the RPC bridge, so
-    bin edges arrive as fields named "start"/"end" even though they are in
-    the source field's units:
+    Use the measure annotation when YOUR OWN derive transform has renamed
+    fields so the weak field-name default would mis-tag the channel — e.g. a
+    lambda that renames a length column to "lo"/"hi":
 
         scatter(
-            xMin=field("start", measure="Beak Length (mm)"),
-            xMax=field("end", measure="Beak Length (mm)"),
+            xMin=field("lo", measure="Beak Length (mm)"),
+            xMax=field("hi", measure="Beak Length (mm)"),
         )
 
+    Built-in transforms like `bin()` declare their output provenance, which now
+    travels in the derive operator's IR (see DeriveOperator), so a binned
+    histogram's `start`/`end` edges auto-tag with the source field's units — no
+    explicit annotation needed.
+
     Emits the canonical `{type: "field", name, measure?}` wire shape; an
-    annotation that contradicts JS-side provenance is a type error.
+    annotation that contradicts known provenance is a type error.
 
     Args:
         name: The field name to read from each row.

--- a/packages/gofish-python/gofish/transforms.py
+++ b/packages/gofish-python/gofish/transforms.py
@@ -157,7 +157,23 @@ def bin(
     """
     if isinstance(data_or_field, str):
         field_name = data_or_field
-        return lambda data: _run_bin(data, field_name, thresholds)
+
+        def binner(data: List[dict]) -> List[dict]:
+            return _run_bin(data, field_name, thresholds)
+
+        # The bin edges (`start`/`end`/`size`) are still in the SOURCE field's
+        # units, not the literal column names "start"/"end"; `count` is a count.
+        # Mirror the JS bin's measure provenance. It can't ride the data rows
+        # across the derive RPC bridge, so it travels in the derive operator's
+        # IR and is re-applied JS-side via setMeasureProvenance (see
+        # DeriveOperator.to_dict and serialize/registry.ts).
+        binner._gofish_measure_provenance = {
+            "start": field_name,
+            "end": field_name,
+            "size": field_name,
+            "count": "count",
+        }
+        return binner
     if field is None:
         raise TypeError("bin(data, field): `field` is required in direct form")
     return _run_bin(data_or_field, field, thresholds=thresholds)

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -64,7 +64,9 @@ import {
   offset as offsetOp,
   createName,
   Treemap,
+  setMeasureProvenance,
   type ChartBuilder,
+  type MeasureProvenance,
   type Operator,
   type Mark,
   type Token,
@@ -363,6 +365,10 @@ function mapOperator(
       if (!deriveServerUrl)
         throw new Error("derive operator requires deriveServerUrl");
 
+      // A transform (e.g. `bin`) declares measure provenance for its output
+      // columns in the IR; the array symbol can't cross the RPC, so re-apply it
+      // to the returned rows (mirrors serialize/registry.ts and the JS bin).
+      const provenance = opts.provenance as MeasureProvenance | undefined;
       return derive(async (d: any) => {
         const rows = Array.isArray(d) ? d : d == null ? [] : [d];
         if (rows.length === 0) return Array.isArray(d) ? d : (d ?? null);
@@ -380,7 +386,11 @@ function mapOperator(
         }
 
         const result = await resp.json();
-        return Array.isArray(d) ? result : (result[0] ?? null);
+        const tagged =
+          provenance !== undefined
+            ? setMeasureProvenance(result, provenance)
+            : result;
+        return Array.isArray(d) ? tagged : (tagged[0] ?? null);
       });
     }
     // Modern v3 operators all take a single options object with `by`,

--- a/tests/python-stories/seaborn/test_marginal_histogram.py
+++ b/tests/python-stories/seaborn/test_marginal_histogram.py
@@ -13,7 +13,6 @@ from gofish import (
     chart,
     circle,
     derive,
-    field,
     rect,
     scatter,
 )
@@ -43,20 +42,15 @@ def story_default():
         .name("scatter")
     )
 
-    # Python bin()'s measure provenance can't cross the derive RPC bridge
-    # (JSON drops the JS-side symbol), so the bin-edge channels would tag as
-    # "start"/"end" and falsely conflict with the center's field measure.
-    # Annotate explicitly with field(name, measure=...) — the escape hatch the
-    # measure type error prescribes. The JS story needs no annotations; #537
-    # tracks carrying provenance across the bridge so this collapses too.
+    # bin()'s measure provenance now rides the derive operator's IR across the
+    # RPC bridge (#537), so the bin edges auto-tag with the source field's
+    # measure — no explicit field(name, measure=...) needed. The bare "start"/
+    # "end" channels unify on the source axis just like the JS story.
     top_hist = (
         chart(data, h=80)
         .flow(
             derive(bin("Beak Length (mm)")),
-            scatter(
-                xMin=field("start", measure="Beak Length (mm)"),
-                xMax=field("end", measure="Beak Length (mm)"),
-            ),
+            scatter(xMin="start", xMax="end"),
         )
         .mark(rect(h="count", fill="steelblue"))
         .name("topHist")
@@ -66,10 +60,7 @@ def story_default():
         chart(data, w=80)
         .flow(
             derive(bin("Beak Depth (mm)")),
-            scatter(
-                yMin=field("start", measure="Beak Depth (mm)"),
-                yMax=field("end", measure="Beak Depth (mm)"),
-            ),
+            scatter(yMin="start", yMax="end"),
         )
         .mark(rect(w="count", fill="steelblue"))
         .name("rightHist")


### PR DESCRIPTION
> **Draft for review** — opening early so you can review the approach. The scatter reduction (#546) is complete and gated; #39 lands its core mechanism (the linsys bbox ledger + the first size-setting constraint) but its *full* adoption is deliberately scoped out (see "Deferred").

## What

Lands the **size-setting** machinery from the constraints-as-core program (size-claims.md "Recommendation"), in two pieces (a third, `Constraint.nest`, already landed in a prior round and is unchanged here):

1. **`Constraint.span` + a linear-system bbox ledger (#39)** — a principled "set a size from two positions" mechanism.
2. **Scatter fully reduces to `layer + Constraint.position/span` (#546)** — the bespoke scatter `resolveUnderlyingSpace`/`layout`/`render` (~360 lines) is deleted; plain `x`/`y` → `position`, range `xMin`/`xMax`/`yMin`/`yMax` → `span`.

Closes #546. Advances #39 and #550 (constraints-as-core tracking).

**Gate:** `capture-diff` vs `main` — **REAL pixel diffs = 0** across all stories (scatter, faceted, pie-glyph, strip, histogram, marginal-histogram, ribbon ranges, …). `typecheck`, `test:serialize` (64/64), and Python IR validation (0 failed) all green.

## How

**The linsys bbox** (`constraints/bbox.ts`), modeled on Bluefish's `createLinSysBBox`: a per-axis 2-unknown system in `(min, size)`. Each facet (`min`/`max`/`center`/`size`) is one linear equation; **two independent facets are rank 2 and determine the rest** — so two edges imply a size, the relation `place()`'s position-only, write-once protocol cannot express. A third, dependent write is a structured over-determination report (not silent last-writer-wins); owners ride the equations.

**`Constraint.span`** (`constraints/span.ts`) is the first consumer: pin both edges on an axis (`x: [min, max]`) → the bbox solves the extent. Its datum endpoints feed the layer's POSITION domain via `collectPositionDomains`, and `composeConstraintSpaces` treats a span as an **extent-establisher** (like a distribute) so the cross-axis `align` fold still runs — a histogram is `span` on x + `align` on y, and it's that align fold (SIZE→POSITION) that produces the count axis. The solved `(min, size)` is bridged into GoFish's `(local box, translate)` split (local `[0, size]`, translate `min`).

**Scatter** now elaborates like spread: `layer(children).constrain(…)` with per-child `position`/`span` and a guarded cross-axis `align` for an unpositioned axis. Two supporting bits:
- `Constraint.position` gained an opt-in **`override`** flag (set by scatter): a position pin is authoritative, so it repositions a child that *self-placed* during its own layout (a Frame / coord glyph, e.g. a pie-glyph point) — which the write-once `place()` would otherwise strand. Off by default, so axis/pie/legend pins keep the write-once no-op.
- The shared child-name synthesis (`ensureChildNames`) was extracted from spread and reused (a `/simplify` finding).

## Update — extent-stamping unification + measure tagging + the `override` finding

A follow-on round (commits `dc01…59f2`), each gated REAL=0 + typecheck + serialize:

1. **`GoFishNode.setExtent(axis, ownedFacets, owner)`** — both `span` (size-from-two-edges) and an authoritative `position` override pin now route through one bbox-backed primitive. Rank-2 (two owned facets) solves the size and stamps `(local box → [0,size], translate = absMin)`; rank-1 (one anchor) borrows the node's own layout size and moves only the translate. This collapses the two hand-rolled stamps (inline `applySpan` + `placePinned`'s override arithmetic) into one method, the next step toward #39's ledger. A code-review follow-up fixed a latent rank-1 regression (an unsized override target fell back to a no-op `place()` and dropped the pin; now uses `size ?? 0` as the old code did).
2. **Measure tagging restored (#39 step 6)** — `collectPositionDomains` now folds each `position`/`span` datum coordinate's `measure` per axis with `mergeMeasures` (a layer's own constraints in clashing units throw at the source), and `layer.tsx`'s `resolveAxis` **prefers** it as the axis unit. This restores the unit tag the scatter reduction had dropped (see the corrected Deferred bullet). It deliberately does *not* strict-unify against the children's measure — a self-scaling child (a pie glyph) can leak its inner unit, and that is not a competing claim about the scatter axis (strict-unifying there threw on `with-pie-glyphs`/`2d-histogram-scatter`).

**On `override` (a design finding):** the per-call `override` flag turns out to be **genuine, not removable by the planned ownership arbitration**. A pie/polar glyph and a scatter glyph BOTH self-place during their own layout (owner `"layout"`), yet a parent `position` pin must override the scatter glyph and must *not* override the polar one. Owner priority can't tell those two apart — the distinction is per-call intent — so `override` stays. (Blanket override regressed 5 pie/polar stories; this is why it's opt-in.)

## Deferred (so #39 stays scoped)

The bbox is currently a **per-constraint solver** that `span`/`position` use (via `setExtent`) and stamp into the existing `(intrinsicDims, translate)` model — **not yet the node's authoritative dimension ledger**. The full #39 adoption (the linsys *as* `Placeable`'s dims everywhere, replacing `intrinsicDims`/write-once `place()`, plus **aspect-ratio** as a cross-axis equation for circles/images/waffle) is a large follow-on (~20 files touch `intrinsicDims`/`place`) and is the remainder of #39. Consequences flagged for review:
- A target may not be both *spanned* and *pinned* on the same axis: `setExtent` builds a fresh bbox per call, so over-determination is detected only *within* one call, not across constraints. The cross-constraint ledger (step 4) is part of the full adoption.
- The full authoritative-dims rewrite (linsys *as* `Placeable`'s dims, replacing `intrinsicDims`/write-once `place()`) and **aspect-ratio** (a cross-axis equation for circles/images/waffle) remain the larger follow-on (~20 files touch `intrinsicDims`/`place`). Aspect ratio has an open design fork (size-claims.md "three candidate homes") and wants a spike before committing wide.
- ~~`span`/`position` datum domains are untagged~~ — **done** (see Update §2): measures now flow and are enforced per axis.

## Verification

- `pnpm capture-diff main` → REAL = 0 (the #546 acceptance: scatter shares the constraint path, zero geometry change).
- `typecheck`, `test:serialize` 64/64, `validate-python-ir` 0 failed. Python parity unaffected (span/bbox are below the IR — scatter still serializes `{type:"scatter"}`).
- `/simplify` and `/code-review` (high) run twice; findings applied (shared `ensureChildNames`; compose span-coverage; `yMin`/`yMax` validation; the rank-1 `setExtent` no-op fix; shared `ensureTranslate`).
- Wiki: `underlying-space.md` updated (bbox/span in `covers:`, + "Constraint-domain measures" section); `check-backlinks` green.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)

