### PR TITLE
Render intrinsic-size charts at their intrinsic size (remove root w/h)

### DIFF
--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -130,14 +130,16 @@ export interface AlignBaselinePolicy {
  *  to the layer-box edge for the anchor (axis titles and chrome pin to the
  *  box). `middle` is box-center either way: it resolves to DIFFERENCE space —
  *  an extent with no anchored origin — so a scale origin is meaningless for it.
- *  The `end` box edge is finite-guarded: an unsized axis hands NaN down, and
- *  the fallback must stay 0 there, not inject NaN translates. */
+ *  The `middle` and `end` box edges are finite-guarded: an unsized axis hands
+ *  NaN down, and the fallback must stay 0 there, not inject NaN translates (a
+ *  `size/2` center would otherwise become NaN and poison every placed
+ *  descendant — e.g. a legend column laid out on an unsized canvas). */
 export const alignFallbackBaseline = (
   anchor: AlignAnchor,
   size: number,
   posScale: ((v: number) => number) | undefined
 ): number => {
-  if (anchor === "middle") return size / 2;
+  if (anchor === "middle") return Number.isFinite(size) ? size / 2 : 0;
   if (posScale) return posScale(0);
   if (anchor === "end") return Number.isFinite(size) ? size : 0;
   return 0; // start | baseline → layer origin

--- a/packages/gofish-graphics/stories/bluefish/Planets.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/Planets.stories.tsx
@@ -4,14 +4,6 @@ import { For, stack, spread, ellipse, layer, text, ref, arrow } from "../../src/
 
 const meta: Meta = {
   title: "Bluefish/Planets",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
@@ -25,7 +17,6 @@ const planets = [
 ];
 
 export const PlanetsOnly: StoryObj<Args> = {
-  args: { w: 800, h: 200 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -47,17 +38,13 @@ export const PlanetsOnly: StoryObj<Args> = {
           strokeWidth: 3,
         })
       )
-    ).render(container, {
-      w: args.w,
-      h: args.h,
-    });
+    ).render(container, {});
 
     return container;
   },
 };
 
 export const PlanetsWithLabelAbove: StoryObj<Args> = {
-  args: { w: 800, h: 200 },
   render: (args: Args) => {
     const container = initializeContainer();
 
@@ -77,17 +64,13 @@ export const PlanetsWithLabelAbove: StoryObj<Args> = {
         ref("Mercury"),
         text({ text: "Mercury" }),
       ]),
-    ]).render(container, {
-      w: args.w,
-      h: args.h,
-    });
+    ]).render(container, {});
 
     return container;
   },
 };
 
 export const PlanetsWithLabelBelow: StoryObj<Args> = {
-  args: { w: 800, h: 200 },
   render: (args: Args) => {
     const container = initializeContainer();
 
@@ -107,17 +90,13 @@ export const PlanetsWithLabelBelow: StoryObj<Args> = {
         text({ text: "Mercury" }),
         ref("Mercury"),
       ]),
-    ]).render(container, {
-      w: args.w,
-      h: args.h,
-    });
+    ]).render(container, {});
 
     return container;
   },
 };
 
 export const PlanetsWithLabelAboveNoSpacing: StoryObj<Args> = {
-  args: { w: 800, h: 200 },
   render: (args: Args) => {
     const container = initializeContainer();
 
@@ -137,17 +116,13 @@ export const PlanetsWithLabelAboveNoSpacing: StoryObj<Args> = {
         ref("Mercury"),
         text({ text: "Mercury", debugBoundingBox: true }),
       ]),
-    ]).render(container, {
-      w: args.w,
-      h: args.h,
-    });
+    ]).render(container, {});
 
     return container;
   },
 };
 
 export const PlanetsWithLabelBelowNoSpacing: StoryObj<Args> = {
-  args: { w: 800, h: 200 },
   render: (args: Args) => {
     const container = initializeContainer();
 
@@ -167,17 +142,13 @@ export const PlanetsWithLabelBelowNoSpacing: StoryObj<Args> = {
         text({ text: "Mercury", debugBoundingBox: true }),
         ref("Mercury"),
       ]),
-    ]).render(container, {
-      w: args.w,
-      h: args.h,
-    });
+    ]).render(container, {});
 
     return container;
   },
 };
 
 export const PlanetsWithArrow: StoryObj<Args> = {
-  args: { w: 800, h: 200 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -206,10 +177,7 @@ export const PlanetsWithArrow: StoryObj<Args> = {
         ref("Mercury"),
       ]),
       arrow({}, [ref("label"), ref("Mercury")]),
-    ]).render(container, {
-      w: args.w,
-      h: args.h,
-    });
+    ]).render(container, {});
 
     return container;
   },

