### PR TITLE
fix(layout): shrink-to-fit min-pin — tight intrinsic canvases (#406, #574)

### DIFF
--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -393,10 +393,10 @@ The `intrinsicDims` represent the element's size in its local coordinate system 
 **Location**: `src/ast/gofish.tsx`
 
 ```typescript
-const placeRoot = (axis, value, shrinkToFit) => {
-  if (shrinkToFit && child.pinAnchor) child.pinAnchor(axis, value, "min");
-  else child.place(axis, value, shrinkToFit ? "min" : "baseline");
-};
+const placeRoot = (axis, value, shrinkToFit) =>
+  shrinkToFit
+    ? child.pinAnchor(axis, value, "min")
+    : child.place(axis, value, "baseline");
 placeRoot("x", x ?? transform?.x ?? 0, w === undefined);
 placeRoot("y", y ?? transform?.y ?? 0, h === undefined);
 ```

--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -319,9 +319,12 @@ default-width bars and a width of `n·barWidth + spacing`). A user-supplied
 dimension is always authoritative. This computed extent — not the raw option — is
 what the render pass uses to size the SVG. The legend is now part of the laid-out
 tree (it is elaborated into the node tree during layout, see Pass 7), so it is
-included in this computed extent when `w`/`h` are omitted. When a dimension _is_
-given, `layout()` additionally measures how far the laid-out tree extends past the
-authoritative extent on each of the four sides — including content a constraint
+included in this computed extent when `w`/`h` are omitted. (When a dimension is
+shrink-to-fit, Pass 10 pins the content's `min` edge to `0` so it fills `[0, size]`
+exactly; the per-side overhangs below then measure `0` on that axis — there is no
+gutter to reserve because the canvas already _is_ the content extent.) When a
+dimension _is_ given, `layout()` additionally measures how far the laid-out tree
+extends past the authoritative extent on each of the four sides — including content a constraint
 seated _beyond_ the canvas, e.g. a marginal histogram's bands above and to the
 right of a scatter — and the render pass reserves exactly that, replacing the
 former fixed `LEGEND_MARGIN` constant. The right side is split into two measured
@@ -387,15 +390,34 @@ The `intrinsicDims` represent the element's size in its local coordinate system 
 
 ### Pass 10: Placement
 
-**Location**: `src/ast/gofish.tsx:209`
+**Location**: `src/ast/gofish.tsx`
 
 ```typescript
-child.place({ x: x ?? transform?.x ?? 0, y: y ?? transform?.y ?? 0 });
+child.place("x", x ?? transform?.x ?? 0, w === undefined ? "min" : "baseline");
+child.place("y", y ?? transform?.y ?? 0, h === undefined ? "min" : "baseline");
 ```
 
-**Implementation**: `src/ast/_node.ts:284-309`
+**Implementation**: `src/ast/_node.ts`
 
