### PR TITLE
Unblock the Semiotic DisplayList integration: toDisplayList on combinators + .name()-only naming (+ chrome role)

### DIFF
--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -193,7 +193,13 @@ three carry structure the flat-absolute fold cannot express on its own:
 Each item also carries optional **provenance** — `datum` (the source row(s) the
 primitive was elaborated from, the hit-testing / accessibility target) and `role`
 (`"node"` for a data-bearing mark, `"overlay"` for chrome such as a label, axis, or
-glyph detail). What is _gone_ versus the frontend IR or the live tree: no operators,
+glyph detail). `role` is a **projection of `datum`-presence**: a `lower` body
+derives it via `roleFor(node.datum)` (`lowerHelpers.ts`) — `"node"` exactly when the
+item carries a datum, `"overlay"` otherwise — so the two fields can never disagree
+and a host can split data from chrome on `role` alone. (Generated chrome carries no
+datum, so axes/legends/value-labels classify as `"overlay"` automatically; before
+this projection they were hard-coded `"node"` and mis-classified as data.) What is
+_gone_ versus the frontend IR or the live tree: no operators,
 no constraints, no underlying-space tags, no channels — the solve consumed all of
 them. What survives is geometry + resolved style + provenance.
 

--- a/apps/docs/docs/internals/frontend/mark-factory.md
+++ b/apps/docs/docs/internals/frontend/mark-factory.md
@@ -173,8 +173,10 @@ which is one application of the shared **modifier factory** in
 node — every slice for an expand mark like `cut`); `tag` stamps metadata on the
 wrapped mark function once (propagating the `__serialize`/`__axisFields` tags
 and stashing the layer name). `attachModifiers` wires the set onto the base and
-adds a top-level `.render()`, re-decorating each method's result with the same
-set so chains stay extensible and the mark-kind tag rides along. `.name()`
+adds the export terminals (`render` / `toSVG` / `toSVGElement` / `save` /
+`toDisplayList`) from the shared `terminals.ts` registry, re-decorating each
+method's result with the same set so chains stay extensible and the mark-kind tag
+rides along. `.name()`
 defers its layer registration via a `__layerRegistration` tag collected in a
 single post-resolve DFS walk (`collectLayerRegistrations`), so registry order
 follows parent-iteration order, not async-completion order. The same factory

--- a/apps/docs/docs/internals/frontend/operator-factory.md
+++ b/apps/docs/docs/internals/frontend/operator-factory.md
@@ -5,6 +5,7 @@ order: 30
 status: draft
 covers:
   - packages/gofish-graphics/src/ast/marks/createOperator.ts
+  - packages/gofish-graphics/src/ast/marks/terminals.ts
 ---
 
 # `createOperator`: turning a layout into a frontend operator
@@ -260,6 +261,20 @@ stashes the passed name on the returned mark function via `stashLayerName`
 (defined in `chartBuilder.ts`, called by the `name` modifier's `tag` hook), so
 [`ChartBuilder.connect()`](/js/api/core/connect) can detect a user-chained name
 without parsing the `__serialize` tag.
+
+The **export terminals** — `render`, `toSVG`, `toSVGElement`, `save`,
+`toDisplayList` — are the dual of modifiers: where a modifier mutates the
+produced node and returns a chainable mark, a terminal _resolves_ the surface to
+a final `GoFishNode` and calls through to that node's method, ending the chain.
+They live in their own registry (`terminals.ts`): a `TERMINALS` list plus
+`attachTerminals(target, resolveNode)`, where each surface supplies only its own
+node-resolution strategy (a combinator mark resolves by calling itself with
+`undefined`; a `withGoFish` promise resolves by awaiting). Both `attachModifiers`
+here and `addRenderMethod` in `withGoFish.ts` call `attachTerminals`, so the set
+of terminals is defined once — adding one (as `toDisplayList` was) touches a
+single list and lands on every surface at once, instead of being hand-rolled per
+surface (which previously left `toDisplayList` off the combinator surface
+entirely).
 
 A second flavor, `attachTransformModifiers`, handles methods that map a mark to
 a _different_ mark rather than mutating its nodes — e.g. `image(...).cut(opts)`

--- a/apps/docs/docs/js/api/core/export.md
+++ b/apps/docs/docs/js/api/core/export.md
@@ -3,7 +3,8 @@
 Get a chart's SVG out as a value instead of mounting it into the page.
 `toSVG()` is the primitive; `save()` is the convenience that infers the format
 from the file extension. These are siblings of [`render`](/js/api/core/render) —
-same options, plus `background` — and chain off any chart, mark, or layer.
+same options, plus `background` — and chain off any chart, mark, layer, or
+combinator (e.g. `layer([chartA, chartB])`, `frame(...)`).
 
 ```ts
 // SVG markup as a string
@@ -69,8 +70,9 @@ doc.items; // [{ kind: "rect", x, y, w, h, style, … }, …]
 ```
 
 It takes the same options as [`render`](/js/api/core/render) (`w`, `h`, `axes`,
-`padding`, …) and is available on a chart builder, a mark, and a layer — the
-post-layout, positioned-output analogue of
+`padding`, …) and is available on a chart builder, a mark, a layer, and a
+combinator root (`layer([chartA, chartB])`, `frame(...)` — every multi-chart
+composition) — the post-layout, positioned-output analogue of
 [`toJSON`](/internals/frontend/serialization-api), which serializes the _pre-layout_
 spec. The list is **viewport-baked**: layout is
 size-dependent, so the document is valid only at its `{ w, h }`, and a resize means