--- a/packages/gofish-graphics/stories/bluefish/Pulley.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/Pulley.stories.tsx
@@ -25,10 +25,6 @@ import {
 
 const meta: Meta = {
   title: "Bluefish/Pulley",
-  argTypes: {
-    w: { control: { type: "number", min: 100, max: 1000, step: 10 } },
-    h: { control: { type: "number", min: 100, max: 1000, step: 10 } },
-  },
 };
 export default meta;
 
@@ -86,7 +82,6 @@ const Weight = createMark(
 );
 
 export const Pulley: StoryObj<Args> = {
-  args: { w: 360, h: 440 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -235,7 +230,7 @@ export const Pulley: StoryObj<Args> = {
         Constraint.zAbove(c.ropeSupport, c.B), // ceiling→B over B
         Constraint.zAbove(c.ropeS, c.C), // s over C
       ])
-      .render(container, { w: args.w, h: args.h });
+      .render(container, {});
 
     return container;
   },

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/PythonTutor.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/PythonTutor.stories.tsx
@@ -13,21 +13,12 @@ import { binding, isPointer, pointer, tuple } from "./types";
 
 const meta: Meta = {
   title: "Bluefish/Python Tutor/Python Tutor",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 400, max: 2000, step: 20 },
-    },
-    h: {
-      control: { type: "number", min: 200, max: 1200, step: 20 },
-    },
-  },
 };
 export default meta;
 
 type Args = { w: number; h: number };
 
 export const PythonTutor: StoryObj<Args> = {
-  args: { w: 1250, h: 600 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -123,7 +114,7 @@ export const PythonTutor: StoryObj<Args> = {
       ]),
       ...stackArrows,
       ...heapArrows,
-    ]).render(container, { w: args.w, h: args.h });
+    ]).render(container, {});
 
     return container;
   },

--- a/packages/gofish-graphics/stories/forwardsyntax/Area.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Area.stories.tsx
@@ -32,8 +32,12 @@ export const Basic: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
+    // An area chart has no intrinsic width, so it fills the container: the
+    // six lakes are spread to span `args.w` (five gaps between them) instead of
+    // a fixed pixel spacing, which would leave the canvas partly empty.
+    const lakes = 6;
     Chart(seafood, { axes: true })
-      .flow(spread({ by: "lake", dir: "x", spacing: 64 }))
+      .flow(spread({ by: "lake", dir: "x", spacing: args.w / (lakes - 1) }))
       .mark(blank({ h: "count" }))
       .connect(area({ opacity: 0.8 }))
       .render(container, {

--- a/packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx
@@ -128,7 +128,7 @@ export const ImageCutWithLabels: StoryObj<Args> = {
           )
         )) as any
       ),
-    ]).render(container, { w: args.w, h: args.h, axes: false });
+    ]).render(container, { axes: false });
 
     return container;
   },
@@ -412,7 +412,7 @@ export const CroissantStack: StoryObj<Args> = {
         Constraint.align({ x: "middle" }, [bands, axis]),
         Constraint.distribute({ dir: "y", spacing: 12 }, [axis, bands]),
       ])
