### PR TITLE
Unified propagation (stage 1): BBox holds σ-affine Monotonic facets (#39)

### DIFF
--- a/apps/docs/docs/internals/design/unified-propagation.md
+++ b/apps/docs/docs/internals/design/unified-propagation.md
@@ -123,17 +123,23 @@ resolve with a spike before committing the solver.
    it** — the risky core. Behavior-preserving; switch readers over one at a time.
    Watch the `baseline` anchor, `embedded`, and the `translate === undefined`
    "unplaced" signal (it must survive as "facet not yet determined", never
-   become 0). 🟡 **Down-payment landed:** `place()`'s positional write now routes
-   through the bbox-backed `setExtent` (rank-1) instead of bespoke
-   `value − anchorPoint` arithmetic. Because `align` (`placeAtAnchor`),
-   `distribute`, `nest`, and `position` all place via `place()`, and `span` /
-   override-`position` already used `setExtent`, **every placement now funnels
-   through the one bbox primitive** — the atomic "land this facet at this
-   coordinate" op is unified (gated REAL = 0). What remains for full stage 2 is
-   the _authoritative read_ side: making `dims` read a **persistent** per-node
-   ledger (today `setExtent` materializes into `(intrinsicDims, translate)` and
-   `dims` reads those), and migrating the 108 direct `intrinsicDims` sites — the
-   interactive part below.
+   become 0). 🟡 **Down-payment attempted and reverted** (recorded so the next
+   attempt doesn't repeat it): rerouting `place()`'s positional write through
+   `setExtent` (so all of align/distribute/nest/position/span funnel through one
+   bbox primitive) was gated REAL = 0, but `/code-review` found a **latent
+   divergence** — `setExtent` reconstructs a `center`/`max` anchor geometrically
+   (`min + size/2`, `min + size`), which disagrees with `place()`'s use of the
+   _stored_ `intrinsic.center`/`max` when a box is asymmetric (e.g. nodes
+   `position.tsx` builds with a nonzero local min, reached via nest/distribute/
+   grid/treemap center-placement). No current story triggers it, but a latent
+   divergence in the hottest layout method — plus a per-placement `BBox`
+   allocation — is not worth a standalone reroute. The correct form is the
+   _authoritative_ stage 2: a **persistent** per-node ledger that `place`,
+   `setExtent`, and `dims` all share, with the local-frame/absolute split
+   reconstructed faithfully (a node knows its size before its position: rank-1,
+   `min`/`center` `undefined`), plus migrating the 108 direct `intrinsicDims`
+   sites. That is the interactive, story-by-story migration below — _not_ a blind
+   reroute.
 3. **Migrate each constraint to a facet-equation emitter** behind today's
    `apply*` signatures, one at a time, gated.
 4. **Replace the placement walk with the propagation solver** — σ solved per

--- a/apps/docs/docs/internals/design/unified-propagation.md
+++ b/apps/docs/docs/internals/design/unified-propagation.md
@@ -116,12 +116,14 @@ resolve with a spike before committing the solver.
 ## What it takes (staged, each gated `capture-diff` REAL = 0)
 
 1. **Ledger holds `Monotonic` facets** — σ-affine values, not only numbers
-   (finishes #39 step 1). Type + tests only; no behavior change.
+   (finishes #39 step 1). Type + tests only; no behavior change. ✅ **Landed**
+   (`BBox` now holds a `Monotonic` per facet; `read(facet, σ)` evaluates,
+   `readMono` returns the claim; all-numeric callers unchanged).
 2. **`dims` reads the ledger; `place`/`setExtent`/intrinsic writes record into
-   it** — the risky core (~38 `place()` callers). Behavior-preserving; switch
-   readers over one at a time. Watch the `baseline` anchor, `embedded`, and the
-   `translate === undefined` "unplaced" signal (it must survive as "facet not yet
-   determined", never become 0).
+   it** — the risky core. Behavior-preserving; switch readers over one at a time.
+   Watch the `baseline` anchor, `embedded`, and the `translate === undefined`
+   "unplaced" signal (it must survive as "facet not yet determined", never
+   become 0).
 3. **Migrate each constraint to a facet-equation emitter** behind today's
    `apply*` signatures, one at a time, gated.
 4. **Replace the placement walk with the propagation solver** — σ solved per
@@ -130,11 +132,37 @@ resolve with a spike before committing the solver.
    into the σ-claim (the label-fits-the-box behavior below).
 5. **Aspect ratio + σ-scope as explicit cross-cutting equations** on top.
 
+### Stage 2 is not a `place()` refactor — it's a representation migration
+
+The size of stage 2 was initially under-estimated as "~38 `place()` callers".
+The reality, measured: **`intrinsicDims` is referenced 108 times across 20
+files, and `transform.translate` across 23** — and crucially it is **not
+encapsulated**. Shapes _set_ their own `intrinsicDims` (`rect`/`ellipse`/`text`/
+`petal`/`polygon`/`image`), and operators _read and write_ it and `translate`
+directly (`treemap`, `offset`, `porterDuff`, `scatter`, `arrow`, `connect`,
+`enclose`, `position`, `coord`). Making a per-node ledger the **authoritative**
+source for `dims` therefore means migrating every one of those sites off direct
+`intrinsicDims`/`translate` manipulation and onto facet writes — not flipping a
+single getter. A purely additive shadow ledger (one that records but doesn't
+drive geometry) would be redundant state, not authority. And the local-frame /
+absolute-position split that `(intrinsicDims, translate)` encodes — used during
+a node's _own_ layout, before its parent places it — has to be reconstructed in
+the ledger (a node knows its size before its position: rank-1, the `min`/`center`
+facets `undefined`). The asymmetric-center / baseline cases are where a naive
+absolute-only ledger silently diverges.
+
+So stage 2 is a **deliberate, interactive, multi-session migration**, gated story
+by story — _not_ something to land in one blind pass. (See the judgment-call note
+on the PR.) Stages 3–5 sit on top of it; stage 4 additionally _changes pixels_
+(labels fit the box), so it needs human "is this better?" judgment per story
+([[feedback_pixel_not_dom_gate]]), and stage 5's aspect-ratio home is an open
+design fork — neither is gate-decidable alone.
+
 Blast radius is the whole layout core (`_node.ts`, `layer.tsx`, every `apply*`,
-`compose.ts`); the pixel gate is the net. Step 4 is the one that can fail to
-converge — it is, in effect, adopting a Bluefish-style constraint solver while
-carrying the max-plus σ-scope and the measure type-system on top. Realistically
-several sessions.
+`compose.ts`, all shapes + geometry operators); the pixel gate is the net. Step 4
+is the one that can fail to converge — it is, in effect, adopting a Bluefish-style
+constraint solver while carrying the max-plus σ-scope and the measure type-system
+on top. Realistically several sessions.
 
 ## The motivating consequence: labels that fit
 

--- a/apps/docs/docs/internals/design/unified-propagation.md
+++ b/apps/docs/docs/internals/design/unified-propagation.md
@@ -199,3 +199,42 @@ That single change — _a placed position's extent participates in solving σ_ �
 both the headline simplification and the behavior the two-pass split can't
 express. Everything else here is the refactor that makes it a one-line
 consequence instead of a special case.
+
+## The visible symptom today: content sits at the origin, not fitted to the canvas
+
+The label-overhang above is the small version. The large, _already-visible_ bug
+(pre-dating this work) is that many graphics render **translated too low / into
+the bottom-left**, with empty space above and to the right. Confirmed examples:
+the bump, croissant, flower, nested-boxes-tree, and python-tutor-memory diagrams.
+
+Measured mechanism (`gofish.tsx`, `PADDING = 40`): the root frame is
+`scale(1, -1) translate(leftReserve, -(height + topReserve))`, i.e. content is
+pinned at the **origin** with a 40px margin, and the canvas is the _requested_
+size. When the content is smaller than the request, it does not fill or center —
+it piles up at the origin, which y-up renders at the **bottom-left**. Two
+variants of one gap:
+
+- **Diagrams** (nested-boxes-tree requests 720×560; the tree is ~150×400):
+  there is no data scale to stretch, so the content is simply origin-anchored in
+  an over-large canvas. It should fit-to-canvas (scale and/or center) or the
+  canvas should shrink-wrap it.
+- **Data charts** (flower: x-axis runs to 140, data reaches ~50): the σ / data
+  scale is not fit to the content's actual extent, so the marks occupy a corner.
+
+Both are the four observations converging: the content's **bbox** must drive the
+**σ-solve** (so the chart fills its canvas), the **baseline = origin** anchoring
+is exactly what drops content to the bottom-left (and is
+[[feedback_baseline_origin_semantics]]'s underdeveloped corner — `place()` still
+carries a `// TODO: revisit baseline case`, aliasing `baseline` to `min`), and
+the fix is "**pick scales to fit the whole chart**". This is _not_ a band-aid
+(don't special-case "center when canvas > content"): charts must _fill_ (their
+axes span the canvas) while a fixed-size diagram may want to _center_, and that
+choice should fall out of whether the axis carries a data scale — which is
+exactly what the unified solve, with the bbox edges folded into the per-scope σ,
+decides. So this symptom is the acceptance test for stage 4, and the reason
+stage 4's pixel changes are _wanted_, not regressions: a chart that now fills its
+canvas where it used to sit in a corner is **correct**.
+
+(Diagram-vs-chart fit — scale-to-fill vs center vs shrink-wrap when content < an
+explicit canvas — is a design sub-decision to settle alongside stage 4, governed
+by whether the scope's axis is a data POSITION or pixel-pure.)

--- a/apps/docs/docs/internals/design/unified-propagation.md
+++ b/apps/docs/docs/internals/design/unified-propagation.md
@@ -123,7 +123,17 @@ resolve with a spike before committing the solver.
    it** — the risky core. Behavior-preserving; switch readers over one at a time.
    Watch the `baseline` anchor, `embedded`, and the `translate === undefined`
    "unplaced" signal (it must survive as "facet not yet determined", never
-   become 0).
+   become 0). 🟡 **Down-payment landed:** `place()`'s positional write now routes
+   through the bbox-backed `setExtent` (rank-1) instead of bespoke
+   `value − anchorPoint` arithmetic. Because `align` (`placeAtAnchor`),
+   `distribute`, `nest`, and `position` all place via `place()`, and `span` /
+   override-`position` already used `setExtent`, **every placement now funnels
+   through the one bbox primitive** — the atomic "land this facet at this
+   coordinate" op is unified (gated REAL = 0). What remains for full stage 2 is
+   the _authoritative read_ side: making `dims` read a **persistent** per-node
+   ledger (today `setExtent` materializes into `(intrinsicDims, translate)` and
+   `dims` reads those), and migrating the 108 direct `intrinsicDims` sites — the
+   interactive part below.
 3. **Migrate each constraint to a facet-equation emitter** behind today's
    `apply*` signatures, one at a time, gated.
 4. **Replace the placement walk with the propagation solver** — σ solved per

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -569,14 +569,23 @@ export class GoFishNode {
 
     if (this.transform?.translate?.[dir] !== undefined) return;
 
-    const anchorToPoint = {
-      min: intrinsic!.min ?? 0,
-      max: intrinsic!.max ?? 0,
-      center: intrinsic!.center ?? 0,
-      baseline: 0,
-    };
-
-    this.ensureTranslate()[dir] = value - anchorToPoint[anchor];
+    // `baseline` pins the LOCAL origin (point 0) directly — it is not a bbox
+    // facet, so it stays a direct translate write.
+    if (anchor === "baseline") {
+      this.ensureTranslate()[dir] = value;
+      return;
+    }
+    // min/center/max: land the anchor at the absolute `value` via the same
+    // bbox-backed mechanism `span`/`position` use (`setExtent` rank-1 — keep the
+    // local box, move only the translate). This is the unified
+    // "position pin → owned facet" path (unified-propagation.md), replacing the
+    // bespoke `value − anchorPoint` arithmetic. Write-once is preserved by the
+    // guard above (we only reach here when the translate is unset).
+    this.setExtent(
+      axis,
+      { [anchor]: value } as Partial<Record<BBoxFacet, number>>,
+      "place"
+    );
   }
 
   /**

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -569,23 +569,14 @@ export class GoFishNode {
 
     if (this.transform?.translate?.[dir] !== undefined) return;
 
-    // `baseline` pins the LOCAL origin (point 0) directly — it is not a bbox
-    // facet, so it stays a direct translate write.
-    if (anchor === "baseline") {
-      this.ensureTranslate()[dir] = value;
-      return;
-    }
-    // min/center/max: land the anchor at the absolute `value` via the same
-    // bbox-backed mechanism `span`/`position` use (`setExtent` rank-1 — keep the
-    // local box, move only the translate). This is the unified
-    // "position pin → owned facet" path (unified-propagation.md), replacing the
-    // bespoke `value − anchorPoint` arithmetic. Write-once is preserved by the
-    // guard above (we only reach here when the translate is unset).
-    this.setExtent(
-      axis,
-      { [anchor]: value } as Partial<Record<BBoxFacet, number>>,
-      "place"
-    );
+    const anchorToPoint = {
+      min: intrinsic!.min ?? 0,
+      max: intrinsic!.max ?? 0,
+      center: intrinsic!.center ?? 0,
+      baseline: 0,
+    };
+
+    this.ensureTranslate()[dir] = value - anchorToPoint[anchor];
   }
 
   /**

--- a/packages/gofish-graphics/src/ast/constraints/bbox.ts
+++ b/packages/gofish-graphics/src/ast/constraints/bbox.ts
@@ -2,6 +2,8 @@
 // @wiki Underlying Space — /internals/core/underlying-space
 // </gofish-wiki>
 
+import * as Monotonic from "../../util/monotonic";
+
 /**
  * A per-axis linear-system bounding box (#39), modeled on Bluefish's
  * `createLinSysBBox`/`solveSystem` (`bbox.ts`). Each axis is a **2-unknown
@@ -30,8 +32,20 @@
  * size-setting constraints write into (size-claims.md "Dimension B"); GoFish's
  * `(intrinsic-local box, translate)` split is bridged at the call site by
  * stamping `min` into the translate and `[0, size]` into the local box.
+ *
+ * **σ-affine facet values (unified-propagation.md, stage 1).** A facet's value
+ * is a {@link Monotonic} — `slope·σ + intercept` — not just a number, so the
+ * ledger can hold a claim that still depends on its scope's scale factor σ (a
+ * bar's `size = count·σ`) and resolve it once σ is solved. A plain `number` is
+ * accepted and coerced to a constant (`slope 0`); the all-numeric case (every
+ * caller today) behaves exactly as before, and {@link read} evaluates at σ
+ * (default 0), so a constant reads back as its number. The σ-aware value is
+ * {@link readMono}. Equations stay printable via `Monotonic.print`.
  */
 export type BBoxFacet = "min" | "max" | "center" | "size";
+
+/** A facet value: a σ-affine claim, or a plain number (a constant claim). */
+export type FacetValue = number | Monotonic.Monotonic;
 
 const COEFFS: Record<BBoxFacet, [number, number]> = {
   min: [1, 0],
@@ -40,11 +54,27 @@ const COEFFS: Record<BBoxFacet, [number, number]> = {
   size: [0, 1],
 };
 
+/** Coerce a number to a constant Monotonic; pass a Monotonic through. */
+const asMono = (v: FacetValue): Monotonic.Monotonic =>
+  typeof v === "number" ? Monotonic.linear(0, v) : v;
+
+/** Equality of two σ-affine claims, by probing at two distinct σ (two points
+ *  pin a line). v1 limitation: exact only for linear claims; a piecewise claim
+ *  agreeing at 0 and 1 but differing on another segment would read as equal —
+ *  acceptable until a size-setting constraint produces a piecewise facet. */
+const monoEqual = (
+  a: Monotonic.Monotonic,
+  b: Monotonic.Monotonic,
+  tolerance: number
+): boolean =>
+  Math.abs(a.run(0) - b.run(0)) <= tolerance &&
+  Math.abs(a.run(1) - b.run(1)) <= tolerance;
+
 export interface BBoxConflict {
   facet: BBoxFacet;
-  /** Value the new equation asserts. */
+  /** Value the new equation asserts (evaluated at σ=0 for the message). */
   asserted: number;
-  /** Value the already-solved system implies. */
+  /** Value the already-solved system implies (evaluated at σ=0). */
   implied: number;
   owner: string | undefined;
   priorOwner: string | undefined;
@@ -52,12 +82,12 @@ export interface BBoxConflict {
 
 interface Equation {
   facet: BBoxFacet;
-  value: number;
+  value: Monotonic.Monotonic;
   owner: string | undefined;
 }
 
-/** Solved unknowns `[min, size]`, or undefined when rank < 2. */
-type Solution = [number, number] | undefined;
+/** Solved unknowns `[min, size]` (σ-affine), or undefined when rank < 2. */
+type Solution = [Monotonic.Monotonic, Monotonic.Monotonic] | undefined;
 
 export class BBox {
   /** Independent equations retained (at most 2 drive the solve). */
@@ -72,20 +102,21 @@ export class BBox {
    */
   add(
     facet: BBoxFacet,
-    value: number,
+    value: FacetValue,
     owner?: string,
     tolerance = 1e-6
   ): BBoxConflict | undefined {
+    const mono = asMono(value);
     // If the system already determines this facet, the write is a redundant
     // check rather than new information (rank-2 over-determination, or a repeat
     // of an existing facet). Verify consistency; report on violation.
     if (this.solution !== undefined) {
-      const implied = this.read(facet)!;
-      if (Math.abs(implied - value) > tolerance) {
+      const implied = this.readMono(facet)!;
+      if (!monoEqual(implied, mono, tolerance)) {
         return {
           facet,
-          asserted: value,
-          implied,
+          asserted: mono.run(0),
+          implied: implied.run(0),
           owner,
           priorOwner: this.eqs[0]?.owner,
         };
@@ -96,11 +127,11 @@ export class BBox {
     if (existing) {
       // Same facet again: a consistent repeat is ignored; a contradiction is a
       // single-owner conflict.
-      if (Math.abs(existing.value - value) > tolerance) {
+      if (!monoEqual(existing.value, mono, tolerance)) {
         return {
           facet,
-          asserted: value,
-          implied: existing.value,
+          asserted: mono.run(0),
+          implied: existing.value.run(0),
           owner,
           priorOwner: existing.owner,
         };
@@ -111,7 +142,7 @@ export class BBox {
     // `min` then `min`): handled above by the same-facet check. Distinct facets
     // are always independent here (the four facets are pairwise independent in
     // 2 unknowns), so two distinct facets solve the system.
-    this.eqs.push({ facet, value, owner });
+    this.eqs.push({ facet, value: mono, owner });
     if (this.eqs.length === 2) this.solve();
     return undefined;
   }
@@ -122,8 +153,10 @@ export class BBox {
     const [b0, b1] = COEFFS[b.facet];
     const det = a0 * b1 - a1 * b0;
     if (Math.abs(det) < 1e-12) return; // dependent (shouldn't happen for distinct facets)
-    const min = (a.value * b1 - b.value * a1) / det;
-    const size = (a0 * b.value - b0 * a.value) / det;
+    // min  = (a·b1 − b·a1) / det,  size = (a0·b − b0·a) / det — as Monotonics.
+    const lin = (k: number, m: Monotonic.Monotonic) => Monotonic.smul(k, m);
+    const min = Monotonic.add(lin(b1 / det, a.value), lin(-a1 / det, b.value));
+    const size = Monotonic.add(lin(a0 / det, b.value), lin(-b0 / det, a.value));
     this.solution = [min, size];
   }
 
@@ -132,14 +165,21 @@ export class BBox {
     return this.solution !== undefined;
   }
 
-  /** Read a facet: from the solve when determined, else from a direct pin, else
-   *  undefined (under-determined). */
-  read(facet: BBoxFacet): number | undefined {
+  /** Read a facet as a σ-affine claim: from the solve when determined, else
+   *  from a direct pin, else undefined (under-determined). */
+  readMono(facet: BBoxFacet): Monotonic.Monotonic | undefined {
     if (this.solution !== undefined) {
       const [min, size] = this.solution;
       const [c0, c1] = COEFFS[facet];
-      return c0 * min + c1 * size;
+      return Monotonic.add(Monotonic.smul(c0, min), Monotonic.smul(c1, size));
     }
     return this.eqs.find((e) => e.facet === facet)?.value;
+  }
+
+  /** Read a facet evaluated at scale factor `sigma` (default 0). A constant
+   *  (all-numeric) facet reads back as its number — the path every caller uses
+   *  today. */
+  read(facet: BBoxFacet, sigma = 0): number | undefined {
+    return this.readMono(facet)?.run(sigma);
   }
 }

--- a/packages/gofish-graphics/src/ast/constraints/bbox.ts
+++ b/packages/gofish-graphics/src/ast/constraints/bbox.ts
@@ -154,9 +154,14 @@ export class BBox {
     const det = a0 * b1 - a1 * b0;
     if (Math.abs(det) < 1e-12) return; // dependent (shouldn't happen for distinct facets)
     // min  = (a·b1 − b·a1) / det,  size = (a0·b − b0·a) / det — as Monotonics.
-    const lin = (k: number, m: Monotonic.Monotonic) => Monotonic.smul(k, m);
-    const min = Monotonic.add(lin(b1 / det, a.value), lin(-a1 / det, b.value));
-    const size = Monotonic.add(lin(a0 / det, b.value), lin(-b0 / det, a.value));
+    const min = Monotonic.add(
+      Monotonic.smul(b1 / det, a.value),
+      Monotonic.smul(-a1 / det, b.value)
+    );
+    const size = Monotonic.add(
+      Monotonic.smul(a0 / det, b.value),
+      Monotonic.smul(-b0 / det, a.value)
+    );
     this.solution = [min, size];
   }
 

--- a/packages/gofish-graphics/src/tests/bbox.test.ts
+++ b/packages/gofish-graphics/src/tests/bbox.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { BBox } from "../ast/constraints/bbox";
+import * as Monotonic from "../util/monotonic";
 
 let passed = 0;
 let failed = 0;
@@ -120,6 +121,45 @@ console.log("# bbox: ownership / over-determination");
   b.add("min", 10);
   b.add("max", 30); // size implied = 20, center implied = 20
   ok("consistent 3rd facet absorbed", b.add("center", 20) === undefined);
+}
+
+console.log("# bbox: σ-affine (Monotonic) facets");
+{
+  // A σ-valued size + a numeric min → max = min + count·σ (a bar's edge).
+  const b = new BBox();
+  b.add("min", 100); // a pinned pixel position (constant)
+  b.add("size", Monotonic.linear(10, 0)); // 10·σ
+  const max = b.readMono("max");
+  ok(
+    "numeric min + σ size ⇒ σ-affine max",
+    max !== undefined && near(max.run(0), 100) && near(max.run(1), 110)
+  );
+  // read() evaluates at σ: at σ=2 the box top is 100 + 10·2 = 120.
+  ok("read(max, σ=2) evaluates", near(b.read("max", 2), 120));
+  // center = min + size/2 = 100 + 5σ.
+  ok("center is σ-affine", near(b.read("center", 2), 110));
+}
+{
+  // A consistent σ-valued 3rd facet is absorbed; a contradicting one conflicts.
+  const b = new BBox();
+  b.add("min", 0);
+  b.add("max", Monotonic.linear(10, 0)); // size now implied = 10σ
+  ok(
+    "consistent σ 3rd facet absorbed",
+    b.add("size", Monotonic.linear(10, 0)) === undefined
+  );
+  const c = b.add("size", Monotonic.linear(20, 0)); // 20σ ≠ 10σ
+  ok(
+    "contradicting σ facet reports conflict",
+    c !== undefined && c.facet === "size"
+  );
+}
+{
+  // A constant facet still reads back as a plain number via read() (default σ=0).
+  const b = new BBox();
+  b.add("min", 10);
+  b.add("size", 20);
+  ok("constant facets read as numbers", b.read("max") === 30);
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);


### PR DESCRIPTION
> **Draft, built on #572** (base branch `nest-linsys-scatter`). Autonomous run toward the unified propagation layout core (`internals/design/unified-propagation.md`). Opening for review; I made the judgment calls below and could not get feedback mid-run — please sanity-check them.

## What this lands

**Stage 1 of the unified-propagation plan: `BBox` holds σ-affine `Monotonic` facets.** (`packages/gofish-graphics/src/ast/constraints/bbox.ts`)

A facet value is now a `Monotonic` (`slope·σ + intercept`), not just a number, so the linsys ledger can hold a claim that still depends on its scope's scale factor σ — a bar's `size = count·σ` — and resolve it once σ is solved. This is the representational change every later stage needs (it's what lets a placed position's σ-affine *edge* fold back into the σ-claim, the "labels fit the box" payoff).

- `add(facet, value: number | Monotonic)` coerces a number to a constant claim (`linear(0, c)`).
- `solve()` does the 2×2 in `Monotonic` arithmetic (`smul`/`add`); `readMono(facet)` returns the σ-affine claim; **`read(facet, σ=0)` evaluates it** — a constant reads back as its number, so every current caller (all numeric) is unchanged.
- Consistency / over-determination checks compare claims by probing at σ=0 and σ=1 (`monoEqual`).

**Gate:** typecheck, full `test` 64/64, 19 `bbox` unit tests (incl. new σ-affine cases), `capture-diff` vs `main` **REAL = 0**. The σ machinery is groundwork — exercised by tests, not yet by a production caller (that arrives with Stage 2's persistent ledger).

Also lands the **design doc** `internals/design/unified-propagation.md` (the locked direction: what collapses, the three couplings kept as overlays, the open override fork, the staged path).

## Judgment calls (please review — made autonomously, no feedback available)

The plan has five stages. I landed Stage 1 clean and **deliberately did not ship Stages 2–5 blind.** Reasoning:

1. **Stage 2 (authoritative ledger) is a representation migration, not a `place()` refactor — deferred to interactive work.** I measured it: `intrinsicDims` is referenced **108× across 20 files** and is **not encapsulated** — shapes set it directly (`rect`/`ellipse`/`text`/…) and operators read+write it and `translate` directly (`treemap`/`offset`/`porterDuff`/`scatter`/`arrow`/`connect`/`enclose`/`coord`). Making a per-node ledger *authoritative* means migrating all those sites, plus reconstructing the local-frame/absolute split in the ledger. That is a story-by-story gated migration, not a single blind pass.

2. **I attempted a Stage-2 down-payment (route `place()` through `setExtent`) and reverted it after `/code-review`.** It gated REAL = 0, but review found a **latent divergence**: `setExtent` reconstructs a `center`/`max` anchor geometrically (`min + size/2`), disagreeing with `place()`'s use of the *stored* `intrinsic.center`/`max` for asymmetric boxes (which `position.tsx` builds). No current story triggers it, but a latent divergence in the hottest layout method — plus a per-placement allocation — wasn't worth shipping for a benefit that only lands with the persistent ledger. The reverted commit + reasoning are in the history (`cf5edafd` → `1c2855c5`) so the next attempt skips the dead end. **Net code change here is Stage 1 only.**

3. **Stage 4 (the solver fusion) deliberately *changes pixels*** (labels fit the box) — validating "is this better?" across stories needs human aesthetic judgment, which the pixel gate can't provide and I shouldn't fake. Deferred.

4. **Stage 5 (aspect ratio) has an open design fork** (its cross-axis home — size-claims.md's "three candidate homes"); and **Stage 0 (override authority)** is a design decision (hard-vs-default equation strength) to resolve with a spike, not a blind guess. Both deferred.

The honest summary: the unification is sound and Stage 1 is the validated foundation; the rest is a multi-session **interactive** migration (the pixel gate validates behavior-preservation, but the scale of the `intrinsicDims` migration and the pixel-changing fusion need a human in the loop). The design doc and `~/.claude/plans/unified-propagation-build.md` lay out the full path.

## Review

- `/code-review` (high) + `/simplify` run on the diff; findings applied (the `place→setExtent` revert above; dropped a no-op `lin` alias). Remaining documented limitation: `monoEqual`'s two-probe equality is exact for linear facets only (no caller produces a piecewise facet yet; flagged in a comment).
- IR unchanged (bbox is below the IR — Python parity unaffected).
- Wiki `check-backlinks` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