--- a/apps/docs/docs/js/api/marks/image.md
+++ b/apps/docs/docs/js/api/marks/image.md
@@ -22,21 +22,20 @@ gf.chart([{ label: "badge" }])
 ## Signature
 
 ```ts
-image({ href, w?, h?, x?, y?, opacity?, filter?, preserveAspectRatio?, name? })
+image({ href, w?, h?, x?, y?, opacity?, filter?, preserveAspectRatio? })
 ```
 
 ## Parameters
 
-| Option                | Type               | Description                                                    |
-| --------------------- | ------------------ | -------------------------------------------------------------- |
-| `href`                | `string`           | Image source — a URL, asset import, or `data:` URI (required)  |
-| `w`                   | `number \| string` | Width — number for fixed pixels, field name to encode data     |
-| `h`                   | `number \| string` | Height — number for fixed pixels, field name to encode data    |
-| `x`, `y`              | `number \| string` | Explicit position accessors                                    |
-| `opacity`             | `number`           | Opacity, `0`–`1`                                               |
-| `filter`              | `string`           | SVG filter reference applied to the image                      |
-| `preserveAspectRatio` | `string`           | SVG `preserveAspectRatio` value (default `"xMidYMid meet"`)    |
-| `name`                | `string`           | Layer name for use with [`selectAll()`](/js/api/selection/ref) |
+| Option                | Type               | Description                                                   |
+| --------------------- | ------------------ | ------------------------------------------------------------- |
+| `href`                | `string`           | Image source — a URL, asset import, or `data:` URI (required) |
+| `w`                   | `number \| string` | Width — number for fixed pixels, field name to encode data    |
+| `h`                   | `number \| string` | Height — number for fixed pixels, field name to encode data   |
+| `x`, `y`              | `number \| string` | Explicit position accessors                                   |
+| `opacity`             | `number`           | Opacity, `0`–`1`                                              |
+| `filter`              | `string`           | SVG filter reference applied to the image                     |
+| `preserveAspectRatio` | `string`           | SVG `preserveAspectRatio` value (default `"xMidYMid meet"`)   |
 
 ## Sizing
 

--- a/apps/docs/docs/js/api/marks/polygon.md
+++ b/apps/docs/docs/js/api/marks/polygon.md
@@ -27,7 +27,7 @@ gf.chart([{}])
 ## Signature
 
 ```ts
-polygon({ points, fill?, stroke?, strokeWidth?, name? })
+polygon({ points, fill?, stroke?, strokeWidth? })
 ```
 
 ## Parameters
@@ -38,7 +38,6 @@ polygon({ points, fill?, stroke?, strokeWidth?, name? })
 | `fill`        | `string`             | `"black"` | Fill color                                                                 |
 | `stroke`      | `string`             | `fill`    | Stroke color (defaults to `fill`)                                          |
 | `strokeWidth` | `number`             | `0`       | Stroke width                                                               |