-      .render(container, { w: args.w, h: args.h, axes: false });
+      .render(container, { axes: false });
 
     return container;
   },

--- a/packages/gofish-graphics/stories/forwardsyntax/WaffleChart.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/WaffleChart.stories.tsx
@@ -7,21 +7,12 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Forward Syntax V3/Waffle Chart",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
 type Args = { w: number; h: number };
 
 export const Default: StoryObj<Args> = {
-  args: { w: 400, h: 400 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -42,10 +33,7 @@ export const Default: StoryObj<Args> = {
         spread({ spacing: 2, dir: "x" })
       )
       .mark(rect({ w: 8, h: 8, fill: "species" }))
-      .render(container, {
-        w: args.w,
-        h: args.h,
-      });
+      .render(container, {});
 
     return container;
   },

--- a/packages/gofish-graphics/stories/lowlevel/BalloonChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/BalloonChart.stories.tsx
@@ -8,14 +8,6 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Low Level Syntax/Balloon Chart",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
@@ -35,7 +27,6 @@ const scatterData = _(seafood)
   .value();
 
 export const Default: StoryObj<Args> = {
-  args: { w: 400, h: 400 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -131,8 +122,6 @@ export const Default: StoryObj<Args> = {
         ])
       )
     ).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
 

--- a/packages/gofish-graphics/stories/lowlevel/BumpChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/BumpChart.stories.tsx
@@ -7,21 +7,12 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Low Level Syntax/Bump Chart",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
 type Args = { w: number; h: number };
 
 export const Default: StoryObj<Args> = {
-  args: { w: 500, h: 300 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -48,10 +39,7 @@ export const Default: StoryObj<Args> = {
           For(d, (d) => ref(`${d.Color}-${d.Year}`))
         )
       ),
-    ]).render(container, {
-      w: args.w,
-      h: args.h,
-    });
+    ]).render(container, {});
 
     return container;
   },

--- a/packages/gofish-graphics/stories/lowlevel/FlowerChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/FlowerChart.stories.tsx
@@ -8,14 +8,6 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Low Level Syntax/Flower Chart",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
@@ -35,7 +27,6 @@ const scatterData = _(seafood)
   .value();
 
 export const Default: StoryObj<Args> = {
-  args: { w: 400, h: 400 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -82,8 +73,6 @@ export const Default: StoryObj<Args> = {
         ])
       )
     ).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
 

--- a/packages/gofish-graphics/stories/lowlevel/NestedBoxesTree.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/NestedBoxesTree.stories.tsx
@@ -10,10 +10,6 @@ import { Layer, Constraint, StackY, rect, text } from "../../src/lib";
 
 const meta: Meta = {
   title: "Low Level Syntax/Nested Boxes Tree",
-  argTypes: {
-    w: { control: { type: "number", min: 100, max: 1200, step: 20 } },
-    h: { control: { type: "number", min: 100, max: 1000, step: 20 } },
-  },
 };
 export default meta;
 
