### PR TITLE
fix(ci): chunk weekly Slack summary + fail on rejected post

### DIFF
--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -70,43 +70,56 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.GOFISH_SLACK_CHANNEL_WEBHOOK_URL }}
         run: |
-          SUMMARY=$(cat summary.txt)
-
           if [ -z "$SLACK_WEBHOOK_URL" ]; then
             echo "⚠️  SLACK_WEBHOOK_URL secret not set. Skipping Slack post."
             exit 0
           fi
 
-          # Build Slack payload with proper escaping
+          # A Slack "section" block's text field is capped at 3000 chars, so a long
+          # summary (a big PR week) must be split across multiple section blocks or
+          # Slack rejects the whole payload with "invalid_blocks". Chunk at line
+          # boundaries, staying under 2900 to leave headroom, and hard-wrap any
+          # single line that is itself too long.
           jq -n \
             --arg header "🐟 GoFish Weekly Update (${{ steps.dates.outputs.week_ago }} → ${{ steps.dates.outputs.today }})" \
-            --arg summary "$SUMMARY" \
-            '{
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": $header,
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "divider"
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": $summary
-                  }
-                }
-              ]
-            }' > payload.json
+            --rawfile summary summary.txt \
+            --argjson max 2900 \
+            '
+              def chunk($limit):
+                reduce (./"\n")[] as $line ({chunks: [], cur: ""};
+                  (if ($line | length) == 0 then [""]
+                   else ($line | [while(length > 0; .[$limit:]) | .[:$limit]]) end) as $parts
+                  | reduce $parts[] as $p (.;
+                      if (.cur | length) == 0 then .cur = $p
+                      elif ((.cur | length) + 1 + ($p | length)) <= $limit
+                        then .cur = .cur + "\n" + $p
+                      else .chunks += [.cur] | .cur = $p
+                      end))
+                | .chunks + (if (.cur | length) > 0 then [.cur] else [] end);
+              {
+                blocks: (
+                  [ {type: "header", text: {type: "plain_text", text: $header, emoji: true}},
+                    {type: "divider"} ]
+                  + ($summary | chunk($max) | map({type: "section", text: {type: "mrkdwn", text: .}}))
+                )
+              }' > payload.json
 
-          curl -X POST "$SLACK_WEBHOOK_URL" \
+          # Slack incoming webhooks return HTTP 200 with body "ok" on success, and an
+          # HTTP 4xx with an error body (e.g. "invalid_blocks") on rejection. curl does
+          # not fail on an error *body*, so check the status/body explicitly — otherwise
+          # a rejected post leaves the job green and the failure goes unnoticed.
+          HTTP_CODE=$(curl -sS -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
-            -d @payload.json
+            --data @payload.json \
+            -w "%{http_code}" -o slack_response.txt)
+          RESPONSE=$(cat slack_response.txt)
+          echo "Slack responded HTTP $HTTP_CODE: $RESPONSE"
+
+          if [ "$HTTP_CODE" != "200" ] || [ "$RESPONSE" != "ok" ]; then
+            echo "::error::Slack rejected the weekly summary (HTTP $HTTP_CODE): $RESPONSE"
+            exit 1
+          fi
+          echo "✅ Weekly summary posted to Slack."
 
       - name: Dry run notice
         if: ${{ inputs.dry_run == 'true' }}


### PR DESCRIPTION
## What happened

The weekly summary workflow ran on **2026-06-18** (a 30-PR week) and reported **success** — but nothing posted to Slack. The summary was stuffed into a single Slack `section` block, whose `text` field is capped at **3000 chars**. The long summary overflowed it, so Slack rejected the whole payload with `invalid_blocks`. Because the `curl` POST never checked the response, the step exited 0 and the run went green, hiding the failure:

```
100  4978  ...  4964  ...
invalid_blocks
```

## Fix

1. **Chunk the summary** across multiple `section` blocks at line boundaries (≤2900 chars each, leaving headroom under the 3000 limit), hard-wrapping any single over-long line. Handles big PR weeks.
2. **Fail loudly** — capture the webhook's HTTP status + body and exit 1 with a `::error::` annotation on anything other than `200`/`ok`, so a rejected post turns the run **red** instead of silently passing.

## Verification

- YAML parses (before and after pre-commit prettier); jq inside the block scalar untouched.
- Ran the jq chunker against a synthetic 9995-char summary (including a 6500-char single line): produced valid JSON, 5 section blocks all ≤2900 chars, content preserved char-for-char.

## Note

This week's update still hasn't posted. After merge it can be re-fired with `gh workflow run weekly-summary.yml`, though the date window is "last 7 days from today" so it regenerates fresh rather than replaying 06-18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)