### PR TITLE
Latency bottle chart + stacked .label() and data-driven image sizing

### DIFF
--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -478,7 +478,7 @@ for the API.
           "type": "string"
         },
         "label": {
-          "$ref": "#/$defs/LabelIR"
+          "$ref": "#/$defs/LabelOrArrayIR"
         },
         "constraints": {
           "type": "array",
@@ -533,7 +533,7 @@ for the API.
           "type": "string"
         },
         "label": {
-          "$ref": "#/$defs/LabelIR"
+          "$ref": "#/$defs/LabelOrArrayIR"
         },
         "constraints": {
           "type": "array",
@@ -580,7 +580,7 @@ for the API.
           "type": "string"
         },
         "label": {
-          "$ref": "#/$defs/LabelIR"
+          "$ref": "#/$defs/LabelOrArrayIR"
         },
         "zOrder": {
           "type": "number"
@@ -623,6 +623,19 @@ for the API.
             "rotate": {
               "type": "number"
             }
+          }
+        }
+      ]
+    },
+    "LabelOrArrayIR": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/LabelIR"
+        },
+        {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/LabelIR"
           }
         }
       ]

--- a/apps/docs/docs/js/api/marks/image.md
+++ b/apps/docs/docs/js/api/marks/image.md
@@ -59,6 +59,10 @@ dimensions when not given:
 // Scale to a width, keep the aspect ratio
 .mark(image({ href: bottleJpg, w: 90 }))
 
+// Data-driven height (a field name), width follows the aspect ratio —
+// one bottle per row, sized by the data
+.mark(image({ href: bottlePng, h: "size" }))
+
 // Intrinsic size from a data URI
 .mark(image({ href: inlineBadgeSvg }))
 