@@ -101,7 +97,6 @@ function buildSubtree(node: TreeNode, depth: number): any {
 }
 
 export const NestedBoxesTree: StoryObj<Args> = {
-  args: { w: 720, h: 560 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -112,7 +107,7 @@ export const NestedBoxesTree: StoryObj<Args> = {
   },
   render: (args: Args) => {
     const container = initializeContainer();
-    buildSubtree(sample, 0).render(container, { w: args.w, h: args.h });
+    buildSubtree(sample, 0).render(container, {});
     return container;
   },
 };

--- a/packages/gofish-graphics/stories/lowlevel/NestedWaffleChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/NestedWaffleChart.stories.tsx
@@ -7,14 +7,6 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Low Level Syntax/Nested Waffle Chart",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
@@ -28,7 +20,6 @@ const classColor = {
 };
 
 export const Default: StoryObj<Args> = {
-  args: { w: 500, h: 340 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -82,8 +73,6 @@ export const Default: StoryObj<Args> = {
         )
         .value()
     ).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
     return container;

--- a/packages/gofish-graphics/stories/lowlevel/StringlineChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/StringlineChart.stories.tsx
@@ -7,21 +7,12 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Low Level Syntax/Stringline Chart",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
 type Args = { w: number; h: number };
 
 export const Default: StoryObj<Args> = {
-  args: { w: 500, h: 400 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -68,8 +59,6 @@ export const Default: StoryObj<Args> = {
         )
       ),
     ]).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
     return container;

--- a/packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx
@@ -7,21 +7,12 @@ import { density1d } from 'fast-kde';
 
 const meta: Meta = {
   title: "Low Level Syntax/Violin Plot",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
 type Args = { w: number; h: number };
 
 export const Default: StoryObj<Args> = {
-  args: { w: 500, h: 300 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -55,8 +46,6 @@ export const Default: StoryObj<Args> = {
         ]);
       })
     ).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
     return container;

--- a/packages/gofish-graphics/stories/lowlevel/Whisker.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/Whisker.stories.tsx
@@ -8,27 +8,16 @@ import {
 
 const meta: Meta = {
   title: "Low Level Syntax/Whisker",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
 type Args = { w: number; h: number };
 
 export const SingleBoxWhisker: StoryObj<Args> = {
-  args: { w: 320, h: 400 },
   render: (args: Args) => {
     const container = initializeContainer();
 
     testSingleBoxWhisker().render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
 
@@ -37,13 +26,10 @@ export const SingleBoxWhisker: StoryObj<Args> = {
 };
 
 export const PairBoxWhisker: StoryObj<Args> = {
-  args: { w: 320, h: 400 },
   render: (args: Args) => {
     const container = initializeContainer();
 
     testPairBoxWhisker().render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
 
@@ -52,7 +38,6 @@ export const PairBoxWhisker: StoryObj<Args> = {
 };
 
 export const BoxWhisker: StoryObj<Args> = {
-  args: { w: 320, h: 400 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -65,8 +50,6 @@ export const BoxWhisker: StoryObj<Args> = {
     const container = initializeContainer();
 
     testBoxWhiskerPlot().render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
 

--- a/tests/python-stories/bluefish/python-tutor/test_python_tutor.py
+++ b/tests/python-stories/bluefish/python-tutor/test_python_tutor.py
@@ -101,5 +101,5 @@ def story_python_tutor():
                 *heap_arrows,
             ]
         ),
-        {"w": 1250, "h": 600},
+        {},
     )

--- a/tests/python-stories/bluefish/test_planets.py
+++ b/tests/python-stories/bluefish/test_planets.py
@@ -37,7 +37,7 @@ def _planet_row():
 
 
 def story_planets_only():
-    return _planet_row(), {"w": 800, "h": 200}
+    return _planet_row(), {}
 
 
 def story_planets_with_label_above():
@@ -51,7 +51,7 @@ def story_planets_with_label_above():
                 alignment="middle",
             ),
         ]),
-        {"w": 800, "h": 200},
+        {},
     )
 
 
@@ -66,7 +66,7 @@ def story_planets_with_label_below():
                 alignment="middle",
             ),
         ]),
-        {"w": 800, "h": 200},
+        {},
     )
 
 
@@ -81,7 +81,7 @@ def story_planets_with_label_above_no_spacing():
                 alignment="middle",
             ),
         ]),
-        {"w": 800, "h": 200},
+        {},
     )
 
 
@@ -96,7 +96,7 @@ def story_planets_with_label_below_no_spacing():
                 alignment="middle",
             ),
         ]),
-        {"w": 800, "h": 200},
+        {},
     )
 
 
@@ -112,5 +112,5 @@ def story_planets_with_arrow():
             ),
             arrow([ref("label"), ref("Mercury")]),
         ]),