-Applies final positioning offsets. This is typically used for positioning the entire chart within its container.
+Pins the whole chart into the container by landing one anchor of the root's bbox
+at a target coordinate. _Which_ anchor depends on whether the axis is sized:
+
+- **Given dimension** → pin the **baseline** (local `0`) to `0`. The canvas box is
+  the baseline-anchored `[0, given]`, and any content seated outside it (axis labels
+  below `0`, ticks above `given`) is reserved as the per-side overhangs in the render
+  pass.
+- **Shrink-to-fit dimension** (`w`/`h` omitted, so `finalH = size`) → pin the **`min`
+  edge** to `0`. The canvas box _is_ the content's full `[min, max]` extent, so the
+  content fills `[0, size]` exactly and the overhang formulas (`-min`, `max - finalH`)
+  compute `0` for that axis with no special-casing.
+
+  Pinning the baseline in this case would leave `min` at a negative offset that
+  `bottomOverhang = -min` (and the left analogue) re-reserves as a _phantom empty band_
+  equal to the offset — the canvas would be ~2× the content on the side where the
+  content sits below/left of its baseline. That double-count was
+  [#574](https://github.com/gofish-graphics/gofish-graphics/issues/574); choosing the
+  anchor by sized-ness is the fix, and it keeps the overhang reservation purely a
+  _given-dimension_ concern.
 
 ### Pass 11: Ordinal Scale Building
 

--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -393,8 +393,12 @@ The `intrinsicDims` represent the element's size in its local coordinate system 
 **Location**: `src/ast/gofish.tsx`
 
 ```typescript
-child.place("x", x ?? transform?.x ?? 0, w === undefined ? "min" : "baseline");
-child.place("y", y ?? transform?.y ?? 0, h === undefined ? "min" : "baseline");
+const placeRoot = (axis, value, shrinkToFit) => {
+  if (shrinkToFit && child.pinAnchor) child.pinAnchor(axis, value, "min");
+  else child.place(axis, value, shrinkToFit ? "min" : "baseline");
+};
+placeRoot("x", x ?? transform?.x ?? 0, w === undefined);
+placeRoot("y", y ?? transform?.y ?? 0, h === undefined);
 ```
 
 **Implementation**: `src/ast/_node.ts`
@@ -411,13 +415,19 @@ at a target coordinate. _Which_ anchor depends on whether the axis is sized:
   content fills `[0, size]` exactly and the overhang formulas (`-min`, `max - finalH`)
   compute `0` for that axis with no special-casing.
 
-  Pinning the baseline in this case would leave `min` at a negative offset that
-  `bottomOverhang = -min` (and the left analogue) re-reserves as a _phantom empty band_
-  equal to the offset — the canvas would be ~2× the content on the side where the
-  content sits below/left of its baseline. That double-count was
-  [#574](https://github.com/gofish-graphics/gofish-graphics/issues/574); choosing the
-  anchor by sized-ness is the fix, and it keeps the overhang reservation purely a
-  _given-dimension_ concern.
+  Leaving `min` off origin in this case is the
+  [#574](https://github.com/gofish-graphics/gofish-graphics/issues/574) double-count:
+  a _negative_ `min` (content below/left of baseline) makes `bottomOverhang = -min`
+  re-reserve a phantom band ~equal to the offset, so the canvas comes out ~2× the
+  content; a _positive_ `min` (a self-placed diagram seated at, say, `(20, 20)`) both
+  gaps the near side and overhangs the far side. Pinning `min` to 0 collapses both,
+  and it keeps the overhang reservation purely a _given-dimension_ concern.
+
+  The min-pin uses **`pinAnchor`**, not the write-once `place()`: a chart whose root
+  carries its own transform (a hand-built diagram like the pulley) has already
+  self-placed that axis, and `place()` short-circuits on a placed axis. `pinAnchor` is
+  the authoritative override — it rebuilds the axis ledger so the pin lands regardless
+  — and for an unplaced root it matches what `place(…, "min")` would have done.
 
 ### Pass 11: Ordinal Scale Building
 

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -329,8 +329,26 @@ export async function layout(
   shadowCheckScaleRoot(niceUnderlyingSpaceY, canvasH, rootScaleFactors[1], 1);
 
   child.layout([layoutW, layoutH], rootScaleFactors, posScales);
-  child.place("x", x ?? transform?.x ?? 0, "baseline");
-  child.place("y", y ?? transform?.y ?? 0, "baseline");
+  // Root placement anchor: when a dimension is GIVEN, the canvas box is the
+  // baseline-anchored [0, given], and content seated outside it (axis labels
+  // below 0, ticks above `given`) is reserved as per-side overhangs below. When
+  // a dimension is SHRINK-TO-FIT (`finalH = size`), the canvas box IS the
+  // content's full [min, max] extent, so we pin the content's `min` edge to 0
+  // instead of its baseline — content then fills [0, size] exactly and the
+  // overhang formulas compute 0 for that axis with no special-casing. Pinning
+  // the baseline here would leave `min` at a negative offset that
+  // `bottomOverhang = -min` re-reserves as a phantom empty band equal to the
+  // offset (#574).
+  child.place(
+    "x",
+    x ?? transform?.x ?? 0,
+    w === undefined ? "min" : "baseline"
+  );
+  child.place(
+    "y",
+    y ?? transform?.y ?? 0,
+    h === undefined ? "min" : "baseline"
+  );
 
   // Final extent: a user-given dimension is authoritative; otherwise prefer the
   // content's laid-out intrinsic size (shrink-to-fit), falling back to the

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -333,22 +333,24 @@ export async function layout(
   // baseline-anchored [0, given], and content seated outside it (axis labels
   // below 0, ticks above `given`) is reserved as per-side overhangs below. When
   // a dimension is SHRINK-TO-FIT (`finalH = size`), the canvas box IS the
-  // content's full [min, max] extent, so we pin the content's `min` edge to 0
-  // instead of its baseline — content then fills [0, size] exactly and the
-  // overhang formulas compute 0 for that axis with no special-casing. Pinning
-  // the baseline here would leave `min` at a negative offset that
-  // `bottomOverhang = -min` re-reserves as a phantom empty band equal to the
-  // offset (#574).
-  child.place(
-    "x",
-    x ?? transform?.x ?? 0,
-    w === undefined ? "min" : "baseline"
-  );
-  child.place(
-    "y",
-    y ?? transform?.y ?? 0,
-    h === undefined ? "min" : "baseline"
-  );
+  // content's full [min, max] extent, so we pin the content's `min` edge to 0:
+  // content then fills [0, size] exactly and the overhang formulas compute 0 for
+  // that axis with no special-casing. Pinning the baseline (or leaving a
+  // self-placed root where it sits) instead would leave `min` off origin, which
+  // the per-side overhangs re-reserve as a phantom empty band — the #574
+  // double-count (a negative `min` bloats the canvas via `-min`; a positive one
+  // both gaps the near side and overhangs the far side, e.g. the pulley diagram).
+  //
+  // `pinAnchor` (not the write-once `place()`) so the min-pin is AUTHORITATIVE:
+  // it rebuilds the ledger even when the root self-placed (a diagram with its own
+  // root transform), which `place()` short-circuits. For an unplaced root it
+  // matches what `place(…, "min")` did.
+  const placeRoot = (axis: "x" | "y", value: number, shrinkToFit: boolean) => {
+    if (shrinkToFit && child.pinAnchor) child.pinAnchor(axis, value, "min");
+    else child.place(axis, value, shrinkToFit ? "min" : "baseline");
+  };
+  placeRoot("x", x ?? transform?.x ?? 0, w === undefined);
+  placeRoot("y", y ?? transform?.y ?? 0, h === undefined);
 
   // Final extent: a user-given dimension is authoritative; otherwise prefer the
   // content's laid-out intrinsic size (shrink-to-fit), falling back to the

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -329,26 +329,21 @@ export async function layout(
   shadowCheckScaleRoot(niceUnderlyingSpaceY, canvasH, rootScaleFactors[1], 1);
 
   child.layout([layoutW, layoutH], rootScaleFactors, posScales);
-  // Root placement anchor: when a dimension is GIVEN, the canvas box is the
-  // baseline-anchored [0, given], and content seated outside it (axis labels
-  // below 0, ticks above `given`) is reserved as per-side overhangs below. When
-  // a dimension is SHRINK-TO-FIT (`finalH = size`), the canvas box IS the
-  // content's full [min, max] extent, so we pin the content's `min` edge to 0:
-  // content then fills [0, size] exactly and the overhang formulas compute 0 for
-  // that axis with no special-casing. Pinning the baseline (or leaving a
-  // self-placed root where it sits) instead would leave `min` off origin, which
-  // the per-side overhangs re-reserve as a phantom empty band — the #574
-  // double-count (a negative `min` bloats the canvas via `-min`; a positive one
-  // both gaps the near side and overhangs the far side, e.g. the pulley diagram).
-  //
-  // `pinAnchor` (not the write-once `place()`) so the min-pin is AUTHORITATIVE:
-  // it rebuilds the ledger even when the root self-placed (a diagram with its own
-  // root transform), which `place()` short-circuits. For an unplaced root it
-  // matches what `place(…, "min")` did.
-  const placeRoot = (axis: "x" | "y", value: number, shrinkToFit: boolean) => {
-    if (shrinkToFit && child.pinAnchor) child.pinAnchor(axis, value, "min");
-    else child.place(axis, value, shrinkToFit ? "min" : "baseline");
-  };
+  // Root placement anchor. A GIVEN dimension keeps the baseline-anchored canvas
+  // box [0, given]; content seated outside it (axis labels below 0, ticks above
+  // `given`) is reserved as the per-side overhangs below. A SHRINK-TO-FIT
+  // dimension makes the canvas box the content's full [min, max] extent, so pin
+  // its `min` edge to 0 — content then fills [0, size] and every overhang
+  // formula computes 0 for that axis. Leaving `min` off origin is the #574
+  // double-count: the overhangs re-reserve it as a phantom band (a negative
+  // `min` bloats the canvas via `-min`; a positive one gaps the near side and
+  // overhangs the far side, e.g. the pulley diagram). The pin uses `pinAnchor`,
+  // not the write-once `place()`, so it lands even when the root self-placed (a
+  // diagram with its own root transform) — `place()` short-circuits a placed axis.
+  const placeRoot = (axis: "x" | "y", value: number, shrinkToFit: boolean) =>
+    shrinkToFit
+      ? child.pinAnchor(axis, value, "min")
+      : child.place(axis, value, "baseline");
   placeRoot("x", x ?? transform?.x ?? 0, w === undefined);
   placeRoot("y", y ?? transform?.y ?? 0, h === undefined);
 

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/PythonTutor.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/PythonTutor.stories.tsx
@@ -16,9 +16,7 @@ const meta: Meta = {
 };
 export default meta;
 
-type Args = { w: number; h: number };
-
-export const PythonTutor: StoryObj<Args> = {
+export const PythonTutor: StoryObj = {
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -27,7 +25,7 @@ export const PythonTutor: StoryObj<Args> = {
         "A Python Tutor style runtime memory diagram showing a global frame of variables whose pointers fan out with arrows into a heap of linked tuples.",
     },
   },
-  render: (args: Args) => {
+  render: () => {
     const container = initializeContainer();
     const data = {
       stack: [

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/PythonTutor.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/PythonTutor.stories.tsx
@@ -105,7 +105,7 @@ export const PythonTutor: StoryObj<Args> = {
     );
 
     Layer([
-      Spread({ dir: "x", alignment: "start", spacing: 100 }, [
+      Spread({ dir: "x", alignment: "end", spacing: 100 }, [
         globalFrame({ stack: data.stack }).name(globalFrameName),
         heap({
           heap: data.heap,

--- a/packages/gofish-graphics/stories/lowlevel/IcicleChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/IcicleChart.stories.tsx
@@ -7,18 +7,8 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Low Level Syntax/Icicle Chart",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
-
-type Args = { w: number; h: number };
 
 const classColor = {
   First: color6[0],
@@ -27,9 +17,8 @@ const classColor = {
   Crew: color6[3],
 };
 
-export const Simplified: StoryObj<Args> = {
-  args: { w: 500, h: 300 },
-  render: (args: Args) => {
+export const Simplified: StoryObj = {
+  render: () => {
     const container = initializeContainer();
 
     stackX({ alignment: "middle" }, [
@@ -52,16 +41,13 @@ export const Simplified: StoryObj<Args> = {
           .value()
       ),
     ]).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
     return container;
   },
 };
 
-export const Default: StoryObj<Args> = {
-  args: { w: 500, h: 300 },
+export const Default: StoryObj = {
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -70,7 +56,7 @@ export const Default: StoryObj<Args> = {
         "Titanic passengers broken down by class and then survival as an icicle diagram, with nested rectangles in successive columns sized to encode each group's count.",
     },
   },
-  render: (args: Args) => {
+  render: () => {
     const container = initializeContainer();
 
     stackX({ alignment: "middle" }, [
@@ -135,8 +121,6 @@ export const Default: StoryObj<Args> = {
           .value()
       ),
     ]).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
     return container;

--- a/packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
@@ -8,18 +8,8 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Low Level Syntax/Nested Mosaic Chart",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
-
-type Args = { w: number; h: number };
 
 const classColor = {
   First: color6[0],
@@ -28,8 +18,7 @@ const classColor = {
   Crew: color6[3],
 };
 
-export const Default: StoryObj<Args> = {
-  args: { w: 500, h: 300 },
+export const Default: StoryObj = {
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -38,7 +27,7 @@ export const Default: StoryObj<Args> = {
         "Titanic survival broken down by passenger class as a mosaic plot, where each cell's width and height encode the proportions of a two-way contingency table.",
     },
   },
-  render: (args: Args) => {
+  render: () => {
     const container = initializeContainer();
     spreadY(
       { reverse: true, spacing: 4, alignment: "start" },
@@ -64,8 +53,6 @@ export const Default: StoryObj<Args> = {
         )
       )
     ).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
     return container;

--- a/packages/gofish-graphics/stories/lowlevel/SankeyTree.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/SankeyTree.stories.tsx
@@ -8,18 +8,8 @@ import _ from "lodash";
 
 const meta: Meta = {
   title: "Low Level Syntax/Sankey Tree",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
-
-type Args = { w: number; h: number };
 
 const classColor = {
   First: color6[0],
@@ -28,8 +18,7 @@ const classColor = {
   Crew: color6[3],
 };
 
-export const Default: StoryObj<Args> = {
-  args: { w: 500, h: 400 },
+export const Default: StoryObj = {
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -38,7 +27,7 @@ export const Default: StoryObj<Args> = {
         "A branching flow diagram where the width of each tapering band encodes the magnitude of a quantity as it splits across successive tiers.",
     },
   },
-  render: (args: Args) => {
+  render: () => {
     const container = initializeContainer();
     const layerSpacing = 64;
     const internalSpacing = 2;
@@ -157,8 +146,6 @@ export const Default: StoryObj<Args> = {
         ]),
       ]),
     ]).render(container, {
-      w: args.w,
-      h: args.h,
       axes: true,
     });
     return container;

--- a/packages/gofish-graphics/stories/piccl/Bottle.stories.tsx
+++ b/packages/gofish-graphics/stories/piccl/Bottle.stories.tsx
@@ -13,21 +13,10 @@ const data = [
 
 const meta: Meta = {
   title: "Piccl/Bottle",
-  argTypes: {
-    w: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-    h: {
-      control: { type: "number", min: 100, max: 1000, step: 10 },
-    },
-  },
 };
 export default meta;
 
-type Args = { w: number; h: number };
-
-export const Default: StoryObj<Args> = {
-  args: { w: 1000, h: 400 },
+export const Default: StoryObj = {
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -35,7 +24,7 @@ export const Default: StoryObj<Args> = {
       description: "A row of wine bottles filled with green liquid to heights that encode percentage values, an isotype-style bar chart with labeled fill lines.",
     },
   },
-  render: (args: Args) => {
+  render: () => {
     const container = initializeContainer();
 
     Chart(data, {axes: false})
@@ -53,10 +42,7 @@ export const Default: StoryObj<Args> = {
         Constraint.distribute({ dir: "y", spacing: 0 }, [line, label]),
         Constraint.align({ x: "end" }, [label, line]),
       ]))
-      .render(container, {
-        w: args.w,
-        h: args.h
-      });
+      .render(container, {});
 
     return container;
   },

--- a/packages/gofish-graphics/stories/piccl/Bottle.stories.tsx
+++ b/packages/gofish-graphics/stories/piccl/Bottle.stories.tsx
@@ -33,7 +33,7 @@ export const Default: StoryObj = {
         [
           paint({blendMode: "color"}, [
           image({ href: bottlePng, h: v(100) }),
-          rect({h: "amount", fill: "#00ff00"}),
+          rect({h: "amount", w: 175, fill: "#00ff00"}),
         ]).name("bottle"),
         rect({h: 1, fill: "#666", w: 175, y: "amount"}).name("line"),
         text({fontSize: 35, fill: "#666", text: (d) => `${d.amount}%`}).name("label")

--- a/tests/python-stories/bluefish/python-tutor/test_python_tutor.py
+++ b/tests/python-stories/bluefish/python-tutor/test_python_tutor.py
@@ -94,7 +94,7 @@ def story_python_tutor():
                         ).name(heap_name),
                     ],
                     dir="x",
-                    alignment="start",
+                    alignment="end",
                     spacing=100,
                 ),
                 *stack_arrows,

--- a/tests/python-stories/low-level-syntax/test_icicle_chart.py
+++ b/tests/python-stories/low-level-syntax/test_icicle_chart.py
@@ -38,7 +38,7 @@ def story_simplified():
             dir="x",
             alignment="middle",
         ),
-        {"w": 500, "h": 300, "axes": True},
+        {"axes": True},
     )
 
 
@@ -107,5 +107,5 @@ def story_default():
             dir="x",
             alignment="middle",
         ),
-        {"w": 500, "h": 300, "axes": True},
+        {"axes": True},
     )

--- a/tests/python-stories/low-level-syntax/test_nested_mosaic_chart.py
+++ b/tests/python-stories/low-level-syntax/test_nested_mosaic_chart.py
@@ -54,5 +54,5 @@ def story_default():
             spacing=4,
             alignment="start",
         ),
-        {"w": 500, "h": 300, "axes": True},
+        {"axes": True},
     )

--- a/tests/python-stories/low-level-syntax/test_sankey_tree.py
+++ b/tests/python-stories/low-level-syntax/test_sankey_tree.py
@@ -167,5 +167,5 @@ def story_default():
 
     return (
         layer([bars, *ribbons]),
-        {"w": 500, "h": 400, "axes": True},
+        {"axes": True},
     )

--- a/tests/python-stories/piccl/test_bottle.py
+++ b/tests/python-stories/piccl/test_bottle.py
@@ -67,5 +67,5 @@ def story_default():
                 Constraint.align([label, line], x="end"),
             ])
         ),
-        {"w": 1000, "h": 400, "axes": False},
+        {"axes": False},
     )

--- a/tests/python-stories/piccl/test_bottle.py
+++ b/tests/python-stories/piccl/test_bottle.py
@@ -51,7 +51,7 @@ def story_default():
                 paint(
                     [
                         image(href=BOTTLE_PNG, h=datum(100)),
-                        rect(h="amount", fill="#00ff00"),
+                        rect(h="amount", w=175, fill="#00ff00"),
                     ],
                     blendMode="color",
                 ).name("bottle"),


### PR DESCRIPTION
## What

Two related changes:

1. **`PythonTutor.stories.tsx`** — switch the top-level `Spread` from `alignment: "start"` to `alignment: "end"`. `"start"` was only a workaround for #406, where `"end"` pushed the whole diagram off the visible canvas.
2. **`gofish.tsx` (engine)** — fix the overhang double-count that the alignment switch exposed (#574), so the diagram renders tight instead of with a large empty band.

## Why #406 is fixed

#406 was a symptom of the bbox model not keeping `min`/`center`/`max`/`size` in sync (#39). The unified-propagation work (#573 stage 1, #576 stage 2) fixed that, so `"end"` no longer translates off-canvas.

## The empty-band fix (#574)

Switching to `"end"` surfaced a second, pre-existing bug: a **large empty band** at the top. Root cause (the known #574 double-count):

- A shrink-to-fit axis sets `finalH = content size = max - min`.
- The root was pinned by its **baseline** (local `0`), so when content sits below its baseline (`min < 0`), the content box `[min, max]` and the assumed canvas box `[0, finalH]` are offset by `min`.
- `bottomOverhang = -min` (and the left analogue on x) then re-reserves that offset as a phantom band — the canvas comes out ~2× the content on that side.

**Fix:** choose the placement anchor by sized-ness.

| case | anchor | result |
|---|---|---|
| dimension **given** | pin `baseline` at 0 | unchanged — overhangs reserve outside-the-box chrome |
| **shrink-to-fit** | pin `min` edge at 0 | content fills `[0, size]`; overhang formulas compute `0`, no phantom band |

No overhang special-casing — the reservation stays purely a *given-dimension* concern. This directly answers "why do we need explicit overhangs at all": for shrink-to-fit we don't; placing the content correctly makes them a no-op.

## Verification

`pnpm capture-diff` vs `main`: **19 shrink-to-fit stories change, all pure rigid shift + tightened canvas** — element-local geometry is byte-identical (verified `dx = dy = 0`). Most shrink (phantom band removed); two legend charts (whisker, stringline) change right-gutter width by a few px via the legend-overhang recalc, with no clipping. `tsc --noEmit` clean. Layout-passes wiki essay updated per the `@wiki` contract.

### Intrinsic-sizing sweep (the rest of #574)

The min-pin generalizes to **`pinAnchor`** (not the write-once `place()`) so it also lands on charts whose root self-places (a hand-built diagram like the pulley, seated at a positive `min`). With that, every chart flagged for excess padding renders tight. Four that still passed explicit `w`/`h` purely as the #574 workaround now shrink-to-fit (dead `w`/`h` scaffolding removed): **icicle, sankey, bottle, nested-mosaic**. The other four were already shrink-to-fit and tighten via the engine fix: **inner-planets, nested-waffle, violin, pulley**.

`capture-diff` vs `main`: **25 shrink-to-fit stories change**. Pulley and the engine-only charts are pure rigid shifts (element-local geometry byte-identical); the four un-sized charts relayout to their intrinsic extent (verified visually). No other stories move.

> ⚠️ Visual baselines will need regenerating on CI (Linux) for the 19 changed stories — intentional.

**Before** (`"start"` workaround):

![before](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-594/before-start.png)

**After** (`"end"` + #574 fix — tight, heap top-aligned with stack, the visual #406 wanted):

![after](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-594/after-end.png)

Closes #406
Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