-| `name`        | `string`             | —         | Name for use with `ref` / `selectAll` / `.constrain()`                     |
 
 ## Coordinates
 

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -307,7 +307,6 @@ export class GoFishNode {
   public _aliases?: { x?: string; y?: string };
   constructor(
     {
-      name,
       key,
       type,
       args,
@@ -318,7 +317,6 @@ export class GoFishNode {
       shared = [false, false],
       color,
     }: {
-      name?: string;
       key?: string;
       type: string;
       args?: any;
@@ -341,7 +339,6 @@ export class GoFishNode {
     children.forEach((child) => {
       child.parent = this;
     });
-    this._name = name;
     this.key = key;
     this.type = type;
     this.args = args;

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -61,7 +61,6 @@ export const coord = createNodeOperator(
   (
     {
       key,
-      name,
       transform: coordTransform,
       grid = false,
       axes,
@@ -69,7 +68,6 @@ export const coord = createNodeOperator(
       ...fancyDims
     }: {
       key?: string;
-      name?: string;
       transform: CoordinateTransform;
       grid?: boolean;
       axes?: AxesOptions;
@@ -86,7 +84,6 @@ export const coord = createNodeOperator(
       {
         type: "coord",
         key,
-        name,
         resolveUnderlyingSpace: (
           children: Size<UnderlyingSpace>[],
           _childNodes: GoFishAST[]

--- a/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
+++ b/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
@@ -15,6 +15,19 @@ import type { CoordinateTransform } from "../coordinateTransforms/coord";
 import { displayTranslate, type Transform } from "../dims";
 import { type Path, type Point, pathToSVGPath } from "../../path";
 
+/**
+ * The display-list `role` of a lowered item, derived from whether it is
+ * data-bound. `role` is a *projection of datum-presence*: an item that carries a
+ * `datum` is a data mark (`"node"` — a hit target); an item with no datum is
+ * generated chrome / decoration (`"overlay"` — axes, legends, annotations,
+ * value labels). Defining role this way keeps the two fields from ever
+ * disagreeing, so a host can trust `role` alone to split data from chrome
+ * without also inspecting `datum`. Shape `lower` bodies call this instead of
+ * hard-coding `role: "node"`, which previously mis-tagged datum-less chrome.
+ */
+export const roleFor = (datum: unknown): DisplayList.DisplayItem["role"] =>
+  datum !== undefined ? "node" : "overlay";
+
 /** Map every point of a path through `toPixel`, then serialize to an SVG `d`.
  *  `toPixel` is affine (translate + y-flip), so no resampling is needed. */
 export const pathToPixelSVG = (path: Path, toPixel: ToPixel): string =>

--- a/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
@@ -3,7 +3,11 @@ import { GoFishAST } from "../_ast";
 import { GoFishNode, type ToPixel } from "../_node";
 import { resolveColorChannel } from "../../color";
 import type { DisplayList } from "gofish-ir";
-import { lowerStyle, pathToPixelSVG } from "../displayList/lowerHelpers";
+import {
+  lowerStyle,
+  pathToPixelSVG,
+  roleFor,
+} from "../displayList/lowerHelpers";
 import {
   Dimensions,
   displayTranslate,
@@ -540,7 +544,7 @@ export const connect = createNodeOperator(
             return {
               kind: "path",
               d: pathToPixelSVG(transformedPath, offsetToPixel),
-              role: "node",
+              role: roleFor(node.datum),
               datum: node.datum,
               style,
             };

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -20,7 +20,6 @@ const unwrapLodashArray = function <T>(value: T[] | Collection<T>): T[] {
 };
 
 export type ScatterProps = {
-  name?: string;
   key?: string;
   x?: PositionValue[];
   y?: PositionValue[];
@@ -39,7 +38,6 @@ export const Scatter = createNodeOperator(
     children: GoFishAST[] | Collection<GoFishAST>
   ) => {
     const {
-      name,
       key,
       x,
       y,
@@ -133,7 +131,6 @@ export const Scatter = createNodeOperator(
       if (!hasY) cs.push(Constraint.align({ y: alignment }, refs));
       return cs;
     });
-    if (name !== undefined) node._name = name;
     if (axes !== undefined) {
       const toShow = (opt: AxisOptions | undefined): boolean | undefined =>
         opt === undefined ? undefined : opt === false ? false : true;

--- a/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/spread.tsx
@@ -38,7 +38,6 @@ const unwrapLodashArray = function <T>(value: T[] | Collection<T>): T[] {
 export const Spread = createNodeOperator(
   async (
     {
-      name,
       key,
       dir,
       spacing = 8,
@@ -51,7 +50,6 @@ export const Spread = createNodeOperator(
       __axisFields: axisFieldMeta,
       ...fancyDims
     }: {
-      name?: string;
       key?: string;
       dir: FancyDirection;
       spacing?: number;
@@ -115,7 +113,6 @@ export const Spread = createNodeOperator(
       ];
     });
 
-    if (name !== undefined) node._name = name;
     // `sharedScale` is a scale-scope annotation (claim hoisting, #549): the node
     // solves σ locally and shares it with descendants. The layer honors this in
     // `layout` (it self-solves per axis when `shared`, into a fresh array).

--- a/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/stack.tsx
@@ -4,7 +4,6 @@ import { MaybeValue } from "../data";
 
 // Type definition for props
 type StackProps = {
-  name?: string;
   key?: string;
   dir: "x" | "y";
   alignment?: "start" | "middle" | "end";

--- a/packages/gofish-graphics/src/ast/graphicalOperators/table.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/table.tsx
@@ -15,14 +15,12 @@ import { childNameKey } from "../constraints/shared";
 export const Table = createNodeOperator(
   async (
     {
-      name,
       key,
       numCols: numColsOpt,
       spacing = 0,
       colKeys,
       rowKeys,
     }: {
-      name?: string;
       key?: string;
       numCols?: number;
       spacing?: number | [number, number];
@@ -69,7 +67,6 @@ export const Table = createNodeOperator(
     node._ordinalKeyMap = keyMap;
 
     if (key !== undefined) node.key = key;
-    if (name !== undefined) node._name = name;
     return node;
   }
 );

--- a/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
@@ -42,7 +42,6 @@ type TreemapTile =
 type TreemapSort = "asc" | "desc" | "none";
 
 type TreemapProps = {
-  name?: string;
   key?: string;
   paddingInner?: number;
   paddingOuter?: number;
@@ -93,7 +92,6 @@ function resolveWeightFromChild(
 export const Treemap = createNodeOperator(
   (opts: TreemapProps, children: GoFishAST[]) => {
     const {
-      name,
       key,
       paddingInner = 0,
       paddingOuter = 0,
@@ -114,7 +112,6 @@ export const Treemap = createNodeOperator(
         type: "treemap",
         args: {
           key,
-          name,
           paddingInner,
           paddingOuter,
           round,
@@ -126,7 +123,6 @@ export const Treemap = createNodeOperator(
           dims,
         },
         key,
-        name,
         shared: [false, false],
         resolveUnderlyingSpace: (): Size<UnderlyingSpace> => {
           // Mirror Spread's explicit-size handling (spread.tsx:123-131): when a
@@ -330,7 +326,7 @@ export const Treemap = createNodeOperator(
 export const treemap = createOperator<any, TreemapProps>(
   (props: TreemapProps, children: GoFishAST[]) => Treemap(props, children),
   {
-    split: ({ name }, d) => new Map(d.map((r, i) => [i, r])),
+    split: (_opts, d) => new Map(d.map((r, i) => [i, r])),
     channels: {
       w: "size",
       h: "size",

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -48,6 +48,7 @@ import {
   positionNode,
   type PositionNodeOptions,
 } from "../graphicalOperators/positionNode";
+import { attachTerminals } from "./terminals";
 
 // Re-exports for callers that previously got these from createOperator.
 export type { LayerContext } from "./chartBuilder";
@@ -138,9 +139,10 @@ export async function applyMark<T>(
  * and the mark-kind tag + IR-serialize metadata ride along.
  *
  * `createModifier` captures that shape as a config; `attachModifiers` wires a
- * set of them (plus a top-level `.render()`) onto a base mark. This is the one
- * system behind `nameableMark` (here), `createMark` (withGoFish.ts), and
- * `makeConstrainableMark` (chart.ts) — replacing three hand-rolled copies.
+ * set of them (plus the export terminals from `terminals.ts`) onto a base mark.
+ * This is the one system behind `nameableMark` (here), `createMark`
+ * (withGoFish.ts), and `makeConstrainableMark` (chart.ts) — replacing three
+ * hand-rolled copies.
  * ------------------------------------------------------------------------ */
 
 /**
@@ -265,45 +267,13 @@ export function attachModifiers<T>(
     writable: true,
     configurable: true,
   });
-  Object.defineProperty(base, "render", {
-    value: async (
-      container: Parameters<GoFishNode["render"]>[0],
-      options: Parameters<GoFishNode["render"]>[1]
-    ) => {
-      const node = await resolveMarkResult((base as any)(undefined));
-      return node.render(container, options);
-    },
-    writable: true,
-    configurable: true,
-  });
-  // SVG-export terminals, mirroring `.render()` above.
-  Object.defineProperty(base, "toSVG", {
-    value: async (options?: Parameters<GoFishNode["toSVG"]>[0]) => {
-      const node = await resolveMarkResult((base as any)(undefined));
-      return node.toSVG(options);
-    },
-    writable: true,
-    configurable: true,
-  });
-  Object.defineProperty(base, "toSVGElement", {
-    value: async (options?: Parameters<GoFishNode["toSVGElement"]>[0]) => {
-      const node = await resolveMarkResult((base as any)(undefined));
-      return node.toSVGElement(options);
-    },
-    writable: true,
-    configurable: true,
-  });
-  Object.defineProperty(base, "save", {
-    value: async (
-      filename: string,
-      options?: Parameters<GoFishNode["save"]>[1]
-    ) => {
-      const node = await resolveMarkResult((base as any)(undefined));
-      return node.save(filename, options);
-    },
-    writable: true,
-    configurable: true,
-  });
+  // Export terminals (render / toSVG / toSVGElement / save / toDisplayList) come
+  // from the shared registry, so adding one touches a single list. A mark
+  // resolves to a node by calling it with `undefined`. See terminals.ts.
+  attachTerminals(
+    base,
+    () => resolveMarkResult((base as any)(undefined)) as Promise<GoFishNode>
+  );
   return base;
 }
 

--- a/packages/gofish-graphics/src/ast/marks/terminals.ts
+++ b/packages/gofish-graphics/src/ast/marks/terminals.ts
@@ -1,0 +1,61 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki The Operator Factory — /internals/frontend/operator-factory
+// </gofish-wiki>
+
+/**
+ * Terminal registry — the shared definition of the "export" methods a mark /
+ * combinator surface exposes (`render`, `toSVG`, `toSVGElement`, `save`,
+ * `toDisplayList`).
+ *
+ * A terminal is the dual of a {@link ModifierConfig}: where a modifier mutates
+ * the produced node and returns a chainable mark, a terminal RESOLVES the
+ * surface to a final `GoFishNode` and calls through to that node's method,
+ * ending the chain. Every terminal has the same shape — "resolve me to a node,
+ * then invoke `node.X(...)`" — differing only in which method and which args.
+ *
+ * Before this registry the terminals were hand-rolled and DUPLICATED across two
+ * surfaces (`attachModifiers` in createOperator.ts and `addRenderMethod` in
+ * withGoFish.ts), so adding one (e.g. `toDisplayList`) meant editing both — and
+ * forgetting a surface silently dropped the method there. Now each surface
+ * supplies only its own node-resolution strategy and calls
+ * {@link attachTerminals}; the list of terminals lives here, once.
+ */
+
+import type { GoFishNode } from "../_node";
+
+/** One export method: its name, and how to invoke it on a resolved node. */
+export type TerminalConfig = {
+  /** Method name exposed on the surface, e.g. "render" | "toDisplayList". */
+  name: string;
+  /** Call the corresponding `GoFishNode` method with the surface call args. */
+  call: (node: GoFishNode, args: any[]) => unknown;
+};
+
+export const TERMINALS: TerminalConfig[] = [
+  { name: "render", call: (n, a) => n.render(a[0], a[1]) },
+  { name: "toSVG", call: (n, a) => n.toSVG(a[0]) },
+  { name: "toSVGElement", call: (n, a) => n.toSVGElement(a[0]) },
+  { name: "save", call: (n, a) => n.save(a[0], a[1]) },
+  { name: "toDisplayList", call: (n, a) => n.toDisplayList(a[0]) },
+];
+
+/**
+ * Attach every terminal in {@link TERMINALS} to `target`. `resolveNode` is the
+ * surface-specific strategy for turning the surface into a final `GoFishNode`
+ * (call a mark with `undefined`; await a promise; etc.) — it should throw if the
+ * surface can't resolve to a node. Each terminal awaits it and calls through, so
+ * every terminal returns a Promise.
+ */
+export function attachTerminals(
+  target: object,
+  resolveNode: () => Promise<GoFishNode>
+): void {
+  for (const t of TERMINALS) {
+    Object.defineProperty(target, t.name, {
+      value: (...args: any[]) =>
+        Promise.resolve(resolveNode()).then((node) => t.call(node, args)),
+      writable: true,
+      configurable: true,
+    });
+  }
+}

--- a/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
@@ -30,6 +30,7 @@ import type { DisplayList } from "gofish-ir";
 import {
   lowerStyle,
   pathToPixelSVG,
+  roleFor,
   valueLabelItems,
 } from "../displayList/lowerHelpers";
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
@@ -206,7 +207,7 @@ export const Ellipse = ({
             ry,
             style: elementStyle,
             datum: node.datum,
-            role: "node",
+            role: roleFor(node.datum),
           };
         };
 
@@ -276,7 +277,7 @@ export const Ellipse = ({
               kind: "path",
               d: pathToPixelSVG(transformed, toPixel),
               datum: node.datum,
-              role: "node",
+              role: roleFor(node.datum),
               style: lowerStyle({
                 fill: "none",
                 stroke: resolvedStroke,
@@ -322,7 +323,7 @@ export const Ellipse = ({
             kind: "path",
             d: pathToPixelSVG(transformed, toPixel),
             datum: node.datum,
-            role: "node",
+            role: roleFor(node.datum),
             style: lowerStyle({
               fill: resolvedFill,
               stroke: resolvedStroke,

--- a/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
@@ -35,7 +35,6 @@ import {
 } from "../displayList/lowerHelpers";
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
 export const Ellipse = ({
-  name,
   fill = color6_old[0],
   stroke = fill,
   strokeWidth = 0,
@@ -43,7 +42,6 @@ export const Ellipse = ({
   label,
   ...fancyDims
 }: {
-  name?: string;
   fill?: MaybeValue<string>;
   stroke?: MaybeValue<string>;
   strokeWidth?: number;
@@ -55,7 +53,6 @@ export const Ellipse = ({
   const dims = elaborateDims(fancyDims);
   const node = new GoFishNode(
     {
-      name,
       type: "ellipse",
       // Expose `dims` so resolveAliases / resolveEmbedding can author it in place
       // (same array the closures below capture). See rect.tsx / _node passes.

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -21,7 +21,7 @@ import {
 import { createMark } from "../withGoFish";
 import { attachCut } from "../graphicalOperators/cut";
 import type { DisplayList } from "gofish-ir";
-import { lowerStyle, pixelBox } from "../displayList/lowerHelpers";
+import { lowerStyle, pixelBox, roleFor } from "../displayList/lowerHelpers";
 
 type ImageDimensions = {
   width: number;
@@ -367,7 +367,7 @@ export const Image = ({
           href,
           preserveAspectRatio,
           datum: node.datum,
-          role: "node",
+          role: roleFor(node.datum),
         };
         if (Object.keys(style).length > 0) item.style = style;
         return [item];

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -223,7 +223,6 @@ const resolveRenderedDimensions = (
 
 export const Image = ({
   key,
-  name,
   href,
   filter,
   opacity,
@@ -231,7 +230,6 @@ export const Image = ({
   ...fancyDims
 }: {
   key?: string;
-  name?: string;
   href: string;
   filter?: string;
   opacity?: number;
@@ -242,12 +240,10 @@ export const Image = ({
 
   const node = new GoFishNode(
     {
-      name,
       key,
       type: "image",
       args: {
         key,
-        name,
         href,
         filter,
         opacity,

--- a/packages/gofish-graphics/src/ast/shapes/petal.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/petal.tsx
@@ -26,13 +26,11 @@ import { createMark } from "../withGoFish";
 /* Implementation inspired by https://web.archive.org/web/20220808041640/http://bl.ocks.org/herrstucki/6199768 */
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
 export const Petal = ({
-  name,
   fill = "black",
   stroke = fill,
   strokeWidth = 0,
   ...fancyDims
 }: {
-  name?: string;
   fill?: MaybeValue<string>;
   stroke?: MaybeValue<string>;
   strokeWidth?: number;
@@ -41,7 +39,6 @@ export const Petal = ({
   const dims = elaborateDims(fancyDims);
   const node = new GoFishNode(
     {
-      name,
       type: "petal",
       // Expose `dims` so resolveAliases / resolveEmbedding can author it in place
       // (same array the closures below capture). See rect.tsx / _node passes.

--- a/packages/gofish-graphics/src/ast/shapes/petal.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/petal.tsx
@@ -2,7 +2,11 @@ import { resolveColorChannel } from "../../color";
 import { GoFishNode } from "../_node";
 import { GoFishAST } from "../_ast";
 import type { DisplayList } from "gofish-ir";
-import { lowerStyle, rectItemFromBox } from "../displayList/lowerHelpers";
+import {
+  lowerStyle,
+  rectItemFromBox,
+  roleFor,
+} from "../displayList/lowerHelpers";
 import { getMeasure, getValue, isValue, MaybeValue, Value } from "../data";
 import {
   Dimensions,
@@ -153,7 +157,7 @@ export const Petal = ({
               tY + h / 2,
               toPixel,
               {
-                role: "node",
+                role: roleFor(node.datum),
                 datum: node.datum,
                 style: lowerStyle({
                   fill: resolvedFill,
@@ -196,7 +200,7 @@ export const Petal = ({
           {
             kind: "path",
             d,
-            role: "node",
+            role: roleFor(node.datum),
             datum: node.datum,
             style: lowerStyle({ fill: resolvedFill }),
           },

--- a/packages/gofish-graphics/src/ast/shapes/polygon.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/polygon.tsx
@@ -17,13 +17,11 @@ import {
  * system places it via `transform.translate`.
  */
 export const Polygon = ({
-  name,
   fill = "black",
   stroke = fill,
   strokeWidth = 0,
   points,
 }: {
-  name?: string;
   fill?: string;
   stroke?: string;
   strokeWidth?: number;
@@ -45,7 +43,6 @@ export const Polygon = ({
 
   return new GoFishNode(
     {
-      name,
       type: "polygon",
       resolveUnderlyingSpace: (
         _children: Size<UnderlyingSpace>[],

--- a/packages/gofish-graphics/src/ast/shapes/polygon.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/polygon.tsx
@@ -5,7 +5,11 @@ import { UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
 import { createMark } from "../withGoFish";
 import { path } from "../../path";
 import type { DisplayList } from "gofish-ir";
-import { lowerStyle, pathToPixelSVG } from "../displayList/lowerHelpers";
+import {
+  lowerStyle,
+  pathToPixelSVG,
+  roleFor,
+} from "../displayList/lowerHelpers";
 
 /**
  * A closed polygon defined by explicit local-coordinate points (GoFish-native
@@ -82,7 +86,7 @@ export const Polygon = ({
             kind: "path",
             d: pathToPixelSVG(poly, toPixel),
             datum: node.datum,
-            role: "node",
+            role: roleFor(node.datum),
             style: lowerStyle({
               fill,
               stroke: stroke ?? fill ?? "black",

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -63,7 +63,6 @@ const DEFAULT_RECT_SIZE = 16;
 /* TODO: what should default embedding behavior be when all values are aesthetic? */
 export const Rect = ({
   key,
-  name,
   fill = color6[0],
   stroke = fill,
   strokeWidth = 0,
@@ -76,7 +75,6 @@ export const Rect = ({
   ...fancyDims
 }: {
   key?: string;
-  name?: string;
   fill?: MaybeValue<string>;
   stroke?: MaybeValue<string>;
   strokeWidth?: number;
@@ -94,12 +92,10 @@ export const Rect = ({
   const dims = elaborateDims(fancyDims);
   const node = new GoFishNode(
     {
-      name,
       key,
       type: "rect",
       args: {
         key,
-        name,
         fill,
         stroke,
         strokeWidth,

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -46,6 +46,7 @@ import {
   lowerStyle,
   pathToPixelSVG,
   rectItemFromBox,
+  roleFor,
   valueLabelItems,
 } from "../displayList/lowerHelpers";
 
@@ -330,7 +331,7 @@ export const Rect = ({
           ry,
           style: elementStyle,
           datum: node.datum,
-          role: "node" as const,
+          role: roleFor(node.datum),
         };
 
         // Both dimensions aesthetic — transformed point.
@@ -404,7 +405,7 @@ export const Rect = ({
               kind: "path",
               d: pathToPixelSVG(transformed, toPixel),
               datum: node.datum,
-              role: "node",
+              role: roleFor(node.datum),
               style: lowerStyle({
                 fill: "none",
                 stroke: resolvedStroke,
@@ -445,7 +446,7 @@ export const Rect = ({
             kind: "path",
             d: pathToPixelSVG(transformed, toPixel),
             datum: node.datum,
-            role: "node",
+            role: roleFor(node.datum),
             style: lowerStyle({
               fill: resolvedFill,
               stroke: resolvedStroke,

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -30,6 +30,7 @@ import type { DisplayList } from "gofish-ir";
 import {
   lowerStyle,
   rectItemFromBox,
+  roleFor,
   toPixelFlipsY,
 } from "../displayList/lowerHelpers";
 type TextDimensions = {
@@ -393,7 +394,7 @@ export const Text = ({
           textAnchor: textAnchor as DisplayList.TextItem["textAnchor"],
           dominantBaseline:
             dominantBaseline as DisplayList.TextItem["dominantBaseline"],
-          role: "node",
+          role: roleFor(node.datum),
           datum: node.datum,
           style: lowerStyle({
             fill: resolvedFill,

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -164,7 +164,6 @@ const resolveTextLayout = (
 
 export const Text = ({
   key,
-  name,
   text: textContent,
   fill = "black",
   stroke,
@@ -177,7 +176,6 @@ export const Text = ({
   ...fancyDims
 }: {
   key?: string;
-  name?: string;
   text: MaybeValue<string | number>;
   fill?: MaybeValue<string>;
   stroke?: MaybeValue<string>;
@@ -199,12 +197,10 @@ export const Text = ({
 
   const node = new GoFishNode(
     {
-      name,
       key,
       type: "text",
       args: {
         key,
-        name,
         text: textContent,
         fill,
         stroke,

--- a/packages/gofish-graphics/src/ast/withGoFish.ts
+++ b/packages/gofish-graphics/src/ast/withGoFish.ts
@@ -38,6 +38,7 @@ import { Mark } from "./types";
 import type { ConstraintSpec, ConstraintRef } from "./constraints";
 import type { LabelAccessor, LabelOptions } from "./labels/labelPlacement";
 import type { Token } from "./createName";
+import { attachTerminals } from "./marks/terminals";
 
 /**
  * Options for rendering a GoFish node
@@ -100,6 +101,9 @@ export interface PromiseWithRender<T> extends Promise<T> {
     filename: string,
     options?: Parameters<GoFishNode["save"]>[1]
   ): Promise<void>;
+  toDisplayList(
+    options?: Parameters<GoFishNode["toDisplayList"]>[0]
+  ): ReturnType<GoFishNode["toDisplayList"]>;
   name(name: string | Token): PromiseWithRender<T>;
   label(accessor: LabelAccessor, options?: LabelOptions): PromiseWithRender<T>;
   setKey(key: string): PromiseWithRender<T>;
@@ -130,57 +134,17 @@ function isChartBuilder(value: any): value is ChartBuilder<any, any> {
  * This allows calling .render(), .name(), .setKey(), .setShared() on promises.
  */
 export function addRenderMethod<T>(promise: Promise<T>): PromiseWithRender<T> {
-  // Add the render method directly to the promise object
-  // In JavaScript, you can add properties to any object, including Promises
-  (promise as any).render = function (
-    container: HTMLElement,
-    options: RenderOptions
-  ): HTMLElement | Promise<HTMLElement> {
-    return promise.then((result) => {
-      // Check if the result has a render method (like GoFishNode)
-      if (hasRenderMethod(result)) {
-        return result.render(container, options);
-      }
-      throw new Error(
-        "Cannot call render on this result. Only GoFishNode instances have a render method."
-      );
-    });
-  };
-
-  // SVG-export terminals, mirroring `.render()` above.
-  (promise as any).toSVG = function (
-    options?: Parameters<GoFishNode["toSVG"]>[0]
-  ): Promise<string> {
-    return promise.then((result) => {
-      if (hasRenderMethod(result)) return result.toSVG(options);
-      throw new Error(
-        "Cannot call toSVG on this result. Only GoFishNode instances support export."
-      );
-    });
-  };
-
-  (promise as any).toSVGElement = function (
-    options?: Parameters<GoFishNode["toSVGElement"]>[0]
-  ): Promise<SVGSVGElement> {
-    return promise.then((result) => {
-      if (hasRenderMethod(result)) return result.toSVGElement(options);
-      throw new Error(
-        "Cannot call toSVGElement on this result. Only GoFishNode instances support export."
-      );
-    });
-  };
-
-  (promise as any).save = function (
-    filename: string,
-    options?: Parameters<GoFishNode["save"]>[1]
-  ): Promise<void> {
-    return promise.then((result) => {
-      if (hasRenderMethod(result)) return result.save(filename, options);
-      throw new Error(
-        "Cannot call save on this result. Only GoFishNode instances support export."
-      );
-    });
-  };
+  // Export terminals (render / toSVG / toSVGElement / save / toDisplayList) come
+  // from the shared registry, so adding one touches a single list. The promise
+  // resolves to a node directly; a non-GoFishNode result is unexportable.
+  // See terminals.ts.
+  attachTerminals(promise, async () => {
+    const result = await promise;
+    if (hasRenderMethod(result)) return result;
+    throw new Error(
+      "Cannot call an export terminal on this result. Only GoFishNode instances support export."
+    );
+  });
 
   // Add chainable methods that return new PromiseWithRender
   (promise as any).name = function (
@@ -499,6 +463,9 @@ export type NameableMark<T> = Mark<T> & {
     filename: string,
     options?: Parameters<GoFishNode["save"]>[1]
   ): Promise<void>;
+  toDisplayList(
+    options?: Parameters<GoFishNode["toDisplayList"]>[0]
+  ): ReturnType<GoFishNode["toDisplayList"]>;
 };
 
 /**

--- a/packages/gofish-graphics/src/tests/stacking.ts
+++ b/packages/gofish-graphics/src/tests/stacking.ts
@@ -30,9 +30,9 @@ export const testStacking = (size: { width: number; height: number }) =>
     frame([
       enclose({}, [
         spreadX({ spacing: 64, sharedScale: true, alignment: "middle" }, [
-          rect({ name: "1", w: 32, h: 32 }),
-          rect({ name: "2", w: 32, h: 64 }),
-          rect({ name: "3", w: 32, h: 40 }),
+          rect({ w: 32, h: 32 }).name("1"),
+          rect({ w: 32, h: 64 }).name("2"),
+          rect({ w: 32, h: 40 }).name("3"),
           // rect({ w: 32, h: 32 }),
           // rect({ w: 32, h: 32 }),
         ]),


### PR DESCRIPTION
Resolves the two **blockers** Elijah raised from the [Semiotic DisplayList integration](https://github.com/nteract/semiotic/pull/1049) (no GitHub issues were filed for these — they come from the integration feedback doc), plus the non-blocking chrome-`role` heads-up.

## Blocker 1 — `toDisplayList()` on the combinator surface

`toDisplayList` lived only on `GoFishNode` and `ChartBuilder`, so any chart whose root is a combinator — `layer([chartA, chartB])`, `frame(...)`, `Layer(...)` — i.e. every multi-chart composition (the flower meadow, the polar ribbon, the memory diagram) — had **no public headless bake path**.

Root cause: the export terminals (`render`/`toSVG`/`toSVGElement`/`save`) were hand-rolled and **duplicated** across `attachModifiers` (the mark/combinator surface) and `addRenderMethod` (the `withGoFish` promise surface). Adding `toDisplayList` to the node classes never reached either.

Fix: a single terminal registry (`terminals.ts` — `TERMINALS` + `attachTerminals(target, resolveNode)`). Each surface supplies only its node-resolution strategy; the terminal set is defined once. Adding a terminal now touches one list and lands on every surface. `toDisplayList` included.

```ts
const doc = await layer([chartA, chartB]).toDisplayList({ w, h }); // now works
```

## Blocker 2 — `name` as a factory argument

`rect({ name: "bars" })` only set the node's `_name`; it skipped the layer registration and IR `tag.name` that the `.name()` modifier performs — so `ref`/`selectAll` threw `Can't find local name` and the name never round-tripped to IR. A silent half-working trap that every relational chart hit.

Removed the `name` option from all shape **and** operator factories (rect/ellipse/text/image/petal/polygon, spread/scatter/table/treemap/stack/coord) and from the `GoFishNode` constructor. `.name("bars")` — which registers and tags — is now the single spelling. Docs and the Python wrapper already only expose `.name()`.

> ⚠️ Breaking: `rect({ name })` etc. no longer typecheck. The only internal user (`tests/stacking.ts`) is migrated.

## Heads-up — chrome `role` (non-blocking)

Generated chrome (axis ticks, gridlines, titles, legend swatches/labels — all datum-less) baked as `role: "node"`, so a host trusting `role` alone would misclassify it as data. Now `role` is a **projection of datum-presence** (`roleFor(node.datum)` in `lowerHelpers.ts`): `"node"` iff the item carries a datum, `"overlay"` otherwise. The two fields can no longer disagree, so `role` is trustworthy on its own. `role` is not read internally and not emitted to SVG — **no pixel change**.

## Not changed (investigated, no action)

- **The "Firefox-only composite" report is false for Chrome.** Rendered the `feImage href="#id"` composite path (`Paint`, `Intersect`) in headless Chromium — both render correctly (filled bottles), not blank. The blank case is `librsvg`/`sharp` (Semiotic's server-side rasterizer), not our browser backend.
- **y-flip is not in the display list.** Coordinates are baked to final absolute y-down pixels via `toPixel`; there's no residual transform or flag. The cited Python-memory inversion is that example's hand-written helpers compensating for legacy behavior, not a display-list wart.

## Verification

- `layer([...]).toDisplayList()` emits a valid display list.
- `.name()` + `selectAll` round-trips (polar-ribbon story renders unchanged).
- Bar chart with axes bakes 3 `node` items (bars, all with datum) + 28 `overlay` (chrome, all datum-less).
- `tsc`, build, and `check-backlinks` all green. Internals essays (operator-factory, mark-factory, rendering) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)