### PR TITLE
feat(export): SVG export — toSVG/save (JS) + .save/.to_svg (Python) (#571)

### DIFF
--- a/apps/docs/docs/.vitepress/config.mts
+++ b/apps/docs/docs/.vitepress/config.mts
@@ -434,6 +434,7 @@ export default defineConfig({
                 { text: "mark", link: "/js/api/core/mark" },
                 { text: "connect", link: "/js/api/core/connect" },
                 { text: "render", link: "/js/api/core/render" },
+                { text: "export (SVG)", link: "/js/api/core/export" },
               ],
             },
             {
@@ -548,6 +549,7 @@ export default defineConfig({
                 { text: "mark", link: "/python/api/core/mark" },
                 { text: "connect", link: "/python/api/core/connect" },
                 { text: "render", link: "/python/api/core/render" },
+                { text: "export (SVG)", link: "/python/api/core/export" },
               ],
             },
             {

--- a/apps/docs/docs/js/api/core/export.md
+++ b/apps/docs/docs/js/api/core/export.md
@@ -1,0 +1,66 @@
+# export (SVG)
+
+Get a chart's SVG out as a value instead of mounting it into the page.
+`toSVG()` is the primitive; `save()` is the convenience that infers the format
+from the file extension. These are siblings of [`render`](/js/api/core/render) —
+same options, plus `background` — and chain off any chart, mark, or layer.
+
+```ts
+// SVG markup as a string
+const svg = await chart(seafood)
+  .flow(spread({ by: "lake", dir: "x" }))
+  .mark(rect({ h: "count" }))
+  .toSVG({ w: 400, h: 250, axes: true });
+
+// Save (browser → download, Node → write file)
+await chart(seafood)
+  .flow(spread({ by: "lake", dir: "x" }))
+  .mark(rect({ h: "count" }))
+  .save("seafood.svg", { w: 400, h: 250, axes: true });
+```
+
+## Methods
+
+```ts
+.toSVG(options?): Promise<string>          // standalone SVG markup
+.toSVGElement(options?): Promise<SVGSVGElement>  // detached DOM element
+.save(filename, options?): Promise<void>   // format inferred from extension
+```
+
+All three are **async** — await them.
+
+## Options
+
+`options` accepts everything [`render`](/js/api/core/render) accepts (`w`, `h`,
+`axes`, `padding`, …) plus:
+
+| Option       | Type             | Description                                                      |
+| ------------ | ---------------- | ---------------------------------------------------------------- |
+| `background` | `string \| null` | Background fill painted behind the chart. Omitted = transparent. |
+
+```ts
+await chart(data)
+  .mark(rect({ h: "value" }))
+  .save("chart.svg", { w: 400, h: 300, background: "white" });
+```
+
+## `save()` dispatch
+
+- **Format** is inferred from the extension. `.svg` is supported today; PNG and
+  HTML are tracked in [#578](https://github.com/gofish-graphics/gofish-graphics/issues/578).
+- **Environment** is detected automatically: in a browser `save()` triggers a
+  download; in Node it writes the file to disk.
+
+## Notes
+
+- **Requires a DOM.** `toSVG()` runs the same layout + render pipeline as
+  `render()` but mounts into a throwaway element, so it needs a browser-like
+  environment (browser, or a notebook front-end). Headless Node rendering —
+  producing the SVG with no browser — is tracked in
+  [#577](https://github.com/gofish-graphics/gofish-graphics/issues/577).
+- **Fonts are referenced, not embedded.** Text keeps its `font-family`
+  references, so a viewer without those fonts sees fallback fonts. Embedding
+  (subsetted `@font-face`) and outlining (text → paths) for fully self-contained
+  output are tracked in [#578](https://github.com/gofish-graphics/gofish-graphics/issues/578).
+- The output carries the SVG/xlink namespaces and a `viewBox`, so it scales when
+  a consumer overrides `width`/`height`.

--- a/apps/docs/docs/js/api/core/render.md
+++ b/apps/docs/docs/js/api/core/render.md
@@ -1,6 +1,7 @@
 # render
 
-Renders the chart into a DOM element.
+Renders the chart into a DOM element. To get the SVG out as a string or file
+instead, see [export](/js/api/core/export).
 
 ## Signature
 

--- a/apps/docs/docs/python/api/core/export.md
+++ b/apps/docs/docs/python/api/core/export.md
@@ -1,0 +1,75 @@
+# export (SVG)
+
+Save a chart to an SVG file. `save()` infers the format from the file extension;
+`to_svg()` returns the markup as a string. These sit alongside
+[`render`](/python/api/core/render).
+
+```python
+from gofish import chart, spread, rect
+
+# Last expression in a cell → displays and writes "seafood.svg".
+chart(seafood, axes=True).flow(spread(by="lake", dir="x")).mark(
+    rect(h="count")
+).save("seafood.svg", w=500, h=300)
+```
+
+## How it works
+
+The SVG is produced by the notebook **front-end**, not the Python kernel, so
+export uses the same widget bridge as rendering:
+
+- `chart(...).save(path, ...)` returns a widget that **writes the file once it
+  renders**. Make it the last expression in a cell (or otherwise display it) so
+  the render — and therefore the write — happen.
+- After a widget has displayed, `widget.to_svg()` returns the markup and
+  `widget.svg` exposes it as a property.
+
+Because the write waits for the front-end to render, it completes
+asynchronously — shortly after the cell with the live widget runs. Truly
+synchronous, headless export (works in plain `.py` scripts / CI) is tracked in
+[#577](https://github.com/gofish-graphics/gofish-graphics/issues/577).
+
+## Signature
+
+```python
+ChartBuilder.save(path, w=800, h=600, debug=False)   # returns a widget
+
+GoFishChartWidget.save(path)        # write now (or defer until rendered)
+GoFishChartWidget.to_svg() -> str   # markup; errors if not yet rendered
+GoFishChartWidget.svg               # markup or None
+```
+
+## Parameters
+
+| Parameter | Type  | Default | Description                                               |
+| --------- | ----- | ------- | --------------------------------------------------------- |
+| `path`    | `str` | —       | Output path. Format inferred from the extension (`.svg`). |
+| `w`       | `int` | `800`   | Chart width in pixels                                     |
+| `h`       | `int` | `600`   | Chart height in pixels                                    |
+
+::: tip Axes are a chart option
+`axes` (and `padding`) are passed to [`chart`](/python/api/core/chart), not
+`save` — mirroring `render`.
+:::
+
+## Working with the widget directly
+
+```python
+w = chart(seafood, axes=True).flow(spread(by="lake", dir="x")).mark(
+    rect(h="count")
+).render(w=500, h=300)   # display this cell
+
+# In a later cell, after it has rendered:
+svg = w.to_svg()
+w.save("seafood.svg")
+```
+
+## Notes
+
+- Only `.svg` is supported today; PNG and HTML are tracked in
+  [#578](https://github.com/gofish-graphics/gofish-graphics/issues/578).
+- Fonts are **referenced**, not embedded — a viewer without those fonts sees
+  fallback fonts. Self-contained output (embedded/outlined fonts) is tracked in
+  [#578](https://github.com/gofish-graphics/gofish-graphics/issues/578).
+- Calling `save()` without ever displaying the widget writes nothing — the
+  front-end must render to produce the SVG.

--- a/apps/docs/docs/python/api/core/render.md
+++ b/apps/docs/docs/python/api/core/render.md
@@ -65,6 +65,6 @@ chart(seafood).flow(spread(by="lake", dir="x")).mark(rect(h="count")).to_ir()
 
 ## Notes
 
-- Rendering requires a notebook kernel — `render()` produces a widget, not a
-  static image or an SVG string.
+- Rendering requires a notebook kernel — `render()` produces a widget. To get
+  an SVG file or string, use [`save` / `to_svg`](/python/api/core/export).
 - A chart must have a [mark](/python/api/core/mark) before it can be rendered.

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -20,8 +20,8 @@ import {
   Size,
   Transform,
 } from "./dims";
-import { gofish } from "./gofish";
-import type { AxesOptions } from "./gofish";
+import { gofish, gofishToSVGElement, gofishToSVG, gofishSave } from "./gofish";
+import type { AxesOptions, GoFishExportOptions } from "./gofish";
 import { GoFishRef } from "./_ref";
 import { GoFishAST } from "./_ast";
 import { CoordinateTransform } from "./coordinateTransforms/coord";
@@ -669,6 +669,34 @@ export class GoFishNode {
       },
       this
     );
+  }
+
+  /**
+   * Render to a detached `<svg>` element instead of mounting into the page.
+   * Same options as {@link render}, plus `background`. Requires a DOM
+   * (browser or notebook front-end); headless Node is tracked in #577.
+   */
+  public toSVGElement(
+    options: GoFishExportOptions = {}
+  ): Promise<SVGSVGElement> {
+    return gofishToSVGElement(options, this);
+  }
+
+  /** Render to a standalone SVG markup string. See {@link toSVGElement}. */
+  public toSVG(options: GoFishExportOptions = {}): Promise<string> {
+    return gofishToSVG(options, this);
+  }
+
+  /**
+   * Render and save to `filename`. Format is inferred from the extension
+   * (only `.svg` today). In a browser this downloads; in Node it writes the
+   * file.
+   */
+  public save(
+    filename: string,
+    options: GoFishExportOptions = {}
+  ): Promise<void> {
+    return gofishSave(filename, options, this);
   }
 
   public name(name: string | Token): this {

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -386,10 +386,56 @@ export async function layout(
   };
 }
 
-/* global pass handler */
-export const gofish = (
-  container: HTMLElement,
-  {
+/* top-level pass handler */
+
+/** Options shared by every render terminal (`render`, `toSVG`, …). */
+export type GoFishRenderOptions = {
+  w?: number;
+  h?: number;
+  x?: number;
+  y?: number;
+  transform?: { x?: number; y?: number };
+  debug?: boolean;
+  defs?: JSX.Element[];
+  axes?: AxesOptions;
+  axisFields?: { x?: string; y?: string };
+  colorConfig?: ColorConfig;
+  padding?: number;
+};
+
+/** Extra options for the SVG-export terminals (`toSVG` / `toSVGElement` / `save`). */
+export type GoFishExportOptions = GoFishRenderOptions & {
+  /** Background fill painted behind the chart. `null`/omitted = transparent. */
+  background?: string | null;
+};
+
+type LayoutData = {
+  underlyingSpaceX: UnderlyingSpace;
+  underlyingSpaceY: UnderlyingSpace;
+  posScales: [
+    ((pos: number) => number) | undefined,
+    ((pos: number) => number) | undefined,
+  ];
+  child: GoFishNode;
+  width: number;
+  height: number;
+  rightOverhang: number;
+  rightContentOverhang: number;
+  topOverhang: number;
+  leftOverhang: number;
+  bottomOverhang: number;
+};
+
+/**
+ * Run the domain-inference + layout passes for `child` and return the
+ * measured layout data. The single place the pipeline is driven — shared by
+ * the live `gofish()` render path and the `gofishToSVG*` export paths.
+ */
+async function runLayout(
+  options: GoFishRenderOptions,
+  child: GoFishNode | Promise<GoFishNode>
+): Promise<LayoutData> {
+  const {
     w,
     h,
     x,
@@ -400,79 +446,70 @@ export const gofish = (
     axes = false,
     axisFields,
     colorConfig,
-    padding,
-  }: {
-    w?: number;
-    h?: number;
-    x?: number;
-    y?: number;
-    transform?: { x?: number; y?: number };
-    debug?: boolean;
-    defs?: JSX.Element[];
-    axes?: AxesOptions;
-    axisFields?: { x?: string; y?: string };
-    colorConfig?: ColorConfig;
-    padding?: number;
-  },
+  } = options;
+  const session: RenderSession = {
+    tokenContext: new Map(),
+    scaleContext: { unit: { color: new Map(), colorConfig } },
+  };
+  try {
+    const contexts = { session };
+
+    // Text mark bbox measurements (via canvas measureText in
+    // text.tsx) depend on resolved font metrics. If a webfont is
+    // still loading when layout runs, measurement uses fallback
+    // metrics, baking the wrong positions into the SVG.
+    // FontFaceSet.ready resolves once all CSS-declared @font-face
+    // loads are done. System-fallback resolution (e.g. "Andale Mono"
+    // → fontconfig monospace on Linux) bypasses this entirely, so
+    // this isn't a full guarantee — but it's a strict improvement
+    // for any consumer using <link>-loaded webfonts.
+    if (typeof document !== "undefined" && document.fonts?.ready) {
+      await document.fonts.ready;
+    }
+
+    return await layout(
+      { w, h, x, y, transform, debug, defs, axes, axisFields },
+      child,
+      contexts
+    );
+  } finally {
+    if (debug) {
+      console.log("scaleContext", session.scaleContext);
+      console.log("tokenContext", session.tokenContext);
+    }
+  }
+}
+
+/** Build the `<svg>` JSX element from already-computed layout data. */
+function renderLayout(
+  data: LayoutData,
+  svgPadding: number,
+  defs?: JSX.Element[]
+): JSX.Element {
+  return render(
+    {
+      width: data.width,
+      height: data.height,
+      svgPadding,
+      defs,
+      rightOverhang: data.rightOverhang,
+      rightContentOverhang: data.rightContentOverhang,
+      topOverhang: data.topOverhang,
+      leftOverhang: data.leftOverhang,
+      bottomOverhang: data.bottomOverhang,
+    },
+    data.child
+  );
+}
+
+export const gofish = (
+  container: HTMLElement,
+  options: GoFishRenderOptions,
   child: GoFishNode | Promise<GoFishNode>
 ) => {
-  const svgPadding = padding ?? PADDING;
-  type LayoutData = {
-    underlyingSpaceX: UnderlyingSpace;
-    underlyingSpaceY: UnderlyingSpace;
-    posScales: [
-      ((pos: number) => number) | undefined,
-      ((pos: number) => number) | undefined,
-    ];
-    child: GoFishNode;
-    width: number;
-    height: number;
-    rightOverhang: number;
-    rightContentOverhang: number;
-    topOverhang: number;
-    leftOverhang: number;
-    bottomOverhang: number;
-  };
+  const svgPadding = options.padding ?? PADDING;
 
-  const runGofish = async (): Promise<LayoutData> => {
-    const session: RenderSession = {
-      tokenContext: new Map(),
-      scaleContext: { unit: { color: new Map(), colorConfig } },
-    };
-    try {
-      const contexts = {
-        session,
-      };
-
-      // Text mark bbox measurements (via canvas measureText in
-      // text.tsx) depend on resolved font metrics. If a webfont is
-      // still loading when layout runs, measurement uses fallback
-      // metrics, baking the wrong positions into the SVG.
-      // FontFaceSet.ready resolves once all CSS-declared @font-face
-      // loads are done. System-fallback resolution (e.g. "Andale Mono"
-      // → fontconfig monospace on Linux) bypasses this entirely, so
-      // this isn't a full guarantee — but it's a strict improvement
-      // for any consumer using <link>-loaded webfonts.
-      if (typeof document !== "undefined" && document.fonts?.ready) {
-        await document.fonts.ready;
-      }
-
-      const layoutResult = await layout(
-        { w, h, x, y, transform, debug, defs, axes, axisFields },
-        child,
-        contexts
-      );
-
-      return layoutResult;
-    } finally {
-      if (debug) {
-        console.log("scaleContext", session.scaleContext);
-        console.log("tokenContext", session.tokenContext);
-      }
-    }
-  };
-
-  const [layoutData] = createResource(runGofish);
+  const [layoutData] = createResource(() => runLayout(options, child));
 
   // Render to the provided container
   solidRender(() => {
@@ -482,26 +519,154 @@ export const gofish = (
         {(() => {
           const data = layoutData();
           if (!data) return null;
-          return render(
-            {
-              width: data.width,
-              height: data.height,
-              svgPadding,
-              defs,
-              rightOverhang: data.rightOverhang,
-              rightContentOverhang: data.rightContentOverhang,
-              topOverhang: data.topOverhang,
-              leftOverhang: data.leftOverhang,
-              bottomOverhang: data.bottomOverhang,
-            },
-            data.child
-          );
+          return renderLayout(data, svgPadding, options.defs);
         })()}
       </Suspense>
     );
   }, container);
   return container;
 };
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const XLINK_NS = "http://www.w3.org/1999/xlink";
+
+/**
+ * Serialize an `<svg>` element to a standalone SVG markup string suitable for
+ * writing to a `.svg` file: ensures the SVG/xlink namespaces and a `viewBox`
+ * are present, and optionally paints a background rect. Works on a clone, so
+ * the passed element is left untouched.
+ */
+export function serializeSVG(
+  svg: SVGSVGElement,
+  opts?: { background?: string | null }
+): string {
+  const el = svg.cloneNode(true) as SVGSVGElement;
+
+  el.setAttribute("xmlns", SVG_NS);
+  if (!el.getAttribute("xmlns:xlink")) el.setAttribute("xmlns:xlink", XLINK_NS);
+
+  // viewBox so the SVG scales when a consumer overrides width/height.
+  const width = el.getAttribute("width");
+  const height = el.getAttribute("height");
+  if (!el.getAttribute("viewBox") && width && height) {
+    el.setAttribute("viewBox", `0 0 ${width} ${height}`);
+  }
+
+  const background = opts?.background;
+  if (background) {
+    const rect = el.ownerDocument.createElementNS(SVG_NS, "rect");
+    rect.setAttribute("x", "0");
+    rect.setAttribute("y", "0");
+    rect.setAttribute("width", "100%");
+    rect.setAttribute("height", "100%");
+    rect.setAttribute("fill", background);
+    el.insertBefore(rect, el.firstChild);
+  }
+
+  const markup = new XMLSerializer().serializeToString(el);
+  return markup.startsWith("<?xml")
+    ? markup
+    : `<?xml version="1.0" encoding="UTF-8"?>\n${markup}`;
+}
+
+/**
+ * Produce a detached `<svg>` element for `child` by running the same
+ * layout + render pipeline as `gofish()`, but mounting into a throwaway
+ * container and returning a clone of the resulting SVG.
+ *
+ * Requires a DOM (browser or notebook front-end). In Node this throws —
+ * headless rendering is tracked in #577.
+ */
+export async function gofishToSVGElement(
+  options: GoFishExportOptions,
+  child: GoFishNode | Promise<GoFishNode>
+): Promise<SVGSVGElement> {
+  if (typeof document === "undefined") {
+    throw new Error(
+      "toSVG requires a DOM (browser or notebook front-end). " +
+        "Headless Node rendering is tracked in #577."
+    );
+  }
+  const data = await runLayout(options, child);
+  const svgPadding = options.padding ?? PADDING;
+  const root = document.createElement("div");
+  // Layout is already awaited, so the SVG mounts synchronously — no Suspense.
+  const dispose = solidRender(
+    () => renderLayout(data, svgPadding, options.defs),
+    root
+  );
+  const svg = root.querySelector("svg");
+  if (!svg) {
+    dispose();
+    throw new Error("toSVG: no <svg> element was produced by the render pass");
+  }
+  // Clone before disposing the reactive root so disposal can't strip it.
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  dispose();
+  return clone;
+}
+
+/** Produce a standalone SVG markup string for `child`. See {@link gofishToSVGElement}. */
+export async function gofishToSVG(
+  options: GoFishExportOptions,
+  child: GoFishNode | Promise<GoFishNode>
+): Promise<string> {
+  return serializeSVG(await gofishToSVGElement(options, child), options);
+}
+
+/**
+ * Write or download an SVG string to `filename`. Format is inferred from the
+ * extension (only `.svg` today; PNG/HTML tracked in #578). In a browser this
+ * triggers a download; in Node it writes the file.
+ */
+export async function saveSVGString(
+  svg: string,
+  filename: string
+): Promise<void> {
+  const dot = filename.lastIndexOf(".");
+  const ext = dot >= 0 ? filename.slice(dot).toLowerCase() : "";
+  if (ext !== ".svg") {
+    throw new Error(
+      `save(): only ".svg" is supported today (got "${ext || filename}"). ` +
+        "PNG and HTML export are tracked in #578."
+    );
+  }
+
+  // Browser: trigger a download via a temporary anchor + object URL.
+  if (
+    typeof document !== "undefined" &&
+    typeof URL !== "undefined" &&
+    typeof URL.createObjectURL === "function"
+  ) {
+    const blob = new Blob([svg], { type: "image/svg+xml" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+    return;
+  }
+
+  // Node: write to disk. Dynamic import keeps `fs` out of the browser bundle;
+  // the indirect specifier stops the bundler/TS from resolving it at build time.
+  const fsModule = "node:fs/promises";
+  const { writeFile } = (await import(/* @vite-ignore */ fsModule)) as {
+    writeFile: (path: string, data: string, encoding: string) => Promise<void>;
+  };
+  await writeFile(filename, svg, "utf-8");
+}
+
+/** Layout + serialize + save for `child`. See {@link saveSVGString}. */
+export async function gofishSave(
+  filename: string,
+  options: GoFishExportOptions,
+  child: GoFishNode | Promise<GoFishNode>
+): Promise<void> {
+  await saveSVGString(await gofishToSVG(options, child), filename);
+}
 
 const PADDING = 40;
 

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -309,6 +309,14 @@ export type ConstrainableMark<T> = Mark<T> & {
     container: Parameters<GoFishNode["render"]>[0],
     options: Parameters<GoFishNode["render"]>[1]
   ): Promise<ReturnType<GoFishNode["render"]>>;
+  toSVG(options?: Parameters<GoFishNode["toSVG"]>[0]): Promise<string>;
+  toSVGElement(
+    options?: Parameters<GoFishNode["toSVGElement"]>[0]
+  ): Promise<SVGSVGElement>;
+  save(
+    filename: string,
+    options?: Parameters<GoFishNode["save"]>[1]
+  ): Promise<void>;
 };
 
 /**

--- a/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
+++ b/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
@@ -435,14 +435,10 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     );
   }
 
-  // render calls resolve and then renders
-  async render(
-    container: Parameters<GoFishNode["render"]>[0],
-    options: Omit<Parameters<GoFishNode["render"]>[1], "axes">
-  ): Promise<ReturnType<GoFishNode["render"]>> {
-    // Auto-infer axis titles from field encodings on the mark and operators.
-    // Mark fields take priority (they encode measured values, e.g. h: "count");
-    // operator fields fill remaining gaps (grouping/layout, e.g. spread by "lake").
+  // Auto-infer axis titles from field encodings on the mark and operators.
+  // Mark fields take priority (they encode measured values, e.g. h: "count");
+  // operator fields fill remaining gaps (grouping/layout, e.g. spread by "lake").
+  private inferAxisFields(): { x?: string; y?: string } {
     const axisFields: { x?: string; y?: string } = {};
     const markMeta = (this.finalMark as any)?.__axisFields as
       | { x?: string; y?: string }
@@ -456,14 +452,62 @@ export class ChartBuilder<TInput, TOutput = TInput> {
       if (meta?.x) axisFields.x ??= meta.x;
       if (meta?.y) axisFields.y ??= meta.y;
     }
+    return axisFields;
+  }
 
+  // The chart-level options every terminal threads through to the node:
+  // resolved axes/color config plus the inferred axis fields.
+  private async resolveForRender<T extends Record<string, unknown>>(
+    options: T
+  ): Promise<{ node: GoFishNode; options: T & Record<string, unknown> }> {
+    const axisFields = this.inferAxisFields();
     const node = await this.resolve();
-    return node.render(container, {
-      ...options,
-      axes: this.options?.axes,
-      colorConfig: this.options?.color,
-      axisFields,
-    });
+    return {
+      node,
+      options: {
+        ...options,
+        axes: this.options?.axes,
+        colorConfig: this.options?.color,
+        axisFields,
+      },
+    };
+  }
+
+  // render calls resolve and then renders
+  async render(
+    container: Parameters<GoFishNode["render"]>[0],
+    options: Omit<Parameters<GoFishNode["render"]>[1], "axes">
+  ): Promise<ReturnType<GoFishNode["render"]>> {
+    const { node, options: opts } = await this.resolveForRender(options);
+    return node.render(container, opts);
+  }
+
+  /** Resolve and render to a standalone SVG markup string. */
+  async toSVG(
+    options: Omit<Parameters<GoFishNode["toSVG"]>[0], "axes"> = {}
+  ): Promise<string> {
+    const { node, options: opts } = await this.resolveForRender(options);
+    return node.toSVG(opts);
+  }
+
+  /** Resolve and render to a detached `<svg>` element. */
+  async toSVGElement(
+    options: Omit<Parameters<GoFishNode["toSVGElement"]>[0], "axes"> = {}
+  ): Promise<SVGSVGElement> {
+    const { node, options: opts } = await this.resolveForRender(options);
+    return node.toSVGElement(opts);
+  }
+
+  /**
+   * Resolve, render, and save to `filename` (format inferred from the
+   * extension — `.svg` today). Browser downloads; Node writes the file.
+   */
+  async save(
+    filename: string,
+    options: Omit<Parameters<GoFishNode["save"]>[1], "axes"> = {}
+  ): Promise<void> {
+    const { node, options: opts } = await this.resolveForRender(options);
+    return node.save(filename, opts);
   }
 }
 

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -247,6 +247,34 @@ export function attachModifiers<T>(
     writable: true,
     configurable: true,
   });
+  // SVG-export terminals, mirroring `.render()` above.
+  Object.defineProperty(base, "toSVG", {
+    value: async (options?: Parameters<GoFishNode["toSVG"]>[0]) => {
+      const node = await resolveMarkResult((base as any)(undefined));
+      return node.toSVG(options);
+    },
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(base, "toSVGElement", {
+    value: async (options?: Parameters<GoFishNode["toSVGElement"]>[0]) => {
+      const node = await resolveMarkResult((base as any)(undefined));
+      return node.toSVGElement(options);
+    },
+    writable: true,
+    configurable: true,
+  });
+  Object.defineProperty(base, "save", {
+    value: async (
+      filename: string,
+      options?: Parameters<GoFishNode["save"]>[1]
+    ) => {
+      const node = await resolveMarkResult((base as any)(undefined));
+      return node.save(filename, options);
+    },
+    writable: true,
+    configurable: true,
+  });
   return base;
 }
 

--- a/packages/gofish-graphics/src/ast/withGoFish.ts
+++ b/packages/gofish-graphics/src/ast/withGoFish.ts
@@ -90,6 +90,14 @@ export interface PromiseWithRender<T> extends Promise<T> {
     container: HTMLElement,
     options: RenderOptions
   ): HTMLElement | Promise<HTMLElement>;
+  toSVG(options?: Parameters<GoFishNode["toSVG"]>[0]): Promise<string>;
+  toSVGElement(
+    options?: Parameters<GoFishNode["toSVGElement"]>[0]
+  ): Promise<SVGSVGElement>;
+  save(
+    filename: string,
+    options?: Parameters<GoFishNode["save"]>[1]
+  ): Promise<void>;
   name(name: string | Token): PromiseWithRender<T>;
   label(accessor: LabelAccessor, options?: LabelOptions): PromiseWithRender<T>;
   setKey(key: string): PromiseWithRender<T>;
@@ -133,6 +141,41 @@ export function addRenderMethod<T>(promise: Promise<T>): PromiseWithRender<T> {
       }
       throw new Error(
         "Cannot call render on this result. Only GoFishNode instances have a render method."
+      );
+    });
+  };
+
+  // SVG-export terminals, mirroring `.render()` above.
+  (promise as any).toSVG = function (
+    options?: Parameters<GoFishNode["toSVG"]>[0]
+  ): Promise<string> {
+    return promise.then((result) => {
+      if (hasRenderMethod(result)) return result.toSVG(options);
+      throw new Error(
+        "Cannot call toSVG on this result. Only GoFishNode instances support export."
+      );
+    });
+  };
+
+  (promise as any).toSVGElement = function (
+    options?: Parameters<GoFishNode["toSVGElement"]>[0]
+  ): Promise<SVGSVGElement> {
+    return promise.then((result) => {
+      if (hasRenderMethod(result)) return result.toSVGElement(options);
+      throw new Error(
+        "Cannot call toSVGElement on this result. Only GoFishNode instances support export."
+      );
+    });
+  };
+
+  (promise as any).save = function (
+    filename: string,
+    options?: Parameters<GoFishNode["save"]>[1]
+  ): Promise<void> {
+    return promise.then((result) => {
+      if (hasRenderMethod(result)) return result.save(filename, options);
+      throw new Error(
+        "Cannot call save on this result. Only GoFishNode instances support export."
       );
     });
   };
@@ -445,6 +488,14 @@ export type NameableMark<T> = Mark<T> & {
     container: Parameters<GoFishNode["render"]>[0],
     options: Parameters<GoFishNode["render"]>[1]
   ): Promise<ReturnType<GoFishNode["render"]>>;
+  toSVG(options?: Parameters<GoFishNode["toSVG"]>[0]): Promise<string>;
+  toSVGElement(
+    options?: Parameters<GoFishNode["toSVGElement"]>[0]
+  ): Promise<SVGSVGElement>;
+  save(
+    filename: string,
+    options?: Parameters<GoFishNode["save"]>[1]
+  ): Promise<void>;
 };
 
 /**

--- a/packages/gofish-graphics/src/lib.ts
+++ b/packages/gofish-graphics/src/lib.ts
@@ -33,6 +33,16 @@ export { wavy } from "./ast/coordinateTransforms/wavy";
 export { gofish as GoFish } from "./ast/gofish";
 export { GoFishSolid } from "./ast/GoFishSolid";
 
+// SVG export
+export {
+  serializeSVG,
+  gofishToSVG,
+  gofishToSVGElement,
+  saveSVGString,
+  gofishSave,
+} from "./ast/gofish";
+export type { GoFishRenderOptions, GoFishExportOptions } from "./ast/gofish";
+
 // Name / scope primitives
 export { createName } from "./ast/createName";
 export type { Token } from "./ast/createName";

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -406,6 +406,19 @@ class Mark:
         )
         return widget
 
+    def save(
+        self,
+        path,
+        w: int = 800,
+        h: int = 600,
+        axes: bool = False,
+        debug: bool = False,
+    ):
+        """Save this mark's render to ``path`` (see ``ChartBuilder.save``)."""
+        widget = self.render(w=w, h=h, axes=axes, debug=debug)
+        widget.save(path)
+        return widget
+
     def _repr_mimebundle_(self, include=None, exclude=None):
         """Auto-display in notebooks (see ChartBuilder._repr_mimebundle_)."""
         return self.render()._repr_mimebundle_(include=include, exclude=exclude)
@@ -1109,6 +1122,22 @@ class ChartBuilder:
             debug=debug,
         )
 
+        return widget
+
+    def save(self, path, w: int = 800, h: int = 600, debug: bool = False):
+        """Save the rendered chart to ``path`` (format inferred from the
+        extension — ``.svg`` today; PNG/HTML tracked in #578).
+
+        The SVG is produced by the notebook front-end, so this returns a widget
+        that writes the file *once it renders*. Make it the last expression in a
+        cell (or otherwise display it) so the render — and the write — happen.
+        Truly synchronous, headless export is tracked in #577.
+
+        Example:
+            >>> chart(data).mark(rect(h="y")).save("chart.svg")
+        """
+        widget = self.render(w=w, h=h, debug=debug)
+        widget.save(path)
         return widget
 
     def _repr_mimebundle_(self, include=None, exclude=None):
@@ -2440,6 +2469,19 @@ class LayerBuilder:
             axes=axes,
             debug=debug,
         )
+        return widget
+
+    def save(
+        self,
+        path,
+        w: int = 800,
+        h: int = 600,
+        axes: bool = False,
+        debug: bool = False,
+    ):
+        """Save the layer's render to ``path`` (see ``ChartBuilder.save``)."""
+        widget = self.render(w=w, h=h, axes=axes, debug=debug)
+        widget.save(path)
         return widget
 
     def _repr_mimebundle_(self, include=None, exclude=None):

--- a/packages/gofish-python/gofish/widget.py
+++ b/packages/gofish-python/gofish/widget.py
@@ -39,6 +39,10 @@ class GoFishChartWidget(anywidget.AnyWidget):
     # {error: str} on failure. Powers .result/.error/.done.
     render_result = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
 
+    # Rendered SVG reported by the JS side once the chart mounts:
+    # {value: "<svg…>"}. Powers .svg / .to_svg() / .save(). See #571.
+    svg_result = traitlets.Dict(allow_none=True, default_value=None).tag(sync=True)
+
     # Python-only registry: lambda_id -> callable. Never synced.
     derive_functions = traitlets.Dict().tag(sync=False)
 
@@ -78,6 +82,12 @@ class GoFishChartWidget(anywidget.AnyWidget):
             derive_functions=derive_functions or {},
             **kwargs,
         )
+
+        # SVG export state (#571). The front-end reports its rendered SVG via
+        # the `svg_result` trait; we stash the latest here and flush any saves
+        # that were requested before the render completed.
+        self._svg: Optional[str] = None
+        self._pending_saves: List[Any] = []
 
     @traitlets.observe("derive_request")
     def _on_derive_request(self, change):
@@ -122,6 +132,77 @@ class GoFishChartWidget(anywidget.AnyWidget):
             self.derive_response = {"request_id": request_id, "result_b64": result_b64}
         except Exception as exc:
             self.derive_response = {"request_id": request_id, "error": str(exc)}
+
+    @traitlets.observe("svg_result")
+    def _on_svg_result(self, change):
+        """Stash the SVG reported by JS and flush any deferred saves.
+
+        JS sets ``svg_result = {value: "<svg…>"}`` once the chart mounts.
+        Saves requested before the render finished are queued in
+        ``_pending_saves`` and written here, when the markup is available.
+        """
+        msg = change["new"]
+        if not msg:
+            return
+        svg = msg.get("value")
+        if not isinstance(svg, str):
+            return
+        self._svg = svg
+        if self._pending_saves:
+            pending, self._pending_saves = self._pending_saves, []
+            for path in pending:
+                self._write_svg(path)
+
+    def _write_svg(self, path) -> None:
+        """Write the captured SVG to ``path`` (extension must be ``.svg``)."""
+        suffix = Path(path).suffix.lower()
+        if suffix != ".svg":
+            raise ValueError(
+                f'save(): only ".svg" is supported today (got "{suffix or path}"). '
+                "PNG and HTML export are tracked in #578."
+            )
+        if self._svg is None:
+            raise RuntimeError("No SVG to write")
+        Path(path).write_text(self._svg, encoding="utf-8")
+
+    @property
+    def svg(self) -> Optional[str]:
+        """The rendered SVG markup, or ``None`` if the chart hasn't rendered yet."""
+        return self._svg
+
+    def to_svg(self) -> str:
+        """Return the rendered SVG markup.
+
+        Requires the widget to have rendered in a live front-end first
+        (display it in a cell, then call ``.to_svg()``). Headless, synchronous
+        rendering is tracked in #577.
+        """
+        if self._svg is None:
+            raise RuntimeError(
+                "Widget hasn't rendered yet — display it in a cell first, then "
+                "call .to_svg(). (Headless rendering is tracked in #577.)"
+            )
+        return self._svg
+
+    def save(self, path) -> None:
+        """Save the rendered SVG to ``path`` (format inferred from extension).
+
+        If the chart has already rendered, the file is written immediately;
+        otherwise the write is deferred until the front-end reports its SVG —
+        so ``save()`` works even when called before display, as long as the
+        widget is then shown in the notebook.
+        """
+        # Validate the extension eagerly so a bad path fails fast.
+        suffix = Path(path).suffix.lower()
+        if suffix != ".svg":
+            raise ValueError(
+                f'save(): only ".svg" is supported today (got "{suffix or path}"). '
+                "PNG and HTML export are tracked in #578."
+            )
+        if self._svg is not None:
+            self._write_svg(path)
+        else:
+            self._pending_saves.append(path)
 
     @property
     def result(self) -> bool:

--- a/packages/gofish-python/tests/test_svg_export.py
+++ b/packages/gofish-python/tests/test_svg_export.py
@@ -1,0 +1,147 @@
+"""In-process tests for SVG export — the notebook case (#571).
+
+In a real notebook the SVG is produced by the JS front-end and handed back to
+the kernel via the ``svg_result`` trait; ``.save()`` / ``.to_svg()`` then run in
+Python. These tests exercise that kernel-side path without a browser by driving
+``svg_result`` exactly the way the widget bundle does once the chart mounts —
+the same approach as ``test_widget_protocol.py`` for the derive bridge.
+
+The one thing that genuinely needs a browser (turning the spec into SVG markup)
+is stubbed with a representative string shaped like ``serializeSVG``'s output;
+everything these tests cover is code that actually runs in Kartik's kernel.
+"""
+
+import pandas as pd
+import pytest
+
+from gofish import chart, rect
+from gofish.widget import GoFishChartWidget
+
+# Representative of what the JS `serializeSVG` reports back over `svg_result`.
+SAMPLE_SVG = (
+    '<?xml version="1.0" encoding="UTF-8"?>\n'
+    '<svg xmlns="http://www.w3.org/2000/svg" '
+    'xmlns:xlink="http://www.w3.org/1999/xlink" '
+    'width="500" height="345" viewBox="0 0 500 345">'
+    '<rect fill="#4190c5" width="60" height="100" x="0" y="0"></rect>'
+    "</svg>"
+)
+
+SEAFOOD = [
+    {"lake": "A", "count": 102},
+    {"lake": "B", "count": 137},
+    {"lake": "C", "count": 124},
+]
+
+
+def _bar_chart():
+    """A minimal real chart builder, like the one a notebook user writes."""
+    return chart(SEAFOOD, axes=True).mark(rect(h="count"))
+
+
+def _emit_svg(widget: GoFishChartWidget, svg: str = SAMPLE_SVG) -> None:
+    """Simulate the front-end reporting its rendered SVG once the chart mounts.
+
+    This is the single browser-side step we stand in for: when the widget
+    renders in a notebook, the JS bundle sets ``svg_result = {"value": ...}``.
+    """
+    widget.svg_result = {"value": svg}
+
+
+class TestSvgResultChannel:
+    def test_svg_result_populates_svg_and_to_svg(self):
+        """Front-end push -> widget.svg / to_svg() return the markup."""
+        widget = _bar_chart().render()
+        assert widget.svg is None  # nothing until the front-end renders
+
+        _emit_svg(widget)
+
+        assert widget.svg == SAMPLE_SVG
+        assert widget.to_svg() == SAMPLE_SVG
+
+    def test_to_svg_before_render_raises_pointing_to_headless(self):
+        """Before the front-end reports, to_svg() can't synthesize one (see #577)."""
+        widget = _bar_chart().render()
+        with pytest.raises(RuntimeError) as exc:
+            widget.to_svg()
+        assert "577" in str(exc.value)
+
+    def test_empty_svg_result_is_ignored(self):
+        """A None/empty svg_result must not clobber state or crash the observer."""
+        widget = _bar_chart().render()
+        widget.svg_result = {}
+        assert widget.svg is None
+        widget.svg_result = {"value": None}
+        assert widget.svg is None
+
+
+class TestSaveAfterRender:
+    def test_save_writes_file_once_rendered(self, tmp_path):
+        widget = _bar_chart().render()
+        _emit_svg(widget)
+
+        out = tmp_path / "chart.svg"
+        widget.save(out)
+
+        assert out.read_text(encoding="utf-8") == SAMPLE_SVG
+
+    def test_save_rejects_non_svg_extension(self, tmp_path):
+        """Unsupported formats fail fast, pointing at the PNG/HTML follow-up (#578)."""
+        widget = _bar_chart().render()
+        _emit_svg(widget)
+        with pytest.raises(ValueError) as exc:
+            widget.save(tmp_path / "chart.png")
+        assert "578" in str(exc.value)
+
+
+class TestNotebookSaveFlow:
+    """The flow Kartik actually writes: `chart(...).save("chart.svg")` as the
+    last expression in a cell. The builder returns a widget with a deferred
+    write; displaying it renders the chart, which fires `svg_result`, which
+    flushes the write."""
+
+    def test_builder_save_returns_widget_and_defers_write(self, tmp_path):
+        out = tmp_path / "chart.svg"
+        widget = _bar_chart().save(out)
+
+        # Returned so the cell auto-displays it; nothing written yet.
+        assert isinstance(widget, GoFishChartWidget)
+        assert not out.exists()
+
+        # Front-end renders -> file appears.
+        _emit_svg(widget)
+        assert out.read_text(encoding="utf-8") == SAMPLE_SVG
+
+    def test_builder_save_rejects_bad_extension_eagerly(self, tmp_path):
+        """The extension is validated when .save() is called, before any render."""
+        with pytest.raises(ValueError) as exc:
+            _bar_chart().save(tmp_path / "chart.pdf")
+        assert "578" in str(exc.value)
+
+    def test_widget_save_before_render_defers(self, tmp_path):
+        """widget.save() called before the SVG arrives queues the write."""
+        widget = _bar_chart().render()
+        out = tmp_path / "chart.svg"
+        widget.save(out)
+        assert not out.exists()
+
+        _emit_svg(widget)
+        assert out.read_text(encoding="utf-8") == SAMPLE_SVG
+
+    def test_multiple_pending_saves_all_flush(self, tmp_path):
+        widget = _bar_chart().render()
+        a, b = tmp_path / "a.svg", tmp_path / "b.svg"
+        widget.save(a)
+        widget.save(b)
+
+        _emit_svg(widget)
+
+        assert a.read_text(encoding="utf-8") == SAMPLE_SVG
+        assert b.read_text(encoding="utf-8") == SAMPLE_SVG
+
+    def test_save_path_accepts_str(self, tmp_path):
+        widget = _bar_chart().render()
+        out = tmp_path / "chart.svg"
+        widget.save(str(out))  # str, not Path
+        _emit_svg(widget)
+        assert out.exists()

--- a/packages/gofish-python/widget-src/index.ts
+++ b/packages/gofish-python/widget-src/index.ts
@@ -16,7 +16,12 @@
  */
 
 import * as Arrow from "apache-arrow";
-import { Layer, Serialize, type ChartBuilder } from "gofish-graphics";
+import {
+  Layer,
+  Serialize,
+  serializeSVG,
+  type ChartBuilder,
+} from "gofish-graphics";
 import type { Frontend } from "gofish-ir";
 
 // Type aliases pointing at the canonical IR schema. Internal usages below
@@ -378,6 +383,65 @@ function renderChart(
 }
 
 // ---------------------------------------------------------------------------
+// SVG export capture (#571)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve once an `<svg>` is present in `container`. The chart mounts
+ * asynchronously (Solid Suspense + async layout/derives swap a "Loading…"
+ * fallback for the `<svg>`), so we observe the container rather than reading
+ * it synchronously. Resolves `null` if none appears within `timeoutMs`.
+ */
+function waitForSVG(
+  container: HTMLElement,
+  timeoutMs = 15_000
+): Promise<SVGSVGElement | null> {
+  const existing = container.querySelector("svg");
+  if (existing) return Promise.resolve(existing as SVGSVGElement);
+  return new Promise((resolve) => {
+    let done = false;
+    const finish = (v: SVGSVGElement | null) => {
+      if (done) return;
+      done = true;
+      observer.disconnect();
+      clearTimeout(timer);
+      resolve(v);
+    };
+    const observer = new MutationObserver(() => {
+      const svg = container.querySelector("svg");
+      if (svg) finish(svg as SVGSVGElement);
+    });
+    observer.observe(container, { childList: true, subtree: true });
+    const timer = setTimeout(
+      () => finish(container.querySelector("svg") as SVGSVGElement | null),
+      timeoutMs
+    );
+  });
+}
+
+/**
+ * Wait for the rendered `<svg>`, serialize it, and report it to the kernel via
+ * the `svg_result` trait so Python's `.save()` / `.to_svg()` can write it.
+ * Best-effort: export is optional, so failures are swallowed.
+ */
+async function captureSVG(
+  model: WidgetModel,
+  container: HTMLElement,
+  log: (...args: any[]) => void
+): Promise<void> {
+  try {
+    const svg = await waitForSVG(container);
+    if (!svg) return;
+    const markup = serializeSVG(svg);
+    model.set("svg_result", { value: markup });
+    model.save_changes();
+    log("Reported svg_result to kernel");
+  } catch (e) {
+    log("captureSVG failed (export unavailable):", e);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // AnyWidget entry point
 // ---------------------------------------------------------------------------
 
@@ -435,6 +499,10 @@ export default {
       } catch {
         /* ignore */
       }
+      // Report the rendered SVG to the kernel for Python-side export (#571).
+      // Fire-and-forget: it waits for the async mount, independent of the
+      // synchronous render_result above.
+      void captureSVG(model, container, log);
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       log("Error in render():", err);


### PR DESCRIPTION
Implements **Phases 1 & 2** of SVG export. Charts could only be mounted into a live DOM (`.render()`); there was no way to get the SVG out as a value, and in Python the SVG lived entirely in the anywidget front-end. This adds first-class export terminals — modeled on Vega's `toSVG(): Promise<string>` primitive + Altair's extension-inferred `save()`, with no global figure state.

Closes #571 once Phases 3 & 4 land — this PR advances it; see the follow-up issues below.

## API

**JS** (siblings of `.render()`, on chart / mark / layer):
```ts
const svg = await chart(data).mark(rect({ h: "value" })).toSVG({ w: 400, h: 300 });
await chart(data).mark(rect({ h: "value" })).save("chart.svg");      // browser → download, Node → write
await chart(data).mark(rect({ h: "value" })).toSVGElement();         // detached <svg> element
```
`toSVG`/`toSVGElement`/`save` take the same options as `render` plus `background`.

**Python** (async-observer — reliable in Jupyter/marimo):
```python
chart(data).mark(rect(h="value")).save("chart.svg")   # last cell expr → displays + writes the file
widget.to_svg()   # markup, after the widget has rendered
widget.svg        # property
```

## How it works

- **JS:** extracted the layout pass into a shared `runLayout`; `toSVG` mounts the same pipeline into a detached container and serializes the `<svg>` (namespaces + `viewBox` + optional background). The live `render()` path reuses the same code — verified byte-identical by `capture-diff`.
- **Python:** the front-end produces the SVG, so after a successful render the widget serializes its `<svg>` and reports it via a new `svg_result` trait. `widget.save()` / `chart(...).save()` write the file once the displayed widget renders (deferred-write observer; reuses the existing trait-RPC pattern). The write completes asynchronously, shortly after the cell renders.

Referenced fonts; `.svg` only for now. No IR-schema change (export is render-time, not serialized IR).

## Verification

- JS unit tests (path/font/serialize), Python suite (92 passed), `validate-python-ir` (150/150), lint clean.
- `capture-diff main` over the bar stories → identical (refactor behavior-preserving).
- **`toSVG()` proven end-to-end in a real browser:** a temp story round-tripped the markup back into the DOM → correct, complete chart with `viewBox`, both namespaces, and the background rect. Python observer/save logic unit-tested (deferred + immediate writes, bad-extension rejection, pre-render error).
- **Notebook case** (`tests/test_svg_export.py`, 10 tests): drives the kernel-side flow Kartik writes — `chart(...).save("chart.svg")` returning a widget, the front-end's `svg_result` push, deferred + immediate writes, `to_svg()`/`svg`, and the `#577`/`#578` error paths — simulating the front-end exactly as `test_widget_protocol.py` does for the derive bridge (no browser).
- ⚠️ One sliver still browser-only: the widget bundle's `captureSVG` *emitting* `svg_result` (MutationObserver + `serializeSVG`). `serializeSVG` and the full render pipeline are proven in a real browser above; a dedicated anywidget-mock Playwright test is a reasonable follow-up.

## Roadmap — the four phases

Export lands in four phases; this PR is the first two. The `toSVG()` primitive from Phase 1 is what Phases 3–4 build on.

- **Phase 1 — JS export terminals** ✅ *(this PR)* — `toSVG()` / `toSVGElement()` / `save()` on chart / mark / layer. `toSVG(): Promise<string>` is the primitive; `save(path)` infers the format from the extension and dispatches on environment (browser download vs Node `fs`). Referenced fonts; `.svg` only; requires a DOM.
- **Phase 2 — Python via the anywidget bridge** ✅ *(this PR)* — the front-end reports its rendered `<svg>` to the kernel via a new `svg_result` trait; `chart(...).save("chart.svg")` / `widget.to_svg()` / `widget.svg`. Async-observer: reliable in Jupyter + marimo, file written once the displayed widget renders.
- **Phase 3 — Headless Node rendering** → #577 — produce the SVG with no browser (Python-without-Jupyter, CI, deterministic docs assets, synchronous `to_svg()`). Keystone: inject text metrics (browser = canvas, Node = fontkit/opentype.js) behind the layout pass; `linkedom` DOM shim + a bundled Node CLI (the Altair / vl-convert pattern).
- **Phase 4 — More formats + self-contained fonts** → #578 — `save()` dispatch to `.png` (resvg-js / canvas) and `.html`; font embedding (subsetted `@font-face`) and outlining (text → paths). Both need a glyph engine, so they pair with Phase 3's tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
