### PR TITLE
ci(release): publish Python package to PyPI in lockstep (#102)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,18 @@
 name: Release
 
-# Unified publish workflow. Publishes `gofish-graphics` and `gofish-ir`
-# in lockstep — they always carry the same version, npm tag, and (for
-# `release` mode) git tag. `gofish-ir` publishes first so the
-# `workspace:*` dependency declared by `gofish-graphics` resolves to a
-# concrete already-published version on the registry.
+# Unified publish workflow. Publishes the npm packages `gofish-graphics`
+# and `gofish-ir`, plus the Python package `gofish-graphics` (PyPI), all in
+# lockstep — they always carry the same version, npm tag, and (for `release`
+# mode) git tag. `gofish-ir` publishes first so the `workspace:*` dependency
+# declared by `gofish-graphics` resolves to a concrete already-published
+# version on the registry.
+#
+# The Python package ships the same version: PyPI has no dist-tags, so the
+# nightly maps to a PEP 440 dev release (`X.Y.Z.devYYYYMMDD`), which pip
+# ignores unless `--pre` is passed. PyPI auth uses trusted publishing (OIDC)
+# — configure a publisher for project `gofish-graphics` pointing at
+# owner/repo `gofish-graphics/gofish-graphics`, workflow `release.yml`, with
+# the environment field left blank.
 #
 #   - Scheduled (4am UTC daily): publishes a nightly-tagged prerelease if
 #     there are commits from the last 24h.
@@ -149,6 +157,57 @@ jobs:
         working-directory: packages/gofish-graphics
         run: pnpm publish --tag "${{ steps.version.outputs.npm_tag }}" --access public --no-git-checks
 
+      # --- Python package (gofish-graphics on PyPI) ---
+      # Published in lockstep with the npm packages. PyPI has no dist-tags, so
+      # nightly builds ship as PEP 440 dev releases (`X.Y.Z.devYYYYMMDD`), which
+      # `pip install` ignores unless `--pre` is passed — the PyPI analogue of the
+      # npm `nightly` tag. Release modes publish the final `X.Y.Z`. Auth is via
+      # PyPI trusted publishing (OIDC), reusing this job's `id-token: write`; no
+      # token secret is needed. The wheel bundles the widget ESM, which is built
+      # from the gofish-graphics/gofish-ir dist produced earlier in this job.
+      - name: Setup Python
+        if: steps.plan.outputs.skip == 'false'
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Compute Python version
+        if: steps.plan.outputs.skip == 'false'
+        id: pyversion
+        run: |
+          MODE="${{ steps.plan.outputs.mode }}"
+          if [ "$MODE" = "nightly" ]; then
+            # Same base as the npm nightly (pre-bump gofish-graphics version),
+            # rendered as a PEP 440 dev release.
+            BASE=$(node -p "require('./packages/gofish-graphics/package.json').version" | sed 's/-nightly.*//')
+            DATE=$(date +'%Y%m%d')
+            PY_VERSION="${BASE}.dev${DATE}"
+          else
+            # Lockstep with the npm release version computed above (e.g. 0.2.0).
+            PY_VERSION="${{ steps.version.outputs.version }}"
+          fi
+          sed -i -E "s/^version = \".*\"/version = \"${PY_VERSION}\"/" packages/gofish-python/pyproject.toml
+          sed -i -E "s/^__version__ = \".*\"/__version__ = \"${PY_VERSION}\"/" packages/gofish-python/gofish/__init__.py
+          echo "py_version=$PY_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Publishing gofish-graphics (PyPI) version: $PY_VERSION"
+
+      - name: Build widget bundle
+        if: steps.plan.outputs.skip == 'false'
+        run: pnpm --filter gofish-python build:widget
+
+      - name: Build Python distribution
+        if: steps.plan.outputs.skip == 'false'
+        run: |
+          python -m pip install --upgrade build
+          python -m build --outdir packages/gofish-python/dist packages/gofish-python
+
+      - name: Publish gofish-graphics to PyPI
+        if: steps.plan.outputs.skip == 'false'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/gofish-python/dist
+          skip-existing: true
+
       - name: Commit, tag, and push (release only)
         if: steps.plan.outputs.skip == 'false' && steps.plan.outputs.mode != 'nightly'
         env:
@@ -170,7 +229,8 @@ jobs:
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add packages/gofish-graphics/package.json packages/gofish-ir/package.json
+          git add packages/gofish-graphics/package.json packages/gofish-ir/package.json \
+                  packages/gofish-python/pyproject.toml packages/gofish-python/gofish/__init__.py
           git commit -m "chore(release): v${VERSION}"
           git tag "${TAG}"
           REMOTE="https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,11 +177,17 @@ jobs:
         run: |
           MODE="${{ steps.plan.outputs.mode }}"
           if [ "$MODE" = "nightly" ]; then
-            # Same base as the npm nightly (pre-bump gofish-graphics version),
-            # rendered as a PEP 440 dev release.
+            # Dev release of the NEXT patch version, dated. It must target the
+            # next version, not the current one: a PEP 440 dev release sorts
+            # BEFORE the final release of the same X.Y.Z, so `0.1.0.devN` loses
+            # to a published `0.1.0` and `pip install --pre` would never pick
+            # it. Bumping the patch makes `0.1.1.devN` sort after `0.1.0`, so
+            # `--pre` resolves to the latest nightly, while any future final
+            # release still wins over its own dev builds.
             BASE=$(node -p "require('./packages/gofish-graphics/package.json').version" | sed 's/-nightly.*//')
+            NEXT=$(echo "$BASE" | awk -F. '{printf "%d.%d.%d", $1, $2, $3 + 1}')
             DATE=$(date +'%Y%m%d')
-            PY_VERSION="${BASE}.dev${DATE}"
+            PY_VERSION="${NEXT}.dev${DATE}"
           else
             # Lockstep with the npm release version computed above (e.g. 0.2.0).
             PY_VERSION="${{ steps.version.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -8,13 +8,26 @@
 
 ## Installation
 
+GoFish is moving fast and the stable release lags well behind active
+development. While the library is pre-1.0, we recommend early adopters install
+the **nightly** build (published whenever `main` changes):
+
+```bash
+npm install gofish-graphics@nightly
+# or
+pnpm add gofish-graphics@nightly
+# or
+yarn add gofish-graphics@nightly
+```
+
+For the last stable release, drop the `@nightly` tag:
+
 ```bash
 npm install gofish-graphics
-# or
-pnpm add gofish-graphics
-# or
-yarn add gofish-graphics
 ```
+
+Using Python? `pip install --pre gofish-graphics` (see the
+[docs](https://gofish.graphics/python/get-started)).
 
 ## Usage
 

--- a/apps/docs/docs/js/get-started.md
+++ b/apps/docs/docs/js/get-started.md
@@ -8,6 +8,19 @@ GoFish is a JavaScript library for making bespoke graphics.
 npm install gofish-graphics
 ```
 
+::: tip Recommended while GoFish is pre-1.0: use the nightly build
+GoFish is moving fast, and the published stable release lags well behind active
+development. While the library is in early development we recommend early
+adopters install the **nightly** build to get the latest features and fixes:
+
+```bash
+npm install gofish-graphics@nightly
+```
+
+Nightlies are published whenever `main` changes. Pin a specific one with
+`gofish-graphics@<version>` once you find a build you like.
+:::
+
 ## 2. Create a chart!
 
 ::: gofish hidden

--- a/apps/docs/docs/python/get-started.md
+++ b/apps/docs/docs/python/get-started.md
@@ -11,6 +11,19 @@ marimo notebooks.
 pip install gofish-graphics
 ```
 
+::: tip Recommended while GoFish is pre-1.0: use the nightly build
+GoFish is moving fast, and the published stable release lags well behind active
+development. While the library is in early development we recommend early
+adopters install the latest **dev** build with `--pre`:
+
+```bash
+pip install --pre gofish-graphics
+```
+
+Dev builds are published whenever `main` changes. Pin a specific one with
+`gofish-graphics==<version>` once you find a build you like.
+:::
+
 Import it as `gofish`:
 
 ::: gofish example:bar-chart hidden

--- a/packages/gofish-python-shim/README.md
+++ b/packages/gofish-python-shim/README.md
@@ -1,0 +1,23 @@
+# `gofish-python` is deprecated — use [`gofish-graphics`](https://pypi.org/project/gofish-graphics/)
+
+The GoFish Python package is now published as **`gofish-graphics`**. The
+`gofish-python` name is deprecated and will receive no further updates.
+
+This release of `gofish-python` contains no code of its own — it only depends
+on `gofish-graphics`, so installing it pulls in the canonical package. The
+import name is unchanged (`import gofish`).
+
+## Migrate
+
+```bash
+pip uninstall gofish-python
+pip install gofish-graphics
+```
+
+Your code does not change — it was already `import gofish` either way:
+
+```python
+from gofish import chart, spread, stack, rect
+```
+
+See the project on GitHub: https://github.com/gofish-graphics/gofish-graphics

--- a/packages/gofish-python-shim/pyproject.toml
+++ b/packages/gofish-python-shim/pyproject.toml
@@ -1,0 +1,35 @@
+# Deprecation tombstone for the PyPI project `gofish-python`.
+#
+# The GoFish Python package is published as `gofish-graphics` (see
+# packages/gofish-python/pyproject.toml). `gofish-python` was an earlier name
+# for the same thing and is now deprecated. This directory builds a final
+# meta-release of `gofish-python`: it ships NO code of its own, only metadata
+# and a dependency on `gofish-graphics`, so `pip install gofish-python`
+# transparently installs the canonical package (both import as `gofish`).
+#
+# This is a one-time manual publish — it is intentionally NOT part of the
+# recurring release workflow and has no package.json, so pnpm ignores it.
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gofish-python"
+# Higher than the last real `gofish-python` (0.1.0) so this tombstone is what
+# `pip install gofish-python` resolves to by default.
+version = "0.2.0"
+description = "Deprecated: install 'gofish-graphics' instead. This package now just pulls in gofish-graphics."
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+dependencies = ["gofish-graphics>=0.1.0"]
+
+[project.urls]
+Homepage = "https://github.com/gofish-graphics/gofish-graphics"
+"Canonical package" = "https://pypi.org/project/gofish-graphics/"
+
+# A meta-package: no importable modules of its own (the `gofish` import comes
+# from the gofish-graphics dependency).
+[tool.setuptools]
+packages = []
+py-modules = []

--- a/packages/gofish-python/pyproject.toml
+++ b/packages/gofish-python/pyproject.toml
@@ -2,8 +2,13 @@
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+# NOTE: the PyPI distribution name is `gofish-graphics` (installed via
+# `pip install gofish-graphics`, imported as `gofish`). The pnpm workspace
+# package is still named `gofish-python` in package.json — that name is
+# internal and never published to npm. The release workflow rewrites the
+# version here in lockstep with the npm packages before building the wheel.
 [project]
-name = "gofish-python"
+name = "gofish-graphics"
 version = "0.1.0"
 description = "Clean AST implementation for GoFish graphics library"
 readme = "README.md"


### PR DESCRIPTION
## What

Extends the unified `Release` workflow (`.github/workflows/release.yml`) to publish the Python package to **PyPI** alongside the npm packages, sharing the same version. Closes #102 (add nightly release for PyPI).

## How it works

The Python publish runs in the same `publish` job, in lockstep with `gofish-graphics`/`gofish-ir` on npm:

- **Nightly** (scheduled daily / `mode=nightly`): PyPI has no dist-tags, so the nightly maps to a PEP 440 **dev release** — `X.Y.Z.devYYYYMMDD`. `pip install gofish-graphics` ignores dev releases unless `--pre` is passed, which is the PyPI analogue of the npm `nightly` tag. No commit/bump.
- **patch/minor/major**: publishes the final `X.Y.Z` and includes the Python version bump (`pyproject.toml` + `gofish/__init__.py`) in the same release commit as the npm bumps, so npm and PyPI never diverge. (The issue only asked for nightly, but covering release mode here avoids a latent "npm published, PyPI didn't" gap on tagged releases.)
- The wheel bundles the widget ESM, built from the `gofish-graphics`/`gofish-ir` dist already produced earlier in the job.
- Re-runs use `skip-existing: true` since PyPI versions are immutable.

## Auth

Uses **PyPI trusted publishing (OIDC)**, reusing the job's existing `id-token: write` permission — no token secret to manage or rotate.

> [!IMPORTANT]
> **One-time setup required before the next nightly run:** add a trusted publisher to the `gofish-graphics` project on PyPI:
> - Owner / repo: `gofish-graphics/gofish-graphics`
> - Workflow filename: `release.yml`
> - Environment name: **leave blank**

## Also fixed

`pyproject.toml` `name` was stale at `gofish-python`. The canonical PyPI distribution is **`gofish-graphics`** (`pip install gofish-graphics`, imports as `gofish`); both names exist on PyPI at 0.1.0, but `gofish-graphics` is the one the docs and npm package use. Renamed it (the internal pnpm workspace package keeps `gofish-python` in `package.json` — never published to npm).

## Verification

- Workflow YAML parses.
- Built the sdist locally with the renamed pyproject: produces `gofish_graphics-0.1.0.tar.gz` with `gofish/_static/widget.esm.js` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: deprecate the `gofish-python` PyPI project

Since `gofish-graphics` is canonical, the old `gofish-python` PyPI project is deprecated. PyPI has no project-level "deprecate" button, so this is done with a tombstone meta-release plus an optional yank.

Added `packages/gofish-python-shim/` — a code-free meta-package (name `gofish-python`, version `0.2.0`, `Requires-Dist: gofish-graphics>=0.1.0`). It carries a deprecation notice on its PyPI page and pulls in `gofish-graphics`, so `pip install gofish-python` keeps working and transparently installs the canonical package (both import as `gofish`). It's a one-time manual publish — deliberately **not** in the recurring release workflow, and has no `package.json` so pnpm ignores it. Verified it builds to a valid empty wheel locally.

### Publishing the tombstone (one-time, manual)

```bash
python -m build packages/gofish-python-shim
python -m twine upload packages/gofish-python-shim/dist/*   # needs a PyPI token for the gofish-python project
```

### Optionally yank the old release

`pip install gofish-python` already prefers `0.2.0` (the tombstone) over `0.1.0`, but yanking the old real release stops `gofish-python==0.1.0` from silently installing the pre-rename code:

- PyPI → **gofish-python** project → **Manage** → **Releases** → `0.1.0` → **Options** → **Yank**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: nightly-build docs nudge + version-sort fix

Stable releases lag well behind `main`, so the get-started pages now steer early adopters to the nightly/dev builds (`npm install gofish-graphics@nightly`, `pip install --pre gofish-graphics`).

This surfaced a bug in the nightly version scheme: a PEP 440 dev release sorts *before* the final release of the same `X.Y.Z`, so `0.1.0.devN` would lose to the published `0.1.0` and `pip install --pre` would never pick it up. Fixed by targeting the **next patch** — `0.1.1.devN` sorts after `0.1.0` (so `--pre` resolves to the latest nightly), while any future final release still wins over its own dev builds. Verified the ordering with `packaging.version`.