-        {"w": 800, "h": 200},
+        {},
     )

--- a/tests/python-stories/bluefish/test_pulley.py
+++ b/tests/python-stories/bluefish/test_pulley.py
@@ -278,5 +278,5 @@ def story_pulley():
                 Constraint.z_above(ropeS, C),  # s over C
             ]
         ),
-        {"w": 360, "h": 440},
+        {},
     )

--- a/tests/python-stories/forward-syntax-v3/test_area.py
+++ b/tests/python-stories/forward-syntax-v3/test_area.py
@@ -5,12 +5,18 @@ from python_stories.data import SEAFOOD, STREAMGRAPH_DATA
 
 
 def story_basic():
+    # An area chart has no intrinsic width, so it fills the container: the six
+    # lakes are spread to span `w` (five gaps between them) instead of a fixed
+    # pixel spacing, which would leave the canvas partly empty. Mirrors
+    # Area.stories.tsx's Basic export.
+    w = 500
+    lakes = 6
     return (
         chart(SEAFOOD)
-        .flow(spread(by="lake", dir="x", spacing=64))
+        .flow(spread(by="lake", dir="x", spacing=w / (lakes - 1)))
         .mark(blank(h="count"))
         .connect(area(opacity=0.8)),
-        {"w": 500, "h": 300, "axes": True},
+        {"w": w, "h": 300, "axes": True},
     )
 
 

--- a/tests/python-stories/forward-syntax-v3/test_cut.py
+++ b/tests/python-stories/forward-syntax-v3/test_cut.py
@@ -361,5 +361,5 @@ def story_croissant_stack():
                 Constraint.distribute([axis, bands], dir="y", spacing=12),
             ]
         ),
-        {"w": 520, "h": 260, "axes": False},
+        {"axes": False},
     )

--- a/tests/python-stories/forward-syntax-v3/test_waffle_chart.py
+++ b/tests/python-stories/forward-syntax-v3/test_waffle_chart.py
@@ -15,5 +15,5 @@ def story_default():
             spread(spacing=2, dir="x"),
         )
         .mark(rect(w=8, h=8, fill="species")),
-        {"w": 400, "h": 400, "axes": True},
+        {"axes": True},
     )

--- a/tests/python-stories/low-level-syntax/test_balloon_chart.py
+++ b/tests/python-stories/low-level-syntax/test_balloon_chart.py
@@ -53,5 +53,5 @@ def story_default():
 
     return (
         layer(scene, coord=wavy(), x=0, y=0),
-        {"w": 400, "h": 400, "axes": True},
+        {"axes": True},
     )

--- a/tests/python-stories/low-level-syntax/test_bump_chart.py
+++ b/tests/python-stories/low-level-syntax/test_bump_chart.py
@@ -207,5 +207,5 @@ def story_default():
 
     return (
         layer([*year_columns, *color_lines]),
-        {"w": 500, "h": 300},
+        {},
     )

--- a/tests/python-stories/low-level-syntax/test_flower_chart.py
+++ b/tests/python-stories/low-level-syntax/test_flower_chart.py
@@ -43,5 +43,5 @@ def story_default():
 
     return (
         layer(flowers),
-        {"w": 400, "h": 400, "axes": True},
+        {"axes": True},
     )

--- a/tests/python-stories/low-level-syntax/test_nested_boxes_tree.py
+++ b/tests/python-stories/low-level-syntax/test_nested_boxes_tree.py
@@ -100,4 +100,4 @@ def buildSubtree(node, depth):
 
 
 def story_nested_boxes_tree():
-    return (buildSubtree(sample, 0), {"w": 720, "h": 560})
+    return (buildSubtree(sample, 0), {})

--- a/tests/python-stories/low-level-syntax/test_nested_waffle_chart.py
+++ b/tests/python-stories/low-level-syntax/test_nested_waffle_chart.py
@@ -68,5 +68,5 @@ def story_default():
             alignment="middle",
             sharedScale=True,
         ),
