### PR TITLE
feat(rendering): free space renders y-down (top-left origin); chart()/coord render y-up (#143, #16)

### DIFF
--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -45,30 +45,52 @@ paints — is the whole architecture of this pass.
 
 ## The coordinate fold: `toPixel`
 
-GoFish lays out in a **y-up** frame (larger _y_ is higher on the page), the
-mathematical convention. SVG is **y-down**. The old renderer reconciled the two with
-two stacked SVG transforms: a per-shape `scale(1,-1)` and a root flip
-`scale(1,-1) translate(leftReserve, -(height + topReserve))`.
+Layout produces a tree of boxes; the lower pass maps each box's coordinates to final
+SVG pixels through a single affine map, `toPixel`, set once per emit on the render
+session (`RenderSession.toPixel` in `_node.ts`). Two conventions share this one map:
 
-The lower pass folds both of those into a single affine map, `toPixel`, set once per
-emit on the render session (`RenderSession.toPixel` in `_node.ts`):
+- **Free space is y-DOWN** (SVG-native, top-left origin). A vertical list written
+  `[A, B]` reads top→bottom, an explicit `y:` grows downward — what you'd expect from
+  SVG, Bluefish, or Typst. This is the **default**:
 
-```ts
-const toPixel: ToPixel = ([gx, gy]) => [
-  gx + leftReserve,
-  height + topReserve - gy,
-];
-```
+  ```ts
+  const toPixel: ToPixel = ([gx, gy]) => [gx + leftReserve, gy + topReserve];
+  ```
 
-A GoFish-space point `(gx, gy)` lands at the SVG pixel
-`(gx + leftReserve, (height + topReserve) − gy)`. `leftReserve` and `topReserve` are
-the measured gutter reserves layout computed for chrome seated past the canvas (see
-[the passes](/internals/layout/passes) for how the per-side overhangs are reserved).
-Because `toPixel` already carries the flip and the viewport offset, the display list
-is in **final absolute pixels** — the SVG backend emits each item verbatim, with **no
-outer flip `<g>` and no per-shape transform**.
+- **A `chart()` (or any `coord` scope) is y-UP** (larger _y_ is higher, the
+  mathematical convention bars and y-axes want). The root mirrors _y_ about the canvas
+  height — reproducing the legacy global flip:
 
-`toPixel` is affine (a translate plus a y-flip), so a straight path stays straight: a
+  ```ts
+  const toPixel: ToPixel = ([gx, gy]) => [
+    gx + leftReserve,
+    height + topReserve - gy,
+  ];
+  ```
+
+Which map is used is decided once at the root: `render()` computes
+`effYUp = options.yUp || subtreeHasChart(child)`, where `subtreeHasChart` walks the
+tree for any `_isChart` node (set by the chart builder) or any `coord` node (a
+coordinate system is inherently y-up). The chart builder also threads `yUp` through its
+render options. This auto-detection means a chart stays y-up even when **composed**
+inside a free-space `gofish([...])`/`.layer()` whose render entry never saw the option
+(see issues #143 / #16). `leftReserve` / `topReserve` are the measured gutter reserves
+for chrome seated past the canvas (see [the passes](/internals/layout/passes)).
+
+> **Historical note.** Before #143, the world was y-up _everywhere_ (one global
+> `scale(1,-1)` at the root, plus a per-shape `scale(1,-1)` to un-mirror content). The
+> y-down default relocated that flip behind the `yUp` switch above. Shape lowering is
+> now **flip-agnostic** — `rectItemFromBox`/image map both box corners through `toPixel`
+> and take the component-wise min/abs; text & label rotation read the flip out of
+> `toPixel` via `toPixelFlipsY` — so the same shape code is correct under either map. A
+> follow-up will express y-up as a true `cartesian` coordinate transform (making it
+> composable per-subtree instead of root-global).
+
+Because `toPixel` already carries the orientation and the viewport offset, the display
+list is in **final absolute pixels** — the SVG backend emits each item verbatim, with
+**no outer flip `<g>` and no per-shape transform**.
+
+`toPixel` is affine (a translate, optionally a y-flip), so a straight path stays straight: a
 shape with a curved path just maps each of its control points through `toPixel` and
 re-serializes (`pathToPixelSVG` in `lowerHelpers.ts`), with no resampling.
 
@@ -185,11 +207,14 @@ filter graphs and assigning their deterministic def ids.
 ## How the live `render()` wires it together
 
 The orchestrator `render()` in `gofish.tsx` is now small. It computes the gutter
-reserves, builds `toPixel`, stores it on the render session, and paints the lowered
-list into an `<svg>`:
+reserves, picks the y-up or y-down `toPixel` (per `effYUp`, above), stores it on the
+render session, and paints the lowered list into an `<svg>`:
 
 ```ts
-const toPixel: ToPixel = ([gx, gy]) => [gx + leftReserve, height + topReserve - gy];
+const effYUp = yUp || subtreeHasChart(child); // chart()/coord ⇒ y-up; else y-down
+const toPixel: ToPixel = effYUp
+  ? ([gx, gy]) => [gx + leftReserve, height + topReserve - gy]
+  : ([gx, gy]) => [gx + leftReserve, gy + topReserve];
 child.getRenderSession().toPixel = toPixel;
 const paintBaked = () => lowerToDisplayList(child).map(paintSVG);
 return (

--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -57,7 +57,7 @@ session (`RenderSession.toPixel` in `_node.ts`). Two conventions share this one 
   const toPixel: ToPixel = ([gx, gy]) => [gx + leftReserve, gy + topReserve];
   ```
 
-- **A `chart()` (or any `coord` scope) is y-UP** (larger _y_ is higher, the
+- **A continuous-_y_ scope (or any `coord` scope) is y-UP** (larger _y_ is higher, the
   mathematical convention bars and y-axes want). The root mirrors _y_ about the canvas
   height — reproducing the legacy global flip:
 
@@ -68,26 +68,39 @@ session (`RenderSession.toPixel` in `_node.ts`). Two conventions share this one 
   ];
   ```
 
-Which map is used is decided once at the root: `render()` computes
-`effYUp = options.yUp || subtreeHasChart(child)`, where `subtreeHasChart` walks the
-tree for any `_isChart` node (set by the chart builder) or any `coord` node (a
-coordinate system is inherently y-up). A low-level construction that is genuinely a
-value-axis chart (e.g. a box-and-whisker built from primitives) opts in with
-`node.render({ yUp: true })`; `axes: true` alone is NOT a y-up signal, because
-hierarchical diagrams (icicle, mosaic) use category axes yet read top-down. The chart builder also threads `yUp` through its
-render options. This auto-detection means a chart stays y-up even when **composed**
-inside a free-space `gofish([...])`/`.layer()` whose render entry never saw the option
-(see issues #143 / #16). `leftReserve` / `topReserve` are the measured gutter reserves
-for chrome seated past the canvas (see [the passes](/internals/layout/passes)).
+Which map is used is decided **semantically**, once, in `layout()`:
+`effYUp = options.yUp || subtreeHasContinuousY(child) || subtreeHasCoord(child)`.
+The rule is "_a cartesian scope whose y is a continuous position scale is inverted_":
+a value axis, a datum-positioned mark, a swarm's distribution. `subtreeHasContinuousY`
+walks the resolved underlying-space tree for **any** node whose y space `isCONTINUOUS`
+— checking the whole subtree, not just the root y, so a faceted scatter or a violin
+(ordinal facet/category axis at the root, continuous scatter/distribution nested
+inside) still flips on the strength of that inner scope. An **all-ordinal** chart
+(heatmap, horizontal bar, strip plot, icicle, mosaic) has no continuous y anywhere and
+stays SVG-native y-down — it reads top→bottom, which is exactly what those want. This
+replaces the older "is it a `chart()`?" structural heuristic: a vertical bar chart
+flips because its value axis is continuous, a horizontal bar chart does not because its
+y is the ordinal category axis. A box-and-whisker built from primitives flips with **no**
+explicit opt-in, because its y is continuous; `options.yUp` remains as an explicit
+override. `leftReserve` / `topReserve` are the measured gutter reserves for chrome
+seated past the canvas (see [the passes](/internals/layout/passes)).
+
+> **Caveat (count-as-magnitude).** A unit visualization that encodes a quantity as a
+> _count of ordinal units_ (a unit column chart: `spread`-ing one dot per row) has no
+> continuous y, so the rule leaves it y-down. Such stories are authored for y-down
+> directly — bottom-aligning their stacks (`alignment: "end"`) so the units grow
+> upward — rather than forced y-up. The principled end-state is to model a unit-count
+> stack as a baseline magnitude (continuous), at which point the rule flips it for free.
 
 > **Historical note.** Before #143, the world was y-up _everywhere_ (one global
 > `scale(1,-1)` at the root, plus a per-shape `scale(1,-1)` to un-mirror content). The
-> y-down default relocated that flip behind the `yUp` switch above. Shape lowering is
+> y-down default relocated that flip behind the `effYUp` switch above. Shape lowering is
 > now **flip-agnostic** — `rectItemFromBox`/image map both box corners through `toPixel`
 > and take the component-wise min/abs; text & label rotation read the flip out of
 > `toPixel` via `toPixelFlipsY` — so the same shape code is correct under either map. A
 > follow-up will express y-up as a true `cartesian` coordinate transform (making it
-> composable per-subtree instead of root-global).
+> composable per-subtree instead of root-global — so a _mixed_ composition can flip only
+> its continuous scopes, which the single global flip cannot).
 
 Because `toPixel` already carries the orientation and the viewport offset, the display
 list is in **final absolute pixels** — the SVG backend emits each item verbatim, with
@@ -211,11 +224,12 @@ filter graphs and assigning their deterministic def ids.
 
 The orchestrator `render()` in `gofish.tsx` is now small. It computes the gutter
 reserves, picks the y-up or y-down `toPixel` (per `effYUp`, above), stores it on the
-render session, and paints the lowered list into an `<svg>`:
+render session, and paints the lowered list into an `<svg>`. The `yUp` boolean is the
+decision already made in `layout()` (continuous-y / coord ⇒ y-up; else y-down),
+threaded in via `LayoutData.yUp` — `render()` does not re-derive it:
 
 ```ts
-const effYUp = yUp || subtreeHasChart(child); // chart()/coord ⇒ y-up; else y-down
-const toPixel: ToPixel = effYUp
+const toPixel: ToPixel = yUp
   ? ([gx, gy]) => [gx + leftReserve, height + topReserve - gy]
   : ([gx, gy]) => [gx + leftReserve, gy + topReserve];
 child.getRenderSession().toPixel = toPixel;

--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -69,11 +69,12 @@ session (`RenderSession.toPixel` in `_node.ts`). Two conventions share this one 
   ```
 
 Which map is used is decided once at the root: `render()` computes
-`effYUp = options.yUp || !!options.axes || subtreeHasChart(child)`, where
-`subtreeHasChart` walks the tree for any `_isChart` node (set by the chart builder)
-or any `coord` node (a coordinate system is inherently y-up). Rendering with
-`axes: true` is also a y-up signal — a value axis is chart-like even for a low-level
-`node.render({ axes: true })` (a box-and-whisker built from primitives). The chart builder also threads `yUp` through its
+`effYUp = options.yUp || subtreeHasChart(child)`, where `subtreeHasChart` walks the
+tree for any `_isChart` node (set by the chart builder) or any `coord` node (a
+coordinate system is inherently y-up). A low-level construction that is genuinely a
+value-axis chart (e.g. a box-and-whisker built from primitives) opts in with
+`node.render({ yUp: true })`; `axes: true` alone is NOT a y-up signal, because
+hierarchical diagrams (icicle, mosaic) use category axes yet read top-down. The chart builder also threads `yUp` through its
 render options. This auto-detection means a chart stays y-up even when **composed**
 inside a free-space `gofish([...])`/`.layer()` whose render entry never saw the option
 (see issues #143 / #16). `leftReserve` / `topReserve` are the measured gutter reserves

--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -69,9 +69,11 @@ session (`RenderSession.toPixel` in `_node.ts`). Two conventions share this one 
   ```
 
 Which map is used is decided once at the root: `render()` computes
-`effYUp = options.yUp || subtreeHasChart(child)`, where `subtreeHasChart` walks the
-tree for any `_isChart` node (set by the chart builder) or any `coord` node (a
-coordinate system is inherently y-up). The chart builder also threads `yUp` through its
+`effYUp = options.yUp || !!options.axes || subtreeHasChart(child)`, where
+`subtreeHasChart` walks the tree for any `_isChart` node (set by the chart builder)
+or any `coord` node (a coordinate system is inherently y-up). Rendering with
+`axes: true` is also a y-up signal — a value axis is chart-like even for a low-level
+`node.render({ axes: true })` (a box-and-whisker built from primitives). The chart builder also threads `yUp` through its
 render options. This auto-detection means a chart stays y-up even when **composed**
 inside a free-space `gofish([...])`/`.layer()` whose render entry never saw the option
 (see issues #143 / #16). `leftReserve` / `topReserve` are the measured gutter reserves

--- a/apps/docs/docs/internals/frontend/axes.md
+++ b/apps/docs/docs/internals/frontend/axes.md
@@ -61,6 +61,22 @@ rather than the visible data extent. The standoff also keeps marks exactly on
 the domain floor (for example, a histogram bin at `y = 0`) from straddling the
 axis line.
 
+### Which side the axis seats on
+
+By default that gutter is the **near/start** edge (the smaller cross-coordinate),
+which renders at the bottom in a y-up chart and the top in y-down free space. The
+public `axes: { x: { side: "start" | "end" } }` option (issue #143/#16,
+frame-relative) flips an axis to the far/end edge instead — so a category x-axis
+can sit at the bottom of an upward-filling y-down chart. The per-dim
+`side` is threaded `elaborateAxes → elaborationsFor → elaborate{Continuous,
+Difference,Ordinal}Axis`, and each seating decision reads it: `gutterConstraints`
+flips the `innerAlign` edge and the `distribute`/standoff order, `tickMark` swaps
+the label/tick order so the tick still faces the content, the ordinal label row
+flips its `distribute([label, content])` pair, and the axis **titles** follow
+their axis to the same edge (`elaborateAxisTitles` takes the same `sides`).
+Default `"start"` reproduces the original seating exactly (continuous charts stay
+byte-identical).
+
 The wrapper inherits the wrapped node's `key` and `_name`, so faceting and
 external refs keep resolving to it. After the rewrite, the whole tree's underlying
 space is recomputed (the cache is cleared) and re-niced; then normal layout runs.

--- a/apps/docs/docs/internals/frontend/legends.md
+++ b/apps/docs/docs/internals/frontend/legends.md
@@ -59,10 +59,17 @@ root = Layer([ content.name("__legendContent"), legendColumn(colorMap) ])
 
 `legendColumn` is a `Spread({ dir: "y" })` of one row per color-map entry. Each
 `legendRow` is a `Spread({ dir: "x" })` of a 10×10 `Rect` swatch and a 10px gray
-`Text` label. The column uses `Spread`'s `reverse: true`: `Spread({ dir: "y" })`
-lays children bottom→top in y-up coordinates (the first child gets the smallest
-y), so the first color-map entry has to render _last_ in the spread to end up at
-the top — matching the old bespoke order, which placed entry 0 at the top.
+`Text` label. The column entries always read top→bottom, but how the spread gets
+there depends on the render orientation (issue #143/#16). It takes
+`reverse: yUp`: under the y-UP chart flip a `Spread({ dir: "y" })` lays children
+bottom→top (the first child gets the smallest y), so the first color-map entry
+must render _last_ to land at the top; in y-DOWN free space the natural order
+already reads top→bottom, so no reverse. A continuous (gradient) colorbar is
+likewise orientation-aware — it is built in fixed y-up logical coordinates (band
+0 at the base, domain max at the top), and for a y-down render it flips which
+value each band/tick shows (and the tick pixel via `valueToBarY`) so a sequential
+scale still reads max-at-top either way, without disturbing the band-overlap
+seam logic.
 
 ### The three constraints
 
@@ -79,8 +86,11 @@ the first one places the anchor the other two read:
    overhang.
 2. `distribute({ dir: "x", spacing: 20 }, [content, column])` — seats the column
    just right of the content's **full** bounding box, including its axis labels.
-3. `align({ y: "end" }, [content, column])` — top-aligns the column with the
-   content top (in y-up coordinates, `end` is the top).
+3. `align({ y: yUp ? "end" : "start" }, [content, column])` — top-aligns the
+   column with the content top. "Top" is the far edge in y-up (`end`) but the
+   near edge in y-down free space (`start`), so the anchor follows the render
+   orientation; otherwise a y-down chart (e.g. a heatmap) seats its legend at the
+   bottom (issue #143/#16).
 
 The wrapper inherits the wrapped node's `key` and `_name` (moved off the content
 via the identity dance), so faceting, refs, and `selectAll` keep resolving to the

--- a/apps/docs/docs/js/api/core/render.md
+++ b/apps/docs/docs/js/api/core/render.md
@@ -11,12 +11,12 @@ instead, see [export](/js/api/core/export).
 
 ## Parameters
 
-| Parameter             | Type          | Description                                                                                                                                                                   |
-| --------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `container`           | `HTMLElement` | The DOM element to render into                                                                                                                                                |
-| `options.w`           | `number?`     | Width in pixels. Optional — see [Inferred size](#inferred-size).                                                                                                              |
-| `options.h`           | `number?`     | Height in pixels. Optional — see [Inferred size](#inferred-size).                                                                                                             |
-| `options.axes`        | `AxesOptions` | Auto-generate axes, labels, and legends. See [Axes](#axes) below.                                                                                                             |
+| Parameter      | Type          | Description                                                       |
+| -------------- | ------------- | ----------------------------------------------------------------- |
+| `container`    | `HTMLElement` | The DOM element to render into                                    |
+| `options.w`    | `number?`     | Width in pixels. Optional — see [Inferred size](#inferred-size).  |
+| `options.h`    | `number?`     | Height in pixels. Optional — see [Inferred size](#inferred-size). |
+| `options.axes` | `AxesOptions` | Auto-generate axes, labels, and legends. See [Axes](#axes) below. |
 
 ## Inferred size
 
@@ -67,7 +67,15 @@ axes: false                                    // no axes (the default)
 axes: { x: true, y: false }                    // x only
 axes: { x: { title: "Year" }, y: true }        // custom x title, inferred y title
 axes: { x: { title: false }, y: true }         // suppress the inferred x title
+axes: { x: { side: "end" } }                   // seat the x-axis on the far edge
 ```
+
+Each per-axis object also accepts `side: "start" | "end"` (default `"start"`).
+The side is **frame-relative**: `"start"` is the near/origin edge (bottom in a
+y-up chart, top in y-down free space) and `"end"` is the far edge. Use
+`{ x: { side: "end" } }` to put a category x-axis at the bottom of an
+upward-filling free-space chart (e.g. a unit/waffle column chart). It currently
+applies to ordinal (category) axes.
 
 `axes` is most naturally a `chart()`/`chart()` option (e.g.
 `gf.chart(data, { axes: true })`); it is also accepted directly on `.render()`, as

--- a/apps/docs/docs/python/api/core/chart.md
+++ b/apps/docs/docs/python/api/core/chart.md
@@ -21,13 +21,13 @@ chart(data, **options) -> ChartBuilder
 
 ## Parameters
 
-| Parameter     | Type                        | Description                                                                                                        |
-| ------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `data`        | `list[dict]` \| `DataFrame` | The dataset to visualize, or [`selectAll()` / `ref()`](#cross-chart-references) for a layer reference              |
-| `axes`        | keyword                     | Auto-generate axes, labels, and legends. See [Axes](#axes) below.                                                  |
-| `coord`       | keyword                     | Coordinate transform, e.g. `coord=clock()`                                                                         |
-| `color`       | keyword                     | Color scale applied to all marks — `palette(...)` or `gradient(...)`                                               |
-| `padding`     | keyword                     | Extra SVG padding (px) — useful for polar charts and overflowing labels                                            |
+| Parameter | Type                        | Description                                                                                           |
+| --------- | --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `data`    | `list[dict]` \| `DataFrame` | The dataset to visualize, or [`selectAll()` / `ref()`](#cross-chart-references) for a layer reference |
+| `axes`    | keyword                     | Auto-generate axes, labels, and legends. See [Axes](#axes) below.                                     |
+| `coord`   | keyword                     | Coordinate transform, e.g. `coord=clock()`                                                            |
+| `color`   | keyword                     | Color scale applied to all marks — `palette(...)` or `gradient(...)`                                  |
+| `padding` | keyword                     | Extra SVG padding (px) — useful for polar charts and overflowing labels                               |
 
 Chart-level options are passed as keyword arguments:
 
@@ -56,7 +56,14 @@ chart(data, axes=False)                       # no axes
 chart(data, axes={"x": True, "y": False})     # x only
 chart(data, axes={"x": {"title": "Year"}, "y": True})   # custom x title
 chart(data, axes={"x": {"title": False}, "y": True})    # suppress inferred x title
+chart(data, axes={"x": {"side": "end"}})                # x-axis on the far edge
 ```
+
+Each per-axis dict also accepts `"side": "start" | "end"` (default `"start"`).
+The side is **frame-relative**: `"start"` is the near/origin edge (bottom in a
+y-up chart, top in y-down free space), `"end"` the far edge — e.g.
+`{"x": {"side": "end"}}` puts a category x-axis at the bottom of an
+upward-filling unit/waffle chart. Currently applies to ordinal (category) axes.
 
 For polar charts, combine with `coord` (and `padding` for label room):
 

--- a/packages/gofish-gotree/src/recursion.ts
+++ b/packages/gofish-gotree/src/recursion.ts
@@ -10,14 +10,15 @@ const resolve = (c: CombinerSpec, depth: number): Combiner =>
 
 // Default combiners use `distribute` constraints (one axis each) rather
 // than the coupled `spread` operator, mirroring the in-example convention.
-// `order: "reverse"` puts parent at HIGH y (top of screen in y-up) for the
-// cartesian default — polar/radial stories override with `order: "forward"`
-// or pass a custom combiner.
+// Free space is now y-DOWN (issue #143/#16), so the default `order: "forward"`
+// puts the parent at LOW y = TOP of screen (root-at-top cartesian trees) with no
+// orientation hack. Polar/radial stories override (or run under a `coord` scope,
+// which stays y-up).
 const DEFAULT_PARENT_CHILD: Combiner = distribute({
   dir: "y",
   spacing: 32,
   alignment: "middle",
-  order: "reverse",
+  order: "forward",
 });
 const DEFAULT_SIBLING: Combiner = distribute({
   dir: "x",

--- a/packages/gofish-gotree/stories/Tree.stories.tsx
+++ b/packages/gofish-gotree/stories/Tree.stories.tsx
@@ -138,7 +138,9 @@ export const LabeledFileTree: StoryObj<Args> = {
           spacing: 36,
           alignment: "middle",
         }),
-        sibling: distribute({ dir: "x", spacing: 12, alignment: "start" }),
+        // Bottom-align siblings (y-down: "end" = bottom) so every leaf lands on
+        // a common bottom row regardless of its depth. See issue #143/#16.
+        sibling: distribute({ dir: "x", spacing: 12, alignment: "end" }),
       },
       fileTreeData
     ).render(container, { w: args.w, h: args.h });

--- a/packages/gofish-gotree/stories/Tree.stories.tsx
+++ b/packages/gofish-gotree/stories/Tree.stories.tsx
@@ -86,14 +86,13 @@ export const NodeLink: StoryObj<Args> = {
             strokeWidth: 1,
           }),
         link: { interpolation: "linear", stroke: "#90a4ae", strokeWidth: 1.5 },
-        // distribute on y → parent first goes at low y; `order: "reverse"`
+        // distribute on y → parent first goes at low y; ``
         // flips so parent ends up at HIGH y = top of screen (y-up). Aligned
         // middle on the orthogonal x axis (separate align constraint).
         parentChild: distribute({
           dir: "y",
           spacing: 48,
           alignment: "middle",
-          order: "reverse",
         }),
         sibling: distribute({ dir: "x", spacing: 24, alignment: "start" }),
       },
@@ -138,7 +137,6 @@ export const LabeledFileTree: StoryObj<Args> = {
           dir: "y",
           spacing: 36,
           alignment: "middle",
-          order: "reverse",
         }),
         sibling: distribute({ dir: "x", spacing: 12, alignment: "start" }),
       },
@@ -371,7 +369,7 @@ export const Sunburst: StoryObj<Args> = {
 };
 
 // Cartesian counterpart of Sunburst — an icicle plot. Same spec exactly,
-// minus `coord: polar()` and with `order: "reverse"` on parentChild so root
+// minus `coord: polar()` and with `` on parentChild so root
 // ends up at the top of the screen (y-up: parent at HIGH y → top) instead
 // of at the bottom. Each tree level is a horizontal band; leaves are at
 // the bottom edge.
@@ -394,13 +392,12 @@ export const IciclePlot: StoryObj<Args> = {
       {
         node: icicleNode,
         link: "none",
-        // Same axis decomposition as Sunburst, but order:"reverse" puts
+        // Same axis decomposition as Sunburst, but  puts
         // root at top of screen (HIGH y in y-up). No coord transform.
         parentChild: distribute({
           dir: "y",
           spacing: 0,
           alignment: "middle",
-          order: "reverse",
         }),
         sibling: distribute({
           dir: "x",

--- a/packages/gofish-gotree/stories/gallery/CartesianDeepTree.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/CartesianDeepTree.stories.tsx
@@ -62,7 +62,10 @@ export const CartesianDeepTree: StoryObj = {
         link: { interpolation: "linear", stroke: "#5f6b7a", strokeWidth: 1.5 },
         parentChild: combine({
           x: { kind: "nest", pad: 0 },
-          y: { kind: "distribute", spacing: 80 },
+          // order "reverse" puts the parent at HIGH y = the bottom in y-down
+          // free space, so the root sits at the bottom and leaves climb upward
+          // (matching the reference). See issue #143/#16.
+          y: { kind: "distribute", spacing: 80, order: "reverse" },
         }),
         sibling: combine({
           x: { kind: "distribute", spacing: 22 },

--- a/packages/gofish-gotree/stories/gallery/Cheops.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/Cheops.stories.tsx
@@ -54,7 +54,10 @@ export const Cheops: StoryObj = {
       }),
       sibling: combine({
         x: { kind: "distribute", spacing: -8 },
-        y: { kind: "align", alignment: "end" },
+        // Align siblings to the TOP of their bands so same-depth nodes share a
+        // row. In y-down free space the top is the near edge → "start" (was
+        // "end", which assumed y-up and dropped shallower nodes). See #143/#16.
+        y: { kind: "align", alignment: "start" },
       }),
     }),
 };

--- a/packages/gofish-gotree/stories/gallery/Cheops.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/Cheops.stories.tsx
@@ -50,7 +50,7 @@ export const Cheops: StoryObj = {
       mode: "bottomUp",
       parentChild: combine({
         x: { kind: "nest", pad: 0 },
-        y: { kind: "distribute", spacing: 2, order: "reverse" },
+        y: { kind: "distribute", spacing: 2 },
       }),
       sibling: combine({
         x: { kind: "distribute", spacing: -8 },

--- a/packages/gofish-gotree/stories/gallery/Dendrogram.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/Dendrogram.stories.tsx
@@ -12,7 +12,7 @@ import { initializeContainer } from "../helper";
 // Mapping (include→nest, juxtapose/flatten→distribute, within/align→align):
 //   parentChild = combine({ x: nest  (parent box grows to span its subtree),
 //                           y: distribute (parent stacked above its subtree) })
-//                 order:"reverse" on y puts the root at the TOP (y-up); leaves
+//                  on y puts the root at the TOP (y-up); leaves
 //                 fall to the bottom (mode=bottom-up).
 //   sibling     = combine({ x: distribute (siblings laid out flat side-by-side),
 //                           y: align (siblings share a baseline) })
@@ -98,7 +98,7 @@ export const Dendrogram: StoryObj = {
         }),
         parentChild: combine({
           x: { kind: "nest", pad: 0 },
-          y: { kind: "distribute", spacing: 70, order: "reverse" },
+          y: { kind: "distribute", spacing: 70 },
         }),
         sibling: combine({
           x: { kind: "distribute", spacing: 22 },

--- a/packages/gofish-gotree/stories/gallery/GardenLayout.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/GardenLayout.stories.tsx
@@ -43,7 +43,7 @@ export const GardenLayout: StoryObj = {
         link: { interpolation: "linear", stroke: "#90a4ae", strokeWidth: 1.5 },
         parentChild: combine({
           x: { kind: "align", alignment: "middle" },
-          y: { kind: "distribute", spacing: 48, order: "reverse" },
+          y: { kind: "distribute", spacing: 48 },
         }),
         sibling: combine({
           x: { kind: "distribute", spacing: 24 },

--- a/packages/gofish-gotree/stories/gallery/HVDrawing.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/HVDrawing.stories.tsx
@@ -27,7 +27,7 @@ const H = combine({
 // V: parent above subtree, children in a column (spread y, centered x).
 const V = combine({
   x: { kind: "align", alignment: "middle" },
-  y: { kind: "distribute", spacing: S, order: "reverse" },
+  y: { kind: "distribute", spacing: S },
 });
 
 export const HVDrawing: StoryObj = {

--- a/packages/gofish-gotree/stories/gallery/IndentedTree.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/IndentedTree.stories.tsx
@@ -18,7 +18,7 @@ import { initializeContainer } from "../helper";
 // left edge (align x "start"). There is no indentation — the dsl encodes
 // depth instead via Element.RootWidth = "rdepth" (reverse depth: the root is
 // the widest bar, leaves the narrowest) plus Color = depth. distribute uses
-// order:"reverse" so y-up places the parent/first-child at the TOP and the
+//  so y-up places the parent/first-child at the TOP and the
 // subtree stacks downward.
 const meta: Meta = {
   title: "GoTree / Gallery / IndentedTree",
@@ -38,7 +38,7 @@ const node = (d: any) =>
 
 const layout = combine({
   x: { kind: "align", alignment: "start" },
-  y: { kind: "distribute", spacing: 4, order: "reverse" },
+  y: { kind: "distribute", spacing: 4 },
 });
 
 export const IndentedTree: StoryObj = {

--- a/packages/gofish-gotree/stories/gallery/Iptp.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/Iptp.stories.tsx
@@ -43,7 +43,9 @@ export const Iptp: StoryObj = {
         }),
         sibling: combine({
           x: { kind: "distribute", spacing: 6 },
-          y: { kind: "align", alignment: "end" },
+          // Align siblings to the TOP of their bands (y-down free space: "start"
+          // = near/top edge) so same-depth nodes share a row. See #143/#16.
+          y: { kind: "align", alignment: "start" },
         }),
       },
       sampleTree

--- a/packages/gofish-gotree/stories/gallery/Iptp.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/Iptp.stories.tsx
@@ -37,9 +37,9 @@ export const Iptp: StoryObj = {
         link: "none",
         parentChild: combine({
           x: { kind: "distribute", spacing: 6 },
-          // order:"reverse" puts the parent at HIGH y (top of screen, y-up) so the
+          //  puts the parent at HIGH y (top of screen, y-up) so the
           // root sits above its subtree — matching the reference's root-at-top.
-          y: { kind: "distribute", spacing: 6, order: "reverse" },
+          y: { kind: "distribute", spacing: 6 },
         }),
         sibling: combine({
           x: { kind: "distribute", spacing: 6 },

--- a/packages/gofish-gotree/stories/gallery/NodeLinkTree.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/NodeLinkTree.stories.tsx
@@ -11,7 +11,7 @@ import { initializeContainer } from "../helper";
 // Mapping (include→nest, juxtapose/flatten→distribute, within/align→align):
 //   parentChild = combine({ x: align middle (parent centered over subtree),
 //                           y: distribute (parent stacked above its subtree) })
-//                 order:"reverse" on y puts the root at the TOP (y-up).
+//                  on y puts the root at the TOP (y-up).
 //   sibling     = combine({ x: distribute (siblings laid out flat side-by-side),
 //                           y: align start (siblings share a baseline/row) })
 const meta: Meta = {
@@ -71,7 +71,7 @@ export const NodeLinkTree: StoryObj = {
         link: { interpolation: "linear", stroke: "#555", strokeWidth: 1.5 },
         parentChild: combine({
           x: { kind: "align", alignment: "middle" },
-          y: { kind: "distribute", spacing: 90, order: "reverse" },
+          y: { kind: "distribute", spacing: 90 },
         }),
         sibling: combine({
           x: { kind: "distribute", spacing: 24 },

--- a/packages/gofish-gotree/stories/gallery/NodeLinkTree.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/NodeLinkTree.stories.tsx
@@ -75,9 +75,11 @@ export const NodeLinkTree: StoryObj = {
         }),
         sibling: combine({
           x: { kind: "distribute", spacing: 24 },
-          // "top" alignment: in y-up the top of the screen is high y → "end",
-          // so every depth-1 node (even childless ones) sits on one row.
-          y: { kind: "align", alignment: "end" },
+          // Align siblings to the TOP of their bands so every depth-1 node (even
+          // childless ones) sits on one row. In y-down free space the top is the
+          // near edge → "start"; otherwise a childless node bottom-aligns down to
+          // the leaf row. See issue #143/#16.
+          y: { kind: "align", alignment: "start" },
         }),
       },
       nodeLinkData

--- a/packages/gofish-gotree/stories/gallery/OrthogonalTree.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/OrthogonalTree.stories.tsx
@@ -43,13 +43,13 @@ export const OrthogonalTree: StoryObj = {
         // left), distribute y reverse (parent at high y = top, GoFish is y-up).
         parentChild: combine({
           x: { kind: "distribute", spacing: 18 },
-          y: { kind: "distribute", spacing: 18, order: "reverse" },
+          y: { kind: "distribute", spacing: 18 },
         }),
         // siblings step down-right: each later sibling further right (x forward)
         // and lower (y reverse) → the diagonal cascade.
         sibling: combine({
           x: { kind: "distribute", spacing: 18 },
-          y: { kind: "distribute", spacing: 18, order: "reverse" },
+          y: { kind: "distribute", spacing: 18 },
         }),
       },
       sampleTree

--- a/packages/gofish-gotree/stories/gallery/OutsideInTree.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/OutsideInTree.stories.tsx
@@ -62,7 +62,6 @@ export const OutsideInTree: StoryObj = {
             kind: "distribute",
             spacing: 70,
             mode: "center",
-            order: "reverse",
           },
         }),
         sibling: combine({

--- a/packages/gofish-gotree/stories/gallery/ReadableTreeLayout.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/ReadableTreeLayout.stories.tsx
@@ -14,7 +14,7 @@ import { initializeContainer } from "../helper";
 //   sibling     = (distribute x, align top y)      → siblings spread across,
 //                 their tops aligned on a level.
 // This is a node-link tree (same layout family as NodeLinkTree). distribute on
-// y uses order:"reverse" so the parent lands at high y = top of screen (y-up),
+// y uses  so the parent lands at high y = top of screen (y-up),
 // matching the reference (root at top, leaves at bottom).
 //
 // TODO: needs orthogonal links implemented — the dsl uses orthogonal (elbow)
@@ -40,7 +40,7 @@ export const ReadableTreeLayout: StoryObj = {
         link: { interpolation: "linear", stroke: "#555555", strokeWidth: 2 },
         parentChild: combine({
           x: { kind: "align", alignment: "middle" },
-          y: { kind: "distribute", spacing: 60, order: "reverse" },
+          y: { kind: "distribute", spacing: 60 },
         }),
         sibling: combine({
           x: { kind: "distribute", spacing: 18 },

--- a/packages/gofish-gotree/stories/gallery/SideTree.stories.tsx
+++ b/packages/gofish-gotree/stories/gallery/SideTree.stories.tsx
@@ -53,7 +53,6 @@ export const SideTree: StoryObj = {
             kind: "distribute",
             spacing: 0.5,
             mode: "center",
-            order: "reverse",
           },
           y: { kind: "distribute", spacing: 70, mode: "center" },
         }),

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -232,15 +232,6 @@ export class GoFishNode {
    * across component boundaries even if a future operator silently scopes.
    */
   public _isComponent: boolean = false;
-  /**
-   * Marks a node produced by the `chart()` builder (issue #143/#16). A chart is
-   * a y-UP render scope; the root render reads this (anywhere in the tree) to
-   * decide y-up vs the SVG-native y-down default, so a chart still renders y-up
-   * even when COMPOSED inside a `gofish([...])`/`.layer()` whose own render entry
-   * never saw the builder's `yUp` option. Free-space content carries no marker
-   * and renders y-down.
-   */
-  public _isChart: boolean = false;
   public _scopeMap?: Map<string, GoFishNode>;
   public parent?: GoFishNode;
   public datum?: any;

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -232,6 +232,15 @@ export class GoFishNode {
    * across component boundaries even if a future operator silently scopes.
    */
   public _isComponent: boolean = false;
+  /**
+   * Marks a node produced by the `chart()` builder (issue #143/#16). A chart is
+   * a y-UP render scope; the root render reads this (anywhere in the tree) to
+   * decide y-up vs the SVG-native y-down default, so a chart still renders y-up
+   * even when COMPOSED inside a `gofish([...])`/`.layer()` whose own render entry
+   * never saw the builder's `yUp` option. Free-space content carries no marker
+   * and renders y-down.
+   */
+  public _isChart: boolean = false;
   public _scopeMap?: Map<string, GoFishNode>;
   public parent?: GoFishNode;
   public datum?: any;
@@ -1187,6 +1196,7 @@ export class GoFishNode {
       axisFields,
       colorConfig,
       padding,
+      yUp,
     }: {
       w?: number;
       h?: number;
@@ -1199,6 +1209,7 @@ export class GoFishNode {
       axisFields?: { x?: string; y?: string };
       colorConfig?: ColorConfig;
       padding?: number;
+      yUp?: boolean;
     }
   ) {
     return gofish(
@@ -1215,6 +1226,7 @@ export class GoFishNode {
         axisFields,
         colorConfig,
         padding,
+        yUp,
       },
       this
     );

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -306,7 +306,8 @@ function elaborateOrdinalAxis(
   dim: 0 | 1,
   space: Extract<UnderlyingSpace, { kind: "ordinal" }>,
   keyMap: Record<string, GoFishNode>,
-  prefix: string
+  prefix: string,
+  side: "start" | "end" = "start"
 ): AxisElaboration {
   const keys = (space.domain ?? []).filter((k) => keyMap[k] !== undefined);
   const trackAxis = dirName(dim); // labels track their key along the axis dim
@@ -334,14 +335,20 @@ function elaborateOrdinalAxis(
           g[rName(i)],
         ])
       );
-      // … and sit just past the content's near edge in the gutter, anchored to
-      // the whole content layer (so the row clears any nested inner labels)
-      // rather than the individual mark.
+      // … and sit just past one of the content's gutter edges, anchored to the
+      // whole content layer (so the row clears any nested inner labels) rather
+      // than the individual mark. `side` picks the edge: "start" seats the row
+      // before the content (label → content), "end" after it (content → label)
+      // — flipping which frame edge (top/bottom or left/right) the axis lands on.
+      const pair =
+        side === "end"
+          ? [g[INNER_REF_NAME], g[lName(i)]]
+          : [g[lName(i)], g[INNER_REF_NAME]];
       cs.push(
-        Constraint.distribute({ dir: gutterDir, spacing: ORDINAL_LABEL_GAP }, [
-          g[lName(i)],
-          g[INNER_REF_NAME],
-        ])
+        Constraint.distribute(
+          { dir: gutterDir, spacing: ORDINAL_LABEL_GAP },
+          pair
+        )
       );
     });
     return cs;
@@ -383,7 +390,10 @@ function collectKeyMap(node: GoFishNode): Record<string, GoFishNode> {
  *    tier. Otherwise the ref captures the pre-shift position and the labels miss
  *    the continuous-axis gutter offset.
  */
-function elaborationsFor(node: GoFishNode): {
+function elaborationsFor(
+  node: GoFishNode,
+  sides: ["start" | "end", "start" | "end"]
+): {
   constrained: AxisElaboration[];
   refBased: AxisElaboration[];
   /** Per-dim [x, y] title anchor (the axis line) for the constrained axes this
@@ -442,7 +452,7 @@ function elaborationsFor(node: GoFishNode): {
       anchors[dim] = e.anchor;
     } else if (isORDINAL(s)) {
       keyMap ??= collectKeyMap(node);
-      refBased.push(elaborateOrdinalAxis(dim, s, keyMap, prefix));
+      refBased.push(elaborateOrdinalAxis(dim, s, keyMap, prefix, sides[dim]));
     } else {
       continue;
     }
@@ -478,7 +488,10 @@ function elaborationsFor(node: GoFishNode): {
  * visited last wins. We don't try to disambiguate (a per-facet title is out of
  * scope); the chart-level title just tracks one of them.
  */
-export async function elaborateAxes(node: GoFishNode): Promise<{
+export async function elaborateAxes(
+  node: GoFishNode,
+  sides: ["start" | "end", "start" | "end"] = ["start", "start"]
+): Promise<{
   node: GoFishNode;
   changed: boolean;
   titleAnchors: [GoFishNode | undefined, GoFishNode | undefined];
@@ -492,7 +505,7 @@ export async function elaborateAxes(node: GoFishNode): Promise<{
   for (let i = 0; i < node.children.length; i++) {
     const child = node.children[i];
     if (child instanceof GoFishNode) {
-      const res = await elaborateAxes(child);
+      const res = await elaborateAxes(child, sides);
       if (res.changed) changed = true;
       // A child's anchor fills a dim slot we haven't claimed yet.
       for (const dim of [0, 1] as (0 | 1)[]) {
@@ -507,7 +520,10 @@ export async function elaborateAxes(node: GoFishNode): Promise<{
     }
   }
 
-  const { constrained, refBased, anchors, owned } = elaborationsFor(node);
+  const { constrained, refBased, anchors, owned } = elaborationsFor(
+    node,
+    sides
+  );
   // Any dim this node owns an axis on is claimed — its own anchor replaces
   // whatever bubbled up from children, INCLUDING replacing it with undefined
   // when the owned axis is ordinal (so the title pass falls back to the plot

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -76,14 +76,26 @@ const tickRect = (dim: 0 | 1): GoFishNode =>
       : { w: 1, h: TICK_LEN, fill: AXIS_COLOR }
   );
 
-/** A short label+tick mark pair, stacked along the cross axis. */
-function tickMark(dim: 0 | 1, label: string, name: string): GoFishNode {
+/** A short label+tick mark pair, stacked along the cross axis. The tick is the
+ *  INNER element (facing the content) and the label the outer one, so the order
+ *  follows `side`: with the axis on the near/start side the inner edge is the
+ *  cross-`end`, so `[label, tick]`; on the far/end side the inner edge is the
+ *  cross-`start`, so `[tick, label]`. */
+function tickMark(
+  dim: 0 | 1,
+  label: string,
+  name: string,
+  side: "start" | "end" = "start"
+): GoFishNode {
+  const text = Text({
+    text: label,
+    fontSize: LABEL_FONT_SIZE,
+    fill: AXIS_COLOR,
+  });
+  const tick = tickRect(dim);
   return (Spread as any)(
     { dir: crossName(dim), spacing: LABEL_TICK_GAP, alignment: "middle" },
-    [
-      Text({ text: label, fontSize: LABEL_FONT_SIZE, fill: AXIS_COLOR }),
-      tickRect(dim),
-    ]
+    side === "end" ? [tick, text] : [text, tick]
   ).name(name) as GoFishNode;
 }
 
@@ -123,32 +135,43 @@ function gutterConstraints(
   g: Record<string, any>,
   lineName: string,
   ticks: any[],
-  crossFloor?: number
+  crossFloor?: number,
+  side: "start" | "end" = "start"
 ): any[] {
   // A degenerate domain can yield zero ticks; emit no gutter rather than
   // dereferencing ticks[0]/ticks[last] (which would create invalid placement
   // constraints).
   if (ticks.length === 0) return [];
   const d = crossName(dim);
-  // "inner" = the edge facing the content (cross-end of the gutter pieces).
-  const innerAlign = cross(dim) === 0 ? { x: "end" } : { y: "end" };
+  const atEnd = side === "end";
+  // "inner" = the edge facing the content. With the axis on the near/start side
+  // the content lies toward cross-`end`; on the far/end side it lies toward
+  // cross-`start`. The ticks+line align flush on that inner edge; labels extend
+  // outward into the gutter.
+  const innerEdge = atEnd ? "start" : "end";
+  const innerAlign = cross(dim) === 0 ? { x: innerEdge } : { y: innerEdge };
   const seat =
     crossFloor !== undefined
       ? // Standoff: the line sits AXIS_CONTENT_GAP outside the plot edge, so
         // marks at the domain floor (a y=0 histogram bin) don't straddle it.
         // Both lines get the same outward offset, so they still frame the
         // corner. `datum(v).offset(px)` = "this data position, plus pixels".
+        // `side` flips which way "outward" is.
         Constraint.position(
           {
-            [d]: datum(crossFloor).offset(-AXIS_CONTENT_GAP),
-            anchor: "end",
+            [d]: datum(crossFloor).offset(
+              atEnd ? AXIS_CONTENT_GAP : -AXIS_CONTENT_GAP
+            ),
+            anchor: innerEdge,
           } as any,
           [g[lineName]]
         )
-      : Constraint.distribute({ dir: d, spacing: AXIS_CONTENT_GAP }, [
-          g[lineName],
-          g[CONTENT_NAME],
-        ]);
+      : Constraint.distribute(
+          { dir: d, spacing: AXIS_CONTENT_GAP },
+          atEnd
+            ? [g[CONTENT_NAME], g[lineName]]
+            : [g[lineName], g[CONTENT_NAME]]
+        );
   return [
     seat,
     // Tick marks' inner edge flush with the line; labels extend into the gutter.
@@ -176,8 +199,11 @@ function positionAxis(opts: {
   /** The other dim's scale floor, when it also carries a position-like axis —
    *  seats this line at the plot corner instead of the content edge. */
   crossFloor?: number;
+  /** Which frame edge to seat the axis on (default near/origin = "start"). */
+  side?: "start" | "end";
 }): AxisElaboration {
   const { dim, prefix, lineMin, lineMax, tickValues } = opts;
+  const side = opts.side ?? "start";
   const lineName = `${prefix}line`;
   const tickName = (i: number) => `${prefix}t${i}`;
   const labelName = (i: number) => `${prefix}l${i}`;
@@ -205,7 +231,9 @@ function positionAxis(opts: {
     // distributes off it — an unplaced-anchor distribute would walk from 0
     // and drag the line into the plot. Tick marks align flush with the line
     // (their inner edge IS the tick).
-    cs.push(...gutterConstraints(dim, g, lineName, ticks, opts.crossFloor));
+    cs.push(
+      ...gutterConstraints(dim, g, lineName, ticks, opts.crossFloor, side)
+    );
     // Each extra label is pinned at its data position along the axis, and —
     // having no tick of its own to provide an offset — DISTRIBUTEs off the
     // (now seated) line, at the same outer offset as the continuous labels
@@ -216,7 +244,9 @@ function positionAxis(opts: {
       cs.push(
         Constraint.distribute(
           { dir: crossName(dim), spacing: TICK_LEN + LABEL_TICK_GAP },
-          [label, g[lineName]]
+          // Label sits on the OUTER side of the line — past it toward the gutter,
+          // which flips with `side`.
+          side === "end" ? [g[lineName], label] : [label, g[lineName]]
         )
       );
     });
@@ -241,7 +271,8 @@ function elaborateContinuousAxis(
   dim: 0 | 1,
   nice: [number, number],
   prefix: string,
-  crossFloor?: number
+  crossFloor?: number,
+  side: "start" | "end" = "start"
 ): AxisElaboration {
   const [niceMin, niceMax] = nice;
   const tickValues = d3Ticks(niceMin, niceMax, TICK_COUNT);
@@ -251,8 +282,9 @@ function elaborateContinuousAxis(
     lineMin: niceMin,
     lineMax: niceMax,
     tickValues,
-    tickNode: (v, _i, name) => tickMark(dim, fmtNum(v), name),
+    tickNode: (v, _i, name) => tickMark(dim, fmtNum(v), name, side),
     crossFloor,
+    side,
   });
 }
 
@@ -261,7 +293,8 @@ function elaborateDifferenceAxis(
   dim: 0 | 1,
   space: CONTINUOUS_TYPE,
   prefix: string,
-  crossFloor?: number
+  crossFloor?: number,
+  side: "start" | "end" = "start"
 ): AxisElaboration {
   // Scale over the RAW width (not a niced max) so the tick scale equals the
   // content's own width-based scaleFactor (size/width) and ticks line up with
@@ -288,6 +321,7 @@ function elaborateDifferenceAxis(
     tickNode: (_v, _i, name) => tickRect(dim).name(name),
     extraLabels,
     crossFloor,
+    side,
   });
 }
 
@@ -443,11 +477,17 @@ function elaborationsFor(
     const prefix = dim === 1 ? "__y" : "__x";
     const crossFloor = floors[cross(dim)];
     if (isPOSITION(s)) {
-      const e = elaborateContinuousAxis(dim, nices[dim]!, prefix, crossFloor);
+      const e = elaborateContinuousAxis(
+        dim,
+        nices[dim]!,
+        prefix,
+        crossFloor,
+        sides[dim]
+      );
       constrained.push(e);
       anchors[dim] = e.anchor;
     } else if (isDIFFERENCE(s)) {
-      const e = elaborateDifferenceAxis(dim, s, prefix, crossFloor);
+      const e = elaborateDifferenceAxis(dim, s, prefix, crossFloor, sides[dim]);
       constrained.push(e);
       anchors[dim] = e.anchor;
     } else if (isORDINAL(s)) {
@@ -665,9 +705,18 @@ export async function elaborateAxisTitles(
     anchors: [GoFishNode | undefined, GoFishNode | undefined];
     plotNode: GoFishNode;
     yUp?: boolean;
+    /** Per-dim axis side, so each title follows its axis to the same edge. */
+    sides?: ["start" | "end", "start" | "end"];
   }
 ): Promise<GoFishNode> {
-  const { xTitle, yTitle, anchors, plotNode, yUp = true } = opts;
+  const {
+    xTitle,
+    yTitle,
+    anchors,
+    plotNode,
+    yUp = true,
+    sides = ["start", "start"],
+  } = opts;
 
   return wrapPreservingIdentity(node, async (content) => {
     content.name(TITLE_CONTENT_NAME);
@@ -714,15 +763,16 @@ export async function elaborateAxisTitles(
             g[X_TITLE_NAME],
           ])
         );
-        // … and seat it below the FULL content bbox: title listed BEFORE the
-        // placed content anchor, so distribute's backward walk places the
-        // title's far (max) edge GAP below the content's min edge — clearing
-        // the tick/ordinal label rows that are part of the content bbox.
+        // … and seat it past the FULL content bbox on the same edge as the
+        // axis: title BEFORE the content seats it on the start edge, AFTER on
+        // the end edge (so it clears the tick/label rows and tracks `side`).
         cs.push(
-          Constraint.distribute({ dir: "y", spacing: TITLE_CONTENT_GAP }, [
-            g[X_TITLE_NAME],
-            g[TITLE_CONTENT_NAME],
-          ])
+          Constraint.distribute(
+            { dir: "y", spacing: TITLE_CONTENT_GAP },
+            sides[0] === "end"
+              ? [g[TITLE_CONTENT_NAME], g[X_TITLE_NAME]]
+              : [g[X_TITLE_NAME], g[TITLE_CONTENT_NAME]]
+          )
         );
       }
       if (yTitle !== undefined) {
@@ -733,12 +783,15 @@ export async function elaborateAxisTitles(
             g[Y_TITLE_NAME],
           ])
         );
-        // … and seat it left of the full content bbox (the gutter).
+        // … and seat it past the content bbox on the axis's side (left for
+        // "start", right for "end").
         cs.push(
-          Constraint.distribute({ dir: "x", spacing: TITLE_CONTENT_GAP }, [
-            g[Y_TITLE_NAME],
-            g[TITLE_CONTENT_NAME],
-          ])
+          Constraint.distribute(
+            { dir: "x", spacing: TITLE_CONTENT_GAP },
+            sides[1] === "end"
+              ? [g[TITLE_CONTENT_NAME], g[Y_TITLE_NAME]]
+              : [g[Y_TITLE_NAME], g[TITLE_CONTENT_NAME]]
+          )
         );
       }
       return cs;

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -603,14 +603,18 @@ export function xAxisTitle(text: string): GoFishNode {
   );
 }
 
-/** The y-axis title: `rotate: 90` (the Text rotate option) makes it read
- *  bottom-to-top in the left gutter. Customization seam, like `xAxisTitle`. */
-export function yAxisTitle(text: string): GoFishNode {
+/** The y-axis title, reading bottom-to-top (facing inward) in the left gutter.
+ *  Text lowering applies `flips ? -rotate : rotate`, so the SAME screen rotation
+ *  (-90°) needs the stored `rotate` to follow the frame: `90` under the y-up flip,
+ *  `-90` in y-down (no flip). Otherwise a y-down chart (heatmap) reads its title
+ *  top-to-bottom, facing outward. See issue #143/#16. Customization seam, like
+ *  `xAxisTitle`. */
+export function yAxisTitle(text: string, yUp = true): GoFishNode {
   return Text({
     text,
     fontSize: TITLE_FONT_SIZE,
     fill: TITLE_COLOR,
-    rotate: 90,
+    rotate: yUp ? 90 : -90,
   }).name(Y_TITLE_NAME);
 }
 
@@ -644,9 +648,10 @@ export async function elaborateAxisTitles(
     yTitle?: string;
     anchors: [GoFishNode | undefined, GoFishNode | undefined];
     plotNode: GoFishNode;
+    yUp?: boolean;
   }
 ): Promise<GoFishNode> {
-  const { xTitle, yTitle, anchors, plotNode } = opts;
+  const { xTitle, yTitle, anchors, plotNode, yUp = true } = opts;
 
   return wrapPreservingIdentity(node, async (content) => {
     content.name(TITLE_CONTENT_NAME);
@@ -665,7 +670,7 @@ export async function elaborateAxisTitles(
       refs.push(
         (ref(anchorNode) as any).name(Y_TITLE_ANCHOR_NAME) as GoFishNode
       );
-      titles.push(yAxisTitle(yTitle));
+      titles.push(yAxisTitle(yTitle, yUp));
     }
 
     const root = (await (layer as any)([

--- a/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
+++ b/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
@@ -38,9 +38,12 @@ export const pathToPixelSVG = (path: Path, toPixel: ToPixel): string =>
     )
   );
 
-/** Build a `RectItem` from a GoFish y-up box (min/max per axis). The y-up top
- *  edge (`gyMax`) maps to the smaller SVG y, so the top-left corner is
- *  `toPixel([gxMin, gyMax])`. */
+/** Build a `RectItem` from a GoFish box (min/max per axis). Flip-AGNOSTIC: maps
+ *  both diagonal corners through `toPixel` and takes the component-wise min for
+ *  the SVG top-left, abs for w/h. Correct under any axis-aligned affine
+ *  `toPixel` — y-down free space (top-left = `toPixel([gxMin, gyMin])`) or the
+ *  `yUp` chart scope (top-left = `toPixel([gxMin, gyMax])`) — so the same shape
+ *  code serves both (issue #143/#16). */
 export const rectItemFromBox = (
   gxMin: number,
   gxMax: number,
@@ -49,16 +52,24 @@ export const rectItemFromBox = (
   toPixel: ToPixel,
   extra: Partial<DisplayList.RectItem> = {}
 ): DisplayList.RectItem => {
-  const [x, y] = toPixel([gxMin, gyMax]);
+  const [ax, ay] = toPixel([gxMin, gyMin]);
+  const [bx, by] = toPixel([gxMax, gyMax]);
   return {
     kind: "rect",
-    x,
-    y,
-    w: gxMax - gxMin,
-    h: gyMax - gyMin,
+    x: Math.min(ax, bx),
+    y: Math.min(ay, by),
+    w: Math.abs(bx - ax),
+    h: Math.abs(by - ay),
     ...extra,
   };
 };
+
+/** True when `toPixel` mirrors the y axis (pixel-y decreases as GoFish-y
+ *  increases) — i.e. an active `yUp` chart scope. Lets orientation-dependent
+ *  shapes (text rotation) pick the right sign by reading the flip out of
+ *  `toPixel` rather than carrying a separate flag (issue #143/#16). */
+export const toPixelFlipsY = (toPixel: ToPixel): boolean =>
+  toPixel([0, 1])[1] < toPixel([0, 0])[1];
 
 /** Assemble a `Style` from resolved presentation values, dropping undefined
  *  keys (and a zero/undefined stroke-width, which the legacy render omitted). */

--- a/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
+++ b/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
@@ -38,12 +38,28 @@ export const pathToPixelSVG = (path: Path, toPixel: ToPixel): string =>
     )
   );
 
-/** Build a `RectItem` from a GoFish box (min/max per axis). Flip-AGNOSTIC: maps
- *  both diagonal corners through `toPixel` and takes the component-wise min for
- *  the SVG top-left, abs for w/h. Correct under any axis-aligned affine
- *  `toPixel` — y-down free space (top-left = `toPixel([gxMin, gyMin])`) or the
- *  `yUp` chart scope (top-left = `toPixel([gxMin, gyMax])`) — so the same shape
- *  code serves both (issue #143/#16). */
+/** Map the two diagonal corners of an axis-aligned GoFish box through `toPixel`
+ *  and return the flip-AGNOSTIC SVG rect: top-left = component-wise min, w/h =
+ *  abs of the mapped span. Correct under any axis-aligned affine `toPixel` —
+ *  y-down free space (top-left = `toPixel(c0)`) or the `yUp` chart scope (the
+ *  flip makes `toPixel(c1)` the top-left) — so rect / image / compositor lower
+ *  bodies share one box mapping (issue #143/#16). */
+export const pixelBox = (
+  c0: Point,
+  c1: Point,
+  toPixel: ToPixel
+): { x: number; y: number; w: number; h: number } => {
+  const [ax, ay] = toPixel(c0);
+  const [bx, by] = toPixel(c1);
+  return {
+    x: Math.min(ax, bx),
+    y: Math.min(ay, by),
+    w: Math.abs(bx - ax),
+    h: Math.abs(by - ay),
+  };
+};
+
+/** Build a `RectItem` from a GoFish box (min/max per axis) — see {@link pixelBox}. */
 export const rectItemFromBox = (
   gxMin: number,
   gxMax: number,
@@ -51,18 +67,11 @@ export const rectItemFromBox = (
   gyMax: number,
   toPixel: ToPixel,
   extra: Partial<DisplayList.RectItem> = {}
-): DisplayList.RectItem => {
-  const [ax, ay] = toPixel([gxMin, gyMin]);
-  const [bx, by] = toPixel([gxMax, gyMax]);
-  return {
-    kind: "rect",
-    x: Math.min(ax, bx),
-    y: Math.min(ay, by),
-    w: Math.abs(bx - ax),
-    h: Math.abs(by - ay),
-    ...extra,
-  };
-};
+): DisplayList.RectItem => ({
+  kind: "rect",
+  ...pixelBox([gxMin, gyMin], [gxMax, gyMax], toPixel),
+  ...extra,
+});
 
 /** True when `toPixel` mirrors the y axis (pixel-y decreases as GoFish-y
  *  increases) — i.e. an active `yUp` chart scope. Lets orientation-dependent

--- a/packages/gofish-graphics/src/ast/displayList/toDisplayList.ts
+++ b/packages/gofish-graphics/src/ast/displayList/toDisplayList.ts
@@ -72,7 +72,7 @@ export async function toDisplayList(
   // renders y-UP (`options.yUp` threaded from the builder): mirror y about the
   // canvas height — bars grow up, y-axis increases upward — reproducing the old
   // global flip. See issue #143/#16.
-  const effYUp = options.yUp || !!options.axes || subtreeHasChart(data.child);
+  const effYUp = options.yUp || subtreeHasChart(data.child);
   const toPixel: ToPixel = effYUp
     ? ([gx, gy]) => [gx + leftReserve, data.height + topReserve - gy]
     : ([gx, gy]) => [gx + leftReserve, gy + topReserve];

--- a/packages/gofish-graphics/src/ast/displayList/toDisplayList.ts
+++ b/packages/gofish-graphics/src/ast/displayList/toDisplayList.ts
@@ -72,7 +72,7 @@ export async function toDisplayList(
   // renders y-UP (`options.yUp` threaded from the builder): mirror y about the
   // canvas height — bars grow up, y-axis increases upward — reproducing the old
   // global flip. See issue #143/#16.
-  const effYUp = options.yUp || subtreeHasChart(data.child);
+  const effYUp = options.yUp || !!options.axes || subtreeHasChart(data.child);
   const toPixel: ToPixel = effYUp
     ? ([gx, gy]) => [gx + leftReserve, data.height + topReserve - gy]
     : ([gx, gy]) => [gx + leftReserve, gy + topReserve];

--- a/packages/gofish-graphics/src/ast/displayList/toDisplayList.ts
+++ b/packages/gofish-graphics/src/ast/displayList/toDisplayList.ts
@@ -11,13 +11,15 @@
  * **final, absolute, y-down pixels** — the {@link DisplayList.DisplayListDocument}
  * a non-SVG backend (Canvas, WebGPU) or a foreign host (Semiotic) consumes.
  *
- * Coordinate model. GoFish lays out in a y-up frame and flips once at the SVG
- * root (`scale(1,-1) translate(leftReserve, -(height+topReserve))`). Composing
- * that root flip with each mark's local flip, a GoFish-space point `(gx, gy)`
- * lands at the SVG pixel `(gx + leftReserve, (height + topReserve) - gy)`. The
- * emitter bakes that mapping (`toPixel`) into every coordinate, so the display
- * list needs no further transform — the reference SVG backend
- * (`DisplayList.displayListToSVG`) emits it verbatim.
+ * Coordinate model. The default frame is SVG-native y-DOWN (top-left origin): a
+ * GoFish-space point `(gx, gy)` lands at `(gx + leftReserve, gy + topReserve)` —
+ * no flip, so a vertical list reads top→bottom. A `chart()` renders y-UP
+ * (`options.yUp`, threaded from the builder): the root mirrors y about the
+ * canvas height, `(gx + leftReserve, height + topReserve - gy)` — bars grow up,
+ * the y-axis increases upward — reproducing the legacy global flip (issue
+ * #143/#16). The emitter bakes the pixel mapping (`toPixel`) into every
+ * coordinate, so the display list needs no further transform — the reference SVG
+ * backend (`DisplayList.displayListToSVG`) emits it verbatim.
  *
  * Each primitive owns its lowering (`lower` on the factory → `INTERNAL_lower`);
  * this module only drives layout, computes the viewport + `toPixel`, and walks
@@ -26,7 +28,11 @@
 
 import type { DisplayList } from "gofish-ir";
 import type { ToPixel } from "../_node";
-import { runLayout, type GoFishRenderOptions } from "../gofish";
+import {
+  runLayout,
+  subtreeHasChart,
+  type GoFishRenderOptions,
+} from "../gofish";
 import { GoFishNode } from "../_node";
 import { lowerToDisplayList } from "./lower";
 
@@ -61,12 +67,15 @@ export async function toDisplayList(
     h: topReserve + data.height + bottomReserve,
   };
 
-  // GoFish y-up → SVG y-down absolute pixels. This single map folds in both the
-  // per-shape local `scale(1,-1)` and the root flip the legacy render used.
-  const toPixel: ToPixel = ([gx, gy]) => [
-    gx + leftReserve,
-    data.height + topReserve - gy,
-  ];
+  // Default frame is SVG-native y-DOWN (top-left origin): a vertical list reads
+  // top→bottom and this map only offsets by the gutter reserves. A `chart()`
+  // renders y-UP (`options.yUp` threaded from the builder): mirror y about the
+  // canvas height — bars grow up, y-axis increases upward — reproducing the old
+  // global flip. See issue #143/#16.
+  const effYUp = options.yUp || subtreeHasChart(data.child);
+  const toPixel: ToPixel = effYUp
+    ? ([gx, gy]) => [gx + leftReserve, data.height + topReserve - gy]
+    : ([gx, gy]) => [gx + leftReserve, gy + topReserve];
 
   // Thread `toPixel` to every `lower` body (and the boundary operators that call
   // `flattenLayout` internally) via the shared render session.

--- a/packages/gofish-graphics/src/ast/displayList/toDisplayList.ts
+++ b/packages/gofish-graphics/src/ast/displayList/toDisplayList.ts
@@ -28,11 +28,7 @@
 
 import type { DisplayList } from "gofish-ir";
 import type { ToPixel } from "../_node";
-import {
-  runLayout,
-  subtreeHasChart,
-  type GoFishRenderOptions,
-} from "../gofish";
+import { runLayout, type GoFishRenderOptions } from "../gofish";
 import { GoFishNode } from "../_node";
 import { lowerToDisplayList } from "./lower";
 
@@ -68,11 +64,13 @@ export async function toDisplayList(
   };
 
   // Default frame is SVG-native y-DOWN (top-left origin): a vertical list reads
-  // top→bottom and this map only offsets by the gutter reserves. A `chart()`
-  // renders y-UP (`options.yUp` threaded from the builder): mirror y about the
-  // canvas height — bars grow up, y-axis increases upward — reproducing the old
-  // global flip. See issue #143/#16.
-  const effYUp = options.yUp || subtreeHasChart(data.child);
+  // top→bottom and this map only offsets by the gutter reserves. A CONTINUOUS-y
+  // root (a chart's value axis, box-and-whisker, hand-drawn axes) or a `coord`
+  // scope renders y-UP: mirror y about the canvas height — bars grow up, the
+  // y-axis increases upward — reproducing the old global flip. That decision is
+  // made in `layout()` from the root y space and threaded here as `data.yUp`.
+  // See issue #143/#16.
+  const effYUp = data.yUp;
   const toPixel: ToPixel = effYUp
     ? ([gx, gy]) => [gx + leftReserve, data.height + topReserve - gy]
     : ([gx, gy]) => [gx + leftReserve, gy + topReserve];

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -11,7 +11,7 @@ import {
   debugInputSceneGraph,
   debugNodeTree,
   debugUnderlyingSpaceTree,
-  type GoFishNode,
+  GoFishNode,
   type RenderSession,
 } from "./_node";
 import { posScaleFromSpace } from "./domain";
@@ -506,6 +506,15 @@ export type GoFishRenderOptions = {
   axisFields?: { x?: string; y?: string };
   colorConfig?: ColorConfig;
   padding?: number;
+  /**
+   * y-UP render scope (issue #143/#16): when true the root `toPixel` mirrors y
+   * about the canvas height — the convention charts want (bars grow up, y-axis
+   * increases upward). Default (free space, raw `gofish()`) is y-DOWN: a
+   * top-left origin where a vertical list reads top→bottom. `chart()` threads
+   * this true; a true y-up coordinate transform (the follow-up) will later make
+   * this composable per-subtree instead of root-global.
+   */
+  yUp?: boolean;
 };
 
 /** Extra options for the SVG-export terminals (`toSVG` / `toSVGElement` / `save`). */
@@ -603,7 +612,8 @@ export async function runLayout(
 function renderLayout(
   data: LayoutData,
   svgPadding: number,
-  defs?: JSX.Element[]
+  defs?: JSX.Element[],
+  yUp?: boolean
 ): JSX.Element {
   return render(
     {
@@ -611,6 +621,7 @@ function renderLayout(
       height: data.height,
       svgPadding,
       defs,
+      yUp,
       rightOverhang: data.rightOverhang,
       rightContentOverhang: data.rightContentOverhang,
       topOverhang: data.topOverhang,
@@ -638,7 +649,7 @@ export const gofish = (
         {(() => {
           const data = layoutData();
           if (!data) return null;
-          return renderLayout(data, svgPadding, options.defs);
+          return renderLayout(data, svgPadding, options.defs, options.yUp);
         })()}
       </Suspense>
     );
@@ -711,7 +722,7 @@ export async function gofishToSVGElement(
   const root = document.createElement("div");
   // Layout is already awaited, so the SVG mounts synchronously — no Suspense.
   const dispose = solidRender(
-    () => renderLayout(data, svgPadding, options.defs),
+    () => renderLayout(data, svgPadding, options.defs, options.yUp),
     root
   );
   const svg = root.querySelector("svg");
@@ -794,6 +805,23 @@ const PADDING = 40;
  * Checks the node itself first, then its immediate children.
  * Returns the coord node's transform.translate values, or null if not found.
  */
+/** True if `node` or any descendant establishes a y-UP scope: a `chart()`-
+ *  produced node (`_isChart`) or a `coord` node (a coordinate system is y-up).
+ *  The root render uses this to pick y-up vs the SVG-native y-down default, so a
+ *  chart or a polar/coord visualization renders y-up even when composed inside a
+ *  free-space `gofish([...])`/`.layer()`. Pure free-space diagrams match neither
+ *  and render y-down. See issue #143/#16. */
+export const subtreeHasChart = (node: GoFishNode): boolean => {
+  // A `chart()` node or any `coord` node (a coordinate system is inherently
+  // y-up — polar/clock/wavy) establishes a y-up scope. See issue #143/#16.
+  if (node._isChart || node.type === "coord") return true;
+  const kids = node.children as (GoFishNode | unknown)[] | undefined;
+  if (kids)
+    for (const k of kids)
+      if (k instanceof GoFishNode && subtreeHasChart(k)) return true;
+  return false;
+};
+
 export const render = (
   {
     width,
@@ -806,6 +834,7 @@ export const render = (
     leftOverhang = 0,
     bottomOverhang = 0,
     svgPadding,
+    yUp = false,
   }: {
     width: number;
     height: number;
@@ -817,6 +846,7 @@ export const render = (
     leftOverhang?: number;
     bottomOverhang?: number;
     svgPadding?: number;
+    yUp?: boolean;
   },
   child: GoFishNode
 ): JSX.Element => {
@@ -858,13 +888,17 @@ export const render = (
   // <g> translate, so it needn't be pixel-snapped — a fractional width is
   // harmless (legend overhangs are fractional text widths).
   // Two-pass render: lower the baked scenegraph into the display-list IR, then
-  // paint each item. Items are final y-down absolute pixels (the `toPixel` fold
-  // carries the gutter offset + the y-flip), so there is no outer flip `<g>` and
-  // no per-shape transform.
-  const toPixel: ToPixel = ([gx, gy]) => [
-    gx + leftReserve,
-    height + topReserve - gy,
-  ];
+  // paint each item. Items are final absolute pixels. The default frame is
+  // SVG-native y-DOWN (top-left origin): a vertical list reads top→bottom and
+  // `toPixel` only offsets by the gutter reserves. A `chart()` renders y-UP
+  // (`yUp` threaded from the builder): the root mirrors y about the canvas
+  // height — bars grow up, the y-axis increases upward — reproducing the old
+  // global flip. See issue #143/#16. (A true y-up coordinate transform — the
+  // follow-up — will make this composable per-subtree instead of root-global.)
+  const effYUp = yUp || subtreeHasChart(child);
+  const toPixel: ToPixel = effYUp
+    ? ([gx, gy]) => [gx + leftReserve, height + topReserve - gy]
+    : ([gx, gy]) => [gx + leftReserve, gy + topReserve];
   child.getRenderSession().toPixel = toPixel;
   const paintBaked = () => lowerToDisplayList(child).map(paintSVG);
   return (

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -649,7 +649,12 @@ export const gofish = (
         {(() => {
           const data = layoutData();
           if (!data) return null;
-          return renderLayout(data, svgPadding, options.defs, options.yUp);
+          return renderLayout(
+            data,
+            svgPadding,
+            options.defs,
+            options.yUp || !!options.axes
+          );
         })()}
       </Suspense>
     );
@@ -722,7 +727,13 @@ export async function gofishToSVGElement(
   const root = document.createElement("div");
   // Layout is already awaited, so the SVG mounts synchronously — no Suspense.
   const dispose = solidRender(
-    () => renderLayout(data, svgPadding, options.defs, options.yUp),
+    () =>
+      renderLayout(
+        data,
+        svgPadding,
+        options.defs,
+        options.yUp || !!options.axes
+      ),
     root
   );
   const svg = root.querySelector("svg");

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -302,6 +302,7 @@ export async function layout(
       anchors: titleAnchors,
       plotNode,
       yUp: effYUp,
+      sides: resolveAxisSides(axes),
     });
     if (contexts?.session) child.setRenderSession(contexts.session);
     // The title pass introduces `ref()` stand-ins (to the axis line / plot) that

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -862,6 +862,20 @@ const PADDING = 40;
  * Checks the node itself first, then its immediate children.
  * Returns the coord node's transform.translate values, or null if not found.
  */
+/** True if `node` or any descendant satisfies `pred`. Shared depth-first walk
+ *  behind the y-up triggers below. */
+const subtreeHas = (
+  node: GoFishNode,
+  pred: (n: GoFishNode) => boolean
+): boolean => {
+  if (pred(node)) return true;
+  const kids = node.children as (GoFishNode | unknown)[] | undefined;
+  if (kids)
+    for (const k of kids)
+      if (k instanceof GoFishNode && subtreeHas(k, pred)) return true;
+  return false;
+};
+
 /** True if `node` or any descendant is a `coord` node (polar/clock/wavy). A
  *  coordinate system currently renders y-up regardless of its y-space kind, so
  *  the root flips when one is present even nested inside free-space
@@ -869,14 +883,8 @@ const PADDING = 40;
  *  cartesian y-up is now decided semantically from the root y space
  *  (`isCONTINUOUS`), but the right convention for polar/coord is still open, so
  *  its legacy behavior is preserved here. See issue #143/#16. */
-export const subtreeHasCoord = (node: GoFishNode): boolean => {
-  if (node.type === "coord") return true;
-  const kids = node.children as (GoFishNode | unknown)[] | undefined;
-  if (kids)
-    for (const k of kids)
-      if (k instanceof GoFishNode && subtreeHasCoord(k)) return true;
-  return false;
-};
+export const subtreeHasCoord = (node: GoFishNode): boolean =>
+  subtreeHas(node, (n) => n.type === "coord");
 
 /** True if `node` or ANY descendant has a CONTINUOUS y underlying space — i.e.
  *  somewhere in the tree y is a real position/magnitude scale (a value axis, a
@@ -891,15 +899,11 @@ export const subtreeHasCoord = (node: GoFishNode): boolean => {
  *  continuous y anywhere and stays SVG-native y-down (reads top→bottom). A true
  *  per-scope coordinate transform (the follow-up) will localize this so a mixed
  *  composition can flip only the continuous scopes; today it is one global flip. */
-export const subtreeHasContinuousY = (node: GoFishNode): boolean => {
-  const sy = node._underlyingSpace?.[1];
-  if (sy !== undefined && isCONTINUOUS(sy)) return true;
-  const kids = node.children as (GoFishNode | unknown)[] | undefined;
-  if (kids)
-    for (const k of kids)
-      if (k instanceof GoFishNode && subtreeHasContinuousY(k)) return true;
-  return false;
-};
+export const subtreeHasContinuousY = (node: GoFishNode): boolean =>
+  subtreeHas(node, (n) => {
+    const sy = n._underlyingSpace?.[1];
+    return sy !== undefined && isCONTINUOUS(sy);
+  });
 
 export const render = (
   {

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -24,6 +24,7 @@ import {
   continuousInterval,
   hasBaseline,
   isBaselineMagnitude,
+  isCONTINUOUS,
   spaceMeasure,
   type UnderlyingSpace,
 } from "./underlyingSpace";
@@ -138,6 +139,7 @@ export async function layout(
 ): Promise<{
   underlyingSpaceX: UnderlyingSpace;
   underlyingSpaceY: UnderlyingSpace;
+  yUp: boolean;
   posScales: [
     ((pos: number) => number) | undefined,
     ((pos: number) => number) | undefined,
@@ -232,6 +234,21 @@ export async function layout(
   const niceUnderlyingSpaceX = child._underlyingSpace![0];
   const niceUnderlyingSpaceY = child._underlyingSpace![1];
 
+  // y-UP scope decision (issue #143/#16). The y axis is "inverted" — origin at
+  // the bottom, values increasing upward — exactly when it carries a CONTINUOUS
+  // scale: a chart's value axis, or any low-level spec with datum-positioned or
+  // baseline-magnitude y (box-and-whisker, hand-drawn axes). An ORDINAL or
+  // UNDEFINED y (a category axis, a free-space diagram, an icicle/mosaic) stays
+  // SVG-native y-DOWN so it reads top→bottom. This is the semantic rule that
+  // replaces the old "is this a chart()?" structural heuristic: a vertical bar
+  // chart flips because its value axis is continuous, a horizontal bar chart
+  // does NOT (its y is the ordinal category axis, which should read top-down),
+  // and a continuous low-level spec flips without needing an explicit `yUp`. A
+  // `coord` (polar/clock) subtree keeps its existing y-up handling (the right
+  // convention there is still open). `yUp` (from options) is an explicit
+  // override on top. See the `subtreeHasCoord`/`isCONTINUOUS` callers.
+  const effYUp = yUp || subtreeHasContinuousY(child) || subtreeHasCoord(child);
+
   // Reference to the content node whose extent defines the final canvas
   // (`finalW`/`finalH` via the `finalDim` readback below). Both the title pass
   // and the legend pass wrap `child`, so `contentNode` keeps pointing at the
@@ -294,9 +311,9 @@ export async function layout(
   if (hasLegend && unitScale) {
     // The legend entries should read top→bottom. Under the y-up chart flip that
     // needs `reverse` (a y-spread lays out bottom→top); in y-down free space the
-    // natural order already reads top→bottom. Pass the effective orientation so
-    // the swatch column reverses only when y-up. See issue #143/#16.
-    const effYUp = yUp || subtreeHasChart(child);
+    // natural order already reads top→bottom. Pass the effective orientation
+    // (`effYUp`, computed above from the root y space) so the swatch column
+    // reverses only when y-up. See issue #143/#16.
     child = await elaborateLegend(
       child,
       unitScale as CategoricalScale | ContinuousColorScale,
@@ -487,6 +504,7 @@ export async function layout(
   return {
     underlyingSpaceX: niceUnderlyingSpaceX,
     underlyingSpaceY: niceUnderlyingSpaceY,
+    yUp: effYUp,
     posScales,
     child,
     width: finalW,
@@ -534,6 +552,8 @@ export type GoFishExportOptions = GoFishRenderOptions & {
 type LayoutData = {
   underlyingSpaceX: UnderlyingSpace;
   underlyingSpaceY: UnderlyingSpace;
+  /** Whether the root renders y-UP (continuous y / coord scope). See #143/#16. */
+  yUp: boolean;
   posScales: [
     ((pos: number) => number) | undefined,
     ((pos: number) => number) | undefined,
@@ -631,8 +651,7 @@ export async function runLayout(
 function renderLayout(
   data: LayoutData,
   svgPadding: number,
-  defs?: JSX.Element[],
-  yUp?: boolean
+  defs?: JSX.Element[]
 ): JSX.Element {
   return render(
     {
@@ -640,7 +659,8 @@ function renderLayout(
       height: data.height,
       svgPadding,
       defs,
-      yUp,
+      // The resolved y-up decision (root y space), computed in `layout()`.
+      yUp: data.yUp,
       rightOverhang: data.rightOverhang,
       rightContentOverhang: data.rightContentOverhang,
       topOverhang: data.topOverhang,
@@ -668,7 +688,7 @@ export const gofish = (
         {(() => {
           const data = layoutData();
           if (!data) return null;
-          return renderLayout(data, svgPadding, options.defs, options.yUp);
+          return renderLayout(data, svgPadding, options.defs);
         })()}
       </Suspense>
     );
@@ -741,7 +761,7 @@ export async function gofishToSVGElement(
   const root = document.createElement("div");
   // Layout is already awaited, so the SVG mounts synchronously — no Suspense.
   const dispose = solidRender(
-    () => renderLayout(data, svgPadding, options.defs, options.yUp),
+    () => renderLayout(data, svgPadding, options.defs),
     root
   );
   const svg = root.querySelector("svg");
@@ -824,20 +844,42 @@ const PADDING = 40;
  * Checks the node itself first, then its immediate children.
  * Returns the coord node's transform.translate values, or null if not found.
  */
-/** True if `node` or any descendant establishes a y-UP scope: a `chart()`-
- *  produced node (`_isChart`) or a `coord` node (a coordinate system is y-up).
- *  The root render uses this to pick y-up vs the SVG-native y-down default, so a
- *  chart or a polar/coord visualization renders y-up even when composed inside a
- *  free-space `gofish([...])`/`.layer()`. Pure free-space diagrams match neither
- *  and render y-down. See issue #143/#16. */
-export const subtreeHasChart = (node: GoFishNode): boolean => {
-  // A `chart()` node or any `coord` node (a coordinate system is inherently
-  // y-up — polar/clock/wavy) establishes a y-up scope. See issue #143/#16.
-  if (node._isChart || node.type === "coord") return true;
+/** True if `node` or any descendant is a `coord` node (polar/clock/wavy). A
+ *  coordinate system currently renders y-up regardless of its y-space kind, so
+ *  the root flips when one is present even nested inside free-space
+ *  `gofish([...])`/`.layer()`. This is the ONE remaining structural y-up trigger:
+ *  cartesian y-up is now decided semantically from the root y space
+ *  (`isCONTINUOUS`), but the right convention for polar/coord is still open, so
+ *  its legacy behavior is preserved here. See issue #143/#16. */
+export const subtreeHasCoord = (node: GoFishNode): boolean => {
+  if (node.type === "coord") return true;
   const kids = node.children as (GoFishNode | unknown)[] | undefined;
   if (kids)
     for (const k of kids)
-      if (k instanceof GoFishNode && subtreeHasChart(k)) return true;
+      if (k instanceof GoFishNode && subtreeHasCoord(k)) return true;
+  return false;
+};
+
+/** True if `node` or ANY descendant has a CONTINUOUS y underlying space — i.e.
+ *  somewhere in the tree y is a real position/magnitude scale (a value axis, a
+ *  datum-positioned mark, a swarm's distribution), not an ordinal/undefined
+ *  category band. This is the y-up trigger (issue #143/#16): the rule is "a
+ *  cartesian scope with a continuous y position is inverted", so the presence of
+ *  ANY such scope flips the (currently global) root frame. Checking the whole
+ *  subtree — not just the root y — is what keeps a faceted scatter or a violin
+ *  swarm upright: their root y is the ordinal facet/category axis, but the
+ *  scatter/distribution NESTED inside is continuous, and that inner scope is what
+ *  wants y-up. An all-ordinal chart (heatmap, horizontal bar, strip plot) has no
+ *  continuous y anywhere and stays SVG-native y-down (reads top→bottom). A true
+ *  per-scope coordinate transform (the follow-up) will localize this so a mixed
+ *  composition can flip only the continuous scopes; today it is one global flip. */
+export const subtreeHasContinuousY = (node: GoFishNode): boolean => {
+  const sy = node._underlyingSpace?.[1];
+  if (sy !== undefined && isCONTINUOUS(sy)) return true;
+  const kids = node.children as (GoFishNode | unknown)[] | undefined;
+  if (kids)
+    for (const k of kids)
+      if (k instanceof GoFishNode && subtreeHasContinuousY(k)) return true;
   return false;
 };
 
@@ -914,8 +956,9 @@ export const render = (
   // height — bars grow up, the y-axis increases upward — reproducing the old
   // global flip. See issue #143/#16. (A true y-up coordinate transform — the
   // follow-up — will make this composable per-subtree instead of root-global.)
-  const effYUp = yUp || subtreeHasChart(child);
-  const toPixel: ToPixel = effYUp
+  // `yUp` is the resolved decision threaded from `layout()` (`LayoutData.yUp`,
+  // computed from the root y space), not a raw option — see `subtreeHasCoord`.
+  const toPixel: ToPixel = yUp
     ? ([gx, gy]) => [gx + leftReserve, height + topReserve - gy]
     : ([gx, gy]) => [gx + leftReserve, gy + topReserve];
   child.getRenderSession().toPixel = toPixel;

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -285,6 +285,7 @@ export async function layout(
       yTitle,
       anchors: titleAnchors,
       plotNode,
+      yUp: effYUp,
     });
     if (contexts?.session) child.setRenderSession(contexts.session);
     // The title pass introduces `ref()` stand-ins (to the axis line / plot) that

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -649,12 +649,7 @@ export const gofish = (
         {(() => {
           const data = layoutData();
           if (!data) return null;
-          return renderLayout(
-            data,
-            svgPadding,
-            options.defs,
-            options.yUp || !!options.axes
-          );
+          return renderLayout(data, svgPadding, options.defs, options.yUp);
         })()}
       </Suspense>
     );
@@ -727,13 +722,7 @@ export async function gofishToSVGElement(
   const root = document.createElement("div");
   // Layout is already awaited, so the SVG mounts synchronously — no Suspense.
   const dispose = solidRender(
-    () =>
-      renderLayout(
-        data,
-        svgPadding,
-        options.defs,
-        options.yUp || !!options.axes
-      ),
+    () => renderLayout(data, svgPadding, options.defs, options.yUp),
     root
   );
   const svg = root.querySelector("svg");

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -118,6 +118,7 @@ export async function layout(
     debug = false,
     axes = false,
     axisFields,
+    yUp = false,
   }: {
     w?: number;
     h?: number;
@@ -128,6 +129,7 @@ export async function layout(
     defs?: JSX.Element[];
     axes?: AxesOptions;
     axisFields?: { x?: string; y?: string };
+    yUp?: boolean;
   },
   child: GoFishNode | Promise<GoFishNode>,
   contexts?: {
@@ -290,9 +292,15 @@ export async function layout(
     (isCategoricalScale(unitScale) && unitScale.color.size > 0) ||
     isContinuousColorScale(unitScale);
   if (hasLegend && unitScale) {
+    // The legend entries should read top→bottom. Under the y-up chart flip that
+    // needs `reverse` (a y-spread lays out bottom→top); in y-down free space the
+    // natural order already reads top→bottom. Pass the effective orientation so
+    // the swatch column reverses only when y-up. See issue #143/#16.
+    const effYUp = yUp || subtreeHasChart(child);
     child = await elaborateLegend(
       child,
-      unitScale as CategoricalScale | ContinuousColorScale
+      unitScale as CategoricalScale | ContinuousColorScale,
+      effYUp
     );
     legendAdded = true;
     if (contexts?.session) child.setRenderSession(contexts.session);
@@ -596,7 +604,18 @@ export async function runLayout(
     }
 
     return await layout(
-      { w, h, x, y, transform, debug, defs, axes, axisFields },
+      {
+        w,
+        h,
+        x,
+        y,
+        transform,
+        debug,
+        defs,
+        axes,
+        axisFields,
+        yUp: options.yUp,
+      },
       child,
       contexts
     );

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -74,7 +74,23 @@ export const isContinuousColorScale = (
   s: Scale | undefined
 ): s is ContinuousColorScale => s !== undefined && "scaleFn" in s;
 export type AxesOptions = boolean | { x?: AxisOptions; y?: AxisOptions };
-export type AxisOptions = boolean | { title?: string | false };
+/** `side` (issue #143/#16): which frame edge the axis seats on — `"start"`
+ *  (default: the near/origin side — bottom in y-up, top in y-down) or `"end"`
+ *  (the far side — top in y-up, bottom in y-down). Frame-relative, matching the
+ *  start/end vocabulary of alignment/distribute. */
+export type AxisOptions =
+  | boolean
+  | { title?: string | false; side?: "start" | "end" };
+
+/** Per-dim axis `side`, defaulting to `"start"` (the existing seating). */
+export function resolveAxisSides(
+  axes: AxesOptions | undefined
+): ["start" | "end", "start" | "end"] {
+  const sideOf = (o: AxisOptions | undefined): "start" | "end" =>
+    o && typeof o === "object" && o.side === "end" ? "end" : "start";
+  if (axes && typeof axes === "object") return [sideOf(axes.x), sideOf(axes.y)];
+  return ["start", "start"];
+}
 
 // Fallback extent for an omitted `w`/`h` on a POSITION or data-driven SIZE axis,
 // which needs a concrete canvas to scale data into (see the per-axis comment in
@@ -213,7 +229,7 @@ export async function layout(
     // handled axis flags; the new subtree is then re-resolved below. A flag the
     // pass doesn't handle (e.g. an UNDEFINED space) is inert — nothing else
     // consumes `node.axis`.
-    const elaborated = await elaborateAxes(child);
+    const elaborated = await elaborateAxes(child, resolveAxisSides(axes));
     titleAnchors = elaborated.titleAnchors;
     if (elaborated.changed) {
       child = elaborated.node;

--- a/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
@@ -3,6 +3,7 @@ import { GoFishAST } from "../_ast";
 import { GoFishNode } from "../_node";
 import type { Placeable, ToPixel } from "../_node";
 import { Size, displayTranslate } from "../dims";
+import { pixelBox } from "../displayList/lowerHelpers";
 import { UnderlyingSpace } from "../underlyingSpace";
 import { createNodeOperator } from "../withGoFish";
 import { unionChildSpaces } from "./alignment";
@@ -114,14 +115,14 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
             const minY = intrinsicDims?.[1]?.min ?? 0;
             const width = intrinsicDims?.[0]?.size ?? 0;
             const height = intrinsicDims?.[1]?.size ?? 0;
-            // Pixel bbox top-left, flip-AGNOSTIC: map both diagonal corners
-            // through the outer toPixel and take the component-wise min. Under
-            // the y-up flip the top edge is `gyMax`; in y-down free space it is
-            // `gyMin` — `min` picks the right one either way (issue #143/#16).
-            const [c0x, c0y] = outer([tx + minX, ty + minY]);
-            const [c1x, c1y] = outer([tx + minX + width, ty + minY + height]);
-            const bx = Math.min(c0x, c1x);
-            const by = Math.min(c0y, c1y);
+            // Pixel bbox top-left, flip-AGNOSTIC (see `pixelBox`): under the
+            // y-up flip the top edge is `gyMax`, in y-down free space it is
+            // `gyMin` — the component-wise min picks the right one (issue #143/#16).
+            const { x: bx, y: by } = pixelBox(
+              [tx + minX, ty + minY],
+              [tx + minX + width, ty + minY + height],
+              outer
+            );
 
             // The two layers are lowered RELATIVE to the bbox pixel origin, not
             // at absolute pixels. The SVG backend places each layer in a
@@ -302,11 +303,12 @@ export const mask = createNodeOperator(
           const minY = intrinsicDims?.[1]?.min ?? 0;
           const width = intrinsicDims?.[0]?.size ?? 0;
           const height = intrinsicDims?.[1]?.size ?? 0;
-          // Flip-agnostic bbox top-left — see the compositor above (#143/#16).
-          const [c0x, c0y] = outer([tx + minX, ty + minY]);
-          const [c1x, c1y] = outer([tx + minX + width, ty + minY + height]);
-          const bx = Math.min(c0x, c1x);
-          const by = Math.min(c0y, c1y);
+          // Flip-agnostic bbox top-left — see `pixelBox` / the compositor (#143/#16).
+          const { x: bx, y: by } = pixelBox(
+            [tx + minX, ty + minY],
+            [tx + minX + width, ty + minY + height],
+            outer
+          );
 
           return [
             {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
@@ -114,10 +114,14 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
             const minY = intrinsicDims?.[1]?.min ?? 0;
             const width = intrinsicDims?.[0]?.size ?? 0;
             const height = intrinsicDims?.[1]?.size ?? 0;
-            // Pixel bbox: the y-up box [tx+minX, …] × [ty+minY, …] mapped
-            // through the outer toPixel. The y-up top edge (gyMax) maps to the
-            // smaller SVG y, so the top-left corner is toPixel([xMin, yMax]).
-            const [bx, by] = outer([tx + minX, ty + minY + height]);
+            // Pixel bbox top-left, flip-AGNOSTIC: map both diagonal corners
+            // through the outer toPixel and take the component-wise min. Under
+            // the y-up flip the top edge is `gyMax`; in y-down free space it is
+            // `gyMin` — `min` picks the right one either way (issue #143/#16).
+            const [c0x, c0y] = outer([tx + minX, ty + minY]);
+            const [c1x, c1y] = outer([tx + minX + width, ty + minY + height]);
+            const bx = Math.min(c0x, c1x);
+            const by = Math.min(c0y, c1y);
 
             // The two layers are lowered RELATIVE to the bbox pixel origin, not
             // at absolute pixels. The SVG backend places each layer in a
@@ -298,7 +302,11 @@ export const mask = createNodeOperator(
           const minY = intrinsicDims?.[1]?.min ?? 0;
           const width = intrinsicDims?.[0]?.size ?? 0;
           const height = intrinsicDims?.[1]?.size ?? 0;
-          const [bx, by] = outer([tx + minX, ty + minY + height]);
+          // Flip-agnostic bbox top-left — see the compositor above (#143/#16).
+          const [c0x, c0y] = outer([tx + minX, ty + minY]);
+          const [c1x, c1y] = outer([tx + minX + width, ty + minY + height]);
+          const bx = Math.min(c0x, c1x);
+          const by = Math.min(c0y, c1y);
 
           return [
             {

--- a/packages/gofish-graphics/src/ast/labels/renderLabel.tsx
+++ b/packages/gofish-graphics/src/ast/labels/renderLabel.tsx
@@ -4,6 +4,7 @@ import { luv } from "culori";
 import type { DisplayList } from "gofish-ir";
 import type { GoFishNode, ToPixel } from "../_node";
 import { displayTranslate, type Transform } from "../dims";
+import { toPixelFlipsY } from "../displayList/lowerHelpers";
 import { getValue, type MaybeValue } from "../data";
 import { resolveColorChannel } from "../../color";
 import {
@@ -140,10 +141,11 @@ function computeLabel(
 
 /**
  * Lower a node's label to a display-list `TextItem` (role `overlay`). Mirrors
- * {@link renderLabelJSX}: the anchor is mapped to a final pixel via `toPixel`,
- * and the label's `rotate(-rotate) scale(1,-1)` under the root flip becomes a
- * screen-space `rotate(+rotate)` about the pixel anchor (the extra flip negates
- * the angle; see the rendering essay).
+ * {@link renderLabelJSX}: the anchor is mapped to a final pixel via `toPixel`.
+ * Rotation sign is flip-AGNOSTIC: in a `yUp` chart scope `toPixel` mirrors y,
+ * which negates the authored `rotate(-rotate)` into a screen `+rotate`; in
+ * y-down free space there is no mirror, so it stays `-rotate`. Read out of
+ * `toPixel` via `toPixelFlipsY` (issue #143/#16).
  */
 export function lowerLabelItems(
   node: GoFishNode,
@@ -166,6 +168,6 @@ export function lowerLabelItems(
     role: "overlay",
     style: { fill: l.labelColor },
   };
-  if (l.rotate) item.rotate = l.rotate;
+  if (l.rotate) item.rotate = toPixelFlipsY(toPixel) ? l.rotate : -l.rotate;
   return [item];
 }

--- a/packages/gofish-graphics/src/ast/legends/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/legends/elaborate.tsx
@@ -93,19 +93,32 @@ const BAR_LABEL_GAP = 4; // gap between a tick mark and its label
  */
 export async function legendColorbar(
   scaleFn: (v: number) => string,
-  domain: [number, number]
+  domain: [number, number],
+  yUp = true
 ): Promise<GoFishNode> {
   const [min, max] = domain;
   const bandH = BAR_HEIGHT / BAND_COUNT;
+  // The bar is laid out in fixed y-up logical coordinates (band 0 at the base,
+  // domain max at the top). The PHYSICAL layout never changes — what flips for a
+  // y-down render is which value each slot shows and where the ticks land — so
+  // the band-overlap seam logic below stays intact (a pure coordinate mirror
+  // would invert the overlap and reopen seams). In y-up the slot at height `y`
+  // shows value `min + y/BAR_HEIGHT·range`; in y-down it shows the mirror, so the
+  // domain max still reads at the top of the (now unflipped) bar. See #143/#16.
   const valueToPx = (v: number) =>
     (max === min ? 0 : (v - min) / (max - min)) * BAR_HEIGHT;
+  // Pixel height (from the band-0 base) at which value `v`'s color/tick belongs.
+  const valueToBarY = (v: number) =>
+    yUp ? valueToPx(v) : BAR_HEIGHT - valueToPx(v);
 
   const bandName = (i: number) => `__cbBand${i}`;
   const tickName = (i: number) => `__cbTick${i}`;
   const labelName = (i: number) => `__cbLabel${i}`;
 
   const bands = Array.from({ length: BAND_COUNT }, (_, i) => {
-    const value = min + ((i + 0.5) / BAND_COUNT) * (max - min);
+    // Slot `i` sits at height `i·bandH`; the value shown there mirrors when y-down.
+    const frac = (yUp ? i + 0.5 : BAND_COUNT - i - 0.5) / BAND_COUNT;
+    const value = min + frac * (max - min);
     return Rect({
       w: BAR_WIDTH,
       h: bandH + BAND_OVERLAP,
@@ -163,7 +176,7 @@ export async function legendColorbar(
     // separate position constraints so the label can sit start-aligned in x
     // while staying middle-aligned in y (one shared anchor can't do both).
     tickValues.forEach((v, i) => {
-      const cy = valueToPx(v);
+      const cy = valueToBarY(v);
       cs.push(
         Constraint.position(
           { x: BAR_WIDTH + TICK_MARK_LEN / 2, y: cy, anchor: "middle" },
@@ -203,7 +216,7 @@ export async function elaborateLegend(
 ): Promise<GoFishNode> {
   const legend =
     "scaleFn" in scale
-      ? await legendColorbar(scale.scaleFn, scale.domain)
+      ? await legendColorbar(scale.scaleFn, scale.domain, yUp)
       : legendColumn(scale.color, yUp);
   return wrapPreservingIdentity(node, async (content) => {
     content.name(CONTENT_NAME);

--- a/packages/gofish-graphics/src/ast/legends/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/legends/elaborate.tsx
@@ -221,8 +221,14 @@ export async function elaborateLegend(
         g[CONTENT_NAME],
         g[LEGEND_NAME],
       ]),
-      // Top-align the column with the content top (y-up: end = top).
-      Constraint.align({ y: "end" }, [g[CONTENT_NAME], g[LEGEND_NAME]]),
+      // Top-align the column with the content top. "Top" is the far edge in
+      // y-up (end) but the near edge in y-down (start), so the anchor follows
+      // the render orientation — otherwise a y-down chart (heatmap) seats the
+      // legend at the bottom. See issue #143/#16.
+      Constraint.align({ y: yUp ? "end" : "start" }, [
+        g[CONTENT_NAME],
+        g[LEGEND_NAME],
+      ]),
     ]);
 
     return root;

--- a/packages/gofish-graphics/src/ast/legends/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/legends/elaborate.tsx
@@ -51,16 +51,20 @@ function legendRow(key: any, color: string): GoFishNode {
 }
 
 /**
- * The swatch column. `reverse: true` because `Spread({dir:"y"})` lays children
- * bottom→top in y-up coordinates, so the first color-map entry must render last
- * (at the top), matching the bespoke legend.
+ * The swatch column. Entries read top→bottom. Under the y-up chart flip a
+ * `Spread({dir:"y"})` lays children bottom→top, so the first color-map entry
+ * must render last (`reverse`) to land at the top; in y-down free space the
+ * natural order already reads top→bottom, so no reverse. See issue #143/#16.
  */
-export function legendColumn(colorMap: Map<any, string>): GoFishNode {
+export function legendColumn(
+  colorMap: Map<any, string>,
+  yUp = true
+): GoFishNode {
   const rows = [...colorMap.entries()].map(([key, color]) =>
     legendRow(key, color)
   );
   return (Spread as any)(
-    { dir: "y", spacing: ROW_GAP, alignment: "start", reverse: true },
+    { dir: "y", spacing: ROW_GAP, alignment: "start", reverse: yUp },
     rows
   ).name(LEGEND_NAME) as GoFishNode;
 }
@@ -194,12 +198,13 @@ export async function legendColorbar(
  */
 export async function elaborateLegend(
   node: GoFishNode,
-  scale: CategoricalScale | ContinuousColorScale
+  scale: CategoricalScale | ContinuousColorScale,
+  yUp = true
 ): Promise<GoFishNode> {
   const legend =
     "scaleFn" in scale
       ? await legendColorbar(scale.scaleFn, scale.domain)
-      : legendColumn(scale.color);
+      : legendColumn(scale.color, yUp);
   return wrapPreservingIdentity(node, async (content) => {
     content.name(CONTENT_NAME);
 

--- a/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
+++ b/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
@@ -508,6 +508,12 @@ export class ChartBuilder<TInput, TOutput = TInput> {
       result = await Layer({}, [node, connectFrame]);
     }
 
+    // Mark the resolved node as a chart so the root render knows to use the
+    // y-UP scope even when this chart is composed inside a `gofish([...])` /
+    // `.layer()` whose render entry never saw the builder's `yUp` option. See
+    // `_isChart` and issue #143/#16.
+    result._isChart = true;
+
     if (this.nodeZOrder !== undefined) {
       result.zOrder(this.nodeZOrder);
     }
@@ -591,6 +597,10 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     return {
       node,
       options: {
+        // A chart is a y-UP render scope (bars grow up, y-axis increases
+        // upward). Free-space `gofish()` renders y-down (SVG-native top-left
+        // origin); `chart()` opts into y-up here. See issue #143/#16.
+        yUp: true,
         ...options,
         axes: this.options?.axes,
         colorConfig: this.options?.color,
@@ -745,6 +755,9 @@ export class LayerBuilder {
     return {
       node,
       options: {
+        // A chart is a y-UP render scope — see the sibling resolveForRender and
+        // issue #143/#16. Free-space `gofish()` stays y-down.
+        yUp: true,
         ...options,
         axes: (options as any).axes ?? meta.axes,
         colorConfig: meta.colorConfig,

--- a/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
+++ b/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
@@ -508,11 +508,12 @@ export class ChartBuilder<TInput, TOutput = TInput> {
       result = await Layer({}, [node, connectFrame]);
     }
 
-    // Mark the resolved node as a chart so the root render knows to use the
-    // y-UP scope even when this chart is composed inside a `gofish([...])` /
-    // `.layer()` whose render entry never saw the builder's `yUp` option. See
-    // `_isChart` and issue #143/#16.
-    result._isChart = true;
+    // y-up is no longer a chart-vs-not flag: the root render decides it
+    // semantically from the resolved y space (a CONTINUOUS value axis flips,
+    // an ORDINAL category axis does not), so a vertical bar chart flips while a
+    // horizontal one reads top-down — and a chart composed inside a
+    // `gofish([...])`/`.layer()` gets the same treatment for free. See
+    // `subtreeHasCoord`/`isCONTINUOUS` in gofish.tsx and issue #143/#16.
 
     if (this.nodeZOrder !== undefined) {
       result.zOrder(this.nodeZOrder);
@@ -597,10 +598,9 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     return {
       node,
       options: {
-        // A chart is a y-UP render scope (bars grow up, y-axis increases
-        // upward). Free-space `gofish()` renders y-down (SVG-native top-left
-        // origin); `chart()` opts into y-up here. See issue #143/#16.
-        yUp: true,
+        // y-up is decided by the root render from the resolved y space (a
+        // CONTINUOUS value axis flips, an ORDINAL category axis reads
+        // top-down) — not forced here. See issue #143/#16.
         ...options,
         axes: this.options?.axes,
         colorConfig: this.options?.color,
@@ -755,9 +755,8 @@ export class LayerBuilder {
     return {
       node,
       options: {
-        // A chart is a y-UP render scope — see the sibling resolveForRender and
-        // issue #143/#16. Free-space `gofish()` stays y-down.
-        yUp: true,
+        // y-up is decided by the root render from the resolved y space — see
+        // the sibling resolveForRender and issue #143/#16.
         ...options,
         axes: (options as any).axes ?? meta.axes,
         colorConfig: meta.colorConfig,

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -21,7 +21,7 @@ import {
 import { createMark } from "../withGoFish";
 import { attachCut } from "../graphicalOperators/cut";
 import type { DisplayList } from "gofish-ir";
-import { lowerStyle } from "../displayList/lowerHelpers";
+import { lowerStyle, pixelBox } from "../displayList/lowerHelpers";
 
 type ImageDimensions = {
   width: number;
@@ -352,13 +352,16 @@ export const Image = ({
         const width = intrinsicDims?.[0]?.size ?? 0;
         const height = intrinsicDims?.[1]?.size ?? 0;
 
-        const [ax, ay] = toPixel([x, y]);
-        const [bx, by] = toPixel([x + width, y + height]);
+        const { x: px, y: py } = pixelBox(
+          [x, y],
+          [x + width, y + height],
+          toPixel
+        );
         const style = lowerStyle({ opacity, filter });
         const item: DisplayList.ImageItem = {
           kind: "image",
-          x: Math.min(ax, bx),
-          y: Math.min(ay, by),
+          x: px,
+          y: py,
           w: Math.abs(width),
           h: Math.abs(height),
           href,

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -335,11 +335,12 @@ export const Image = ({
           },
         };
       },
-      // IR lowering — structural mirror of `render`. The legacy
-      // `transform="scale(1,-1)" y={-y-height}` y-flip folds into `toPixel`: the
-      // y-up box has min-x `x` and spans y `[y, y+height]`, so its display
-      // top-left corner is `(x, y+height)`, which `toPixel` maps to the y-down
-      // top-left pixel.
+      // IR lowering — structural mirror of `render`. Flip-AGNOSTIC: the box
+      // spans x `[x, x+width]`, y `[y, y+height]`; map both diagonal corners
+      // through `toPixel` and take the component-wise min for the SVG top-left.
+      // Correct under y-down free space and the `yUp` chart scope alike — where
+      // `toPixel` un-mirrors, the top-left is `(x, y+height)`; in y-down it is
+      // `(x, y)` (issue #143/#16).
       lower: (
         { intrinsicDims, transform, toPixel },
         _children,
@@ -351,12 +352,13 @@ export const Image = ({
         const width = intrinsicDims?.[0]?.size ?? 0;
         const height = intrinsicDims?.[1]?.size ?? 0;
 
-        const [px, py] = toPixel([x, y + height]);
+        const [ax, ay] = toPixel([x, y]);
+        const [bx, by] = toPixel([x + width, y + height]);
         const style = lowerStyle({ opacity, filter });
         const item: DisplayList.ImageItem = {
           kind: "image",
-          x: px,
-          y: py,
+          x: Math.min(ax, bx),
+          y: Math.min(ay, by),
           w: Math.abs(width),
           h: Math.abs(height),
           href,

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -27,7 +27,11 @@ import {
 } from "../underlyingSpace";
 import { createMark } from "../withGoFish";
 import type { DisplayList } from "gofish-ir";
-import { lowerStyle, rectItemFromBox } from "../displayList/lowerHelpers";
+import {
+  lowerStyle,
+  rectItemFromBox,
+  toPixelFlipsY,
+} from "../displayList/lowerHelpers";
 type TextDimensions = {
   width: number;
   height: number;
@@ -301,10 +305,12 @@ export const Text = ({
           renderData: { layout },
         };
       },
-      // IR lowering — mirror of `render`. The anchor maps through `toPixel`; the
-      // legacy `… rotate(rotate) scale(1,-1)` under the root flip nets to a
-      // screen-space rotate of `-rotate` about the pixel anchor (the extra flip
-      // negates the angle — see the rendering essay). Unrotated → upright text.
+      // IR lowering — mirror of `render`. The anchor maps through `toPixel`.
+      // Rotation sign is flip-AGNOSTIC: in a `yUp` chart scope `toPixel` mirrors
+      // y, which negates a screen-space rotate (`-rotate`); in y-down free space
+      // there is no mirror, so the rotate passes through (`+rotate`). We read the
+      // flip out of `toPixel` via `toPixelFlipsY` (issue #143/#16). Unrotated →
+      // upright text either way.
       lower: (
         { transform, renderData, toPixel },
         _children,
@@ -383,7 +389,7 @@ export const Text = ({
             filter,
           }),
         };
-        if (rotate) textItem.rotate = -rotate;
+        if (rotate) textItem.rotate = toPixelFlipsY(toPixel) ? -rotate : rotate;
         items.push(textItem);
         return items;
       },

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -312,7 +312,7 @@ export const Text = ({
       // flip out of `toPixel` via `toPixelFlipsY` (issue #143/#16). Unrotated →
       // upright text either way.
       lower: (
-        { transform, renderData, toPixel },
+        { transform, renderData, toPixel, intrinsicDims },
         _children,
         node
       ): DisplayList.DisplayItem[] => {
@@ -321,8 +321,21 @@ export const Text = ({
           : textContent;
         const text = finalText == null ? "" : String(finalText);
 
+        const flips = toPixelFlipsY(toPixel);
         const [anchorX, anchorY] = displayTranslate(transform);
-        const [px, py] = toPixel([anchorX, anchorY]);
+        const [px, py0] = toPixel([anchorX, anchorY]);
+        // Text's vertical box is asymmetric about the baseline (ascent ≠ descent
+        // for `auto`). Under the y-up flip that asymmetry resolves correctly; in
+        // y-down free space the SVG baseline must shift by (minY + maxY) so the
+        // glyphs fill the un-mirrored layout box (zero for a symmetric `central`
+        // baseline, and zero under the flip → charts stay byte-identical). The
+        // rotated case carries its footprint in the rotate transform. #143/#16.
+        const baselineShift =
+          flips || rotate
+            ? 0
+            : 2 * (intrinsicDims?.[1]?.min ?? 0) +
+              (intrinsicDims?.[1]?.size ?? 0);
+        const py = py0 + baselineShift;
 
         const unitScale = node.getRenderSession().scaleContext?.unit;
         const resolvedFill = resolveColorChannel(fill, unitScale);
@@ -389,7 +402,7 @@ export const Text = ({
             filter,
           }),
         };
-        if (rotate) textItem.rotate = toPixelFlipsY(toPixel) ? -rotate : rotate;
+        if (rotate) textItem.rotate = flips ? -rotate : rotate;
         items.push(textItem);
         return items;
       },

--- a/packages/gofish-graphics/src/tests/nestedMosaic.ts
+++ b/packages/gofish-graphics/src/tests/nestedMosaic.ts
@@ -37,7 +37,7 @@ const classColor = {
 
 export const testNestedMosaic = () =>
   stackY(
-    { reverse: true, spacing: 4, alignment: "middle" },
+    { spacing: 4, alignment: "middle" },
     // TODO: I could probably make the width be uniform flexible basically
     _(titanic)
       .groupBy("class")
@@ -59,7 +59,6 @@ export const testNestedMosaic = () =>
                     w:
                       (_(sItems).sumBy("count") / _(items).sumBy("count")) *
                       100,
-                    reverse: true,
                     spacing: 0,
                     alignment: "middle",
                     sharedScale: true,

--- a/packages/gofish-graphics/src/tests/nestedWaffle.ts
+++ b/packages/gofish-graphics/src/tests/nestedWaffle.ts
@@ -40,7 +40,7 @@ const classColor = {
 
 export const testNestedWaffle = () =>
   stackY(
-    { reverse: true, spacing: 8, alignment: "middle", sharedScale: true },
+    { spacing: 8, alignment: "middle", sharedScale: true },
     _(titanic)
       .groupBy("class")
       .map((cls) =>
@@ -51,7 +51,7 @@ export const testNestedWaffle = () =>
             .map((sex) =>
               enclose({}, [
                 stackY(
-                  { reverse: true, spacing: 0.5, alignment: "end" },
+                  { spacing: 0.5, alignment: "end" },
                   _(sex) // Was missing this lodash chain before .reverse()
                     .reverse()
                     .flatMap((d) => Array(d.count).fill(d))

--- a/packages/gofish-graphics/src/tests/sankeyIcicle.ts
+++ b/packages/gofish-graphics/src/tests/sankeyIcicle.ts
@@ -69,7 +69,7 @@ export const testSankeyIcicle = () =>
   frame([
     spread({ dir: "x", spacing: layerSpacing, alignment: "middle" }, [
       stackY(
-        { reverse: true, alignment: "middle" },
+        { alignment: "middle" },
         _(titanic)
           .groupBy("class")
           .map((items, cls) =>
@@ -83,7 +83,7 @@ export const testSankeyIcicle = () =>
           .value()
       ),
       spreadY(
-        { reverse: true, spacing: internalSpacing, alignment: "middle" },
+        { spacing: internalSpacing, alignment: "middle" },
         _(titanic)
           .groupBy("class")
           .map((items, cls) =>
@@ -92,7 +92,6 @@ export const testSankeyIcicle = () =>
                 stackY(
                   {
                     name: `${cls}-tgt`,
-                    reverse: true,
                     alignment: "middle",
                   },
                   _(items)
@@ -110,7 +109,6 @@ export const testSankeyIcicle = () =>
                 spreadY(
                   {
                     h: _(items).sumBy("count") / 10,
-                    reverse: true,
                     spacing: internalSpacing * 2,
                     alignment: "middle",
                   },
@@ -125,7 +123,6 @@ export const testSankeyIcicle = () =>
                           stackY(
                             {
                               name: `${cls}-${sex}-tgt`,
-                              reverse: true,
                               alignment: "middle",
                             },
                             _(items)
@@ -156,7 +153,6 @@ export const testSankeyIcicle = () =>
                           spreadY(
                             {
                               w: 40,
-                              reverse: true,
                               spacing: internalSpacing * 4,
                               alignment: "middle",
                             },

--- a/packages/gofish-graphics/stories/atom/TitanicFacet.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/TitanicFacet.stories.tsx
@@ -48,7 +48,9 @@ export const Default: StoryObj<Args> = {
             .flow(
               derive((rows) => orderBy(rows, ["survived"], ["desc"])),
               derive((rows) => chunk(rows, Math.ceil(Math.sqrt(rows.length)))),
-              spread({ spacing: 2, dir: "y" }),
+              // Fill each cell bottom-up (y-down free space: reverse so the
+              // partial last row lands at the top), like a waffle that grows up.
+              spread({ spacing: 2, dir: "y", reverse: true }),
               spread({ spacing: 2, dir: "x" })
             )
             .mark(circle({ r: 4, fill: "survived" }))

--- a/packages/gofish-graphics/stories/atom/UnitColumnChart.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/UnitColumnChart.stories.tsx
@@ -49,8 +49,9 @@ export const Default: StoryObj<Args> = {
 
     chart(titanicPassengers, {
       color: palette(["#2b8cbe", "#ff8408"]),
-      // x = pclass (the columns); y is the dot-row index, so suppress it.
-      axes: { x: true, y: false },
+      // x = pclass (the columns) at the bottom (y-end), under the upward-filling
+      // columns; y is the dot-row index, so suppress it.
+      axes: { x: { side: "end" }, y: false },
     })
       // Bottom-align the columns (y-down free space: "end" = bottom) so the
       // unit stacks share a baseline and grow upward. (The pclass tick labels
@@ -62,7 +63,8 @@ export const Default: StoryObj<Args> = {
           .flow(
             derive((rows) => orderBy(rows, ["survived"], ["desc"])),
             derive((rows) => chunk(rows, args.cols)),
-            spread({ spacing: 2, dir: "y" }),
+            // Reverse the rows so the ragged partial row lands at the top.
+            spread({ spacing: 2, dir: "y", reverse: true }),
             spread({ spacing: 2, dir: "x" })
           )
           .mark(circle({ r: 4, fill: "survived" }))

--- a/packages/gofish-graphics/stories/atom/UnitColumnChart.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/UnitColumnChart.stories.tsx
@@ -35,7 +35,7 @@ export default meta;
 type Args = { w: number; h: number; cols: number };
 
 export const Default: StoryObj<Args> = {
-  args: { w: 520, h: 420, cols: 14 },
+  args: { w: 520, h: 580, cols: 14 },
   tags: ["gallery"],
   parameters: {
     gallery: {

--- a/packages/gofish-graphics/stories/atom/UnitColumnChart.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/UnitColumnChart.stories.tsx
@@ -52,7 +52,11 @@ export const Default: StoryObj<Args> = {
       // x = pclass (the columns); y is the dot-row index, so suppress it.
       axes: { x: true, y: false },
     })
-      .flow(spread({ by: "pclass", dir: "x", spacing: 24, alignment: "start" }))
+      // Bottom-align the columns (y-down free space: "end" = bottom) so the
+      // unit stacks share a baseline and grow upward. (The pclass tick labels
+      // collapsing to the origin is a pre-existing nested-chart axis limitation,
+      // independent of y-up/down.)
+      .flow(spread({ by: "pclass", dir: "x", spacing: 24, alignment: "end" }))
       .mark((d) =>
         chart(d)
           .flow(

--- a/packages/gofish-graphics/stories/atom/UnitHistogram.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/UnitHistogram.stories.tsx
@@ -43,7 +43,7 @@ export default meta;
 type Args = { w: number; h: number; width: number };
 
 export const Default: StoryObj<Args> = {
-  args: { w: 900, h: 380, width: 3 },
+  args: { w: 900, h: 560, width: 3 },
   tags: ["gallery"],
   parameters: {
     gallery: {
@@ -57,8 +57,9 @@ export const Default: StoryObj<Args> = {
 
     chart(agedPassengers, {
       color: palette(["#2b8cbe", "#ff8408"]),
-      // x = pclass (the panels); y is the dot-row index, so suppress it.
-      axes: { x: true, y: false },
+      // x = pclass (the panels) at the bottom (y-end); y is the dot-row index,
+      // so suppress it.
+      axes: { x: { side: "end" }, y: false },
     })
       // Bottom-align panels and their age-bin bars (y-down free space: "end" =
       // bottom) so every unit stack shares a baseline and grows upward.
@@ -71,7 +72,8 @@ export const Default: StoryObj<Args> = {
               .flow(
                 derive((rows) => orderBy(rows, ["survived"], ["desc"])),
                 derive((rows) => chunk(rows, args.width)),
-                spread({ spacing: 1.5, dir: "y" }),
+                // Reverse so the ragged partial row lands at the top.
+                spread({ spacing: 1.5, dir: "y", reverse: true }),
                 spread({ spacing: 1.5, dir: "x" })
               )
               .mark(circle({ r: 3, fill: "survived" }))

--- a/packages/gofish-graphics/stories/atom/UnitHistogram.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/UnitHistogram.stories.tsx
@@ -60,10 +60,12 @@ export const Default: StoryObj<Args> = {
       // x = pclass (the panels); y is the dot-row index, so suppress it.
       axes: { x: true, y: false },
     })
-      .flow(spread({ by: "pclass", dir: "x", spacing: 40, alignment: "start" }))
+      // Bottom-align panels and their age-bin bars (y-down free space: "end" =
+      // bottom) so every unit stack shares a baseline and grows upward.
+      .flow(spread({ by: "pclass", dir: "x", spacing: 40, alignment: "end" }))
       .mark((panel) =>
         chart(panel)
-          .flow(spread({ by: "ageBin", dir: "x", spacing: 6, alignment: "start" }))
+          .flow(spread({ by: "ageBin", dir: "x", spacing: 6, alignment: "end" }))
           .mark((bin) =>
             chart(bin)
               .flow(

--- a/packages/gofish-graphics/stories/atom/Violin.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/Violin.stories.tsx
@@ -73,7 +73,17 @@ export const Default: StoryObj<Args> = {
       .flow(spread({ by: "pclass", dir: "x", spacing: 48, alignment: "middle" }))
       .mark((panel) =>
         chart(panel)
-          .flow(spread({ by: "ageBin", dir: "y", spacing: 1, alignment: "middle" }))
+          // Reverse so age increases UPWARD (youngest bin at the bottom) in
+          // y-down free space — the density silhouette stacks up the age axis.
+          .flow(
+            spread({
+              by: "ageBin",
+              dir: "y",
+              spacing: 1,
+              alignment: "middle",
+              reverse: true,
+            })
+          )
           .mark((bin) =>
             chart(bin)
               .flow(spread({ dir: "x", spacing: 1, alignment: "middle" }))

--- a/packages/gofish-graphics/stories/atom/Violin.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/Violin.stories.tsx
@@ -67,8 +67,9 @@ export const Default: StoryObj<Args> = {
 
     chart(agedPassengers, {
       color: palette(["#2b8cbe", "#ff8408"]),
-      // x = pclass (the violins); y is the dot-row index, so suppress it.
-      axes: { x: true, y: false },
+      // x = pclass (the violins) at the bottom (y-end); y is the dot-row index,
+      // so suppress it.
+      axes: { x: { side: "end" }, y: false },
     })
       .flow(spread({ by: "pclass", dir: "x", spacing: 48, alignment: "middle" }))
       .mark((panel) =>

--- a/packages/gofish-graphics/stories/bluefish/Planets.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/Planets.stories.tsx
@@ -60,9 +60,11 @@ export const PlanetsWithLabelAbove: StoryObj<Args> = {
           }).name(planet.name)
         )
       ),
+      // y-down free space: first child renders on top, so label-first puts the
+      // label ABOVE the planet (issue #143/#16).
       spread({ dir: "y", spacing: 60, alignment: "middle" }, [
-        ref("Mercury"),
         text({ text: "Mercury" }),
+        ref("Mercury"),
       ]),
     ]).render(container, {});
 
@@ -86,9 +88,10 @@ export const PlanetsWithLabelBelow: StoryObj<Args> = {
           }).name(planet.name)
         )
       ),
+      // y-down free space: label-second puts the label BELOW the planet.
       spread({ dir: "y", spacing: 60, alignment: "middle" }, [
-        text({ text: "Mercury" }),
         ref("Mercury"),
+        text({ text: "Mercury" }),
       ]),
     ]).render(container, {});
 
@@ -112,9 +115,10 @@ export const PlanetsWithLabelAboveNoSpacing: StoryObj<Args> = {
           }).name(planet.name)
         )
       ),
+      // y-down: label-first → label ABOVE the planet (issue #143/#16).
       spread({ dir: "y", spacing: 0, alignment: "middle" }, [
-        ref("Mercury"),
         text({ text: "Mercury", debugBoundingBox: true }),
+        ref("Mercury"),
       ]),
     ]).render(container, {});
 
@@ -138,9 +142,10 @@ export const PlanetsWithLabelBelowNoSpacing: StoryObj<Args> = {
           }).name(planet.name)
         )
       ),
+      // y-down: label-second → label BELOW the planet.
       spread({ dir: "y", spacing: 0, alignment: "middle" }, [
-        text({ text: "Mercury", debugBoundingBox: true }),
         ref("Mercury"),
+        text({ text: "Mercury", debugBoundingBox: true }),
       ]),
     ]).render(container, {});
 

--- a/packages/gofish-graphics/stories/bluefish/Pulley.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/Pulley.stories.tsx
@@ -65,12 +65,13 @@ const Weight = createMark(
   }) =>
     Layer([
       polygon({
-        // GoFish y-up: full-width bottom edge at y=0, inset top edge at y=height.
+        // y-down free space (issue #143/#16): the inset top edge is at y=0, the
+        // full-width bottom edge at y=height — a weight wider at the bottom.
         points: [
-          [0, 0],
-          [width, 0],
-          [width - 10, height],
-          [10, height],
+          [10, 0],
+          [width - 10, 0],
+          [width, height],
+          [0, height],
         ],
         fill: "#545454",
         stroke: "#545454",
@@ -129,10 +130,11 @@ export const Pulley: StoryObj<Args> = {
         Constraint.align({ x: ["middle", "start"] }, [c.A, c.B]),
         Constraint.align({ x: ["end", "start"] }, [c.B, c.C]),
 
-        // vertical placement (GoFish is y-up; pair order flipped vs Bluefish)
-        Constraint.distribute({ dir: "y", spacing: 40, mode: "edge" }, [c.B, c.ceiling]),
-        Constraint.distribute({ dir: "y", spacing: 30, mode: "edge" }, [c.A, c.B]),
-        Constraint.distribute({ dir: "y", spacing: 50, mode: "edge" }, [c.C, c.B]),
+        // vertical placement: y-down free space matches Bluefish's ttb order
+        // (ceiling on top, pulleys below, weights at the bottom) — #143/#16.
+        Constraint.distribute({ dir: "y", spacing: 40, mode: "edge" }, [c.ceiling, c.B]),
+        Constraint.distribute({ dir: "y", spacing: 30, mode: "edge" }, [c.B, c.A]),
+        Constraint.distribute({ dir: "y", spacing: 50, mode: "edge" }, [c.B, c.C]),
 
         // ceiling centered over the cluster (substitute for Bluefish <Group>)
         Constraint.align({ x: "middle" }, [c.B, c.ceiling]),
@@ -140,7 +142,7 @@ export const Pulley: StoryObj<Args> = {
         // weights (negative spacing offsets each weight so its inset trapezoid
         // top sits under the rope source points — not natural anchor points,
         // so these stay as `distribute`)
-        Constraint.distribute({ dir: "y", spacing: 50, mode: "edge" }, [c.w2, c.C]),
+        Constraint.distribute({ dir: "y", spacing: 50, mode: "edge" }, [c.C, c.w2]),
         Constraint.distribute({ dir: "x", spacing: -20, mode: "edge" }, [c.A, c.w2]),
         Constraint.distribute({ dir: "x", spacing: -15, mode: "edge" }, [c.w1, c.A]),
         Constraint.align({ y: "middle" }, [c.w2, c.w1]),
@@ -149,9 +151,9 @@ export const Pulley: StoryObj<Args> = {
         // one side and y-anchors to one corner of the wheel.
         ...(
           [
-            { pulley: c.A, label: c.Alabel, side: "left", y: "end" },
-            { pulley: c.B, label: c.Blabel, side: "right", y: "end" },
-            { pulley: c.C, label: c.Clabel, side: "right", y: "start" },
+            { pulley: c.A, label: c.Alabel, side: "left", y: "start" },
+            { pulley: c.B, label: c.Blabel, side: "right", y: "start" },
+            { pulley: c.C, label: c.Clabel, side: "right", y: "end" },
           ] as const
         ).flatMap(({ pulley, label, side, y }) => [
           Constraint.distribute(

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/PythonTutor.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/PythonTutor.stories.tsx
@@ -103,7 +103,9 @@ export const PythonTutor: StoryObj = {
     );
 
     Layer([
-      Spread({ dir: "x", alignment: "end", spacing: 100 }, [
+      // y-down free space: cross-axis "start" tops-aligns the global frame and
+      // the heap (issue #143/#16).
+      Spread({ dir: "x", alignment: "start", spacing: 100 }, [
         globalFrame({ stack: data.stack }).name(globalFrameName),
         heap({
           heap: data.heap,

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/elmTuple.ts
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/elmTuple.ts
@@ -43,7 +43,9 @@ export const elmTuple = createMark(
           ),
     ]).constrain(({ box, label, val }) => [
       Constraint.align({ x: "middle", y: "middle" }, [val, box]),
-      Constraint.align({ x: "start", y: "end" }, [label, box]),
+      // y-down free space: "start" is the top edge — keep the index label in
+      // the top-left of the cell (issue #143/#16).
+      Constraint.align({ x: "start", y: "start" }, [label, box]),
     ]);
   }
 );

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/globalFrame.ts
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/globalFrame.ts
@@ -35,9 +35,12 @@ export const globalFrame = createMark(({ stack }: GlobalFrameProps) => {
       )
     ).name(variablesTag),
   ]).constrain(({ label, frame, frameBorder, variables }) => [
-    Constraint.align({ x: "middle", y: "end" }, [label, frame]),
+    // y-down free space: "start" is the top edge. The "Global Frame" label
+    // sits at the top, variables stack below it (label-first), reading
+    // top→bottom (issue #143/#16).
+    Constraint.align({ x: "middle", y: "start" }, [label, frame]),
     Constraint.align({ x: "start", y: "middle" }, [frameBorder, frame]),
     Constraint.align({ x: "end" }, [variables, label]),
-    Constraint.distribute({ dir: "y", spacing: 10 }, [variables, label]),
+    Constraint.distribute({ dir: "y", spacing: 10 }, [label, variables]),
   ]);
 });

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/globalFrame.ts
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/globalFrame.ts
@@ -26,7 +26,7 @@ export const globalFrame = createMark(({ stack }: GlobalFrameProps) => {
       text: "Global Frame",
     }).name("label"),
     Spread(
-      { dir: "y", alignment: "end", spacing: 10, reverse: true },
+      { dir: "y", alignment: "end", spacing: 10 },
       stack.map((slot) =>
         stackSlot({
           variable: slot.variable,

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/heap.ts
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/heap.ts
@@ -10,7 +10,7 @@ export interface HeapProps {
 export const heap = createMark(
   ({ heap: heapObjects, heapArrangement }: HeapProps) =>
     Spread(
-      { dir: "y", alignment: "start", spacing: 75, reverse: true },
+      { dir: "y", alignment: "start", spacing: 75 },
       heapArrangement.map((row) =>
         Spread(
           { dir: "x", alignment: "end", spacing: 75 },

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/heapObject.ts
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/heapObject.ts
@@ -12,7 +12,7 @@ export const heapObject = createMark(
   ({ objectType, objectValues }: HeapObjectProps) => {
     const elmTuplesTag = createName("elmTuples");
     return Spread(
-      { dir: "y", alignment: "start", spacing: 10, reverse: true },
+      { dir: "y", alignment: "start", spacing: 10 },
       [
         text({
           fontFamily,

--- a/packages/gofish-graphics/stories/bluefish/PythonTutor/stackSlot.ts
+++ b/packages/gofish-graphics/stories/bluefish/PythonTutor/stackSlot.ts
@@ -40,7 +40,9 @@ export const stackSlot = createMark(
             ),
       ]).constrain(({ box, boxBorderBottom, boxBorderLeft, value }) => [
         Constraint.align({ x: "middle", y: "middle" }, [box, value]),
-        Constraint.align({ x: "middle", y: "start" }, [box, boxBorderBottom]),
+        // y-down free space: "end" is the bottom edge — keep the bottom border
+        // at the bottom of the box (issue #143/#16).
+        Constraint.align({ x: "middle", y: "end" }, [box, boxBorderBottom]),
         Constraint.align({ x: "start", y: "middle" }, [box, boxBorderLeft]),
       ]),
     ]);

--- a/packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx
@@ -92,7 +92,9 @@ export const ImageCutWithLabels: StoryObj<Args> = {
 
     layer<Datum>([
       chart(bottleData)
-        .flow(spread({ dir: "y", spacing: 20, reverse: true }))
+        // y-down free space: no reverse, so the first ingredient (Grape juice,
+        // the bulk) fills the bottle body at the bottom and Marketing sits up top.
+        .flow(spread({ dir: "y", spacing: 20 }))
         .mark(
           image({ href: bottlePng, w: 193, h: 600 })
             .cut({ dir: "y", size: "amount", inset: 4 })

--- a/packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx
@@ -91,10 +91,12 @@ export const ImageCutWithLabels: StoryObj<Args> = {
     type Datum = { category: string; amount: number };
 
     layer<Datum>([
-      chart(bottleData)
-        // y-down free space: no reverse, so the first ingredient (Grape juice,
-        // the bulk) fills the bottle body at the bottom and Marketing sits up top.
-        .flow(spread({ dir: "y", spacing: 20 }))
+      // The cut ties each slice's image band to data order (slice i = band i,
+      // top→bottom). To land Grape juice (the bulk) at the BOTTOM showing the
+      // bottle BODY, it must be the LAST data row (bottom band) AND positioned
+      // last — so reverse the data and keep `reverse: true` on the spread.
+      chart([...bottleData].reverse())
+        .flow(spread({ dir: "y", spacing: 20, reverse: true }))
         .mark(
           image({ href: bottlePng, w: 193, h: 600 })
             .cut({ dir: "y", size: "amount", inset: 4 })

--- a/packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx
@@ -408,9 +408,10 @@ export const CroissantStack: StoryObj<Args> = {
 
     layer([bands, axis])
       .constrain(({ bands, axis }: any) => [
-        // Axis row centered under the bands (both are W wide).
+        // Axis row centered under the bands (both are W wide). y-down free
+        // space: bands-first renders on top, axis below (issue #143/#16).
         Constraint.align({ x: "middle" }, [bands, axis]),
-        Constraint.distribute({ dir: "y", spacing: 12 }, [axis, bands]),
+        Constraint.distribute({ dir: "y", spacing: 12 }, [bands, axis]),
       ])
       .render(container, { axes: false });
 

--- a/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
@@ -411,8 +411,9 @@ export const NormalizedStackedBarWithLabels: StoryObj<Args> = {
         derive((d: any[]) =>
           d.map((row) => ({ ...row, sex: row.sex === 1 ? "Male" : "Female" }))
         ),
-        // One row per age group, stacked horizontally
-        spread({ by: "age",  dir: "y", reverse: true, spacing: 2 }),
+        // One row per age group; y-down reads top→bottom, so age 0 lands at the
+        // top (matching the Vega-Lite reference).
+        spread({ by: "age", dir: "y", spacing: 2 }),
         // Normalize within each age group so bars span 0→1
         derive((d: any[]) =>
           d.map((row) => ({

--- a/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
@@ -400,7 +400,11 @@ export const NormalizedStackedBarWithLabels: StoryObj<Args> = {
 
     chart(
       context.loaded.population.filter((row: any) => row.year === 2000) as any[],
-      { color: palette({ Female: "#675193", Male: "#ca8861" }), axes: true }
+      {
+        color: palette({ Female: "#675193", Male: "#ca8861" }),
+        // Keep the continuous proportion x-axis at the bottom (y-end).
+        axes: { x: { side: "end" }, y: true },
+      }
     )
       .flow(
         // Decode the sex field to a readable string

--- a/packages/gofish-graphics/stories/forwardsyntax/WaffleChart.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/WaffleChart.stories.tsx
@@ -26,7 +26,9 @@ export const Default: StoryObj<Args> = {
 
     chart(seafood, { axes: true })
       .flow(
-      spread({ by: "lake",  spacing: 8, dir: "x", axes: false }),
+      // Bottom-align the lake columns (y-down free space: "end" = bottom) so the
+      // waffles sit on a shared baseline and fill upward rather than hang down.
+      spread({ by: "lake", spacing: 8, dir: "x", axes: false, alignment: "end" }),
         derive((d) => d.flatMap((d) => repeat(d, "count"))),
         derive((d) => _.chunk(d, 5)),
         spread({ spacing: 2, dir: "y" }),

--- a/packages/gofish-graphics/stories/forwardsyntax/WaffleChart.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/WaffleChart.stories.tsx
@@ -31,7 +31,9 @@ export const Default: StoryObj<Args> = {
       spread({ by: "lake", spacing: 8, dir: "x", axes: false, alignment: "end" }),
         derive((d) => d.flatMap((d) => repeat(d, "count"))),
         derive((d) => _.chunk(d, 5)),
-        spread({ spacing: 2, dir: "y" }),
+        // Reverse the rows so the ragged (partial) last row lands at the TOP and
+        // the full rows fill the baseline upward (y-down free space).
+        spread({ spacing: 2, dir: "y", reverse: true }),
         spread({ spacing: 2, dir: "x" })
       )
       .mark(rect({ w: 8, h: 8, fill: "species" }))

--- a/packages/gofish-graphics/stories/forwardsyntax/WaffleChart.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/WaffleChart.stories.tsx
@@ -24,7 +24,9 @@ export const Default: StoryObj<Args> = {
   render: (args: Args) => {
     const container = initializeContainer();
 
-    chart(seafood, { axes: true })
+    // x-axis at the bottom (y-end) so the lake labels sit under the upward-
+    // filling waffle columns rather than above them.
+    chart(seafood, { axes: { x: { side: "end" } } })
       .flow(
       // Bottom-align the lake columns (y-down free space: "end" = bottom) so the
       // waffles sit on a shared baseline and fill upward rather than hang down.

--- a/packages/gofish-graphics/stories/lowlevel/Axes.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/Axes.stories.tsx
@@ -149,7 +149,7 @@ export const ContinuousYAxis: StoryObj<Args> = {
           Constraint.align({ y: "middle" }, [g.axis, g.title]),
         ];
       })
-      .render(container, { w: args.w, h: args.h, yUp: true });
+      .render(container, { w: args.w, h: args.h });
 
     return container;
   },
@@ -204,7 +204,7 @@ export const NonUniformYAxis: StoryObj<Args> = {
           Constraint.align({ y: "middle" }, [g.axis, g.title]),
         ];
       })
-      .render(container, { w: args.w, h: args.h, yUp: true });
+      .render(container, { w: args.w, h: args.h });
 
     return container;
   },

--- a/packages/gofish-graphics/stories/lowlevel/Axes.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/Axes.stories.tsx
@@ -149,7 +149,7 @@ export const ContinuousYAxis: StoryObj<Args> = {
           Constraint.align({ y: "middle" }, [g.axis, g.title]),
         ];
       })
-      .render(container, { w: args.w, h: args.h });
+      .render(container, { w: args.w, h: args.h, yUp: true });
 
     return container;
   },
@@ -204,7 +204,7 @@ export const NonUniformYAxis: StoryObj<Args> = {
           Constraint.align({ y: "middle" }, [g.axis, g.title]),
         ];
       })
-      .render(container, { w: args.w, h: args.h });
+      .render(container, { w: args.w, h: args.h, yUp: true });
 
     return container;
   },

--- a/packages/gofish-graphics/stories/lowlevel/IcicleChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/IcicleChart.stories.tsx
@@ -28,7 +28,7 @@ export const Simplified: StoryObj = {
         fill: neutral,
       }),
       stackY(
-        { reverse: true, alignment: "middle" },
+        { alignment: "middle" },
         _(titanic)
           .groupBy("class")
           .map((items, cls) =>
@@ -66,7 +66,7 @@ export const Default: StoryObj = {
         fill: neutral,
       }),
       stackY(
-        { reverse: true, alignment: "middle" },
+        { alignment: "middle" },
         _(titanic)
           .groupBy("class")
           .map((items, cls) =>
@@ -78,7 +78,7 @@ export const Default: StoryObj = {
               [
                 rect({ w: 40, fill: classColor[cls] }),
                 stackY(
-                  { reverse: true, alignment: "middle" },
+                  { alignment: "middle" },
                   _(items)
                     .groupBy("sex")
                     .map((items, sex) =>
@@ -91,7 +91,7 @@ export const Default: StoryObj = {
                         stackY(
                           {
                             w: 40,
-                            reverse: true,
+
                             alignment: "middle",
                           },
                           _(items)

--- a/packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
@@ -42,6 +42,9 @@ export const Default: StoryObj = {
                 w: (_(sItems).sumBy("count") / _(items).sumBy("count")) * 100,
                 alignment: "middle",
                 sharedScale: true,
+                // y-down: reverse so the colored (survived) part stacks ABOVE
+                // the gray (did-not-survive) part.
+                reverse: true,
               },
               For(groupBy(sItems, "survived"), (items, survived) =>
                 rect({

--- a/packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
@@ -30,7 +30,9 @@ export const Default: StoryObj = {
   render: () => {
     const container = initializeContainer();
     spreadY(
-      { spacing: 4, alignment: "start" },
+      // y-down free space: reverse so the first class (First) reads at the top
+      // and Crew at the bottom.
+      { spacing: 4, alignment: "start", reverse: true },
       For(groupBy(titanic, "class"), (items, cls) =>
         spreadX(
           { key: cls, h: _(items).sumBy("count") / 10, spacing: 2, alignment: "middle" },

--- a/packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
@@ -30,14 +30,13 @@ export const Default: StoryObj = {
   render: () => {
     const container = initializeContainer();
     spreadY(
-      { reverse: true, spacing: 4, alignment: "start" },
+      { spacing: 4, alignment: "start" },
       For(groupBy(titanic, "class"), (items, cls) =>
         spreadX(
           { key: cls, h: _(items).sumBy("count") / 10, spacing: 2, alignment: "middle" },
           For(groupBy(items, "sex"), (sItems, sex) =>
             stackY(
               {
-                reverse: true,
                 w: (_(sItems).sumBy("count") / _(items).sumBy("count")) * 100,
                 alignment: "middle",
                 sharedScale: true,

--- a/packages/gofish-graphics/stories/lowlevel/NestedWaffleChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/NestedWaffleChart.stories.tsx
@@ -40,7 +40,7 @@ export const Default: StoryObj<Args> = {
               .groupBy("sex")
               .map((sex) =>
                 spreadY(
-                  { spacing: 0.5, alignment: "end" },
+                  { spacing: 0.5, alignment: "start" },
                   _(sex) // Was missing this lodash chain before .reverse()
                     .reverse()
                     .flatMap((d) => Array(d.count).fill(d))
@@ -52,7 +52,7 @@ export const Default: StoryObj<Args> = {
                     .reverse()
                     .map((d) =>
                       spreadX(
-                        { spacing: 0.5, alignment: "end" },
+                        { spacing: 0.5, alignment: "start" },
                         d.map((d) =>
                           ellipse({
                             w: 4,

--- a/packages/gofish-graphics/stories/lowlevel/SankeyTree.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/SankeyTree.stories.tsx
@@ -34,7 +34,9 @@ export const Default: StoryObj = {
     layer([
       spreadX({ spacing: layerSpacing, alignment: "middle" }, [
         stackY(
-          { spacing: 0, alignment: "middle" },
+          // y-down: reverse every vertical ordering so the tiers read the same
+          // way they did under the old y-up convention. See issue #143/#16.
+          { spacing: 0, alignment: "middle", reverse: true },
           For(groupBy(titanic, "class"), (items, cls) =>
             rect({
               w: 40,
@@ -44,11 +46,11 @@ export const Default: StoryObj = {
           )
         ),
         spreadY(
-          { spacing: internalSpacing, alignment: "middle" },
+          { spacing: internalSpacing, alignment: "middle", reverse: true },
           For(groupBy(titanic, "class"), (items, cls) =>
             spreadX({ spacing: layerSpacing, alignment: "middle" }, [
               stackY(
-                { spacing: 0, alignment: "middle" },
+                { spacing: 0, alignment: "middle", reverse: true },
                 For(groupBy(items, "sex"), (items, sex) =>
                   rect({
                     w: 40,
@@ -62,6 +64,7 @@ export const Default: StoryObj = {
                   h: _(items).sumBy("count") / 10,
                   spacing: internalSpacing * 2,
                   alignment: "middle",
+                  reverse: true,
                 },
                 For(groupBy(items, "sex"), (items, sex) =>
                   spreadX({ spacing: layerSpacing, alignment: "middle" }, [
@@ -69,6 +72,7 @@ export const Default: StoryObj = {
                       {
                         spacing: 0,
                         alignment: "middle",
+                        reverse: true,
                       },
                       For(groupBy(items, "survived"), (survivedItems, survived) =>
                         rect({
@@ -83,6 +87,7 @@ export const Default: StoryObj = {
                         w: 40,
                         spacing: internalSpacing * 4,
                         alignment: "middle",
+                        reverse: true,
                       },
                       For(groupBy(items, "survived"), (survivedItems, survived) => {
                         return rect({

--- a/packages/gofish-graphics/stories/lowlevel/StringlineChart.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/StringlineChart.stories.tsx
@@ -28,7 +28,6 @@ export const Default: StoryObj<Args> = {
     layer({}, [
       spreadY(
         {
-          reverse: true,
           spacing: 8,
           alignment: "start",
         },

--- a/packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx
@@ -34,7 +34,7 @@ export const Default: StoryObj<Args> = {
           stackY(
             { alignment: "middle" },
             For(density, (d) =>
-              rect({ y: d.x / 40, w: d.y * 100000, h: 0, fill: v(species) }).name(
+              rect({ y: -d.x / 40, w: d.y * 100000, h: 0, fill: v(species) }).name(
                 `${species}-${d.x}`
               )
             )

--- a/packages/gofish-graphics/stories/lowlevel/Whisker.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/Whisker.stories.tsx
@@ -19,6 +19,7 @@ export const SingleBoxWhisker: StoryObj<Args> = {
 
     testSingleBoxWhisker().render(container, {
       axes: true,
+      yUp: true,
     });
 
     return container;
@@ -31,6 +32,7 @@ export const PairBoxWhisker: StoryObj<Args> = {
 
     testPairBoxWhisker().render(container, {
       axes: true,
+      yUp: true,
     });
 
     return container;
@@ -51,6 +53,7 @@ export const BoxWhisker: StoryObj<Args> = {
 
     testBoxWhiskerPlot().render(container, {
       axes: true,
+      yUp: true,
     });
 
     return container;

--- a/packages/gofish-graphics/stories/lowlevel/Whisker.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/Whisker.stories.tsx
@@ -19,7 +19,6 @@ export const SingleBoxWhisker: StoryObj<Args> = {
 
     testSingleBoxWhisker().render(container, {
       axes: true,
-      yUp: true,
     });
 
     return container;
@@ -32,7 +31,6 @@ export const PairBoxWhisker: StoryObj<Args> = {
 
     testPairBoxWhisker().render(container, {
       axes: true,
-      yUp: true,
     });
 
     return container;
@@ -53,7 +51,6 @@ export const BoxWhisker: StoryObj<Args> = {
 
     testBoxWhiskerPlot().render(container, {
       axes: true,
-      yUp: true,
     });
 
     return container;

--- a/packages/gofish-graphics/stories/vega-lite/StripPlot.stories.tsx
+++ b/packages/gofish-graphics/stories/vega-lite/StripPlot.stories.tsx
@@ -33,10 +33,11 @@ export const Default: StoryObj<Args> = {
         cylinders: Math.round(d.Cylinders),
       }));
 
-    chart(cars, { axes: true })
+    chart(cars, { axes: { x: { side: "end" }, y: true } })
       .flow(
-        derive((d) => [...d].sort((a, b) => b.cylinders - a.cylinders)),
-        spread({ by: "cylinders",  dir: "y" }),
+        // Ascending so cylinders read 3 at the top → 8 at the bottom in y-down.
+        derive((d) => [...d].sort((a, b) => a.cylinders - b.cylinders)),
+        spread({ by: "cylinders", dir: "y" }),
         scatter({ x: "horsepower" })
       )
       .mark(

--- a/tests/python-stories/atom/test_titanic_facet.py
+++ b/tests/python-stories/atom/test_titanic_facet.py
@@ -25,7 +25,9 @@ def story_default():
             .flow(
                 derive(order_by_survived),
                 derive(chunk_rows),
-                spread(spacing=2, dir="y"),
+                # Fill each cell bottom-up (y-down free space: reverse so the
+                # partial last row lands at the top), like a waffle that grows up.
+                spread(spacing=2, dir="y", reverse=True),
                 spread(spacing=2, dir="x"),
             )
             .mark(circle(r=4, fill="survived"))

--- a/tests/python-stories/bluefish/python-tutor/_components.py
+++ b/tests/python-stories/bluefish/python-tutor/_components.py
@@ -58,7 +58,7 @@ def stack_slot(variable: str, value=None):
                 lambda box, boxBorderBottom, boxBorderLeft, value: [
                     Constraint.align([box, value], x="middle", y="middle"),
                     Constraint.align(
-                        [box, boxBorderBottom], x="middle", y="start"
+                        [box, boxBorderBottom], x="middle", y="end"
                     ),
                     Constraint.align(
                         [box, boxBorderLeft], x="start", y="middle"
@@ -104,7 +104,7 @@ def elm_tuple(tupleIndex: str, tupleData=None):
     ).constrain(
         lambda box, label, val: [
             Constraint.align([val, box], x="middle", y="middle"),
-            Constraint.align([label, box], x="start", y="end"),
+            Constraint.align([label, box], x="start", y="start"),
         ]
     )
 
@@ -138,7 +138,6 @@ def heap_object(objectType: str, objectValues: list):
         dir="y",
         alignment="start",
         spacing=10,
-        reverse=True,
     )
 
 
@@ -182,7 +181,6 @@ def heap(heap: list, heapArrangement: list):
         dir="y",
         alignment="start",
         spacing=75,
-        reverse=True,
     )
 
 
@@ -213,14 +211,13 @@ def global_frame(stack: list):
                 dir="y",
                 alignment="end",
                 spacing=10,
-                reverse=True,
             ).name(variables_tag),
         ]
     ).constrain(
         lambda label, frame, frameBorder, variables: [
-            Constraint.align([label, frame], x="middle", y="end"),
+            Constraint.align([label, frame], x="middle", y="start"),
             Constraint.align([frameBorder, frame], x="start", y="middle"),
             Constraint.align([variables, label], x="end"),
-            Constraint.distribute([variables, label], dir="y", spacing=10),
+            Constraint.distribute([label, variables], dir="y", spacing=10),
         ]
     )

--- a/tests/python-stories/bluefish/python-tutor/test_python_tutor.py
+++ b/tests/python-stories/bluefish/python-tutor/test_python_tutor.py
@@ -94,7 +94,7 @@ def story_python_tutor():
                         ).name(heap_name),
                     ],
                     dir="x",
-                    alignment="end",
+                    alignment="start",
                     spacing=100,
                 ),
                 *stack_arrows,

--- a/tests/python-stories/bluefish/test_planets.py
+++ b/tests/python-stories/bluefish/test_planets.py
@@ -45,7 +45,7 @@ def story_planets_with_label_above():
         layer([
             _planet_row(),
             spread(
-                [ref("Mercury"), text(text="Mercury")],
+                [text(text="Mercury"), ref("Mercury")],
                 dir="y",
                 spacing=60,
                 alignment="middle",
@@ -60,7 +60,7 @@ def story_planets_with_label_below():
         layer([
             _planet_row(),
             spread(
-                [text(text="Mercury"), ref("Mercury")],
+                [ref("Mercury"), text(text="Mercury")],
                 dir="y",
                 spacing=60,
                 alignment="middle",
@@ -75,7 +75,7 @@ def story_planets_with_label_above_no_spacing():
         layer([
             _planet_row(),
             spread(
-                [ref("Mercury"), text(text="Mercury", debugBoundingBox=True)],
+                [text(text="Mercury", debugBoundingBox=True), ref("Mercury")],
                 dir="y",
                 spacing=0,
                 alignment="middle",
@@ -90,7 +90,7 @@ def story_planets_with_label_below_no_spacing():
         layer([
             _planet_row(),
             spread(
-                [text(text="Mercury", debugBoundingBox=True), ref("Mercury")],
+                [ref("Mercury"), text(text="Mercury", debugBoundingBox=True)],
                 dir="y",
                 spacing=0,
                 alignment="middle",

--- a/tests/python-stories/bluefish/test_pulley.py
+++ b/tests/python-stories/bluefish/test_pulley.py
@@ -63,13 +63,14 @@ def weight(width: float, height: float, label: str):
     return layer(
         [
             polygon(
-                # GoFish y-up: full-width bottom edge at y=0, inset top edge
-                # at y=height.
+                # y-down free space (issue #143/#16): the inset top edge is at
+                # y=0, the full-width bottom edge at y=height — a weight wider
+                # at the bottom.
                 points=[
-                    [0, 0],
-                    [width, 0],
-                    [width - 10, height],
-                    [10, height],
+                    [10, 0],
+                    [width - 10, 0],
+                    [width, height],
+                    [0, height],
                 ],
                 fill="#545454",
                 stroke="#545454",
@@ -125,16 +126,17 @@ def story_pulley():
                         # by half a wheel), C.start on B.end.
                         Constraint.align([A, B], x=["middle", "start"]),
                         Constraint.align([B, C], x=["end", "start"]),
-                        # Vertical placement (GoFish is y-up; pair order
-                        # flipped vs Bluefish).
+                        # Vertical placement: y-down free space matches
+                        # Bluefish's ttb order (ceiling on top, pulleys below,
+                        # weights at the bottom) — #143/#16.
                         Constraint.distribute(
-                            [B, ceiling], dir="y", spacing=40, mode="edge"
+                            [ceiling, B], dir="y", spacing=40, mode="edge"
                         ),
                         Constraint.distribute(
-                            [A, B], dir="y", spacing=30, mode="edge"
+                            [B, A], dir="y", spacing=30, mode="edge"
                         ),
                         Constraint.distribute(
-                            [C, B], dir="y", spacing=50, mode="edge"
+                            [B, C], dir="y", spacing=50, mode="edge"
                         ),
                         # Ceiling centered over the cluster.
                         Constraint.align([B, ceiling], x="middle"),
@@ -142,7 +144,7 @@ def story_pulley():
                         # its inset trapezoid top sits under the rope source
                         # points.
                         Constraint.distribute(
-                            [w2, C], dir="y", spacing=50, mode="edge"
+                            [C, w2], dir="y", spacing=50, mode="edge"
                         ),
                         Constraint.distribute(
                             [A, w2], dir="x", spacing=-20, mode="edge"
@@ -156,15 +158,15 @@ def story_pulley():
                         Constraint.distribute(
                             [Alabel, A], dir="x", spacing=1, mode="edge"
                         ),
-                        Constraint.align([A, Alabel], y="end"),
+                        Constraint.align([A, Alabel], y="start"),
                         Constraint.distribute(
                             [B, Blabel], dir="x", spacing=1, mode="edge"
                         ),
-                        Constraint.align([B, Blabel], y="end"),
+                        Constraint.align([B, Blabel], y="start"),
                         Constraint.distribute(
                             [C, Clabel], dir="x", spacing=1, mode="edge"
                         ),
-                        Constraint.align([C, Clabel], y="start"),
+                        Constraint.align([C, Clabel], y="end"),
                     ]
                 ),
                 # ── tier 2: rope segments — read the placed shapes ──────────

--- a/tests/python-stories/forward-syntax-v3/test_cut.py
+++ b/tests/python-stories/forward-syntax-v3/test_cut.py
@@ -356,9 +356,10 @@ def story_croissant_stack():
     return (
         layer([bands, axis]).constrain(
             lambda bands, axis, **_: [
-                # Axis row centered under the bands (both W wide).
+                # Axis row centered under the bands (both W wide). y-down free
+                # space: bands-first renders on top, axis below (issue #143/#16).
                 Constraint.align([bands, axis], x="middle"),
-                Constraint.distribute([axis, bands], dir="y", spacing=12),
+                Constraint.distribute([bands, axis], dir="y", spacing=12),
             ]
         ),
         {"axes": False},

--- a/tests/python-stories/forward-syntax-v3/test_labels.py
+++ b/tests/python-stories/forward-syntax-v3/test_labels.py
@@ -206,7 +206,8 @@ def story_normalized_stacked_bar_with_labels():
         )
         .flow(
             derive(_decode_sex),
-            spread(by="age", dir="y", reverse=True, spacing=2),
+            # y-down reads top→bottom, so age 0 lands at the top (Vega-Lite ref).
+            spread(by="age", dir="y", spacing=2),
             derive(_add_proportion),
             derive(_order_by_sex),
             stack(by="sex", dir="x"),

--- a/tests/python-stories/forward-syntax-v3/test_labels.py
+++ b/tests/python-stories/forward-syntax-v3/test_labels.py
@@ -216,5 +216,6 @@ def story_normalized_stacked_bar_with_labels():
                 "people", position="center", color="white"
             )
         ),
-        {"w": 350, "h": 400, "axes": True},
+        # Keep the continuous proportion x-axis at the bottom (y-end).
+        {"w": 350, "h": 400, "axes": {"x": {"side": "end"}, "y": True}},
     )

--- a/tests/python-stories/forward-syntax-v3/test_waffle_chart.py
+++ b/tests/python-stories/forward-syntax-v3/test_waffle_chart.py
@@ -18,5 +18,6 @@ def story_default():
             spread(spacing=2, dir="x"),
         )
         .mark(rect(w=8, h=8, fill="species")),
-        {"axes": True},
+        # x-axis at the bottom (y-end), under the upward-filling columns.
+        {"axes": {"x": {"side": "end"}}},
     )

--- a/tests/python-stories/forward-syntax-v3/test_waffle_chart.py
+++ b/tests/python-stories/forward-syntax-v3/test_waffle_chart.py
@@ -8,10 +8,13 @@ def story_default():
     return (
         chart(SEAFOOD)
         .flow(
-            spread(by="lake", spacing=8, dir="x", axes=False),
+            # Bottom-align the lake columns (y-down: "end" = bottom) so the
+            # waffles sit on a baseline and fill upward.
+            spread(by="lake", spacing=8, dir="x", axes=False, alignment="end"),
             derive(lambda d: [item for row in d for item in repeat(row, "count")]),
             derive(lambda d: [d[i : i + 5] for i in range(0, len(d), 5)]),
-            spread(spacing=2, dir="y"),
+            # Reverse the rows so the ragged partial row lands at the top.
+            spread(spacing=2, dir="y", reverse=True),
             spread(spacing=2, dir="x"),
         )
         .mark(rect(w=8, h=8, fill="species")),

--- a/tests/python-stories/low-level-syntax/test_icicle_chart.py
+++ b/tests/python-stories/low-level-syntax/test_icicle_chart.py
@@ -31,7 +31,6 @@ def story_simplified():
                         for cls, items in by_class.items()
                     ],
                     dir="y",
-                    reverse=True,
                     alignment="middle",
                 ),
             ],
@@ -58,7 +57,6 @@ def story_default():
             ],
             dir="y",
             w=40,
-            reverse=True,
             alignment="middle",
         )
 
@@ -80,7 +78,6 @@ def story_default():
                 for sex, s_items in group_by(items, "sex").items()
             ],
             dir="y",
-            reverse=True,
             alignment="middle",
         )
 
@@ -100,7 +97,6 @@ def story_default():
                 stack(
                     [_class_band(cls, items) for cls, items in by_class.items()],
                     dir="y",
-                    reverse=True,
                     alignment="middle",
                 ),
             ],

--- a/tests/python-stories/low-level-syntax/test_nested_mosaic_chart.py
+++ b/tests/python-stories/low-level-syntax/test_nested_mosaic_chart.py
@@ -27,10 +27,12 @@ def story_default():
                 for survived, items in group_by(sex_items, "survived").items()
             ],
             dir="y",
-            reverse=True,
             w=(sum_by(sex_items, "count") / sum_by(class_items, "count")) * 100,
             alignment="middle",
             sharedScale=True,
+            # y-down: reverse so the colored (survived) part stacks ABOVE the
+            # gray (did-not-survive) part.
+            reverse=True,
         )
 
     def _class_row(cls, items):
@@ -50,9 +52,11 @@ def story_default():
         spread(
             [_class_row(cls, items) for cls, items in group_by(TITANIC, "class").items()],
             dir="y",
-            reverse=True,
+            # y-down free space: reverse so the first class (First) reads at the
+            # top and Crew at the bottom.
             spacing=4,
             alignment="start",
+            reverse=True,
         ),
         {"axes": True},
     )

--- a/tests/python-stories/low-level-syntax/test_nested_waffle_chart.py
+++ b/tests/python-stories/low-level-syntax/test_nested_waffle_chart.py
@@ -29,7 +29,7 @@ def _unit_row(rows):
         ],
         dir="x",
         spacing=0.5,
-        alignment="end",
+        alignment="start",
     )
 
 
@@ -44,7 +44,7 @@ def _sex_block(sex_rows, class_rows):
         [_unit_row(chunk) for chunk in reversed(chunks)],
         dir="y",
         spacing=0.5,
-        alignment="end",
+        alignment="start",
     )
 
 

--- a/tests/python-stories/low-level-syntax/test_sankey_tree.py
+++ b/tests/python-stories/low-level-syntax/test_sankey_tree.py
@@ -48,6 +48,7 @@ def story_default():
                     dir="y",
                     spacing=0,
                     alignment="middle",
+                    reverse=True,
                 ).name(f"{cls}-{sex}-tgt"),
                 # target: the survival bars spread apart
                 spread(
@@ -62,6 +63,7 @@ def story_default():
                     w=40,
                     spacing=_INTERNAL_SPACING * 4,
                     alignment="middle",
+                    reverse=True,
                 ),
             ],
             dir="x",
@@ -85,6 +87,7 @@ def story_default():
                     dir="y",
                     spacing=0,
                     alignment="middle",
+                    reverse=True,
                 ).name(f"{cls}-tgt"),
                 # target: each sex expands into its own survival sub-tree
                 spread(
@@ -96,6 +99,7 @@ def story_default():
                     h=sum_by(items, "count") / 10,
                     spacing=_INTERNAL_SPACING * 2,
                     alignment="middle",
+                    reverse=True,
                 ),
             ],
             dir="x",
@@ -116,12 +120,14 @@ def story_default():
                 dir="y",
                 spacing=0,
                 alignment="middle",
+                reverse=True,
             ),
             spread(
                 [_class_node(cls, items) for cls, items in by_class.items()],
                 dir="y",
                 spacing=_INTERNAL_SPACING,
                 alignment="middle",
+                reverse=True,
             ),
         ],
         dir="x",

--- a/tests/python-stories/low-level-syntax/test_stringline_chart.py
+++ b/tests/python-stories/low-level-syntax/test_stringline_chart.py
@@ -46,7 +46,6 @@ def story_default():
             for station, station_rows in by_station.items()
         ],
         dir="y",
-        reverse=True,
         spacing=8,
         alignment="start",
     )

--- a/tests/python-stories/low-level-syntax/test_violin_plot.py
+++ b/tests/python-stories/low-level-syntax/test_violin_plot.py
@@ -40,7 +40,7 @@ def story_default():
                 stack(
                     [
                         rect(
-                            y=x / 40, w=y * 100000, h=0, fill=datum(species)
+                            y=-x / 40, w=y * 100000, h=0, fill=datum(species)
                         ).name(name)
                         for (x, y), name in zip(points, names)
                     ],

--- a/tests/python-stories/vega-lite/test_strip_plot.py
+++ b/tests/python-stories/vega-lite/test_strip_plot.py
@@ -17,10 +17,12 @@ def story_default():
     return (
         chart(cars)
         .flow(
-            derive(lambda d: sorted(d, key=lambda r: r["cylinders"], reverse=True)),
+            # Ascending so cylinders read 3 at the top → 8 at the bottom in y-down.
+            derive(lambda d: sorted(d, key=lambda r: r["cylinders"])),
             spread(by="cylinders", dir="y"),
             scatter(x="horsepower"),
         )
         .mark(rect(w=1, h=10, fill="rgb(31, 119, 180)", opacity=0.7)),
-        {"w": 400, "h": 300, "axes": True},
+        # Horsepower (continuous) x-axis at the bottom (y-end).
+        {"w": 400, "h": 300, "axes": {"x": {"side": "end"}, "y": True}},
     )


### PR DESCRIPTION
## What

Makes **free space render y-down** (SVG-native, top-left origin) so a vertical list `[A, B]` reads top→bottom, while **`chart()` (and any `coord` scope) renders y-up** — bars grow up, the y-axis increases upward — reproducing the old global flip exactly.

Closes #143
Closes #16

## Mechanism (render-level flag, auto-detected)

- `toPixel` is y-down by default; y-up when `effYUp = options.yUp || subtreeHasChart(child)`, where `subtreeHasChart` finds any `_isChart` node (chart builder) or any `coord` node. This keeps **composed charts** (`gofish([chart, chart])`) and **polar/coord** viz y-up even when their render entry never saw the option.
- Shape lowering is **flip-agnostic** (`rectItemFromBox`/image map both corners + min/abs; text/label rotate sign via `toPixelFlipsY`), so the same code is correct under either map.
- **Bridge unchanged** — the parity harness builds via `chart()` so `_isChart` auto-detects; `yUp` stays implicit (no IR schema change).
- Docs: updated the Rendering internals essay.

## Status / what to review

**Charts are byte-identical** — every `chart()`-built chart (vega-lite + forward-syntax bar/stacked/grouped/aggregate, legends, value labels) matches `main` pixel-for-pixel. The visual-test diffs in this PR are **all free-space**, which intentionally flips to y-down (this is the point of #143/#16).

Validated + fixed:
- Free-space orientation hacks dropped → top-down: PythonTutor (matches main's order), Icicle, Stringline, Mosaic, Waffle, Sankey, and **gofish-gotree** (cartesian trees now root-at-top).
- Directional showpieces fixed: **Planets** above/below, **Croissant Chart**.
- Benign mirrors confirmed correct: Pulley, Bump.

**Needs your eye (the reason this is a draft):** ~50 low-level test/demo stories (constraint/alignment permutations, `nest`, `image-mixed-primitives`, `porter-duff`) flip intentionally and mostly still read correctly, but I did **not** exhaustively eyeball them. A few low-level structured-viz (`circle-treemap`, `node-link-diagram`, `nested-boxes-tree`, the `axes--*` low-level charts) may want the same order-swap if they read upside-down. Tell me which to fix vs. leave.

The CI **visual-test baselines** for the free-space stories will need regenerating on Linux CI (charts won't change).

## Follow-up

Express y-up as a true `cartesian` coordinate transform (per-subtree composability) instead of the root-level pixel-map flip — needs the linear mark fast-path to honor `space.transform` + the cartesian domain = resolved content extent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)