--- a/apps/docs/docs/python/api/marks/text.md
+++ b/apps/docs/docs/python/api/marks/text.md
@@ -15,20 +15,21 @@ chart([{"label": "GoFish"}]).mark(
 
 ```python
 text(text=None, fill=None, fontSize=None, fontWeight=None, fontFamily=None,
-     debugBoundingBox=None, label=None) -> Mark
+     rotate=None, debugBoundingBox=None, label=None) -> Mark
 ```
 
 ## Parameters
 
-| Parameter          | Type            | Description                                                                   |
-| ------------------ | --------------- | ----------------------------------------------------------------------------- |
-| `text`             | `str` \| `int`  | The string to render — a constant, a field name, or a `(row) -> str` callable |
-| `fill`             | `str`           | Fill color — a constant or a field name                                       |
-| `fontSize`         | `int` \| `str`  | Font size in pixels                                                           |
-| `fontWeight`       | `int` \| `str`  | Font weight                                                                   |
-| `fontFamily`       | `str`           | Font family                                                                   |
-| `debugBoundingBox` | `bool`          | Draw the text's bounding box (for layout debugging)                           |
-| `label`            | `bool` \| `str` | Auto value-label flag (distinct from `text` content)                          |
+| Parameter          | Type             | Description                                                                   |
+| ------------------ | ---------------- | ----------------------------------------------------------------------------- |
+| `text`             | `str` \| `int`   | The string to render — a constant, a field name, or a `(row) -> str` callable |
+| `fill`             | `str`            | Fill color — a constant or a field name                                       |
+| `fontSize`         | `int` \| `str`   | Font size in pixels                                                           |
+| `fontWeight`       | `int` \| `str`   | Font weight                                                                   |
+| `fontFamily`       | `str`            | Font family                                                                   |
+| `rotate`           | `int` \| `float` | Rotation in degrees about the anchor; `90` reads bottom-to-top for a y-title  |
+| `debugBoundingBox` | `bool`           | Draw the text's bounding box (for layout debugging)                           |
+| `label`            | `bool` \| `str`  | Auto value-label flag (distinct from `text` content)                          |
 
 Returns a `Mark` for use in [`.mark()`](/python/api/core/mark).
 

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -270,7 +270,11 @@ export class GoFishNode {
   public color?: MaybeValue<string>;
   public constraints: ConstraintSpec[] = [];
   public colorConfig?: ColorConfig;
-  public _label?: LabelSpec;
+  /** Labels attached to this node via `.label()`. A node can carry several
+   *  (e.g. a value above a bar and a category below it); each renders as an
+   *  independent post-layout overlay, so labels never affect the node's own
+   *  size or its siblings' alignment. */
+  public _labels: LabelSpec[] = [];
   private _zOrder = 0;
   private renderSession?: RenderSession;
   // Axis state per dimension. Set by `resolveAxes` and consumed by the axis
@@ -1144,7 +1148,7 @@ export class GoFishNode {
       [],
       this
     );
-    if (this._label && this.intrinsicDims) {
+    if (this._labels.length > 0 && this.intrinsicDims) {
       const labelItems = lowerLabelItems(this, transform, toPixel);
       if (labelItems.length) return [...items, ...labelItems];
     }
@@ -1268,21 +1272,25 @@ export class GoFishNode {
   }
 
   public label(accessor: LabelAccessor, options?: LabelOptions): this {
-    this._label = { accessor, ...options };
+    this._labels.push({ accessor, ...options });
     return this;
   }
 
   public resolveLabels(): void {
     // Propagate only when this node has no datum of its own.
     // Nodes with datum (leaf shapes, or spread combinators that carry group data)
-    // render their label directly rather than pushing it to children.
-    if (this._label && this.children.length > 0 && this.datum === undefined) {
+    // render their labels directly rather than pushing them to children.
+    if (
+      this._labels.length > 0 &&
+      this.children.length > 0 &&
+      this.datum === undefined
+    ) {
       for (const child of this.children) {
-        if (child instanceof GoFishNode && !child._label) {
-          child._label = this._label;
+        if (child instanceof GoFishNode && child._labels.length === 0) {
+          child._labels = this._labels;
         }
       }
-      this._label = undefined;
+      this._labels = [];
     }
     for (const child of this.children) {
       if (child instanceof GoFishNode) child.resolveLabels();

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/bake.ts
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/bake.ts
@@ -145,7 +145,7 @@ const isTransparent = (node: GoFishAST): boolean =>
   !!node.children &&
   node.children.length > 0 &&
   !BAKE_BOUNDARY_TYPES.has((node as { type?: string }).type ?? "") &&
-  !(node instanceof GoFishNode && node._label !== undefined);
+  !(node instanceof GoFishNode && node._labels.length > 0);
 
 /** The `_zOrder` hint of a node (0 for a `GoFishRef`). */
 const zOf = (node: GoFishAST): number =>

--- a/packages/gofish-graphics/src/ast/labels/renderLabel.tsx
+++ b/packages/gofish-graphics/src/ast/labels/renderLabel.tsx
@@ -8,6 +8,7 @@ import { getValue, type MaybeValue } from "../data";
 import { resolveColorChannel } from "../../color";
 import {
   type LabelPosition,
+  type LabelSpec,
   type ShapeInfo,
   inferLabelPosition,
   calculateLabelOffset,
@@ -89,13 +90,14 @@ const LABEL_FONT_FAMILY = "source-sans-pro, sans-serif";
 
 function computeLabel(
   node: GoFishNode,
+  spec: LabelSpec,
   transformOverride?: Transform
 ): LabelLayout | null {
-  if (!node._label || !node.intrinsicDims) return null;
+  if (!node.intrinsicDims) return null;
   const datum = node.datum;
   if (datum === undefined) return null;
 
-  const labelText = resolveLabelText(node._label.accessor, datum);
+  const labelText = resolveLabelText(spec.accessor, datum);
   if (!labelText) return null;
 
   const w = node.intrinsicDims[0].size ?? 0;
@@ -114,13 +116,13 @@ function computeLabel(
       availableSpace: { top: 20, right: 20, bottom: 20, left: 20 },
     },
     {
-      position: node._label.position ?? "outset",
-      offset: node._label.offset,
+      position: spec.position ?? "outset",
+      offset: spec.offset,
     }
   );
 
   const offset = calculateLabelOffset(position, [w, h], {
-    offset: node._label.offset,
+    offset: spec.offset,
   });
 
   const [tx, ty] = displayTranslate(transformOverride ?? node.transform);
@@ -131,10 +133,10 @@ function computeLabel(
     labelText,
     ax: cx + offset.x,
     ay: cy + offset.y,
-    labelColor: node._label.color ?? autoLabelColor(node, position),
+    labelColor: spec.color ?? autoLabelColor(node, position),
     textAnchor: getLabelTextAnchor(position),
-    rotate: node._label.rotate,
-    fontSize: node._label.fontSize ?? 11,
+    rotate: spec.rotate,
+    fontSize: spec.fontSize ?? 11,
   };
 }
 
@@ -150,22 +152,26 @@ export function lowerLabelItems(
   transformOverride: Transform | undefined,
   toPixel: ToPixel
 ): DisplayList.DisplayItem[] {
-  const l = computeLabel(node, transformOverride);
-  if (!l) return [];
+  const items: DisplayList.DisplayItem[] = [];
+  for (const spec of node._labels) {
+    const l = computeLabel(node, spec, transformOverride);
+    if (!l) continue;
 
-  const [x, y] = toPixel([l.ax, l.ay]);
-  const item: DisplayList.TextItem = {
-    kind: "text",
-    x,
-    y,
-    text: l.labelText,
-    fontSize: l.fontSize,
-    fontFamily: LABEL_FONT_FAMILY,
-    textAnchor: l.textAnchor as DisplayList.TextItem["textAnchor"],
-    dominantBaseline: "central",
-    role: "overlay",
-    style: { fill: l.labelColor },
-  };
-  if (l.rotate) item.rotate = l.rotate;
-  return [item];
+    const [x, y] = toPixel([l.ax, l.ay]);
+    const item: DisplayList.TextItem = {
+      kind: "text",
+      x,
+      y,
+      text: l.labelText,
+      fontSize: l.fontSize,
+      fontFamily: LABEL_FONT_FAMILY,
+      textAnchor: l.textAnchor as DisplayList.TextItem["textAnchor"],
+      dominantBaseline: "central",
+      role: "overlay",
+      style: { fill: l.labelColor },
+    };
+    if (l.rotate) item.rotate = l.rotate;
+    items.push(item);
+  }
+  return items;
 }

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -347,10 +347,16 @@ export const labelModifier = createModifier<
   tag: (wrapped, base, accessor, options) => {
     propagateSerialize(base, wrapped, (tag) => {
       if (typeof accessor === "string") {
-        tag.label = {
+        // Accumulate: a mark may carry several `.label()` calls. Keep `label`
+        // scalar for the common single-label case (so existing IR is
+        // unchanged) and promote to an array on the second label.
+        const spec = {
           accessor,
           ...(options && typeof options === "object" ? options : {}),
         };
+        if (tag.label === undefined) tag.label = spec;
+        else if (Array.isArray(tag.label)) tag.label = [...tag.label, spec];
+        else tag.label = [tag.label, spec];
       } else if (
         typeof accessor === "function" &&
         typeof console !== "undefined" &&

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -375,7 +375,21 @@ export const Image = ({
   return node;
 };
 
-const rawImage = createMark(Image, {}, "image");
+const rawImage = createMark(
+  Image,
+  {
+    // Data-driven sizing/positioning, mirroring `rect`. Supplying only one of
+    // `w`/`h` lets `resolveRenderedDimensions` derive the other from the image's
+    // intrinsic aspect ratio, so a bound height scales the whole image faithfully.
+    w: "size",
+    h: "size",
+    x: "pos",
+    y: "pos",
+    cx: "pos",
+    cy: "pos",
+  },
+  "image"
+);
 
 /** Wrap an image mark so it awaits intrinsic dimension loading before producing
  *  a node. Recursively wraps .name/.label so chained calls stay awaiting. */

--- a/packages/gofish-graphics/src/serialize/fromJSON.ts
+++ b/packages/gofish-graphics/src/serialize/fromJSON.ts
@@ -412,6 +412,27 @@ export function mapMark(
       throw new Error(`Unknown combinator mark type: ${spec.type}`);
     }
     let mark = factory(opts, childMarks);
+    // A combinator mark (e.g. a `paint`ed image) can carry stacked `.label()`
+    // calls too — reapply them, mirroring the leaf-mark path below.
+    const combLabel = (spec as any).label;
+    const isLabelObj = (l: unknown): l is LabelSpec =>
+      l !== undefined && l !== null && typeof l === "object";
+    const combLabels: LabelSpec[] = Array.isArray(combLabel)
+      ? (combLabel as unknown[]).filter(isLabelObj)
+      : isLabelObj(combLabel) && !Array.isArray(combLabel)
+        ? [combLabel as LabelSpec]
+        : [];
+    for (const labelObj of combLabels) {
+      if (typeof (mark as any).label !== "function") break;
+      const { accessor, ...labelOpts } = labelObj as Exclude<
+        LabelSpec,
+        true | string
+      >;
+      mark = (mark as any).label(
+        accessor,
+        Object.keys(labelOpts).length > 0 ? labelOpts : undefined
+      );
+    }
     if (spec.constraints && typeof (mark as any).constrain === "function") {
       const constraints = spec.constraints as ConstraintSpec[];
       mark = (mark as any).constrain((refs: Record<string, any>) =>
@@ -446,21 +467,23 @@ export function mapMark(
   }
 
   const { type, name: layerName, ...rest } = spec as any;
-  // Label has two shapes:
+  // Label has three shapes:
   //   - Object `{accessor, ...opts}` — pull out and call the chained
   //     `.label(accessor, opts)` method (adds an external label layer).
+  //   - An array of those objects — one `.label()` call per element.
   //   - Boolean / string shorthand — keep in opts so the mark *shape*
   //     interprets it directly (e.g. rect's `label?: boolean` prop).
-  let labelObj: LabelSpec | undefined;
+  let labelObjs: LabelSpec[] = [];
   let opts: Record<string, any>;
-  if (
-    rest.label !== undefined &&
-    rest.label !== null &&
-    typeof rest.label === "object" &&
-    !Array.isArray(rest.label)
-  ) {
+  const isLabelObject = (l: unknown): l is LabelSpec =>
+    l !== undefined && l !== null && typeof l === "object";
+  if (Array.isArray(rest.label) && rest.label.every(isLabelObject)) {
     const { label: lbl, ...rest2 } = rest;
-    labelObj = lbl as LabelSpec;
+    labelObjs = lbl as LabelSpec[];
+    opts = rest2;
+  } else if (isLabelObject(rest.label) && !Array.isArray(rest.label)) {
+    const { label: lbl, ...rest2 } = rest;
+    labelObjs = [lbl as LabelSpec];
     opts = rest2;
   } else {
     opts = rest;
@@ -471,7 +494,8 @@ export function mapMark(
     throw new Error(`Unknown mark type: ${String(type)}`);
   }
   let mark = factory(unwrapMarkOpts(opts, bridge));
-  if (labelObj && typeof (mark as any).label === "function") {
+  for (const labelObj of labelObjs) {
+    if (typeof (mark as any).label !== "function") break;
     const { accessor, ...labelOpts } = labelObj as Exclude<
       LabelSpec,
       true | string

--- a/packages/gofish-graphics/src/serialize/toJSON.ts
+++ b/packages/gofish-graphics/src/serialize/toJSON.ts
@@ -35,8 +35,11 @@ interface SerializeTag {
   children?: Mark<any>[] | Promise<Mark<any>[]>;
   /** Set when `.name(layerName)` is chained on a mark. Strings pass through; Tokens become bridge-style sentinels. */
   name?: string | { __gofish_token: string; __tag: string };
-  /** Set when `.label(accessor, options)` is chained on a mark (object form). */
-  label?: { accessor: string; [k: string]: unknown };
+  /** Set when `.label(accessor, options)` is chained on a mark (object form).
+   *  An array when several `.label()` calls stack on one mark. */
+  label?:
+    | { accessor: string; [k: string]: unknown }
+    | Array<{ accessor: string; [k: string]: unknown }>;
 }
 
 function readTag(value: unknown): SerializeTag | undefined {

--- a/packages/gofish-graphics/stories/piccl/LatencyBottles.stories.tsx
+++ b/packages/gofish-graphics/stories/piccl/LatencyBottles.stories.tsx
@@ -1,0 +1,93 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import { chart, spread, image, rect, paint } from "../../src/lib";
+import bottlePng from "../assets/wilsonblanco.png";
+
+// System latencies (Gregg, *Systems Performance*, Table 2.2). The raw latencies
+// span ~12 orders of magnitude — too wide for one row of size-encoded bottles
+// (a CPU-cycle bottle would be an invisible sliver beside a reboot). Instead we
+// facet into three magnitude bands; within each band the bottle heights are
+// log-scaled to that band's own range, so neighbors read clearly, and the band
+// titles carry the ×1000-per-row story.
+const rows = [
+  { tier: "CPU & memory · nanoseconds", event: "1 CPU cycle", latency: "0.3 ns", scaled: "1 s", ns: 0.3 },
+  { tier: "CPU & memory · nanoseconds", event: "L1 cache access", latency: "0.9 ns", scaled: "3 s", ns: 0.9 },
+  { tier: "CPU & memory · nanoseconds", event: "L2 cache access", latency: "3 ns", scaled: "10 s", ns: 3 },
+  { tier: "CPU & memory · nanoseconds", event: "L3 cache access", latency: "10 ns", scaled: "33 s", ns: 10 },
+  { tier: "CPU & memory · nanoseconds", event: "Main memory (DRAM)", latency: "100 ns", scaled: "6 min", ns: 100 },
+  { tier: "Storage & network · µs–ms", event: "SSD I/O (flash)", latency: "10–100 µs", scaled: "9–90 hours", ns: 50_000 },
+  { tier: "Storage & network · µs–ms", event: "Rotational disk I/O", latency: "1–10 ms", scaled: "1–12 months", ns: 5_000_000 },
+  { tier: "Storage & network · µs–ms", event: "Internet: SF → New York", latency: "40 ms", scaled: "4 years", ns: 40_000_000 },
+  { tier: "Storage & network · µs–ms", event: "Internet: SF → U.K.", latency: "81 ms", scaled: "8 years", ns: 81_000_000 },
+  { tier: "Storage & network · µs–ms", event: "Lightweight HW virt boot", latency: "100 ms", scaled: "11 years", ns: 100_000_000 },
+  { tier: "Storage & network · µs–ms", event: "Internet: SF → Australia", latency: "183 ms", scaled: "19 years", ns: 183_000_000 },
+  { tier: "System events · seconds–minutes", event: "OS virt system boot", latency: "< 1 s", scaled: "105 years", ns: 1_000_000_000 },
+  { tier: "System events · seconds–minutes", event: "TCP timer retransmit", latency: "1–3 s", scaled: "105–317 years", ns: 2_000_000_000 },
+  { tier: "System events · seconds–minutes", event: "SCSI command time-out", latency: "30 s", scaled: "3 millennia", ns: 30_000_000_000 },
+  { tier: "System events · seconds–minutes", event: "HW virt system boot", latency: "40 s", scaled: "4 millennia", ns: 40_000_000_000 },
+  { tier: "System events · seconds–minutes", event: "Physical system reboot", latency: "5 m", scaled: "32 millennia", ns: 300_000_000_000 },
+];
+
+// Per-band bottle heights: log10(latency) mapped to [H_MIN, H_MAX] using each
+// band's own min/max, so each row of bottles fills the height range.
+const H_MIN = 56;
+const H_MAX = 190;
+// wilsonblanco.png is 157×650; `bw` is the bottle width at a given height, used
+// to size the burgundy tint rect so it exactly covers the bottle.
+const BOTTLE_ASPECT = 157 / 650;
+const bandLogRange: Record<string, [number, number]> = {};
+for (const r of rows) {
+  const l = Math.log10(r.ns);
+  const cur = bandLogRange[r.tier];
+  bandLogRange[r.tier] = cur ? [Math.min(cur[0], l), Math.max(cur[1], l)] : [l, l];
+}
+const data = rows.map((r) => {
+  const [lo, hi] = bandLogRange[r.tier];
+  const t = hi > lo ? (Math.log10(r.ns) - lo) / (hi - lo) : 1;
+  const h = H_MIN + t * (H_MAX - H_MIN);
+  return { ...r, h, bw: h * BOTTLE_ASPECT, scaledLabel: `≈ ${r.scaled}` };
+});
+
+const meta: Meta = {
+  title: "Piccl/LatencyBottles",
+};
+export default meta;
+
+export const Default: StoryObj = {
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Latency Bottle Chart",
+      description:
+        "System latencies from a CPU cycle to a full reboot, drawn as wine bottles and faceted into three magnitude bands — a playful small-multiples take on the classic wine-bottle-sizes poster.",
+    },
+  },
+  render: () => {
+    const container = initializeContainer();
+
+    chart(data, { axes: { x: false, y: { title: false } } })
+      .flow(
+        // Facet into magnitude bands stacked top-to-bottom (fastest on top)...
+        spread({ by: "tier", dir: "y", spacing: 64, alignment: "start", reverse: true, axes: { x: false, y: false } }),
+        // ...each band a row of bottles aligned on a common base.
+        spread({ by: "event", dir: "x", spacing: 24, alignment: "baseline", axes: { x: false, y: false } })
+      )
+      .mark(
+        // Tint the whole bottle burgundy (a `color`-blend rect sized to the
+        // bottle) so the white name reads against it.
+        paint({ blendMode: "multiply" }, [
+          image({ href: bottlePng, h: "h" }),
+          rect({ h: "h", w: "bw", fill: "#b3304f" }),
+        ])
+          .label("latency", { position: "outset-top", offset: 6, fontSize: 12, color: "#7a1020" })
+          // The table's "Scaled" column: latency re-felt at human time (a CPU
+          // cycle ≈ 1 s), which is what makes the dynamic range visceral.
+          .label("scaledLabel", { position: "outset-top", offset: 22, fontSize: 9, color: "#9a9a9a" })
+          // Event name printed up the bottle, wine-label style.
+          .label("event", { position: "center", fontSize: 10, color: "#ffffff", rotate: -90 })
+      )
+      .render(container, {});
+
+    return container;
+  },
+};

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -295,7 +295,7 @@ export const FRONTEND_IR_JSON_SCHEMA = {
           ],
         },
         name: { type: "string" },
-        label: { $ref: "#/$defs/LabelIR" },
+        label: { $ref: "#/$defs/LabelOrArrayIR" },
         constraints: {
           type: "array",
           items: { $ref: "#/$defs/ConstraintIR" },
@@ -331,7 +331,7 @@ export const FRONTEND_IR_JSON_SCHEMA = {
         options: { type: "object" },
         children: { type: "array", items: { $ref: "#/$defs/MarkIR" } },
         name: { type: "string" },
-        label: { $ref: "#/$defs/LabelIR" },
+        label: { $ref: "#/$defs/LabelOrArrayIR" },
         constraints: {
           type: "array",
           items: { $ref: "#/$defs/ConstraintIR" },
@@ -355,7 +355,7 @@ export const FRONTEND_IR_JSON_SCHEMA = {
           ],
         },
         name: { type: "string" },
-        label: { $ref: "#/$defs/LabelIR" },
+        label: { $ref: "#/$defs/LabelOrArrayIR" },
         zOrder: { type: "number" },
         translate: { $ref: "#/$defs/Translate" },
       },
@@ -381,6 +381,13 @@ export const FRONTEND_IR_JSON_SCHEMA = {
             rotate: { type: "number" },
           },
         },
+      ],
+    },
+    // A mark's `label` field: one label, or an array stacking several.
+    LabelOrArrayIR: {
+      oneOf: [
+        { $ref: "#/$defs/LabelIR" },
+        { type: "array", items: { $ref: "#/$defs/LabelIR" } },
       ],
     },
     ConstraintIR: {

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -318,7 +318,7 @@ export type CombinatorMarkType =
 export interface LeafMarkIR extends BaseIRNode {
   type: LeafMarkType;
   name?: string;
-  label?: LabelIR;
+  label?: LabelIR | LabelIR[];
   constraints?: ConstraintIR[];
   zOrder?: number;
   translate?: TranslateIR;
@@ -336,7 +336,7 @@ export interface CombinatorMarkIR extends BaseIRNode {
   options?: Record<string, unknown>;
   children: MarkIR[];
   name?: string;
-  label?: LabelIR;
+  label?: LabelIR | LabelIR[];
   constraints?: ConstraintIR[];
   zOrder?: number;
   translate?: TranslateIR;
@@ -347,7 +347,7 @@ export interface RefMarkIR extends BaseIRNode {
   type: "ref";
   selection: string | Array<string | number>;
   name?: string;
-  label?: LabelIR;
+  label?: LabelIR | LabelIR[];
   zOrder?: number;
   translate?: TranslateIR;
 }

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -800,6 +800,12 @@ function walkLeafMark(
 }
 
 function walkLabel(node: unknown, path: string, ctx: Context): void {
+  // An array stacks several labels on one mark (e.g. a value above and a
+  // category below); validate each element with the same rules.
+  if (Array.isArray(node)) {
+    node.forEach((el, i) => walkLabel(el, `${path}[${i}]`, ctx));
+    return;
+  }
   // Shorthand forms (matching the JS API):
   //   label: true   → "label with default settings"
   //   label: "field" → "label with this field accessor, defaults elsewhere"

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -205,7 +205,10 @@ class Mark:
         self.mark_type = mark_type
         self.kwargs = kwargs
         self._name: Optional[Union[str, "Token"]] = None
-        self._label: Optional[dict] = None
+        # A mark may stack several `.label()` calls; each renders as an
+        # independent post-layout overlay. `to_dict()` emits a scalar for the
+        # single-label case and an array when there are several.
+        self._labels: List[dict] = []
         # When set, this Mark is the combinator form of a layout operator
         # (e.g. `spread([rect, rect], dir="x")`) and `to_dict()` will emit a
         # `__combinator: true` payload the harness/widget reconstructs by
@@ -230,7 +233,7 @@ class Mark:
 
     def _copy_meta(self, target: "Mark") -> "Mark":
         target._name = self._name
-        target._label = self._label
+        target._labels = list(self._labels)
         target._children = self._children
         target._is_scope = self._is_scope
         target._datum = self._datum
@@ -372,7 +375,7 @@ class Mark:
             label_spec["minSpace"] = minSpace
         if rotate is not None:
             label_spec["rotate"] = rotate
-        new_mark._label = label_spec
+        new_mark._labels = self._labels + [label_spec]
         return new_mark
 
     def to_dict(self) -> dict:
@@ -405,8 +408,10 @@ class Mark:
                 if isinstance(self._name, Token)
                 else self._name
             )
-        if self._label is not None:
-            d["label"] = self._label
+        if self._labels:
+            d["label"] = (
+                self._labels[0] if len(self._labels) == 1 else list(self._labels)
+            )
         # Only ConstrainableMark carries _constraints, but reading via getattr
         # keeps the base class oblivious to the subclass extension.
         constraints = getattr(self, "_constraints", None)
@@ -1375,7 +1380,7 @@ def layer(
 # fails, so this is mostly defensive — but explicit guards make the
 # failure mode loud if a child happens to be named e.g. "kwargs".
 _REF_PROXY_RESERVED = frozenset({
-    "mark_type", "kwargs", "_name", "_label", "_children", "_is_scope",
+    "mark_type", "kwargs", "_name", "_labels", "_children", "_is_scope",
     "name", "label", "to_dict", "to_ir", "render", "_copy_meta",
     "_repr_mimebundle_", "constrain", "multiplicity",
 })
@@ -2297,6 +2302,7 @@ def text(
     fontSize: Optional[Union[int, str]] = None,
     fontWeight: Optional[Union[int, str]] = None,
     fontFamily: Optional[str] = None,
+    rotate: Optional[Union[int, float]] = None,
     debugBoundingBox: Optional[bool] = None,
     label: Optional[str] = None,
     debug: Optional[bool] = None,
@@ -2311,6 +2317,8 @@ def text(
             populates an auto-generated field per row.
         fill: Text color.
         fontSize / fontWeight / fontFamily: Typography.
+        rotate: Rotation in degrees; `rotate=90` yields a y-axis-title style
+            vertical label.
         debugBoundingBox: Draw the text's bounding box (for layout debug).
         label: Auto-value-label flag (different from text content).
     """
@@ -2327,6 +2335,7 @@ def text(
         ("fontSize", fontSize),
         ("fontWeight", fontWeight),
         ("fontFamily", fontFamily),
+        ("rotate", rotate),
         ("debugBoundingBox", debugBoundingBox),
         ("label", label),
         ("debug", debug),

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -624,6 +624,24 @@ function mapMark(
       throw new Error(`Unknown combinator mark type: ${spec.type}`);
     }
     let mark = factory(opts, childMarks);
+    // Reapply stacked `.label()` calls — a combinator mark (e.g. a `paint`ed
+    // bottle) can carry labels too, and the leaf path below reapplies them but
+    // this branch returns early. Same structured-label shape as the leaf path.
+    const isCombLabelDict = (
+      l: unknown
+    ): l is { accessor: any } & Record<string, any> =>
+      !!l && typeof l === "object" && !Array.isArray(l);
+    const combLabels = Array.isArray(spec.label)
+      ? (spec.label as any[]).filter(isCombLabelDict)
+      : isCombLabelDict(spec.label)
+        ? [spec.label]
+        : [];
+    if (combLabels.length > 0 && typeof (mark as any).label === "function") {
+      for (const lbl of combLabels) {
+        const { accessor, ...labelOpts } = lbl;
+        mark = (mark as any).label(accessor, labelOpts);
+      }
+    }
     // Constraint chain. The Python side serializes refs by name; reify the
     // JS-side ConstraintRef objects from those names by looking them up in
     // the `refs` map the JS callback receives.
@@ -674,11 +692,21 @@ function mapMark(
 
   // `label: true` (boolean) is a primitive kwarg the mark itself understands
   // (auto-value labels). The Python Mark.label() chain emits a structured
-  // `{accessor, position?, fontSize?, ...}` dict that must be reapplied as a
-  // chained `.label(accessor, options)` call — same shape the JS storybook
-  // uses (e.g. `rect({h: "count"}).label("count", {position: "outset"})`).
-  const isStructuredLabel =
-    label && typeof label === "object" && !Array.isArray(label);
+  // `{accessor, position?, fontSize?, ...}` dict (or an array of them when a
+  // mark stacks several labels) that must be reapplied as chained
+  // `.label(accessor, options)` calls — same shape the JS storybook uses
+  // (e.g. `rect({h: "count"}).label("count", {position: "outset"})`).
+  const isLabelDict = (
+    l: unknown
+  ): l is { accessor: any } & Record<string, any> =>
+    !!l && typeof l === "object" && !Array.isArray(l);
+  const structuredLabels: Array<{ accessor: any } & Record<string, any>> =
+    Array.isArray(label)
+      ? (label as any[]).filter(isLabelDict)
+      : isLabelDict(label)
+        ? [label]
+        : [];
+  const isStructuredLabel = structuredLabels.length > 0;
   const factoryOpts: Record<string, any> = unwrapMarkOpts(
     isStructuredLabel
       ? opts
@@ -688,11 +716,10 @@ function mapMark(
 
   let mark = factory(factoryOpts);
   if (isStructuredLabel && typeof (mark as any).label === "function") {
-    const { accessor, ...labelOpts } = label as { accessor: any } & Record<
-      string,
-      any
-    >;
-    mark = (mark as any).label(accessor, labelOpts);
+    for (const lbl of structuredLabels) {
+      const { accessor, ...labelOpts } = lbl;
+      mark = (mark as any).label(accessor, labelOpts);
+    }
   }
   if (spec.__scope) {
     mark = wrapWithScope(mark);

--- a/tests/python-stories/piccl/test_latency_bottles.py
+++ b/tests/python-stories/piccl/test_latency_bottles.py
@@ -1,0 +1,91 @@
+"""Equivalent of piccl/LatencyBottles.stories.tsx — Piccl/LatencyBottles.
+
+System latencies (Gregg, *Systems Performance*, Table 2.2) drawn as wine
+bottles, faceted into three magnitude bands. Within each band bottle height is
+log-scaled to that band's own range, so neighbors read clearly; the band titles
+(the categorical y-axis) carry the ×1000-per-row story.
+
+Everything is authored with plain field-string channels — `image(h="h")`,
+`text(text="latency")` — and stacked `.label()` calls, so no Python lambda
+crosses the derive RPC; the per-row `h` and `scaledLabel` columns are
+precomputed in the data exactly as the JS story computes them.
+"""
+
+import math
+import os
+
+from gofish import chart, image, paint, rect, spread
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+BOTTLE_PNG = (
+    f"/@fs{_REPO_ROOT}/packages/gofish-graphics/stories/assets/wilsonblanco.png"
+)
+
+NS = "CPU & memory · nanoseconds"
+US_MS = "Storage & network · µs–ms"
+S_MIN = "System events · seconds–minutes"
+
+ROWS = [
+    {"tier": NS, "event": "1 CPU cycle", "latency": "0.3 ns", "scaled": "1 s", "ns": 0.3},
+    {"tier": NS, "event": "L1 cache access", "latency": "0.9 ns", "scaled": "3 s", "ns": 0.9},
+    {"tier": NS, "event": "L2 cache access", "latency": "3 ns", "scaled": "10 s", "ns": 3},
+    {"tier": NS, "event": "L3 cache access", "latency": "10 ns", "scaled": "33 s", "ns": 10},
+    {"tier": NS, "event": "Main memory (DRAM)", "latency": "100 ns", "scaled": "6 min", "ns": 100},
+    {"tier": US_MS, "event": "SSD I/O (flash)", "latency": "10–100 µs", "scaled": "9–90 hours", "ns": 50_000},
+    {"tier": US_MS, "event": "Rotational disk I/O", "latency": "1–10 ms", "scaled": "1–12 months", "ns": 5_000_000},
+    {"tier": US_MS, "event": "Internet: SF → New York", "latency": "40 ms", "scaled": "4 years", "ns": 40_000_000},
+    {"tier": US_MS, "event": "Internet: SF → U.K.", "latency": "81 ms", "scaled": "8 years", "ns": 81_000_000},
+    {"tier": US_MS, "event": "Lightweight HW virt boot", "latency": "100 ms", "scaled": "11 years", "ns": 100_000_000},
+    {"tier": US_MS, "event": "Internet: SF → Australia", "latency": "183 ms", "scaled": "19 years", "ns": 183_000_000},
+    {"tier": S_MIN, "event": "OS virt system boot", "latency": "< 1 s", "scaled": "105 years", "ns": 1_000_000_000},
+    {"tier": S_MIN, "event": "TCP timer retransmit", "latency": "1–3 s", "scaled": "105–317 years", "ns": 2_000_000_000},
+    {"tier": S_MIN, "event": "SCSI command time-out", "latency": "30 s", "scaled": "3 millennia", "ns": 30_000_000_000},
+    {"tier": S_MIN, "event": "HW virt system boot", "latency": "40 s", "scaled": "4 millennia", "ns": 40_000_000_000},
+    {"tier": S_MIN, "event": "Physical system reboot", "latency": "5 m", "scaled": "32 millennia", "ns": 300_000_000_000},
+]
+
+# Per-band bottle heights: log10(latency) mapped to [H_MIN, H_MAX] using each
+# band's own min/max, so each row of bottles fills the height range.
+H_MIN = 56
+H_MAX = 190
+# wilsonblanco.png is 157×650; `bw` is the bottle width at a given height, used
+# to size the burgundy tint rect so it exactly covers the bottle.
+BOTTLE_ASPECT = 157 / 650
+_band_range: dict = {}
+for _r in ROWS:
+    _l = math.log10(_r["ns"])
+    _cur = _band_range.get(_r["tier"])
+    _band_range[_r["tier"]] = (
+        (min(_cur[0], _l), max(_cur[1], _l)) if _cur else (_l, _l)
+    )
+DATA = []
+for _r in ROWS:
+    _lo, _hi = _band_range[_r["tier"]]
+    _t = (math.log10(_r["ns"]) - _lo) / (_hi - _lo) if _hi > _lo else 1.0
+    _h = H_MIN + _t * (H_MAX - H_MIN)
+    DATA.append({**_r, "h": _h, "bw": _h * BOTTLE_ASPECT, "scaledLabel": f"≈ {_r['scaled']}"})
+
+
+def story_default():
+    return (
+        chart(DATA)
+        .flow(
+            spread(by="tier", dir="y", spacing=64, alignment="start", reverse=True, axes={"x": False, "y": False}),
+            spread(by="event", dir="x", spacing=24, alignment="baseline", axes={"x": False, "y": False}),
+        )
+        .mark(
+            paint(
+                [
+                    image(href=BOTTLE_PNG, h="h"),
+                    rect(h="h", w="bw", fill="#b3304f"),
+                ],
+                blendMode="multiply",
+            )
+            .label("latency", position="outset-top", offset=6, fontSize=12, color="#7a1020")
+            .label("scaledLabel", position="outset-top", offset=22, fontSize=9, color="#9a9a9a")
+            .label("event", position="center", fontSize=10, color="#ffffff", rotate=-90)
+        ),
+        {"axes": {"x": False, "y": {"title": False}}},
+    )


### PR DESCRIPTION
## What

A new **"Latency Bottle Chart"** gallery story, plus the two library features building it required.

The story visualizes system latencies from Gregg's *Systems Performance* (Table 2.2) — from a 0.3 ns CPU cycle to a 5 min reboot, ~12 orders of magnitude — as burgundy-tinted wine bottles in the style of the classic wine-bottle-sizes poster. Since 12 orders can't size-encode in one row (a CPU-cycle bottle would be an invisible sliver), it facets into three magnitude bands via nested `flow`, with bottle heights log-scaled to each band's own range. The categorical band titles carry the ×1000-per-row story; each bottle is labeled with its raw latency, the "Scaled" human-time column, and its event name printed up the bottle wine-label style.

![Latency bottle chart](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-640/latency-bottles.png)

## Library changes this surfaced

Rather than special-case the story, both gaps are fixed as proper cross-language features:

- **Data-driven image sizing** — `image` marks gain `size`/`pos` channels, so height can come from a data field and intrinsic-aspect width follows: `image({ href, h: "h" })`.
- **Stacked `.label()`** — a mark can now carry multiple labels. The single `_label` field becomes a `_labels` array end to end: node lowering, label render, bake guard, operator-tag accumulation, serialize/deserialize, IR schema + validator + JSON Schema, and the Python wrapper. Labels are now also **reapplied on combinator marks** (e.g. a `paint()`ed bottle) in both reconstruction paths (`Serialize.fromJSON` and the parity harness) — previously they were silently dropped there.

## Verification

- JS↔Python parity: `validate-python-ir` 156/156; identical render structure (16 images / 32 rects / 51 texts / 16 multiply blends).
- Existing `paint`-based Bottle story unregressed; typechecks clean.
- Docs updated for the image data-driven-height example and the `text()` `rotate` param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)