-        {"w": 500, "h": 340, "axes": True},
+        {"axes": True},
     )

--- a/tests/python-stories/low-level-syntax/test_stringline_chart.py
+++ b/tests/python-stories/low-level-syntax/test_stringline_chart.py
@@ -63,5 +63,5 @@ def story_default():
 
     return (
         layer([stations_tier, *train_lines]),
-        {"w": 500, "h": 400, "axes": True},
+        {"axes": True},
     )

--- a/tests/python-stories/low-level-syntax/test_whisker.py
+++ b/tests/python-stories/low-level-syntax/test_whisker.py
@@ -11,7 +11,7 @@ from gofish import layer, spread, connect, rect, ref, datum
 from python_stories.data import GENDER_PAY_GAP, PAY_GRADE
 from python_stories._lowlevel_helpers import group_by, order_by
 
-_RENDER = {"w": 320, "h": 400, "axes": True}
+_RENDER = {"axes": True}
 
 
 def _box_and_whisker(d, tag):


### PR DESCRIPTION
Many gallery charts have a natural pixel size (fixed-size marks, fixed-`spacing` spreads) but were handed an explicit container `w`/`h` *larger* than that size — so the canvas became padding and the chart clustered in a corner. This drops the root `w`/`h` from those charts so they shrink-to-fit and render at their intrinsic size.

## Changes

**Intrinsic-size charts — root `w`/`h` removed (shrink-to-fit):**
waffle, balloon, bump, violin, stringline, nested-boxes, nested-waffle, flower, bottle-fill, pulley, python-tutor, annotated-planets, inner-planets (+ planet siblings), grouped box-and-whisker (+ whisker siblings), croissant, what's-in-a-bottle-of-wine. The now-dead `w`/`h` `argTypes`/`args` scaffolding is removed alongside.

**Area chart — rewritten to *fill* its container:** an area chart has no intrinsic width, so instead of a fixed `spacing: 64` (which left the canvas partly empty) the six lakes are spread to span `args.w`.

**Mosaic — left sized** (proportional on both axes; no intrinsic size).

## Engine fix

Removing `w`/`h` surfaced a latent NaN: `alignFallbackBaseline`'s `middle` anchor returned `size/2`, which on an **unsized** axis is `NaN/2 = NaN`, poisoning the legend column's placement (every swatch rendered `y="NaN"`). The `end` anchor was already finite-guarded for exactly this case; this completes the guard for `middle`. Sized charts are unaffected (their `size` is finite) — `capture-diff` confirms only the intentionally-edited charts moved.

## Deferred — #574

**Icicle** and **Sankey** don't fix cleanly: their `middle`-aligned roots put the content origin at the *center*, so the unsized overhang reservation double-counts (~150px empty band). That's the "content sits at the origin" symptom the **#39** unified-propagation work owns, so both are left sized and tracked in #574.

## Verification

- Every changed chart re-rendered via `capture-one` and visually verified (tight, correct legends, no NaN).
- `capture-diff` vs base: exactly the 23 intentionally-edited stories moved; no collateral regressions.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots (before → after)

| Chart | Before | After |
|---|---|---|
| Waffle (shrink-to-fit) | <img src="https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-575/waffle-chart--default--before.png" width="380"> | <img src="https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-575/waffle-chart--default--after.png" width="380"> |
| Balloon | <img src="https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-575/balloon-chart--default--before.png" width="380"> | <img src="https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-575/balloon-chart--default--after.png" width="380"> |
| Bump | <img src="https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-575/bump-chart--default--before.png" width="380"> | <img src="https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-575/bump-chart--default--after.png" width="380"> |
| Area (rewritten to fill) | <img src="https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-575/area--basic--before.png" width="380"> | <img src="https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-575/area--basic--after.png" width="380"> |
