### PR TITLE
σ-affine simplification, stages 0–3: placement lattice, span→position, grid containment

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -416,8 +416,16 @@ out first. The bottom-up space pass applies only the inside-out portion via
 `applyNestLayoutProposal` does the corresponding layout-time arithmetic on the
 derived axes.
 Grid is also selected through the proposal plan (`selectGridConstraint`):
-because a grid owns both track partitions for a layer, more than one grid
-constraint is a proposal conflict rather than a declaration-order choice.
+because a grid owns both track partitions for a layer — and bypasses the
+space/size fold entirely — it is a whole-layer layout mode, not a composable
+constraint. `selectGridConstraint` therefore enforces two exclusivity rules
+(it is the one site both the space pass and the layout pass flow through): more
+than one grid constraint is a proposal conflict rather than a declaration-order
+choice, and a grid mixed with any non-z-order constraint (align / distribute /
+position / nest) throws — that sibling would be applied by placement but never
+enter the space fold, so it would silently half-apply. z-order constraints
+(zAbove / zBelow) are render-time paint order and compose freely alongside a
+grid. Grid has no public factory; it is `table`'s private elaboration target.
 The same proposal plan marks datum-valued `position` targets
 (`buildPositionTargetDims`) so the layer does not also forward the consumed
 data→pixel scale to that child axis; literal pixel pins are not marked because

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -80,6 +80,50 @@ domains. This information is later used to draw axes for the combined
 chart. We need to store intermediate results about these domains, and
 that's basically the role of the underlying space data structure.
 
+## The one equation, and three roles for one unknown
+
+Every continuous axis is, in the end, one affine map — per **σ-scope** (the
+region over which a single scale is shared):
+
+```
+px(d) = pxMin + σ·(d − domainMin)          σ = pixels per data unit
+```
+
+`σ` (sigma) is the slope: pixels per unit of data. `domainMin` is the low edge
+of the data interval. Per node and axis there is exactly one position unknown —
+the **baseline**, the screen coordinate of the node's local data-0. Three things
+that the word "origin" historically ran together must be kept distinct, because
+each lives at a different stage of the pipeline:
+
+- **alignment** is a _constraint_: equations between per-node baselines
+  (`baseline_A = baseline_B`, and analogous relations for other anchors). It says
+  nothing about pixels; it only records which baselines must agree.
+- **placement** (`free | determined | conflict`) is the _abstract value_: is the
+  baseline subsystem under-determined, solvable, or inconsistent? This is all
+  that bottom-up space resolution can know — it runs before pixels exist, so it
+  computes the _determinacy_ of the baseline, not the baseline itself.
+- **the intercept** is the _concrete value_: the solved shared baseline of a
+  σ-scope, in pixels — `pxMin` above, read as `posScale(0)`. It exists only after
+  σ and the frame anchor resolve, so it is always a **derived read**, never
+  stored state.
+
+A false friend to never conflate with that intercept: the `width` Monotonic
+carries its _own_ intercept — the σ-independent pixel part of an _extent_
+(spacing, fixed chrome), the intercept of the size-vs-σ line `size = slope·σ +
+intercept`. That is an intercept of the size equation, not of the data→screen
+map; the two never mean the same thing.
+
+**The two scale carriers, honestly.** Layout currently threads two parallel
+per-axis channels downward (see [Layout dispatch](#layout-dispatch)).
+`scaleFactors` carries only the slope σ, for _unanchored_ extents — a free
+magnitude has no committed baseline, so its intercept is implicit in where its
+parent places it (baseline placement + `transform.translate`) and never needs to
+travel with the scale. `posScales` carries the _whole_ map `px(d)` for _anchored_
+extents, closing σ and the intercept together over one function. So "anchored"
+shows up operationally as "has a posScale"; "unanchored" as "has only a scale
+factor." Stage 4 of [the σ-affine plan](/internals/design/sigma-affine-simplification)
+folds these two into a single affine record.
+
 ## Why an explicit IR
 
 Conventional grammars of graphics treat a scale as a function from a data
@@ -139,30 +183,38 @@ generation.
 ## The three space kinds
 
 Each axis (x and y) of each node carries one of `continuous`, `ordinal`, or
-`undefined`. The continuous kind is one shape carrying three facts — and the
-two that older designs tangled are kept apart: a **`placement`** (a _layout_
-fact: is this extent positioned, and where) and a **`dataDomain`** (a
-_data-space_ fact: the axis range, if any).
+`undefined`. The continuous kind stores two facts: a **`width`** (a σ-affine
+_size_ Monotonic) and a **`dataDomain`** (a _data-space_ fact: the axis range, if
+any). The **`placement`** (the _layout_ fact: is this extent positioned) is not a
+third stored field — it is a **derived view** of `dataDomain`'s shape, a bare
+determinacy lattice read via `spacePlacement(space)`:
 
 ```ts
 // underlyingSpace.ts
-type Placement =
-  | { tag: "free" }                   // sized, position not yet committed (a bar's height)
-  | { tag: "determined"; at: number } // committed at this DATA coordinate (a scatter point's x)
-  | { tag: "conflict" };              // no absolute position possible (a centered streamgraph band)
+type Placement = "free" | "determined" | "conflict";
 
 type DataDomain = Interval | "delta" | undefined;
 
 type CONTINUOUS_TYPE = {
   kind: "continuous";
   width: Monotonic;       // the σ-affine SIZE: slope·σ + intercept
-  placement: Placement;   // the abstract POSITION/baseline (layout)
-  dataDomain: DataDomain; // the data-space extent (scales / axes / nicing / measures)
+  dataDomain: DataDomain; // data-space extent AND the sole placement carrier
   measure?: Measure;
 };
 type ORDINAL_TYPE   = { kind: "ordinal";   domain?: string[]; measure?: Measure; ... };
 type UNDEFINED_TYPE = { kind: "undefined"; ... };
+
+// placement is in bijection with dataDomain's shape:
+const spacePlacement = (s: CONTINUOUS_TYPE): Placement =>
+  s.dataDomain === undefined ? "free"        // sized, position not yet committed (a bar's height)
+    : s.dataDomain === "delta" ? "conflict"  // no absolute position possible (a centered streamgraph band)
+      : "determined";                        // committed to a DATA interval (a scatter point's x)
 ```
+
+The committed coordinate itself (the old `placement.at`) is not a separate
+payload: it is simply the `dataDomain` interval's `min`, read back with
+`continuousInterval(space)?.min`. Storing it twice was redundant — it always
+equaled `dataDomain.min` — so placement collapses to a bare lattice.
 
 `ORDINAL` carries a `measure` too (the grouping field, e.g. `"lake"`) — the
 discrete analogue of `CONTINUOUS`'s measure. It's set from the grouping operator
@@ -184,15 +236,17 @@ placement:
 | (kind `ordinal`)   | labels at laid-out keys      | —                   | bars by category, facets      |
 | (kind `undefined`) | no guide                     | —                   | an aesthetic / literal-px dim |
 
-The three pieces correspond directly to the σ-affine layout solve (see
-[Size resolution](#size-resolution) and the solver): `width` is the abstract
-**SIZE** (slope·σ + intercept), `placement` is the abstract **baseline** (the
-σ-independent position intercept), and the underlying-space pass is essentially
-an _abstract interpretation_ of that solve — it computes the structure (which
-extents are sized, which are positioned) bottom-up before the concrete pixels
-exist. Carrying `placement` as a first-class value is what lets alignment ask
-"is this child already positioned?" directly (see [The contract](#the-contract))
-instead of reconstructing it.
+These map directly onto the σ-affine layout solve (see
+[the one equation](#the-one-equation-and-three-roles-for-one-unknown),
+[Size resolution](#size-resolution), and the solver): `width` is the abstract
+**SIZE** (slope·σ + intercept), and `placement` is the abstract **value** of the
+baseline — its _determinacy_ (free / determined / conflict), not its pixel
+intercept. The underlying-space pass is essentially an _abstract interpretation_
+of the solve: it computes the structure (which extents are sized, which are
+positioned) bottom-up before the concrete pixels — and therefore the concrete
+baseline intercept — exist. Deriving `placement` from `dataDomain` is what lets
+alignment ask "is this child already positioned?" directly (see
+[The contract](#the-contract)) instead of reconstructing it.
 
 This shape is the endpoint of issue #586's collapse. The old
 `POSITION`/`SIZE`/`DIFFERENCE` were one semantic thing — a data-driven extent —
@@ -200,27 +254,30 @@ observed at three pipeline stages; carrying that as three kinds baked a _stage_
 distinction into the _type_. A first cut collapsed them to a single overloaded
 `origin: number | "free" | "impossible"` scalar, but that conflated the layout
 fact with the data fact (a baseline magnitude vs a data axis anchored at 0 —
-which build no posScale vs a posScale). Splitting `origin` into `placement` +
-`dataDomain` keeps them distinct. The `SIZE`/`POSITION`/`DIFFERENCE`
-constructors survive as thin builders:
+which build no posScale vs a posScale). Keeping the layout fact _derived from_
+`dataDomain` keeps them distinct while storing only one field. The
+`SIZE`/`POSITION`/`DIFFERENCE` constructors survive as thin builders over a
+single `anchor` argument (`number | "free" | "impossible"` — the number is the
+domain min, not a zero point), and each fixes `dataDomain`, from which placement
+falls out:
 
-- a former `SIZE` (`rect({ h: "count" })`) is `{ placement: free, dataDomain: undefined }`;
-- a former `POSITION([a, b])` is `{ placement: determined(a), dataDomain: [a, b] }`;
-- a former `DIFFERENCE(w)` is `{ placement: conflict, dataDomain: "delta" }`.
+- a former `SIZE` (`rect({ h: "count" })`) has `dataDomain: undefined` → placement `free`;
+- a former `POSITION([a, b])` has `dataDomain: [a, b]` → placement `determined` (at `a`);
+- a former `DIFFERENCE(w)` has `dataDomain: "delta"` → placement `conflict`.
 
 The pre/post-solve distinction is handled by _when_ σ is substituted, not by
 _which kind_: σ is always `width.inverse(size)`, and the extent at σ is always
 `width.run(σ)`. The one genuine state transition is **`middle`-alignment drops
-the anchor** — centering scrambles the children's baselines, so the result is
-`placement: conflict` + `dataDomain: "delta"` (the streamgraph). A `conflict`
-placement is absorbing: no alignment re-anchors it.
+the anchor** — centering scrambles the children's baselines, so the result has
+`dataDomain: "delta"` (the streamgraph), which derives placement `conflict`. A
+`conflict` placement is absorbing: no alignment re-anchors it.
 
-`isDIFFERENCE` deliberately keys on `dataDomain === "delta"`, not on placement,
-so that a (future) `conflict` placement that still has a real data domain would
-not wrongly render delta ticks. The anchored data interval is read back with
-`continuousInterval(space)` — which is simply the `dataDomain` when it is an
-interval (used by posScale construction and axis nicing); it returns `undefined`
-otherwise.
+`isDIFFERENCE` keys on `dataDomain === "delta"` — the same field placement
+derives from — so the two never disagree. The anchored data interval is read
+back with `continuousInterval(space)`, which is simply the `dataDomain` when it
+is an interval (used by posScale construction and axis nicing) and `undefined`
+otherwise; its `.min` is the committed baseline coordinate (the old
+`placement.at`).
 
 These kinds map closely to Stevens's statistical data types, but not cleanly:
 an `Interval` `dataDomain` covers both interval and ratio, and `"delta"` is
@@ -729,7 +786,7 @@ measure**.
 
 ```ts
 // underlyingSpace.ts
-export type CONTINUOUS_TYPE = { kind: "continuous"; width: Monotonic; placement: Placement; dataDomain: DataDomain; measure?: Measure; ... };
+export type CONTINUOUS_TYPE = { kind: "continuous"; width: Monotonic; dataDomain: DataDomain; measure?: Measure; ... };
 ```
 
 **Merging.** Two helpers in `underlyingSpace.ts` decide what happens when two

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -350,24 +350,26 @@ composes its targets' spaces into the layer's claim on that axis:
   inside-out on one axis and outside-in on the other is rejected as mixed — the
   layer enforces both at constraint-collection time (see [[size-claims]]).
 
-- `Constraint.span` (`constraints/span.ts`) is the second size-setting
-  constraint: pin BOTH edges of a target on an axis (`x: [min, max]`) and the
-  **size falls out** — the relation `place()`'s position-only protocol cannot
-  express. It is built on the **linear-system bbox** (`constraints/bbox.ts`,
-  #39): a per-axis 2-unknown system in `(min, size)` where each facet
-  (`min`/`max`/`center`/`size`) is one equation; two independent facets are
-  rank 2, so the rest are inferred (two edges ⇒ a size), and a third, dependent
-  write is a structured over-determination report rather than a silent
-  last-writer-wins. A span's datum endpoints feed the axis's POSITION domain via
-  `collectPositionDomains` (like a `position` pin's coordinate), and
-  `composeConstraintSpaces` treats a span as an **extent-establisher** (like a
-  distribute), so the cross-axis `align` fold still runs — a histogram is a span
-  on x plus an `align` on y, and it is that align fold (SIZE→POSITION) that makes
-  the count axis. The solved `(min, size)` is bridged into GoFish's
+- The **interval form** of `Constraint.position` (`{ x: [min, max] }`, lowered
+  by `constraints/span.ts`) is the second size-setting constraint: pin BOTH
+  edges of a target on an axis and the **size falls out** — the relation
+  `place()`'s position-only protocol cannot express. It is built on the
+  **linear-system bbox** (`constraints/bbox.ts`, #39): a per-axis 2-unknown
+  system in `(min, size)` where each facet (`min`/`max`/`center`/`size`) is one
+  equation; two independent facets are rank 2, so the rest are inferred (two
+  edges ⇒ a size), and a third, dependent write is a structured
+  over-determination report rather than a silent last-writer-wins. An interval's
+  datum endpoints feed the axis's POSITION domain via `collectPositionDomains`
+  (like a point coordinate does), and `composeConstraintSpaces` treats an
+  interval position as an **extent-establisher** (like a distribute), so the
+  cross-axis `align` fold still runs — a histogram is an interval position on x
+  plus an `align` on y, and it is that align fold (SIZE→POSITION) that makes the
+  count axis. The solved `(min, size)` is bridged into GoFish's
   `(local box, translate)` split by stamping `[0, size]` into the local box and
-  deriving the absolute `min` through the placement ledger. `scatter` uses both:
-  plain `x`/`y` → `Constraint.position`, range `xMin`/`xMax`/`yMin`/`yMax` →
-  `Constraint.span` (the operator no longer has a bespoke layout). A categorical
+  deriving the absolute `min` through the placement ledger. `scatter` uses both
+  forms of `Constraint.position`: plain `x`/`y` → a point coordinate, range
+  `xMin`/`xMax`/`yMin`/`yMax` → an interval coordinate (the operator no longer
+  has a bespoke layout). A categorical
   scatter channel such as `x: "lake"` lowers to discrete placement coordinates
   `i / count · axisSize`; those are placement coordinates, not datum values, so
   they become numeric placement facts without affecting the layer's data domain.
@@ -470,14 +472,15 @@ path; spread, scatter, table, axes, and hand-written constraints all lower to
 the same solver entrypoint. Span edge claims are still pre-validated with the
 bbox helper so duplicate edge claims collapse and contradictory spans report a
 span-specific conflict, but the resulting edge pins participate in the same
-relation solve as placement. An incompatible same-solve `span` + `position` on the same
-target/axis reports an over-determined placement instead of letting one silently
-yield to the other.
+relation solve as placement. An incompatible same-solve interval + point
+`position` on the same target/axis reports an over-determined placement instead
+of letting one silently yield to the other.
 
 Placement-time alignment dispatches on the same resolution. `align` emits
 relations between child anchors; it no longer chooses an absolute fallback
-baseline for an otherwise-floating system. If no explicit `position`, `span`,
-self-placement, or other strong pin fixes a connected component, the solver
+baseline for an otherwise-floating system. If no explicit `position` (point or
+interval), self-placement, or other strong pin fixes a connected component, the
+solver
 normalizes that component so its minimum solved coordinate is `0`. A user who
 needs the aligned system to appear at a particular place must say so explicitly
 with a placement constraint.
@@ -857,11 +860,11 @@ only when its measure matches the dim's own position measure — a foreign-measu
 size (a bubble's area) stays a flat point. See the embedding-resolution pass under
 [layout passes](/internals/layout/passes#pass-8-5-embedding-resolution).
 
-**Constraint-domain measures.** A `position`/`span` constraint's datum
-coordinate carries the same resolved measure, and `collectPositionDomains`
-folds those per axis with `mergeMeasures` — so a layer's own positioning
-constraints in clashing units (a span with one endpoint in `mm` and the other
-in `inch`) throw at the source. The layer's `resolveAxis` (`layer.tsx`) then
+**Constraint-domain measures.** A `position` constraint's datum coordinate
+carries the same resolved measure, and `collectPositionDomains` folds those per
+axis with `mergeMeasures` — so a layer's own positioning constraints in clashing
+units (an interval coordinate with one endpoint in `mm` and the other in `inch`)
+throw at the source. The layer's `resolveAxis` (`layer.tsx`) then
 treats this constraint-domain measure as the axis's unit: it **prefers** the
 constraint measure and falls back to the children's POSITION measure only when
 the coordinates are untagged (literal pixels). It deliberately does _not_

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -255,11 +255,14 @@ distinction into the _type_. A first cut collapsed them to a single overloaded
 `origin: number | "free" | "impossible"` scalar, but that conflated the layout
 fact with the data fact (a baseline magnitude vs a data axis anchored at 0 —
 which build no posScale vs a posScale). Keeping the layout fact _derived from_
-`dataDomain` keeps them distinct while storing only one field. The
-`SIZE`/`POSITION`/`DIFFERENCE` constructors survive as thin builders over a
-single `anchor` argument (`number | "free" | "impossible"` — the number is the
-domain min, not a zero point), and each fixes `dataDomain`, from which placement
-falls out:
+`dataDomain` keeps them distinct while storing only one field. There is no
+scalar "anchor" builder type either — a second spelling of the same three-way
+split would just be `Placement` with a payload again. The three placement cases
+ARE the three named constructors (`POSITION` anchored, `SIZE` free,
+`DIFFERENCE` conflict), plus `anchorAt(space, min)` for re-anchoring an
+existing space at a data coordinate (the domain min, not a zero point) while
+preserving its σ-affine width. Each constructor fixes `dataDomain`, from which
+placement falls out:
 
 - a former `SIZE` (`rect({ h: "count" })`) has `dataDomain: undefined` → placement `free`;
 - a former `POSITION([a, b])` has `dataDomain: [a, b]` → placement `determined` (at `a`);

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -1,0 +1,267 @@
+---
+title: "Plan: Unify Sizing/Positioning Around the σ-Affine Model"
+section: Speculative Notes
+order: 61
+status: speculative
+---
+
+# Plan: unify sizing/positioning around the σ-affine model
+
+Staged simplification of the layout engine, from vocabulary fixes to the #39
+endgame. Each stage lands independently and is gated on **pixel equality**
+across all stories (`capture-diff` as inner loop; the CI visual baselines as
+the outer gate). No compatibility shims anywhere — callsites migrate in the
+same change.
+
+## The one equation, and three roles for one unknown
+
+Every continuous axis is one affine map per σ-scope:
+
+```
+px(d) = pxMin + σ·(d − domainMin)          σ = pixels per data unit
+```
+
+Per node and axis there is one position unknown — the **baseline**, the screen
+coordinate of the node's local data-0. Three things currently share the word
+"origin" and must be kept distinct:
+
+- **alignment** is a _constraint_: equations between baselines
+  (`baseline_A = baseline_B`), or between other facets for other anchors;
+- **placement** (`free | determined | conflict`) is the _abstract value_: is
+  the baseline subsystem under-determined / solvable / inconsistent — all that
+  bottom-up space resolution can know, since pixels don't exist yet;
+- **the intercept** is the _concrete value_: the solved shared baseline of a
+  σ-scope, in pixels. It exists only after σ and the frame anchor resolve, and
+  should always be a derived read (`posScale(0)`), never stored state.
+
+False friend to never conflate: the `width` Monotonic's own intercept is the
+σ-independent pixel part of an _extent_ (spacing, fixed chrome) — an intercept
+of the size-vs-σ line, not of the data→screen map.
+
+Root cause the stages chip away at: the placement solve gives each node **one**
+unknown per axis (its `min`) while sizing runs in a **separate** σ-fold pass,
+with the intercept held off-ledger in `transform.translate`. `span` and `grid`
+are the two places that model can't express something, so each grew a bespoke
+side-regime; the align guards and scale-forwarding rules are hand-maintained
+consistency between the two passes.
+
+---
+
+## Stage 0 — vocabulary and docs (no behavior)
+
+Write the equation and the three-roles framing into
+`apps/docs/docs/internals/core/underlying-space.md`, plus one paragraph naming
+the current two carriers honestly: `scaleFactors` carries only the slope σ for
+unanchored extents (intercept implicit in baseline placement + translate);
+`posScales` carries the whole map for anchored ones.
+
+- Files: the essay; touch-ups to doc comments in `underlyingSpace.ts`,
+  `solver/index.ts`.
+- Gate: `pnpm --filter docs check-backlinks`, docs build.
+- Size: small. Can ride along with Stage 1.
+
+## Stage 1 — placement becomes a bare lattice, then a derived view
+
+`placement.at` is stored redundantly: it always equals `dataDomain.min` (both
+are built from the same `origin` argument in `CONTINUOUS()`,
+`underlyingSpace.ts:153-165`; the one mutation site — nicing,
+`_node.ts:729-736` — rewrites them in lockstep). Every reader consumes only the
+tag except one: `positionNode.tsx:28`.
+
+1. Drop the payload: `Placement = "free" | "determined" | "conflict"`.
+   Rewrite `offsetSpace` (`positionNode.tsx:19-35`) to read
+   `continuousInterval(space)?.min`. Delete `originOf` (zero callers).
+2. Stop storing `placement` at all: it is in bijection with the shape of
+   `dataDomain` (`free ↔ undefined`, `determined ↔ interval`,
+   `conflict ↔ "delta"`) — make it a derived getter. The stored space is then
+   `{ width, dataDomain, measure, … }` and the three-field lockstep at nicing
+   collapses to two.
+3. Naming: the builder `Origin` type (`number | "free" | "impossible"`) stays
+   as constructor input but gets renamed to say what the number is (the domain
+   min, not a zero point) — e.g. `anchor: number | "unanchored" | "delta"`.
+   Bikeshed at implementation time; the constraint is that "origin" disappears
+   from the space vocabulary.
+
+- Files: `underlyingSpace.ts`, `positionNode.tsx`, `_node.ts` (nicing,
+  `placementOn`, debug printer), `alignment.ts` (tag reads), essay.
+- Gate: `capture-diff main` empty; typecheck.
+- Size: small (≈ a day).
+
+## Stage 2 — `span` folds into `position` (surface unification)
+
+`span` is not a new concept: it is two `position` pins on two anchors of one
+target. Give `position` an interval form and delete the eighth constraint type:
+
+- `Constraint.position({ x: v })` — point (today's behavior);
+- `Constraint.position({ x: [a, b] })` — interval; lowers to the edge-pin +
+  extent path that `span` uses today.
+
+Producers/consumers to migrate (the whole surface):
+
+- `scatter.tsx:116-125` — emit interval-form `position` instead of
+  `Constraint.span`;
+- `constraints/index.ts` — factory, `ConstraintSpec` union,
+  `collectPositionDomains` (merge the two branches at `index.ts:203-224`);
+- `compose.ts` — the span-specific special cases (`spans` filter, presence
+  test, `spanCover`) key on "position with interval form" instead;
+- `src/tests/constraintConfluence.test.ts` — the one direct callsite.
+
+The internal lowering machinery (edge pins, extent side-channel) stays until
+Stage 5; this stage removes the _type_ and the parallel code paths that
+dispatch on it. Not in the wire IR (span is created during JS elaboration;
+scatter serializes as `xMin`/`xMax`), so no schema/Python work.
+
+- Gate: pixel equality; `validate-python-ir` + `capture-python` untouched but
+  run once to confirm.
+- Size: small-medium.
+
+## Stage 3 — contain `grid`
+
+`grid` is a third layout regime, not a constraint: a grid layer exits the
+pipeline at `layer.tsx:134-135` (space fold early-return), `layer.tsx:211-212`
+(cell budget), with an exclusivity rule (`proposalPlan.ts:271-285`) no other
+constraint needs. Latent inconsistency: placement applies _all_ constraints on
+a grid layer while spaces/sizing see _only_ the grid, so `grid` + `position`/
+`nest`/`align` silently half-applies (a datum position never gets a posScale
+and its facts are dropped).
+
+1. Close the cliff: throw on `grid` mixed with any non-z-order constraint.
+   Honest error now; routing them through is Stage 6 work.
+2. Demote `Constraint.grid` to `table`'s private elaboration target (it has no
+   other producer). The public surface for grids is `table`.
+3. Leave the flex-track limitation (equal tracks only) documented as is —
+   content-sized tracks are the Stage 6 generalization, where a grid becomes
+   2·(numCols+numRows) track variables in the linear system.
+
+- Files: `proposalPlan.ts` (or the layer constraint intake), `constraints/index.ts`
+  (factory removal), `table.tsx`, confluence test, essay.
+- Gate: pixel equality; new throw covered by a unit test.
+- Size: small.
+
+## Stage 4 — one affine scale carrier (refactor-first enabler)
+
+Replace the two parallel per-axis channels
+
+```
+scaleFactors: Size<number | undefined>                  // slope only
+posScales:    Size<((d: number) => number) | undefined> // whole map, opaque
+```
+
+with a single per-axis affine scale record, e.g.
+
+```
+type AxisScale = { sigma: number; map?: { domainMin: number; pxMin: number } }
+```
+
+(exact shape decided at implementation; the requirements are: slope readable
+alone, intercept explicit rather than closed over, and "anchored" = presence of
+the map half). Unanchored consumers read `sigma`; anchored consumers evaluate
+the map; `posScale(0)` — the intercept — becomes a one-line derived read.
+
+What this dissolves:
+
+- `positionTargetDims` + `childPosScalesFor`'s three-way pick
+  (`proposalPlan.ts:287-363`): "a constraint consumed the scale that placed
+  this child" becomes an explicit per-axis field decision instead of a
+  reconstructed name-set;
+- the dual stash logic in `buildChildScalePlan` (`proposalPlan.ts:205-257`),
+  including making the #618 inherited-σ guard a statement about one object;
+- every `computeSize(size, scaleFactor)` / `computeAesthetic(v, posScale)`
+  pair dispatching on which channel happens to be defined.
+
+Wide but mechanical: ~22 files mention the two carriers (Layout signature in
+`_node.ts:150-157`, `gofish.tsx` root, `layer.tsx`, `spread.tsx`, coord
+transforms, marks). Strictly behavior-preserving — the record is built from
+exactly the numbers the two channels carry today.
+
+- Gate: pixel equality across all stories (this is the stage where
+  `capture-diff` earns its keep); no per-story exceptions.
+- Size: medium (a few days). Do NOT bundle any behavior change into it.
+
+## Stage 5 — rank-2 placement solve
+
+Extend the relational placement solver from one unknown per (node, axis) to
+the per-node box `(min, size)` — i.e., adopt the ledger/`SolverBox` cell
+_inside_ the cross-node solve (`placementSolver.ts`). The node-side ledger
+(`_node.ts` `_bbox`) is already rank-2; only the cross-node pass is rank-1.
+
+Payoffs, all deletions:
+
+- interval-form `position` (née span) becomes two facet equations on one box —
+  delete the extent side-channel: `collectSpanExtents`, the `spanExtentByKey`
+  threading through `classifyAxisFacts` (`placementSolver.ts:107-115`), the
+  post-solve `setExtent` re-application (`placementSolver.ts:295-298`), and
+  `spanCover` in `compose.ts:269-281`;
+- align anchors become facet-equality relations
+  (`min/center/max = baseline + (minCoeff + k)·size`), making the
+  determinacy question ("is this child already positioned?") a structural read
+  instead of the `placementOn`/guard protocol;
+- conflicts stay named: the box-level `BBox` conflict contract and the
+  relation-graph conflict contract merge into one report.
+
+Known behavior edge to decide explicitly (not silently): the current fold
+treats `start`/`end` align as baseline-equivalent (`alignment.ts:135-136`),
+which is only true for `minCoeff = 0` boxes. The rank view computes the true
+answer for mixed-sign/asymmetric boxes. Ship the _engine_ in
+compatibility-of-results mode first (pixel gate), then decide whether to adopt
+the sharper transfer function as a separate, visible change.
+
+- Files: `placementSolver.ts`, `placementLowering.ts`, `span.ts` (absorbed),
+  `align.ts`, `compose.ts`, confluence test (which becomes the spec of the new
+  solve).
+- Gate: pixel equality; `GOFISH_CONFLICT_CHECK` clean across stories.
+- Size: medium-large. Independent of Stage 4 in principle; do 4 first anyway
+  (it simplifies what the solver hands back to scale consumers).
+
+## Stage 6 — σ into the same system (the #39 endgame)
+
+Fold the σ resolution into the same linear system, per scope
+(`AxisScope`, `solver/index.ts`):
+
+- facet values become σ-affine Monotonics; the **frame equation**
+  `content(σ) = allocated` resolves σ once per σ-scope (this is already how
+  `buildChildScalePlan` finds σ — `width.inverse` — just deferred to the
+  boundary and made the only site);
+- the Stage-4 `AxisScale` record becomes a _view_ of the solved scope
+  (σ = slope, intercept = the scope's solved baseline at data-0);
+- `transform.translate` completes its retirement into a projection of the
+  ledger (#39 stage 3-D, already in motion);
+- `grid` generalizes to track variables + equations (equal tracks = equal-flex
+  special case; content-sized tracks = Σ-over-max rows in the same system),
+  deleting the layer bypasses from Stage 3;
+- `placement` (the Stage-1 derived view) retires as stored/derived _space_
+  state entirely — determinacy is the rank/consistency of the baseline
+  subsystem, read off the solve; space resolution keeps only the data facts
+  (`width`, `dataDomain`, `measure`).
+
+De-risking already exists: the Phase-0 spike (`solver/index.ts`), the shadow
+checker (`solver/shadow.ts`, `GOFISH_SOLVER_CHECK`) — extend shadow coverage
+mode-by-mode before each flip, same observe→assert discipline that landed the
+ledger.
+
+- Gate: shadow-clean per covered mode before flipping; pixel equality at each
+  flip; benign DOM reshuffles acceptable per the established policy.
+- Size: large; its own multi-PR plan when we get there. This document is the
+  map, not the schedule, for Stage 6.
+
+---
+
+## Order and dependencies
+
+```
+0 (docs) ─┐
+1 (lattice) ─┐            independent quick wins, any order
+2 (span→position) ─┤
+3 (grid cliff) ─┘
+4 (one scale carrier) ──► 5 (rank-2 placement) ──► 6 (σ in-system)
+```
+
+Stages 0–3 are each a small PR and can land this week in any order. Stage 4 is
+the enabling refactor and should land alone, with nothing else in the diff.
+Stage 5 consumes 4. Stage 6 consumes 4+5 and subsumes the leftovers of 2
+(span's internal machinery) and 3 (grid's bypasses).
+
+Wiki obligation: most touched files carry the `@wiki Underlying Space`
+backlink — `underlying-space.md` must be updated in the same change for every
+stage, and `constraints-as-core.md` / the solver notes for Stages 5–6
+(`pnpm --filter docs sync-backlinks` when `covers:` changes).

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -181,68 +181,196 @@ exactly the numbers the two channels carry today.
 ## Stage 5 — rank-2 placement solve
 
 Extend the relational placement solver from one unknown per (node, axis) to
-the per-node box `(min, size)` — i.e., adopt the ledger/`SolverBox` cell
-_inside_ the cross-node solve (`placementSolver.ts`). The node-side ledger
-(`_node.ts` `_bbox`) is already rank-2; only the cross-node pass is rank-1.
+the per-node box `(min, size)` — i.e., adopt the ledger/`BBox` cell _inside_
+the cross-node solve (`placementSolver.ts`). The node-side ledger (`_node.ts`
+`_bbox`) is already rank-2; only the cross-node pass is rank-1.
 
-Payoffs, all deletions:
+### Where rank-1 is baked in today
 
-- interval-form `position` (née span) becomes two facet equations on one box —
-  delete the extent side-channel: `collectSpanExtents`, the `spanExtentByKey`
-  threading through `classifyAxisFacts` (`placementSolver.ts:107-115`), the
-  post-solve `setExtent` re-application (`placementSolver.ts:295-298`), and
-  `spanCover` in `compose.ts:269-281`;
-- align anchors become facet-equality relations
-  (`min/center/max = baseline + (minCoeff + k)·size`), making the
-  determinacy question ("is this child already positioned?") a structural read
-  instead of the `placementOn`/guard protocol;
-- conflicts stay named: the box-level `BBox` conflict contract and the
-  relation-graph conflict contract merge into one report.
+The fact vocabulary (`placementFacts.ts`) has four fact kinds — `pin`,
+`relation`, `edge-pin` (span only), `participant` — and every one of them is
+affine in a _single_ variable per node (`start`), because
+`PlacementProgramLowerer.anchorOffset` (`placementProgramLowerer.ts:31-53`)
+pre-evaluates every anchor to a numeric offset from `start` using the target's
+_already-known_ size (`localAnchor`/`dims`) at lowering time. A target whose
+size isn't known yet (a span target) can't be offset, hence the `spannedSize`
+side-channel callback threaded through the lowerer, the `edge-pin` fact kind,
+the `max → min − size` rewrite in `classifyAxisFacts`
+(`placementSolver.ts:107-115`), and the post-solve `setExtent` re-application
+(`placementSolver.ts:295-298`).
 
-Known behavior edge to decide explicitly (not silently): the current fold
-treats `start`/`end` align as baseline-equivalent (`alignment.ts:135-136`),
-which is only true for `minCoeff = 0` boxes. The rank view computes the true
-answer for mixed-sign/asymmetric boxes. Ship the _engine_ in
-compatibility-of-results mode first (pixel gate), then decide whether to adopt
-the sharper transfer function as a separate, visible change.
+### The rank-2 design
 
-- Files: `placementSolver.ts`, `placementLowering.ts`, `span.ts` (absorbed),
-  `align.ts`, `compose.ts`, confluence test (which becomes the spec of the new
-  solve).
-- Gate: pixel equality; `GOFISH_CONFLICT_CHECK` clean across stories.
-- Size: medium-large. Independent of Stage 4 in principle; do 4 first anyway
-  (it simplifies what the solver hands back to scale consumers).
+1. **Facet facts.** Facts reference `(node, facet)` with
+   facet ∈ {min, center, max, size, baseline}:
+   `pin(node, facet, value, owner)` and
+   `relate(from(node, facet), to(node, facet), gap, owner)`. The
+   anchor→facet mapping (`BOX_ANCHOR`) stays in lowering, but _no numeric
+   pre-evaluation happens there_ — offsets move into the solver. `edge-pin`
+   and the `spannedSize` callback are deleted; span's two edges are ordinary
+   `min`/`max` facet pins.
+2. **Per-node cells with two-tier authority.** Each (node, axis) gets a `BBox`
+   (`constraints/bbox.ts` — the existing 2-unknown cell with named-owner
+   conflicts). Constraint-owned equations are _strong_; the node's self-layout
+   size and any self-placed min (today's
+   `PlacementOwnershipPlan.initiallyPlaced`/`authoritative` sets) seed as
+   _weak_ defaults that a strong rank-2 determination discards — which is
+   exactly what `setExtent`'s ledger reset does today, made explicit as tiers
+   instead of four hand-maintained name-sets.
+3. **Two-phase solve per axis.**
+   - _Cell closure:_ apply strong pins; a cell reaching rank 2 has its size
+     determined (the span case); every other cell takes its weak layout size.
+     After closure all participating sizes are known — reachable programs
+     never leave a size free (align/distribute/nest/grid emit no size
+     equations).
+   - _Difference graph, unchanged:_ relation offsets are now computed inside
+     the solver from closed cells (the same `localAnchorPoint` arithmetic
+     `anchorOffset` does today, moved from lowering-time to post-closure).
+     The BFS components, pin application, `distributeOriginFor` sequence
+     origin, and normalized-origin fallback (`placementSolver.ts:222-251`)
+     are preserved verbatim — that part of the solver is already general.
+   - `baseline` participates in closure as `min + c` where `c` is a
+     node-local constant from `localAnchor` (independent of the size unknown;
+     a span-determined box has baseline ≡ min since its local frame resets to
+     `[0, size]`).
+4. **One commit path.** Every solved cell writes back through a single
+   function — rank-2-determined → `setExtent({min, max})`, position-only →
+   `pinAnchor(min)` — replacing the three-way branch at
+   `placementSolver.ts:289-301`. `BBox` conflicts and graph conflicts merge
+   into one named-conflict report shape (same owner/asserted/implied fields).
+5. **Deletions.** `span.ts`'s `collectSpanExtents`/`SpanExtent`/
+   `lowerSpanEdgePins`, the `edge-pin` fact kind, the `classifyAxisFacts`
+   rewrite, `PlacementOwnershipPlan.spanPinned`, the `spannedSize` lowerer
+   parameter, and the extent maps threaded through
+   `lowerPlacementConstraints`/`solvePlacementConstraints`.
+
+### Landing sequence (shadow-first, same discipline as the ledger)
+
+- **5a.** Emit facet-facts _alongside_ the current program; run the rank-2
+  solve in shadow and assert it reproduces the rank-1 result across all
+  stories (extend `GOFISH_SOLVER_CHECK`). No behavior.
+- **5b.** Flip the commit path to the rank-2 solve. Pixel gate.
+- **5c.** Delete the rank-1 path and the span side-channel.
+
+### Non-goals, held explicitly
+
+- The align `start`/`end`-as-baseline transfer function in _space resolution_
+  (`alignment.ts:135-136`) is unchanged; it is only exact for `minCoeff = 0`
+  boxes. The rank-2 solver computes the true placement for asymmetric boxes —
+  observe any divergence under the shadow check first, then decide adoption as
+  a separate visible change.
+- Signed sizes stay magnitudes (`Math.abs` semantics preserved; sign is a
+  layout fact carried by the local frame, not a solver unknown).
+- No changes to the space folds (`compose.ts`) beyond what Stage 2 already
+  re-keyed.
+
+### Tests and gates
+
+- Confluence test grows cases: interval-position + align on the same axis
+  (both declaration orders), interval-position inside a distribute chain,
+  authoritative override pins on rank-2 cells, and a conflict case asserting
+  both owners are named.
+- Gates: pixel equality across stories; `GOFISH_CONFLICT_CHECK` sweep clean;
+  the 5a shadow assertion clean before 5b flips.
+- Size: medium-large. Depends on Stage 4 only softly; do 4 first anyway (it
+  simplifies what the solver hands back to scale consumers).
 
 ## Stage 6 — σ into the same system (the #39 endgame)
 
-Fold the σ resolution into the same linear system, per scope
-(`AxisScope`, `solver/index.ts`):
+Fold the σ resolution into the same linear system, per scope. The two hooks
+already exist: `BBox` facet values are already σ-affine `Monotonic`s (the
+"unified-propagation stage 1" note in `bbox.ts` — every caller just happens to
+pass constants today), and `AxisScope`/`SolverBox` (`solver/index.ts`) is the
+validated Phase-0 model.
 
-- facet values become σ-affine Monotonics; the **frame equation**
-  `content(σ) = allocated` resolves σ once per σ-scope (this is already how
-  `buildChildScalePlan` finds σ — `width.inverse` — just deferred to the
-  boundary and made the only site);
-- the Stage-4 `AxisScale` record becomes a _view_ of the solved scope
-  (σ = slope, intercept = the scope's solved baseline at data-0);
-- `transform.translate` completes its retirement into a projection of the
-  ledger (#39 stage 3-D, already in motion);
-- `grid` generalizes to track variables + equations (equal tracks = equal-flex
-  special case; content-sized tracks = Σ-over-max rows in the same system),
-  deleting the layer bypasses from Stage 3;
-- `placement` (the Stage-1 derived view) retires as stored/derived _space_
-  state entirely — determinacy is the rank/consistency of the baseline
-  subsystem, read off the solve; space resolution keeps only the data facts
-  (`width`, `dataDomain`, `measure`).
+### The sites that become one mechanism
 
-De-risking already exists: the Phase-0 spike (`solver/index.ts`), the shadow
-checker (`solver/shadow.ts`, `GOFISH_SOLVER_CHECK`) — extend shadow coverage
-mode-by-mode before each flip, same observe→assert discipline that landed the
-ledger.
+σ (or its posScale twin) is solved today at four+ places, in a hand-ordered
+priority. All become _one_ rule — **only a σ-scope root solves; everyone else
+inherits**:
 
-- Gate: shadow-clean per covered mode before flipping; pixel equality at each
-  flip; benign DOM reshuffles acceptable per the established policy.
-- Size: large; its own multi-PR plan when we get there. This document is the
-  map, not the schedule, for Stage 6.
+1. the root: `gofish.tsx:385-392` (`width.inverse` against the canvas),
+   `posScaleFromSpace` at `gofish.tsx:371-377`, and the recentering writeback
+   around `gofish.tsx:405-437`;
+2. self-scaling regions (explicit pixel size on an axis):
+   `buildChildScalePlan` step 2 (`proposalPlan.ts:205-216`);
+3. composed constraint budgets: step 3 (`proposalPlan.ts:218-244`) — whose
+   #618 propagate-vs-re-root guard is exactly the "intermediates must not
+   re-root" rule, hand-written; it becomes structural;
+4. shared-scale scopes: step 4 (`proposalPlan.ts:246-257`) + spread's
+   `sharedScale` annotation;
+5. coord boundaries (the scoped-resolution thread: bake/resolution must be
+   boundary-recursive, not root-global).
+
+σ-scope roots are therefore: the root, an explicit-pixel-size axis, a
+`sharedScale` operator, a coord boundary. One `AxisScope` per (scope root,
+axis): a registry of member cells; the **frame equation**
+`content(σ) = allocated` solved once by `Monotonic.inverse`; the scope's
+posScale and σ are _views_ of the solved system (the Stage-4 `AxisScale`
+record becomes exactly this view: σ = slope, `map` = anchored min facet +
+pixel min; the intercept is `posScale(0)`, derived, never stored).
+
+### Sub-stages, each gated
+
+- **6a — observe.** Extend `solver/shadow.ts` coverage to the modes it skips:
+  center-mode distribute, pre-placed/data-positioned chains, nest, grid,
+  coord scopes. Run all stories under `GOFISH_SOLVER_CHECK` until clean.
+  No behavior change; this is the risk-retirement step and can start any time
+  after Stage 5a exists.
+- **6b — one solve site.** Move the root inversion + the three
+  `buildChildScalePlan` steps behind a single scope-root API with the same
+  numbers and priority. The #618 guard becomes "not a root → inherit".
+  Pixel gate.
+- **6c — σ-affine claims flow.** Marks/folds contribute width `Monotonic`s
+  into cells instead of pre-multiplied numbers; evaluation defers to the
+  scope boundary; the "evaluate at σ, hand concrete sizes down" double
+  bookkeeping (`computeSize`'s scaleFactor path) collapses. Pixel gate.
+- **6d — translate retirement (#39 stage 3-D).** Render consumes baked
+  absolute coordinates through the `displayTranslate`/`translateString`
+  chokepoints (`dims.ts:268-294` was written to make this a one-function
+  change); the per-container `<g translate>` wrappers collapse. Expect benign
+  DOM reshuffles — this is precisely the pixel-not-DOM gate case.
+- **6e — grid as tracks.** A grid scope introduces `numCols + numRows` track
+  cells; each cell(i, j) gets equations `cell.min = track.min` and
+  `cell.size = track.size` per axis. Equal-flex is "all track sizes equal +
+  Σ tracks + gaps = W" (today's `sliceExtent`, as equations); content-sized
+  tracks are `track.size ≥ max(cell claims)` — note `max` leaves the linear
+  fragment (piecewise claims; see the `monoEqual` two-point-probe caveat in
+  `bbox.ts`), so this lands as an iterate-or-piecewise extension, and is the
+  point where `table` gains content-sized tracks. The Stage-3 layer bypasses
+  (space-fold early return, cell-budget special case, mixing throw) delete;
+  `gridSpaces`' ORDINAL axes contribution stays but composes.
+- **6f — determinacy from rank.** The Stage-1 `spacePlacement` view retires:
+  free/determined/conflict is read off the scope system's baseline-subsystem
+  rank/consistency. Space resolution keeps only data facts
+  (`width`, `dataDomain`, `measure`). The align transfer functions become
+  transfer functions _of the solver's abstract domain_, closing the
+  "guards should be blindingly obvious" thread.
+
+### Open design questions (resolve during 6, tracked now)
+
+- **Authority model (#583):** Stage 5's weak/strong tiers may need a third
+  tier (user-explicit vs constraint-derived) once σ-affine claims and
+  placement claims live in one system.
+- **Multi-measure scopes:** a scope keyed by (axis, measure) — the
+  measure-keyed set of underlying spaces idea — would retire the
+  childPosScales workaround and permit dual-axis charts; decide whether 6b's
+  scope registry is keyed that way from the start.
+- **Where scope state lives:** on the render session (like `toPixel`) vs a
+  map keyed by scope-root uid; must survive resume/re-layout.
+- **Piecewise claims:** `max`-composition (6e) and any future clamp break the
+  two-point `monoEqual` probe; decide the claim representation before 6e.
+
+### Debuggability requirement
+
+Every scope must be dumpable as printable equations (`Monotonic.print` per
+facet, one line per member cell, frame equation last) behind a debug flag —
+the printable-equations bar the σ-affine model was chosen for.
+
+- Gate: shadow-clean per covered mode before each flip; pixel equality at
+  every flip; benign DOM reshuffles acceptable only at 6d.
+- Size: large; each sub-stage is its own PR. This document is the map, not
+  the schedule, for Stage 6.
 
 ---
 

--- a/apps/docs/docs/js/api/constraints/constrain.md
+++ b/apps/docs/docs/js/api/constraints/constrain.md
@@ -147,14 +147,31 @@ at its value rather than assuming uniform spacing.
 Constraint.position({ x?, y?, anchor? }, [ref]);
 ```
 
-| Option   | Type              | Default    | Description                                         |
-| -------- | ----------------- | ---------- | --------------------------------------------------- |
-| `x`      | `number \| Value` | —          | x coordinate — literal pixel or `datum(n)` (scaled) |
-| `y`      | `number \| Value` | —          | y coordinate — literal pixel or `datum(n)` (scaled) |
-| `anchor` | `Alignment`       | `"middle"` | Which anchor of the ref lands on the coordinate     |
+| Option   | Type                        | Default    | Description                                                    |
+| -------- | --------------------------- | ---------- | -------------------------------------------------------------- |
+| `x`      | `number \| Value \| [a, b]` | —          | x coordinate — point (literal/`datum(n)`) or interval `[a, b]` |
+| `y`      | `number \| Value \| [a, b]` | —          | y coordinate — point (literal/`datum(n)`) or interval `[a, b]` |
+| `anchor` | `Alignment`                 | `"middle"` | Which anchor of the ref lands on a **point** coordinate        |
 
 At least one of `x` / `y` is required. Only `datum` coordinates feed the layer's
 inferred scale; literal pixels are placed directly and don't define the domain.
+
+**Interval form.** A coordinate may be a two-element `[min, max]` interval
+instead of a point. The ref's min edge lands at `min`, its max edge at `max`,
+and the two edges **determine its size** on that axis (each endpoint is a
+literal pixel or `datum(n)`, never a categorical position). This is the
+size-setting range form the `scatter` operator's `xMin`/`xMax`/`yMin`/`yMax`
+channels lower to — use it directly to make a ref span a data range:
+
+```ts
+// Bar occupying x ∈ [datum(0), datum(count)] — its width is set by the two
+// edges, not by an intrinsic size.
+Constraint.position({ x: [datum(0), datum(count)] }, [bar]);
+```
+
+`anchor` and `override` apply to point coordinates only; an interval already
+pins both edges. Both endpoints of an interval unify their measures, so a range
+in mixed units is an error.
 
 A datum coordinate can carry a **pixel offset** applied after the scale
 mapping — "this data position, plus pixels":

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -53,7 +53,7 @@ import {
   isPOSITION,
   isUNDEFINED,
   continuousInterval,
-  placementOf,
+  spacePlacement,
   CONTINUOUS_TYPE,
   type Placement,
   UnderlyingSpace,
@@ -120,10 +120,11 @@ export type Placeable = {
    *  uses this to express every anchor as `absoluteMin + constant`, including
    *  `baseline` for asymmetric boxes such as text and negative bars. */
   localAnchor?: (axis: FancyDirection, anchor: Anchor) => number | undefined;
-  /** This target's abstract {@link Placement} on `dir` (free / determined(at) /
-   *  conflict), or `undefined` for a non-continuous axis. `align` reads it to
-   *  leave self-positioned children alone. Omitted by `ref` stand-ins (→
-   *  `undefined`, so they get the fallback baseline like any chrome). */
+  /** This target's abstract {@link Placement} on `dir` (`"free"` /
+   *  `"determined"` / `"conflict"`), or `undefined` for a non-continuous axis.
+   *  `align` reads it to leave self-positioned children alone. Omitted by `ref`
+   *  stand-ins (→ `undefined`, so they get the fallback baseline like any
+   *  chrome). */
   placementOn?: (dir: Direction) => Placement | undefined;
   place: (axis: FancyDirection, value: number, anchor?: Anchor) => void;
   /** Write an axis extent from owned bbox facets (the size-setting primitive
@@ -726,10 +727,10 @@ export class GoFishNode {
         if (isPOSITION(space)) {
           const iv = continuousInterval(space)!;
           const [niceMin, niceMax] = nice(iv.min, iv.max, 10);
-          // Nicing changes the DATA domain (and the width derived from it) and
-          // re-pins the placement at the niced min — all in lockstep.
+          // Nicing changes the DATA domain (and the width derived from it);
+          // placement is a derived view of dataDomain, so the niced interval
+          // keeps it "determined" without a separate write.
           (space as CONTINUOUS_TYPE).dataDomain = interval(niceMin, niceMax);
-          (space as CONTINUOUS_TYPE).placement = placementOf(niceMin);
           (space as CONTINUOUS_TYPE).width = Monotonic.linear(
             niceMax - niceMin,
             0
@@ -894,14 +895,16 @@ export class GoFishNode {
   }
 
   /** This node's abstract {@link Placement} on `dir` (the layout half of its
-   *  underlying space) — `free` (awaiting a position), `determined(at)` (already
-   *  committed to a data coordinate), or `conflict`. `undefined` for a
+   *  underlying space) — `"free"` (awaiting a position), `"determined"` (already
+   *  committed to a data coordinate), or `"conflict"`. `undefined` for a
    *  non-continuous / unresolved axis (chrome). `align` reads it to leave
    *  self-positioned children (a scatter facet) where their own scale puts them
    *  — the principled replacement for the data-positioned guard. */
   public placementOn(dir: Direction): Placement | undefined {
     const sp = this._underlyingSpace?.[dir];
-    return sp !== undefined && isCONTINUOUS(sp) ? sp.placement : undefined;
+    return sp !== undefined && isCONTINUOUS(sp)
+      ? spacePlacement(sp)
+      : undefined;
   }
 
   private get _displayTransform(): Transform | undefined {
@@ -1430,9 +1433,10 @@ export const debugUnderlyingSpaceTree = (
   ): string => {
     const fmt = (s: UnderlyingSpace): string => {
       if (isCONTINUOUS(s)) {
-        return s.placement.tag === "determined"
+        const placement = spacePlacement(s);
+        return placement === "determined"
           ? `position(${toJSON(continuousInterval(s)!)})`
-          : s.placement.tag === "free"
+          : placement === "free"
             ? `size(${s.width.run(1)})`
             : `difference(${s.width.run(1)})`;
       } else if (isORDINAL(s)) {

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -85,7 +85,7 @@ function isDataPositionedAlignTarget(
     typeof target?.placementOn === "function"
       ? target.placementOn(axis)
       : undefined;
-  return placement !== undefined && placement.tag !== "free";
+  return placement !== undefined && placement !== "free";
 }
 
 export function lowerAlignPlacement(

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -54,8 +54,19 @@ import * as Interval from "../../util/interval";
 import type { Measure } from "../data";
 import { distributeSpaceFold, type DistributeConstraint } from "./distribute";
 import { alignSpaceFold, type AlignConstraint } from "./align";
-import type { SpanConstraint } from "./span";
+import { isPositionInterval, type PositionConstraint } from "./position";
 type AlignAnchor = "start" | "middle" | "end" | "baseline";
+
+/** A position constraint whose coordinates are *purely* interval form (at least
+ *  one interval axis, no point axis). This is span's old regime: it size-sets
+ *  its axis without blocking composition. A position carrying any *point*
+ *  coordinate is conservatively NOT span-like — it bails composition to the
+ *  layer's default union (the distribute-relative-to-a-pin solve is deferred). */
+const isPureIntervalPosition = (c: ConstraintSpec): c is PositionConstraint =>
+  c.type === "position" &&
+  (c.x === undefined || isPositionInterval(c.x)) &&
+  (c.y === undefined || isPositionInterval(c.y)) &&
+  (isPositionInterval(c.x) || isPositionInterval(c.y));
 
 const axisIndex = (axis: "x" | "y"): 0 | 1 => (axis === "x" ? 0 : 1);
 
@@ -190,27 +201,28 @@ export function composeConstraintSpaces(
   const aligns = constraints.filter(
     (c): c is AlignConstraint => c.type === "align"
   );
-  // `span` (the size-setting interval constraint, #39/#546) establishes its
-  // axis's extent like a distribute does — its datum range already feeds the
-  // layer's POSITION domain via `collectPositionDomains`, so it needs no fold
-  // here, but its PRESENCE means this is NOT a pure overlay: the cross-axis
-  // align fold (SIZE→POSITION) must still run (e.g. a histogram = span on x,
-  // align on y; the align fold is what makes the count axis).
-  const spans = constraints.filter(
-    (c): c is SpanConstraint => c.type === "span"
-  );
-  // Compose only layers that are PURELY distributes + aligns + spans. A
-  // `position` pin (or z-order) puts the layer in a different regime — the
-  // distribute-relative-to-a-pin solve is deferred (layout-synthesis.md) — so
-  // leave it to the layer's default union, which already merges position
-  // data domains.
+  // An interval-form `position` (the size-setting range form, #39/#546)
+  // establishes its axis's extent like a distribute does — its datum range
+  // already feeds the layer's POSITION domain via `collectPositionDomains`, so
+  // it needs no fold here, but its PRESENCE means this is NOT a pure overlay:
+  // the cross-axis align fold (SIZE→POSITION) must still run (e.g. a histogram =
+  // interval position on x, align on y; the align fold is what makes the count
+  // axis).
+  const spans = constraints.filter(isPureIntervalPosition);
+  // Compose only layers that are PURELY distributes + aligns + interval
+  // positions. A *point* position pin (or z-order) puts the layer in a different
+  // regime — the distribute-relative-to-a-pin solve is deferred
+  // (layout-synthesis.md) — so leave it to the layer's default union, which
+  // already merges position data domains. A position mixing a point on one axis
+  // with an interval on the other is conservatively point-form: not span-like,
+  // so it bails here too.
   if (distributes.length + aligns.length + spans.length !== constraints.length)
     return undefined;
-  // No series and no span → a pure overlay. Align-only composition WOULD fold
-  // (alignSpaceFold converts SIZE→POSITION), but for a pure overlay that
-  // conversion only changes the layer's reported space (e.g. a legend's), so
-  // defer it: fall to the default union. (A span on the other axis makes it not
-  // an overlay, so the align fold runs.)
+  // No series and no interval position → a pure overlay. Align-only composition
+  // WOULD fold (alignSpaceFold converts SIZE→POSITION), but for a pure overlay
+  // that conversion only changes the layer's reported space (e.g. a legend's),
+  // so defer it: fall to the default union. (An interval position on the other
+  // axis makes it not an overlay, so the align fold runs.)
   if (distributes.length === 0 && spans.length === 0) return undefined;
 
   const indexByName = buildNameIndex(childNodes);
@@ -265,13 +277,13 @@ export function composeConstraintSpaces(
     }
   }
 
-  // A span COVERS its children on the axis it sizes. Its datum range already
-  // feeds the POSITION domain through `collectPositionDomains`, and the
-  // placement solver later turns the resolved pixel endpoints into the target's
-  // extent. It contributes no fold here, but its children must be marked covered
-  // so the per-axis loop below does not also fold their raw extent in as an
-  // overlay sibling (double-counting) when a distribute/align shares the same
-  // axis.
+  // An interval position COVERS its children on the axis it sizes. Its datum
+  // range already feeds the POSITION domain through `collectPositionDomains`,
+  // and the placement solver later turns the resolved pixel endpoints into the
+  // target's extent. It contributes no fold here, but its children must be
+  // marked covered so the per-axis loop below does not also fold their raw
+  // extent in as an overlay sibling (double-counting) when a distribute/align
+  // shares the same axis.
   const spanCover: [Set<number>, Set<number>] = [new Set(), new Set()];
   for (const s of spans) {
     const idx = idxOf(s.children);

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -39,8 +39,8 @@ import * as Monotonic from "../../util/monotonic";
 import type { GoFishAST } from "../_ast";
 import { Size } from "../dims";
 import {
-  CONTINUOUS,
   POSITION,
+  SIZE,
   UNDEFINED,
   UnderlyingSpace,
   continuousInterval,
@@ -130,7 +130,7 @@ export function scaleBaselineMagnitude(
   scale: number
 ): UnderlyingSpace {
   return isBaselineMagnitude(space) && scale !== 1
-    ? CONTINUOUS(Monotonic.smul(scale, space.width), "free", space.measure)
+    ? SIZE(Monotonic.smul(scale, space.width), space.measure)
     : space;
 }
 

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -19,7 +19,6 @@ import {
   isZOrderConstraint,
 } from "./zorder";
 import { createNestConstraint } from "./nest";
-import { createGridConstraint, isGridConstraint } from "./grid";
 import { spanDatumInterval } from "./span";
 import { isPositionInterval } from "./position";
 import type { AlignConstraint, AlignOptions } from "./align";
@@ -27,7 +26,7 @@ import type { DistributeConstraint, DistributeOptions } from "./distribute";
 import type { PositionConstraint, PositionOptions } from "./position";
 import type { ZAboveConstraint, ZBelowConstraint } from "./zorder";
 import type { NestConstraint, NestOptions } from "./nest";
-import type { GridConstraint, GridOptions } from "./grid";
+import type { GridConstraint } from "./grid";
 import { type ConstraintPosScales, type ConstraintRef } from "./shared";
 import { solvePlacementConstraints } from "./placementSolver";
 
@@ -51,7 +50,10 @@ export type {
   ZOrderConstraint,
 } from "./zorder";
 export type { NestConstraint, NestOptions } from "./nest";
-export type { GridConstraint, GridOptions } from "./grid";
+// `GridConstraint` stays in the ConstraintSpec union, but grid is not part of
+// the public authoring surface: it is `table`'s private elaboration target
+// (`createGridConstraint` in ./grid, used by table.tsx). No `Constraint.grid`.
+export type { GridConstraint } from "./grid";
 export { isZOrderConstraint } from "./zorder";
 export { isNestConstraint, nestedSpace } from "./nest";
 export { isGridConstraint, gridSpaces, gridCellSize } from "./grid";
@@ -96,9 +98,6 @@ export const Constraint = {
     children: [ConstraintRef, ConstraintRef]
   ): NestConstraint {
     return createNestConstraint(options, children);
-  },
-  grid(options: GridOptions, children: ConstraintRef[]): GridConstraint {
-    return createGridConstraint(options, children);
   },
 };
 

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -20,18 +20,14 @@ import {
 } from "./zorder";
 import { createNestConstraint } from "./nest";
 import { createGridConstraint, isGridConstraint } from "./grid";
-import {
-  createSpanConstraint,
-  isSpanConstraint,
-  spanDatumInterval,
-} from "./span";
+import { spanDatumInterval } from "./span";
+import { isPositionInterval } from "./position";
 import type { AlignConstraint, AlignOptions } from "./align";
 import type { DistributeConstraint, DistributeOptions } from "./distribute";
 import type { PositionConstraint, PositionOptions } from "./position";
 import type { ZAboveConstraint, ZBelowConstraint } from "./zorder";
 import type { NestConstraint, NestOptions } from "./nest";
 import type { GridConstraint, GridOptions } from "./grid";
-import type { SpanConstraint, SpanOptions } from "./span";
 import { type ConstraintPosScales, type ConstraintRef } from "./shared";
 import { solvePlacementConstraints } from "./placementSolver";
 
@@ -43,7 +39,12 @@ export type {
 } from "./shared";
 export type { AlignConstraint, AlignOptions } from "./align";
 export type { DistributeConstraint, DistributeOptions } from "./distribute";
-export type { PositionConstraint, PositionOptions } from "./position";
+export type {
+  PositionConstraint,
+  PositionInterval,
+  PositionOptions,
+} from "./position";
+export { isPositionInterval } from "./position";
 export type {
   ZAboveConstraint,
   ZBelowConstraint,
@@ -51,11 +52,9 @@ export type {
 } from "./zorder";
 export type { NestConstraint, NestOptions } from "./nest";
 export type { GridConstraint, GridOptions } from "./grid";
-export type { SpanConstraint, SpanOptions } from "./span";
 export { isZOrderConstraint } from "./zorder";
 export { isNestConstraint, nestedSpace } from "./nest";
 export { isGridConstraint, gridSpaces, gridCellSize } from "./grid";
-export { isSpanConstraint } from "./span";
 export { getPositioningConstraintRefs } from "./proposalPlan";
 export { BBox } from "./bbox";
 
@@ -66,8 +65,7 @@ export type ConstraintSpec =
   | ZAboveConstraint
   | ZBelowConstraint
   | NestConstraint
-  | GridConstraint
-  | SpanConstraint;
+  | GridConstraint;
 
 // --- Factory ---
 
@@ -101,9 +99,6 @@ export const Constraint = {
   },
   grid(options: GridOptions, children: ConstraintRef[]): GridConstraint {
     return createGridConstraint(options, children);
-  },
-  span(options: SpanOptions, children: ConstraintRef[]): SpanConstraint {
-    return createSpanConstraint(options, children);
   },
 };
 
@@ -149,17 +144,21 @@ export function collectConstraintRefs(
  * data interval. This is the constraint system's *fragment* of underlying-space
  * resolution: a `Constraint.position({ y: datum(v) })` declares that its target
  * lives at data value `v`, so the union of those values is the layer's POSITION
- * domain on that axis. Literal (raw-pixel) coordinates are *not* data and don't
- * contribute. The layer's `resolveUnderlyingSpace` merges this with the
- * children's spaces (see `layer.tsx`).
+ * domain on that axis. An interval coordinate (`{ x: [a, b] }`) contributes its
+ * whole datum range `interval(min(a,b), max(a,b))`. Literal (raw-pixel)
+ * coordinates and endpoints are *not* data and don't contribute. The layer's
+ * `resolveUnderlyingSpace` merges this with the children's spaces (see
+ * `layer.tsx`).
  *
  * Measure (Stage-1 guard): a datum coordinate's `measure` is folded per axis
  * with {@link mergeMeasures} (equal measures unify; two *different* defined
  * measures throw — a unit conflict among a layer's own position constraints).
- * The layer's `resolveAxis` then treats this as the axis's unit, PREFERRING it
- * over the children's POSITION measure (falling back to the children only for
- * untagged literal-pixel coords) — restoring the unit tag the scatter reduction
- * dropped, without strict-unifying against a self-scaling child's leaked unit.
+ * An interval's two endpoints unify their measures the same way (an interval in
+ * mixed units is a conflict). The layer's `resolveAxis` then treats this as the
+ * axis's unit, PREFERRING it over the children's POSITION measure (falling back
+ * to the children only for untagged literal-pixel coords) — restoring the unit
+ * tag the scatter reduction dropped, without strict-unifying against a
+ * self-scaling child's leaked unit.
  */
 export function collectPositionDomains(constraints: ConstraintSpec[]): {
   x?: Interval.Interval;
@@ -171,66 +170,62 @@ export function collectPositionDomains(constraints: ConstraintSpec[]): {
   let y: Interval.Interval | undefined;
   let xMeasure: Measure | undefined;
   let yMeasure: Measure | undefined;
-  const fold = (
-    acc: Interval.Interval | undefined,
+  const pointInterval = (
     coord: PositionConstraint["x"]
   ): Interval.Interval | undefined => {
-    if (!isValue(coord)) return acc;
+    if (!isValue(coord)) return undefined;
     const n = getValue(coord as MaybeValue<number>);
-    const iv = Interval.interval(n, n);
-    return acc ? Interval.unionAll(acc, iv) : iv;
+    return Interval.interval(n, n);
   };
   const unionIv = (
     acc: Interval.Interval | undefined,
     iv: Interval.Interval | undefined
   ) => (iv === undefined ? acc : acc ? Interval.unionAll(acc, iv) : iv);
-  // A datum endpoint's measure; literals carry none. `[min,max]` span endpoints
-  // unify their two measures the same way (a span in mixed units is a conflict).
+  // A point datum's measure; literals carry none. An interval's `[min,max]`
+  // endpoints unify their two measures the same way (mixed units are a conflict).
   const coordMeasure = (
     coord: PositionConstraint["x"] | undefined
-  ): Measure | undefined =>
-    coord === undefined ? undefined : getMeasure(coord);
-  const spanMeasure = (
-    span: SpanConstraint["x"] | undefined
-  ): Measure | undefined =>
-    span === undefined
+  ): Measure | undefined => {
+    if (coord === undefined) return undefined;
+    return isPositionInterval(coord)
+      ? mergeMeasures(
+          getMeasure(coord[0]),
+          getMeasure(coord[1]),
+          "position interval endpoints"
+        )
+      : getMeasure(coord);
+  };
+  const coordInterval = (
+    coord: PositionConstraint["x"] | undefined
+  ): Interval.Interval | undefined =>
+    coord === undefined
       ? undefined
-      : mergeMeasures(
-          getMeasure(span[0]),
-          getMeasure(span[1]),
-          "span endpoints"
-        );
+      : isPositionInterval(coord)
+        ? spanDatumInterval(coord)
+        : pointInterval(coord);
   for (const c of constraints) {
-    if (c.type === "position") {
-      x = fold(x, c.x);
-      y = fold(y, c.y);
-      xMeasure = mergeMeasures(
-        xMeasure,
-        coordMeasure(c.x),
-        "position constraints"
-      );
-      yMeasure = mergeMeasures(
-        yMeasure,
-        coordMeasure(c.y),
-        "position constraints"
-      );
-    } else if (isSpanConstraint(c)) {
-      // A span's two endpoints contribute their data range to the axis domain,
-      // so the layer builds a posScale covering the spanned interval.
-      x = unionIv(x, spanDatumInterval(c.x));
-      y = unionIv(y, spanDatumInterval(c.y));
-      xMeasure = mergeMeasures(xMeasure, spanMeasure(c.x), "span constraints");
-      yMeasure = mergeMeasures(yMeasure, spanMeasure(c.y), "span constraints");
-    }
+    if (c.type !== "position") continue;
+    x = unionIv(x, coordInterval(c.x));
+    y = unionIv(y, coordInterval(c.y));
+    xMeasure = mergeMeasures(
+      xMeasure,
+      coordMeasure(c.x),
+      "position constraints"
+    );
+    yMeasure = mergeMeasures(
+      yMeasure,
+      coordMeasure(c.y),
+      "position constraints"
+    );
   }
   return { x, y, xMeasure, yMeasure };
 }
 
 /**
- * Apply a layer's constraints as one relational placement problem. `span`
- * contributes extent facts to the same solve, so declaration order cannot choose
- * whether size or position wins. z-order constraints are resolved separately at
- * render time.
+ * Apply a layer's constraints as one relational placement problem. An
+ * interval-form `position` contributes extent facts to the same solve, so
+ * declaration order cannot choose whether size or position wins. z-order
+ * constraints are resolved separately at render time.
  *
  * @param constraints - The constraint specs to compose
  * @param nameToPlaceable - Map from child name to its Placeable
@@ -250,7 +245,6 @@ export function applyConstraints(
       | AlignConstraint
       | DistributeConstraint
       | PositionConstraint
-      | SpanConstraint
       | NestConstraint
       | GridConstraint => !isZOrderConstraint(constraint)
   );

--- a/packages/gofish-graphics/src/ast/constraints/nest.ts
+++ b/packages/gofish-graphics/src/ast/constraints/nest.ts
@@ -2,11 +2,7 @@
 // @wiki Underlying Space — /internals/core/underlying-space
 // </gofish-wiki>
 
-import {
-  CONTINUOUS,
-  UnderlyingSpace,
-  isBaselineMagnitude,
-} from "../underlyingSpace";
+import { SIZE, UnderlyingSpace, isBaselineMagnitude } from "../underlyingSpace";
 import * as Monotonic from "../../util/monotonic";
 import type { ConstraintRef } from "./shared";
 import type { PlacementFactEmitter } from "./placementFacts";
@@ -121,9 +117,8 @@ export function nestedSpace(
   // parent spread's auto-fit solves a scale factor against it); data-positioned
   // or origin-less content keeps `outer`.
   if (isBaselineMagnitude(innerSpace)) {
-    return CONTINUOUS(
+    return SIZE(
       Monotonic.adds(innerSpace.width, 2 * padding),
-      "free",
       innerSpace.measure
     );
   }

--- a/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
@@ -21,8 +21,8 @@ import type { NestConstraint } from "./nest";
 import { lowerNestPlacement } from "./nest";
 import { PlacementProgramLowerer } from "./placementProgramLowerer";
 import type { PositionConstraint } from "./position";
-import { lowerPositionPlacement } from "./position";
-import type { SpanConstraint, SpanExtent } from "./span";
+import { isPositionInterval, lowerPositionPlacement } from "./position";
+import type { SpanExtent } from "./span";
 import { collectSpanExtents, lowerSpanEdgePins } from "./span";
 import { axisIndex, type Axis, type ConstraintPosScales } from "./shared";
 import type { PlacementProgram } from "./placementFacts";
@@ -31,7 +31,6 @@ export type PlacementConstraint =
   | AlignConstraint
   | DistributeConstraint
   | PositionConstraint
-  | SpanConstraint
   | NestConstraint
   | GridConstraint;
 
@@ -138,6 +137,9 @@ class PlacementOwnershipPlan {
     for (const axis of POSITION_AXES) {
       const coordinate = constraint[axis];
       if (coordinate === undefined) continue;
+      // Interval axes are pinned via their edge-pin extent (noteSpanExtent), not
+      // as a single point pin here.
+      if (isPositionInterval(coordinate)) continue;
       const idx = axisIndex(axis);
       const value = resolveCoordinate(
         coordinate,
@@ -165,12 +167,14 @@ export function lowerPlacementConstraints(
     sizes
   );
 
+  // Interval-form `position` axes lower to edge pins (min/max edges determine
+  // the extent); their point-form axes lower via `lowerPositionPlacement` below.
   const spanEdgePins = constraints.flatMap((constraint, constraintIndex) =>
-    constraint.type === "span"
+    constraint.type === "position"
       ? lowerSpanEdgePins(
           constraint,
           targets,
-          `span[${constraintIndex}]`,
+          `position[${constraintIndex}]`,
           (axis, coordinate) =>
             resolveCoordinate(coordinate, posScales?.[axisIndex(axis)])
         )
@@ -218,9 +222,9 @@ export function lowerPlacementConstraints(
   constraints.forEach((constraint, constraintIndex) => {
     const owner = `${constraint.type}[${constraintIndex}]`;
 
-    if (constraint.type === "span") return;
-
     if (constraint.type === "position") {
+      // Point axes emit a single pin here; interval axes were already lowered to
+      // edge pins above (lowerPositionPlacement skips them).
       lowerPositionPlacement(constraint, owner, {
         emitter: lowerer,
         targets,

--- a/packages/gofish-graphics/src/ast/constraints/position.ts
+++ b/packages/gofish-graphics/src/ast/constraints/position.ts
@@ -1,28 +1,51 @@
-import type { MaybeValue, PositionValue } from "../data";
+import {
+  isDiscretePosition,
+  type MaybeValue,
+  type PositionValue,
+} from "../data";
 import type { PlacementFactEmitter } from "./placementFacts";
 import type { AlignAnchor, Axis, ConstraintRef } from "./shared";
 
+/** The **interval** form of a position coordinate: pin the target's min edge at
+ *  `[0]` and its max edge at `[1]`, letting the two edges DETERMINE the size
+ *  (#39/#546). Endpoints are pixel literals or datums (`value(n)`), never
+ *  discrete positions. Lowers to the edge-pin + extent path (see `span.ts`). */
+export type PositionInterval = [MaybeValue<number>, MaybeValue<number>];
+
+/** Distinguish a position coordinate's interval form (a two-element array) from
+ *  its point form. Point coordinates (`number` / `Value` / `DiscretePosition`)
+ *  are never arrays, so this test is exact. */
+export const isPositionInterval = (
+  coord: PositionValue | PositionInterval | undefined
+): coord is PositionInterval => Array.isArray(coord);
+
 /**
  * Options for a `position` constraint. Mirrors how you position a shape (or use
- * the `position` operator): give an `x` and/or `y` that is either a **literal**
- * pixel coordinate or a **datum** (`datum(n)` / `value(n)`). A literal is placed
- * as-is; a datum is mapped through the layer's position scale — which the layer
- * derives from the datum coordinates of its `position` constraints (their union
- * is the layer's POSITION domain on that axis). At least one of `x`/`y` is
- * required.
+ * the `position` operator): give an `x` and/or `y` that is either
+ *   - a **point**: a **literal** pixel coordinate or a **datum**
+ *     (`datum(n)` / `value(n)`); a literal is placed as-is, a datum maps
+ *     through the layer's position scale; OR
+ *   - an **interval** `[min, max]`: two edges that pin the target and DETERMINE
+ *     its size (the size-setting range form; each endpoint is a pixel literal
+ *     or a datum, never a discrete position).
+ * The layer derives its POSITION domain from the datum coordinates of its
+ * `position` constraints (point values plus interval endpoints). At least one
+ * of `x`/`y` is required.
  */
 export interface PositionOptions {
-  x?: PositionValue;
-  y?: PositionValue;
+  x?: PositionValue | PositionInterval;
+  y?: PositionValue | PositionInterval;
   /** Which anchor of the target lands on the coordinate. Defaults to "middle"
    *  (the target's center sits on the value), matching how `scatter`/`position`
-   *  place marks at their center. `"baseline"` pins the target's origin. */
+   *  place marks at their center. `"baseline"` pins the target's origin.
+   *  Point form only — an interval coordinate pins both edges itself. */
   anchor?: AlignAnchor;
   /** Authoritative pin: also reposition a target that ALREADY self-placed during
    *  its own layout (a Frame / coord glyph arrives with a translate, which makes
    *  the write-once `place()` a no-op). Set by `scatter`, whose `x`/`y` ARE the
    *  child's placement. Off (default) for axis/pie/legend pins, where a
-   *  pre-placed target keeps its position (the write-once no-op).
+   *  pre-placed target keeps its position (the write-once no-op). Point form
+   *  only — an interval coordinate already sets the target's extent.
    *
    *  Interim: once #39's linsys ledger ({@link BBox}) becomes the node's actual
    *  dimension state, per-equation ownership subsumes this — a pin would simply
@@ -33,12 +56,23 @@ export interface PositionOptions {
 
 export interface PositionConstraint {
   type: "position";
-  x?: PositionValue;
-  y?: PositionValue;
+  x?: PositionValue | PositionInterval;
+  y?: PositionValue | PositionInterval;
   anchor: AlignAnchor;
   override: boolean;
   children: ConstraintRef[];
 }
+
+const validateInterval = (axis: Axis, interval: PositionInterval): void => {
+  for (const endpoint of interval) {
+    if (isDiscretePosition(endpoint)) {
+      throw new Error(
+        `Constraint.position: interval \`${axis}\` endpoints must be pixel ` +
+          `literals or datums, not discrete positions`
+      );
+    }
+  }
+};
 
 export const createPositionConstraint = (
   { x, y, anchor, override }: PositionOptions,
@@ -47,6 +81,17 @@ export const createPositionConstraint = (
   if (x === undefined && y === undefined) {
     throw new Error(
       "Constraint.position: at least one of `x` or `y` must be specified"
+    );
+  }
+  if (isPositionInterval(x)) validateInterval("x", x);
+  if (isPositionInterval(y)) validateInterval("y", y);
+  // `override` is a point-form no-op-escape: it repositions a self-placed
+  // target. An interval already sets the target's extent, so the combination is
+  // meaningless — reject it rather than silently ignore.
+  if ((override ?? false) && (isPositionInterval(x) || isPositionInterval(y))) {
+    throw new Error(
+      "Constraint.position: `override` applies to point coordinates only, " +
+        "not interval `[min, max]` coordinates"
     );
   }
   return {
@@ -77,8 +122,12 @@ export function lowerPositionPlacement(
     ) => number | undefined;
   }
 ): void {
-  const emit = (axis: Axis, coordinate: PositionValue | undefined) => {
-    if (coordinate === undefined) return;
+  const emit = (
+    axis: Axis,
+    coordinate: PositionValue | PositionInterval | undefined
+  ) => {
+    // Interval coordinates lower to edge pins (span.ts), not a single point pin.
+    if (coordinate === undefined || isPositionInterval(coordinate)) return;
     const value = resolveCoordinate(axis, coordinate);
     if (value === undefined) return;
     for (const child of constraint.children) {

--- a/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
+++ b/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
@@ -28,7 +28,7 @@ export type SliceSegment = {
 
 /**
  * The set of names whose position or extent is owned by geometric constraints
- * (`align` / `distribute` / `position` / `span` / `nest` / `grid`). Used by
+ * (`align` / `distribute` / `position` / `nest` / `grid`). Used by
  * `layer.tsx` to decide which children skip phase-1 baseline placement. z-order
  * constraints don't position, so they are excluded.
  *
@@ -284,11 +284,14 @@ export function selectGridConstraint(
   return selected;
 }
 
-/** Per-child axes whose placement is owned by datum-valued position
+/** Per-child axes whose placement is owned by datum-valued *point* position
  * constraints. Those children must not also receive the same posScale from the
  * enclosing layer: the constraint consumes the scale to place them. Literal
  * pixel positions are deliberately excluded because they do not consume a data
- * scale, so the child may still need that scale for its own geometry. */
+ * scale, so the child may still need that scale for its own geometry. Interval
+ * (`[min, max]`) coordinates are also excluded — `isValue` is false for the
+ * array — matching the pre-unification span behavior, where the target still
+ * received the layer scale for its own geometry. */
 export function buildPositionTargetDims(
   constraints: readonly ConstraintSpec[]
 ): Map<string, Set<0 | 1>> {

--- a/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
+++ b/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
@@ -281,6 +281,24 @@ export function selectGridConstraint(
     }
     selected = constraint;
   }
+  // A grid is a whole-layer layout mode, not a composable constraint: it owns
+  // both track partitions and bypasses the space/size fold, while placement
+  // still applies every sibling constraint — so a grid mixed with any other
+  // positioning constraint silently half-applies (its facts never enter the
+  // space fold). Reject non-z-order siblings; z-order (zAbove/zBelow) is
+  // render-time paint order and composes. This lifts when grids become track
+  // equations (Stage 6e, design/sigma-affine-simplification.md).
+  if (selected !== undefined) {
+    for (const constraint of constraints) {
+      if (constraint.type === "grid" || isZOrderConstraint(constraint)) {
+        continue;
+      }
+      throw new Error(
+        `Constraint.grid cannot be combined with a '${constraint.type}' constraint on the same layer. ` +
+          `Put the grid in its own layer, or nest layers, so each layout mode owns its own scope.`
+      );
+    }
+  }
   return selected;
 }
 

--- a/packages/gofish-graphics/src/ast/constraints/span.ts
+++ b/packages/gofish-graphics/src/ast/constraints/span.ts
@@ -4,31 +4,29 @@
 
 import type { Placeable } from "../_node";
 import { getValue, isValue, MaybeValue } from "../data";
-import { ConstraintRef, Axis } from "./shared";
+import { Axis } from "./shared";
 import { BBox, type BBoxFacet } from "./bbox";
 import * as Interval from "../../util/interval";
 import { edgePinFact, type PlacementEdgePin } from "./placementFacts";
+import type { PositionConstraint, PositionInterval } from "./position";
+import { isPositionInterval } from "./position";
 
 /**
- * A **size-setting** constraint (#39/#546): pin BOTH edges of each target on an
- * axis (`x: [min, max]`) and let the edges *determine the size*. This is the
- * first consumer of the linsys bbox ({@link BBox}): two anchors on one axis are
- * rank 2, so the extent (`size = max − min`) falls out — the relation scatter's
- * `xMin`/`xMax` interval channels need, which `place()`'s position-only,
- * write-once protocol could not express (it can pin a point, not set a size).
+ * The internal **size-setting** lowering (#39/#546) that backs the interval form
+ * of `position` (`x: [min, max]`): pin BOTH edges of each target on an axis and
+ * let the edges *determine the size*. This is the first consumer of the linsys
+ * bbox ({@link BBox}): two anchors on one axis are rank 2, so the extent
+ * (`size = max − min`) falls out — the relation scatter's `xMin`/`xMax` interval
+ * channels need, which point placement's write-once protocol could not express
+ * (it can pin a point, not set a size).
  *
  * Each endpoint is a literal pixel coordinate or a datum (`value(n)`) mapped
- * through the layer's posScale, exactly like `position`. The resolved
+ * through the layer's posScale, exactly like a point position. The resolved
  * `(min, size)` is stamped into GoFish's `(local box, translate)` split: the
  * target's local box becomes `[0, size]` and its translate becomes the absolute
- * `min` on that axis.
+ * `min` on that axis. Kept as its own module until the rank-2 placement solve
+ * (Stage 5) folds it into the general cell closure.
  */
-export interface SpanConstraint {
-  type: "span";
-  x?: [MaybeValue<number>, MaybeValue<number>];
-  y?: [MaybeValue<number>, MaybeValue<number>];
-  children: ConstraintRef[];
-}
 
 /** One lowered span edge plus the resolved target needed to derive extent metadata. */
 export interface SpanEdgeClaim {
@@ -54,33 +52,12 @@ export interface SpanExtent {
   size: number;
 }
 
-export interface SpanOptions {
-  x?: [MaybeValue<number>, MaybeValue<number>];
-  y?: [MaybeValue<number>, MaybeValue<number>];
-}
-
-export const createSpanConstraint = (
-  { x, y }: SpanOptions,
-  children: ConstraintRef[]
-): SpanConstraint => {
-  if (x === undefined && y === undefined) {
-    throw new Error(
-      "Constraint.span: at least one of `x` or `y` must be specified"
-    );
-  }
-  return { type: "span", x, y, children };
-};
-
-export const isSpanConstraint = (
-  c: { type: string } | undefined
-): c is SpanConstraint => c !== undefined && c.type === "span";
-
 /** Each endpoint contributes its datum value to the axis's POSITION domain
- *  (parallel to `collectPositionDomains` for `position` constraints), so the
- *  layer builds a posScale that covers the spanned range. Literal-pixel
- *  endpoints are not data and don't contribute. */
+ *  (parallel to point coordinates in `collectPositionDomains`), so the layer
+ *  builds a posScale that covers the spanned range. Literal-pixel endpoints are
+ *  not data and don't contribute. */
 export function spanDatumInterval(
-  span: [MaybeValue<number>, MaybeValue<number>] | undefined
+  span: PositionInterval | undefined
 ): Interval.Interval | undefined {
   if (span === undefined) return undefined;
   const vals = span.filter(isValue).map((v) => getValue(v)!);
@@ -88,8 +65,10 @@ export function spanDatumInterval(
   return Interval.interval(Math.min(...vals), Math.max(...vals));
 }
 
+/** Lower the interval-form axes of a `position` constraint to edge pins. Point
+ *  axes are skipped here (they lower to a single pin via `lowerPositionPlacement`). */
 export function lowerSpanEdgePins(
-  constraint: SpanConstraint,
+  constraint: PositionConstraint,
   targets: Map<string, Placeable>,
   owner: string,
   resolveCoordinate: (
@@ -98,11 +77,9 @@ export function lowerSpanEdgePins(
   ) => number | undefined
 ): SpanEdgeClaim[] {
   const out: SpanEdgeClaim[] = [];
-  const emitAxis = (
-    axis: Axis,
-    span: [MaybeValue<number>, MaybeValue<number>] | undefined
-  ) => {
-    if (span === undefined) return;
+  const emitAxis = (axis: Axis, coord: PositionConstraint["x"]) => {
+    if (!isPositionInterval(coord)) return;
+    const span = coord;
     const min = resolveCoordinate(axis, span[0]);
     const max = resolveCoordinate(axis, span[1]);
     if (min === undefined || max === undefined) return;

--- a/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
@@ -3,10 +3,10 @@
 // </gofish-wiki>
 
 import {
-  CONTINUOUS,
   DIFFERENCE,
   ORDINAL,
   POSITION,
+  SIZE,
   UNDEFINED,
   isCONTINUOUS,
   isORDINAL,
@@ -83,9 +83,8 @@ export function unionChildSpaces(
     nonUndefined.length === conts.length &&
     conts.every((s) => spacePlacement(s) === "free")
   ) {
-    return CONTINUOUS(
+    return SIZE(
       Monotonic.max(...conts.map((s) => s.width)),
-      "free",
       forgetAllMeasures(conts.map((s) => s.measure))
     );
   }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/alignment.ts
@@ -15,6 +15,7 @@ import {
   mergeAllMeasures,
   forgetAllMeasures,
   spaceMeasure,
+  spacePlacement,
   continuousExtentInterval,
   UnderlyingSpace,
 } from "../underlyingSpace";
@@ -80,7 +81,7 @@ export function unionChildSpaces(
   // would change geometry. UNDEFINED siblings (fixed-pixel) still never veto.
   if (
     nonUndefined.length === conts.length &&
-    conts.every((s) => s.placement.tag === "free")
+    conts.every((s) => spacePlacement(s) === "free")
   ) {
     return CONTINUOUS(
       Monotonic.max(...conts.map((s) => s.width)),
@@ -99,7 +100,7 @@ export function unionChildSpaces(
   let measure: Measure | undefined;
   for (const s of conts) {
     intervals.push(continuousExtentInterval(s));
-    if (s.placement.tag === "determined") hasAnchored = true;
+    if (spacePlacement(s) === "determined") hasAnchored = true;
     measure = mergeMeasures(measure, s.measure, "overlay union");
   }
   const union = Interval.unionAll(...intervals);
@@ -124,7 +125,7 @@ export function resolveAlignmentSpace(
   // conflict — that's how a histogram's count axis carries a "count" tag
   // forward; mixed/positioned children unify measures as TYPES (throw on a real
   // clash).
-  const allBaseline = conts.every((s) => s.placement.tag === "free");
+  const allBaseline = conts.every((s) => spacePlacement(s) === "free");
   const measure = allBaseline
     ? forgetAllMeasures(conts.map(spaceMeasure))
     : mergeAllMeasures(conts.map(spaceMeasure), "alignment");
@@ -133,7 +134,8 @@ export function resolveAlignmentSpace(
   // unanchored ("conflict") child can't be re-anchored by alignment (it is
   // absorbing). Either way the result is unanchored.
   const drop =
-    alignment === "middle" || conts.some((s) => s.placement.tag === "conflict");
+    alignment === "middle" ||
+    conts.some((s) => spacePlacement(s) === "conflict");
 
   const union = Interval.unionAll(...conts.map(continuousExtentInterval));
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
@@ -3,7 +3,7 @@ import { GoFishNode } from "../_node";
 import { Size, translateString } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import {
-  CONTINUOUS,
+  anchorAt,
   continuousInterval,
   isCONTINUOUS,
   UNDEFINED,
@@ -25,15 +25,13 @@ const offsetSpace = (
   const value = isValue(offset) ? getValue(offset) : offset;
   if (value === undefined) return space;
 
-  // An anchored space offsets from its domain min (≡ the old placement `at`); a
-  // free / difference space anchors at `value` itself.
+  // An anchored space offsets from its domain min; a free / difference space
+  // anchors at `value` itself. Width stays σ-affine — see anchorAt.
   const iv = continuousInterval(space);
-  const anchor = iv !== undefined ? iv.min + value : value;
-  return CONTINUOUS(
-    space.width,
-    anchor,
-    space.measure ?? getMeasure(offset),
-    space.coordinateTransform
+  return anchorAt(
+    space,
+    iv !== undefined ? iv.min + value : value,
+    space.measure ?? getMeasure(offset)
   );
 };
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
@@ -4,6 +4,7 @@ import { Size, translateString } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import {
   CONTINUOUS,
+  continuousInterval,
   isCONTINUOUS,
   UNDEFINED,
   UnderlyingSpace,
@@ -24,11 +25,13 @@ const offsetSpace = (
   const value = isValue(offset) ? getValue(offset) : offset;
   if (value === undefined) return space;
 
-  const origin =
-    space.placement.tag === "determined" ? space.placement.at + value : value;
+  // An anchored space offsets from its domain min (≡ the old placement `at`); a
+  // free / difference space anchors at `value` itself.
+  const iv = continuousInterval(space);
+  const anchor = iv !== undefined ? iv.min + value : value;
   return CONTINUOUS(
     space.width,
-    origin,
+    anchor,
     space.measure ?? getMeasure(offset),
     space.coordinateTransform
   );

--- a/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/scatter.tsx
@@ -82,17 +82,19 @@ export const Scatter = createNodeOperator(
     // Elaborate to a layer carrying per-child placement constraints (#546),
     // sharing the constraint path instead of a bespoke layout (as spread
     // delegates to distribute/align):
-    //   - plain x / y      → Constraint.position (centers the child on its datum;
-    //                        `override` repositions a child that self-placed in
-    //                        its own layout, e.g. a Frame / coord glyph).
-    //   - range xMin/xMax  → Constraint.span: two edges DETERMINE the size via
-    //                        the linsys bbox (#39) — the size-setting the bespoke
-    //                        layout used to do by hand on intrinsicDims.
+    //   - plain x / y      → point Constraint.position (centers the child on its
+    //                        datum; `override` repositions a child that
+    //                        self-placed in its own layout, e.g. a Frame / coord
+    //                        glyph).
+    //   - range xMin/xMax  → interval Constraint.position ({ x: [min, max] }):
+    //                        two edges DETERMINE the size via the linsys bbox
+    //                        (#39) — the size-setting the bespoke layout used to
+    //                        do by hand on intrinsicDims.
     //   - an axis with neither → a plain cross-axis align (data-positioned
-    //                        children are already placed by their span/position
+    //                        children are already placed by their position
     //                        constraints, so the align walk skips them).
-    // The layer derives the data→pixel posScale from the position/span datum
-    // coords (collectPositionDomains).
+    // The layer derives the data→pixel posScale from the position datum coords
+    // (point values plus interval endpoints — collectPositionDomains).
     const childList = children as GoFishAST[];
     const names = ensureChildNames(childList, "scatter");
     const node = (await layer(
@@ -122,7 +124,7 @@ export const Scatter = createNodeOperator(
         if (yMin?.[i] !== undefined && yMax?.[i] !== undefined)
           span.y = [yMin[i], yMax[i]];
         if (span.x !== undefined || span.y !== undefined)
-          cs.push(Constraint.span(span, [refs[i]]));
+          cs.push(Constraint.position(span, [refs[i]]));
       });
       // A cross-axis align over the (data-positioned) points: it shares the
       // frame; `align` leaves the points where their own scale puts them by

--- a/packages/gofish-graphics/src/ast/graphicalOperators/table.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/table.tsx
@@ -3,7 +3,7 @@ import { GoFishAST } from "../_ast";
 import { createNodeOperator } from "../withGoFish";
 import { createOperator } from "../marks/createOperator";
 import { layer } from "./layer";
-import { Constraint } from "../constraints";
+import { createGridConstraint } from "../constraints/grid";
 import { childNameKey } from "../constraints/shared";
 
 /**
@@ -46,7 +46,9 @@ export const Table = createNodeOperator(
 
     const node = (await layer(children)) as GoFishNode;
     node.constrain((ref) => [
-      Constraint.grid(
+      // grid is table's private elaboration target — not part of the public
+      // `Constraint` factory (see constraints/index.ts).
+      createGridConstraint(
         { numCols, spacing, colKeys, rowKeys },
         cellNames.map((n) => ref[n] ?? { name: n })
       ),

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -38,10 +38,10 @@ export type UnderlyingSpaceKind = "continuous" | "ordinal" | "undefined";
  * The subtlety #586's first cut got wrong: a baseline magnitude (`"free"`) is
  * NOT the same as a data axis anchored at 0 (`anchor: 0`) — the former builds no
  * posScale and forgets measures, the latter does the opposite. Conflating them
- * via `anchor === 0` silently dropped the unit-clash guard and over-niced; the
- * named `"free"`/`"impossible"` states keep them apart. A former DIFFERENCE
- * width `w` is `linear(w, 0)`; a former POSITION `[a,b]` is
- * `width = linear(b-a, 0), anchor = a`.
+ * via "anchored at 0" silently dropped the unit-clash guard and over-niced; the
+ * distinct `undefined`/`"delta"` domain states keep them apart. A former
+ * DIFFERENCE width `w` is `linear(w, 0)` with domain `"delta"`; a former
+ * POSITION `[a,b]` is `width = linear(b-a, 0)` with domain `[a,b]`.
  *
  * The stored fields are just `width` + `dataDomain` (+ measure, etc.). The
  * abstract PLACEMENT ({@link Placement}) is a DERIVED VIEW of `dataDomain`'s
@@ -76,33 +76,6 @@ export type Placement = "free" | "determined" | "conflict";
  *  or `undefined` for a baseline magnitude (no data axis at all). This is the
  *  sole placement carrier: {@link spacePlacement} reads its shape. */
 export type DataDomain = Interval | "delta" | undefined;
-
-/** The convenient builder form of the placement + dataDomain: a numeric DATA
- *  coordinate (the domain min — anchored, NOT a zero point), `"free"`
- *  (magnitude), or `"impossible"` (difference). Constructors take this; the
- *  stored field is `dataDomain`, from which placement is derived. */
-export type Anchor = number | "free" | "impossible";
-
-/** Derive the abstract {@link Placement} from the builder {@link Anchor}. */
-export const placementOf = (anchor: Anchor): Placement =>
-  anchor === "free"
-    ? "free"
-    : anchor === "impossible"
-      ? "conflict"
-      : "determined";
-
-/** Derive the {@link DataDomain} from the builder {@link Anchor} + width:
- *  numeric → `[anchor, anchor + width.run(1)]`; `"impossible"` → `"delta"`;
- *  `"free"` → `undefined`. */
-export const dataDomainOf = (
-  anchor: Anchor,
-  width: Monotonic.Monotonic
-): DataDomain =>
-  typeof anchor === "number"
-    ? interval(anchor, anchor + width.run(1))
-    : anchor === "impossible"
-      ? "delta"
-      : undefined;
 
 /** Read the abstract {@link Placement} off a stored CONTINUOUS space. Placement
  *  is not stored: it is a view of `dataDomain`'s shape (`undefined → "free"`,
@@ -151,15 +124,20 @@ export type UNDEFINED_TYPE = {
 
 export type UnderlyingSpace = CONTINUOUS_TYPE | ORDINAL_TYPE | UNDEFINED_TYPE;
 
+/** Low-level constructor: takes the stored {@link DataDomain} directly. There
+ *  is no scalar "anchor" builder type — the three placement cases ARE the three
+ *  named constructors ({@link POSITION} anchored, {@link SIZE} free,
+ *  {@link DIFFERENCE} conflict), plus {@link anchorAt} for re-anchoring an
+ *  existing space at a data coordinate. */
 export const CONTINUOUS = (
   width: Monotonic.Monotonic,
-  anchor: Anchor,
+  dataDomain: DataDomain,
   measure?: Measure,
   coordinateTransform?: CoordinateTransform
 ): CONTINUOUS_TYPE => ({
   kind: "continuous",
   width,
-  dataDomain: dataDomainOf(anchor, width),
+  dataDomain,
   measure,
   coordinateTransform,
 });
@@ -205,7 +183,7 @@ export const POSITION = (
 ): UnderlyingSpace =>
   CONTINUOUS(
     Monotonic.linear(domain.max - domain.min, 0),
-    domain.min,
+    domain,
     measure,
     coordinateTransform
   );
@@ -216,7 +194,7 @@ export const isPOSITION = (space: UnderlyingSpace): space is CONTINUOUS_TYPE =>
  *  fact (`dataDomain === "delta"`), NOT on placement, so a future `conflict`
  *  placement that still has a real data domain doesn't render delta ticks. */
 export const DIFFERENCE = (width: number, measure?: Measure): UnderlyingSpace =>
-  CONTINUOUS(Monotonic.linear(width, 0), "impossible", measure);
+  CONTINUOUS(Monotonic.linear(width, 0), "delta", measure);
 export const isDIFFERENCE = (
   space: UnderlyingSpace
 ): space is CONTINUOUS_TYPE =>
@@ -226,7 +204,25 @@ export const isDIFFERENCE = (
 export const SIZE = (
   domain: Monotonic.Monotonic,
   measure?: Measure
-): UnderlyingSpace => CONTINUOUS(domain, "free", measure);
+): UnderlyingSpace => CONTINUOUS(domain, undefined, measure);
+
+/** Re-anchor a continuous space at data coordinate `min`, preserving its
+ *  σ-affine `width`: the result's domain is `[min, min + width.run(1)]`. This
+ *  is the one construction the named constructors can't express — anchoring a
+ *  free (or difference) extent without flattening its width to a constant, or
+ *  shifting an anchored one (the `position` operator does both). `measure`
+ *  defaults to the space's own. */
+export const anchorAt = (
+  space: CONTINUOUS_TYPE,
+  min: number,
+  measure?: Measure
+): CONTINUOUS_TYPE =>
+  CONTINUOUS(
+    space.width,
+    interval(min, min + space.width.run(1)),
+    measure ?? space.measure,
+    space.coordinateTransform
+  );
 
 /** Has a baseline (a place it hangs from): a baseline magnitude or an anchored
  *  coordinate, but NOT a difference ({@link spacePlacement} === "conflict"). The

--- a/packages/gofish-graphics/src/ast/underlyingSpace.ts
+++ b/packages/gofish-graphics/src/ast/underlyingSpace.ts
@@ -13,113 +13,114 @@ export type UnderlyingSpaceKind = "continuous" | "ordinal" | "undefined";
 /**
  * A data-driven extent on one shared scale. Collapses the former POSITION /
  * SIZE / DIFFERENCE trichotomy (issue #586): the extent is always a `width`
- * Monotonic in σ, and the only surviving distinction is `origin`:
+ * Monotonic in σ, and the only surviving distinction is the `anchor` a
+ * constructor is given — the builder input that says whether, and at what data
+ * coordinate, the extent commits an absolute position:
  *
- * `origin` answers "can this extent be given an absolute position?", and has
- * three states — the old POSITION/SIZE/DIFFERENCE distinction re-expressed as
- * one field instead of three kinds:
- *
- *   - `origin: "free"` — a BASELINE MAGNITUDE (the old `SIZE`): a sized-but-
+ *   - `anchor: "free"` — a BASELINE MAGNITUDE (the old `SIZE`): a sized-but-
  *     unplaced extent with a local baseline at 0 but no committed position. Its
- *     origin is not yet assigned but CAN be (a baseline-align anchors it → a
- *     numeric origin; a middle-align makes it `"impossible"`). Builds no
+ *     position is not yet assigned but CAN be (a baseline-align anchors it → a
+ *     numeric anchor; a middle-align makes it `"impossible"`). Builds no
  *     posScale; composes as a magnitude (measures FORGET on conflict), scales
  *     with a parent `transform.scale`, and is never niced.
- *   - `origin: number` — ANCHORED (the old `POSITION`): the origin IS assigned,
- *     at this data-space coordinate (which may be 0!). Builds a posScale, is
- *     niced, renders an absolute axis over `[origin, origin + width.run(1)]`.
- *     Measures unify as TYPES (THROW on a clash) — a count axis must not
- *     silently merge with millimeters.
- *   - `origin: "impossible"` — UNANCHORED (the old `DIFFERENCE`): an absolute
- *     origin is impossible — only differences are meaningful (a centered /
+ *   - `anchor: number` — ANCHORED (the old `POSITION`): the position IS assigned.
+ *     The number is the DOMAIN MIN — the data-space coordinate of the extent's
+ *     low edge (which may be 0!), NOT a zero point. Builds a posScale, is niced,
+ *     renders an absolute axis over `[anchor, anchor + width.run(1)]`. Measures
+ *     unify as TYPES (THROW on a clash) — a count axis must not silently merge
+ *     with millimeters.
+ *   - `anchor: "impossible"` — UNANCHORED (the old `DIFFERENCE`): an absolute
+ *     position is impossible — only differences are meaningful (a centered /
  *     difference extent). No posScale; renders a delta axis over
  *     `[0, width.run(1)]`. Produced by middle-align, which drops the anchor;
  *     absorbing — alignment never re-anchors it.
  *
  * The subtlety #586's first cut got wrong: a baseline magnitude (`"free"`) is
- * NOT the same as a data axis anchored at 0 (`origin: 0`) — the former builds no
+ * NOT the same as a data axis anchored at 0 (`anchor: 0`) — the former builds no
  * posScale and forgets measures, the latter does the opposite. Conflating them
- * via `origin === 0` silently dropped the unit-clash guard and over-niced; the
+ * via `anchor === 0` silently dropped the unit-clash guard and over-niced; the
  * named `"free"`/`"impossible"` states keep them apart. A former DIFFERENCE
  * width `w` is `linear(w, 0)`; a former POSITION `[a,b]` is
- * `width = linear(b-a, 0), origin = a`.
+ * `width = linear(b-a, 0), anchor = a`.
+ *
+ * The stored fields are just `width` + `dataDomain` (+ measure, etc.). The
+ * abstract PLACEMENT ({@link Placement}) is a DERIVED VIEW of `dataDomain`'s
+ * shape — {@link spacePlacement} — not stored state.
  */
 /**
  * The abstract PLACEMENT of an extent — the missing "baseline" half of the
  * σ-affine box solve, lifted to the underlying-space pass (the `width` Monotonic
  * is already the abstract SIZE half). A determinacy lattice over "has this
- * extent committed a position, and where?":
+ * extent committed a position?":
  *
- *   - `free` (⊥) — sized but not yet placed; a parent can still anchor it (old
- *     SIZE / `origin: "free"`).
- *   - `determined(at)` — committed at data coordinate `at` (old POSITION; `at`
- *     is the domain min, which may be 0). NOTE `at` is a DATA coordinate, not a
- *     pixel — the pixel baseline is assigned top-down at layout (#39 ledger).
- *   - `conflict` (⊤) — no single position is possible (old DIFFERENCE; also the
- *     eventual home for disagreeing aligns).
+ *   - `"free"` (⊥) — sized but not yet placed; a parent can still anchor it (old
+ *     SIZE).
+ *   - `"determined"` — committed at a data coordinate (old POSITION). The
+ *     coordinate itself is the `dataDomain` min (which may be 0); it is a DATA
+ *     coordinate, not a pixel — the pixel baseline is assigned top-down at
+ *     layout (#39 ledger).
+ *   - `"conflict"` (⊤) — no single position is possible (old DIFFERENCE; also
+ *     the eventual home for disagreeing aligns).
  *
- * "space as abstract interpretation" (#586 follow-up): `placement` is the
- * LAYOUT fact (is this extent positioned, and where), the abstract baseline half
- * of the σ-affine solve. It is now authoritative — the old `origin` field is
- * retired; an `Origin`-shaped value survives only as a builder argument
- * ({@link CONTINUOUS}) and via {@link originOf} for legacy reads. See the spec.
- */
-export type Placement =
-  | { tag: "free" }
-  | { tag: "determined"; at: number }
-  | { tag: "conflict" };
+ * "space as abstract interpretation" (#586 follow-up): placement is the LAYOUT
+ * fact (is this extent positioned) — the abstract baseline half of the σ-affine
+ * solve, all that bottom-up space resolution can know before pixels exist. It is
+ * a bare determinacy lattice, in bijection with the shape of `dataDomain`
+ * (`undefined ↔ free`, interval ↔ determined, `"delta"` ↔ conflict), so it is a
+ * derived read ({@link spacePlacement}) rather than stored state. See the spec. */
+export type Placement = "free" | "determined" | "conflict";
 
 /** The DATA-space fact: the `[min,max]` data interval of an anchored axis
  *  (drives posScale / nicing / measure-throw / an absolute axis), `"delta"` for
  *  a difference axis (delta ticks over `[0, width.run(1)]`, no absolute zero),
- *  or `undefined` for a baseline magnitude (no data axis at all). Independent of
- *  `placement` — kept separate so an axis-rendering choice (delta vs absolute)
- *  never keys on the layout determinacy. */
+ *  or `undefined` for a baseline magnitude (no data axis at all). This is the
+ *  sole placement carrier: {@link spacePlacement} reads its shape. */
 export type DataDomain = Interval | "delta" | undefined;
 
-/** The convenient builder form of (placement, dataDomain): a numeric data
- *  coordinate (anchored), `"free"` (magnitude), or `"impossible"` (difference).
- *  Constructors take this; the stored fields are `placement` + `dataDomain`. */
-export type Origin = number | "free" | "impossible";
+/** The convenient builder form of the placement + dataDomain: a numeric DATA
+ *  coordinate (the domain min — anchored, NOT a zero point), `"free"`
+ *  (magnitude), or `"impossible"` (difference). Constructors take this; the
+ *  stored field is `dataDomain`, from which placement is derived. */
+export type Anchor = number | "free" | "impossible";
 
-/** Derive the abstract {@link Placement} from the builder {@link Origin}. */
-export const placementOf = (origin: Origin): Placement =>
-  origin === "free"
-    ? { tag: "free" }
-    : origin === "impossible"
-      ? { tag: "conflict" }
-      : { tag: "determined", at: origin };
+/** Derive the abstract {@link Placement} from the builder {@link Anchor}. */
+export const placementOf = (anchor: Anchor): Placement =>
+  anchor === "free"
+    ? "free"
+    : anchor === "impossible"
+      ? "conflict"
+      : "determined";
 
-/** Derive the {@link DataDomain} from the builder {@link Origin} + width:
- *  numeric → `[origin, origin + width.run(1)]`; `"impossible"` → `"delta"`;
+/** Derive the {@link DataDomain} from the builder {@link Anchor} + width:
+ *  numeric → `[anchor, anchor + width.run(1)]`; `"impossible"` → `"delta"`;
  *  `"free"` → `undefined`. */
 export const dataDomainOf = (
-  origin: Origin,
+  anchor: Anchor,
   width: Monotonic.Monotonic
 ): DataDomain =>
-  typeof origin === "number"
-    ? interval(origin, origin + width.run(1))
-    : origin === "impossible"
+  typeof anchor === "number"
+    ? interval(anchor, anchor + width.run(1))
+    : anchor === "impossible"
       ? "delta"
       : undefined;
 
-/** Recover the builder {@link Origin} from a stored CONTINUOUS space (for the
- *  few legacy callers that still want the scalar form). */
-export const originOf = (space: CONTINUOUS_TYPE): Origin =>
-  space.placement.tag === "free"
+/** Read the abstract {@link Placement} off a stored CONTINUOUS space. Placement
+ *  is not stored: it is a view of `dataDomain`'s shape (`undefined → "free"`,
+ *  `"delta" → "conflict"`, interval → `"determined"`). */
+export const spacePlacement = (space: CONTINUOUS_TYPE): Placement =>
+  space.dataDomain === undefined
     ? "free"
-    : space.placement.tag === "conflict"
-      ? "impossible"
-      : space.placement.at;
+    : space.dataDomain === "delta"
+      ? "conflict"
+      : "determined";
 
 export type CONTINUOUS_TYPE = {
   kind: "continuous";
   /** Abstract SIZE: the σ-affine extent `slope·σ + intercept`. */
   width: Monotonic.Monotonic;
-  /** Abstract POSITION/baseline (layout): is this placed, and at what data
-   *  coordinate. See {@link Placement}. */
-  placement: Placement;
-  /** Data-space extent for scales/axes/nicing/measures. See {@link DataDomain}. */
+  /** Data-space extent for scales/axes/nicing/measures, AND the sole carrier of
+   *  the abstract placement (read via {@link spacePlacement}). See
+   *  {@link DataDomain}. */
   dataDomain: DataDomain;
   spacing?: number;
   ordinalGroupId?: string;
@@ -152,14 +153,13 @@ export type UnderlyingSpace = CONTINUOUS_TYPE | ORDINAL_TYPE | UNDEFINED_TYPE;
 
 export const CONTINUOUS = (
   width: Monotonic.Monotonic,
-  origin: Origin,
+  anchor: Anchor,
   measure?: Measure,
   coordinateTransform?: CoordinateTransform
 ): CONTINUOUS_TYPE => ({
   kind: "continuous",
   width,
-  placement: placementOf(origin),
-  dataDomain: dataDomainOf(origin, width),
+  dataDomain: dataDomainOf(anchor, width),
   measure,
   coordinateTransform,
 });
@@ -190,11 +190,11 @@ export const continuousExtentInterval = (space: CONTINUOUS_TYPE): Interval =>
 /** A baseline magnitude — a sized-but-unplaced extent (the old `SIZE`): no
  *  committed position. Distinct from a data-positioned anchored extent
  *  ({@link isPOSITION}, even at data-min 0) and a difference
- *  ({@link isDIFFERENCE}). Keys on the LAYOUT fact (`placement`). */
+ *  ({@link isDIFFERENCE}). Keys on the LAYOUT fact ({@link spacePlacement}). */
 export const isBaselineMagnitude = (
   space: UnderlyingSpace
 ): space is CONTINUOUS_TYPE =>
-  isCONTINUOUS(space) && space.placement.tag === "free";
+  isCONTINUOUS(space) && spacePlacement(space) === "free";
 
 /** ANCHORED continuous space (old POSITION) — has a data interval; builds a
  *  posScale and an absolute axis. Keys on the DATA fact (`dataDomain`). */
@@ -229,10 +229,10 @@ export const SIZE = (
 ): UnderlyingSpace => CONTINUOUS(domain, "free", measure);
 
 /** Has a baseline (a place it hangs from): a baseline magnitude or an anchored
- *  coordinate, but NOT a difference (`placement.tag === "conflict"`). The gate
- *  for "can be a self-scaling region / needs a concrete canvas". */
+ *  coordinate, but NOT a difference ({@link spacePlacement} === "conflict"). The
+ *  gate for "can be a self-scaling region / needs a concrete canvas". */
 export const hasBaseline = (space: UnderlyingSpace): space is CONTINUOUS_TYPE =>
-  isCONTINUOUS(space) && space.placement.tag !== "conflict";
+  isCONTINUOUS(space) && spacePlacement(space) !== "conflict";
 
 export const ORDINAL = (
   domain?: string[],

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -628,20 +628,51 @@ console.log("# constraint confluence: grid proposal ownership");
     selectGridConstraint([grid2]) === grid2
   );
 
-  const throws = (constraints: GridConstraint[]): boolean => {
+  const throwsWith = (
+    constraints: Constraint[],
+    fragment: string
+  ): boolean => {
     try {
       selectGridConstraint(constraints);
       return false;
     } catch (error) {
-      return (
-        error instanceof Error &&
-        error.message.includes("Constraint.grid proposal conflict")
-      );
+      return error instanceof Error && error.message.includes(fragment);
     }
   };
   ok(
     "duplicate grid proposal ownership throws in either order",
-    throws([grid2, grid1]) && throws([grid1, grid2])
+    throwsWith([grid2, grid1], "Constraint.grid proposal conflict") &&
+      throwsWith([grid1, grid2], "Constraint.grid proposal conflict")
+  );
+
+  // grid mixed with any non-z-order constraint half-applies (placement sees it,
+  // the space/size fold does not), so selectGridConstraint rejects it.
+  const alignMix: AlignConstraint = {
+    type: "align",
+    y: "middle",
+    children: [A, B],
+  };
+  ok(
+    "grid mixed with align throws in either order",
+    throwsWith(
+      [grid2, alignMix],
+      "Constraint.grid cannot be combined with a 'align' constraint"
+    ) &&
+      throwsWith(
+        [alignMix, grid2],
+        "Constraint.grid cannot be combined with a 'align' constraint"
+      )
+  );
+
+  // z-order (zAbove/zBelow) is render-time paint order and composes with grid.
+  const zAboveMix: ZAboveConstraint = {
+    type: "zAbove",
+    children: [A, B],
+  };
+  ok(
+    "grid alongside a z-order constraint is allowed",
+    selectGridConstraint([grid2, zAboveMix]) === grid2 &&
+      selectGridConstraint([zAboveMix, grid2]) === grid2
   );
 }
 

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -23,10 +23,7 @@ import {
   relationFact,
 } from "../ast/constraints/placementFacts";
 import type { PositionConstraint } from "../ast/constraints/position";
-import {
-  lowerSpanEdgePins,
-  type SpanConstraint,
-} from "../ast/constraints/span";
+import { lowerSpanEdgePins } from "../ast/constraints/span";
 import type { ZAboveConstraint } from "../ast/constraints/zorder";
 import type { Anchor, Dimensions, FancyDirection } from "../ast/dims";
 import { elaborateDirection, localAnchorPoint } from "../ast/dims";
@@ -35,7 +32,10 @@ import {
   applyNestSpacePlan,
   buildNestPlan,
 } from "../ast/constraints/nestPlan";
-import { resolveLayerBaseSpaces } from "../ast/constraints/compose";
+import {
+  composeConstraintSpaces,
+  resolveLayerBaseSpaces,
+} from "../ast/constraints/compose";
 import {
   buildChildScalePlan,
   buildDistributeSliceMap,
@@ -54,7 +54,6 @@ type Constraint =
   | AlignConstraint
   | DistributeConstraint
   | PositionConstraint
-  | SpanConstraint
   | NestConstraint
   | GridConstraint;
 type Geometry = Record<string, { min?: number; center?: number; max?: number }>;
@@ -208,9 +207,16 @@ const distributeWithSpacing = (
   spacing,
 });
 
-const span = (name: string, min: number, max: number): SpanConstraint => ({
-  type: "span",
+// The interval form of `position`, replacing the retired `Constraint.span`.
+const span = (
+  name: string,
+  min: number,
+  max: number
+): PositionConstraint => ({
+  type: "position",
   x: [min, max],
+  anchor: "middle",
+  override: false,
   children: [child(name)],
 });
 
@@ -956,6 +962,106 @@ console.log("# constraint confluence: placement constraint lowering");
       spanEdgeFacts[1].fact.edge === "max" &&
       !("target" in spanEdgeFacts[1].fact)
   );
+
+  // A single position constraint carrying a POINT on one axis and an INTERVAL on
+  // the other: the interval axis lowers to an edge-pin extent, the point axis to
+  // a single pin. Both forms coexist on one constraint.
+  const mixed: PositionConstraint = {
+    type: "position",
+    x: 12,
+    y: [10, 30],
+    anchor: "middle",
+    override: false,
+    children: [child("C")],
+  };
+  const loweredMixed = lowerPlacementConstraints(
+    [mixed],
+    targets("C"),
+    [300, 200]
+  );
+  ok(
+    "interval+point on one constraint: interval axis yields a span extent",
+    loweredMixed.spanExtents.some(
+      (extent) =>
+        extent.axis === "y" && extent.name === "C" && extent.size === 20
+    ) && !loweredMixed.spanExtents.some((extent) => extent.axis === "x")
+  );
+  ok(
+    "interval+point on one constraint: point axis yields a single pin",
+    loweredMixed.program.axes[0].some(
+      (fact) => fact.type === "pin" && fact.expr.node === "C"
+    )
+  );
+}
+
+console.log("# constraint confluence: interval position + align");
+{
+  // An interval position on x (sizes A) plus an align on x (overlays B onto A's
+  // center) must be declaration-order-independent — the interval and align feed
+  // the same relational solve.
+  const spanA = span("A", 10, 30);
+  const alignAB: AlignConstraint = {
+    type: "align",
+    x: "middle",
+    children: [A, B],
+  };
+  expectConfluent(
+    "interval-position/align",
+    solve([spanA, alignAB], ["A", "B"]),
+    solve([alignAB, spanA], ["A", "B"]),
+    {
+      A: { min: 10, center: 20, max: 30 },
+      B: { min: 15, center: 20, max: 25 },
+    }
+  );
+}
+
+console.log("# constraint confluence: interval vs point compose bail");
+{
+  // compose treats an interval position as span-like (it composes alongside a
+  // distribute), but a constraint carrying ANY point coordinate bails to the
+  // layer's default union — conservatively, even when it also carries an
+  // interval on the other axis.
+  const childNodes = [
+    { _name: "A", key: "A" },
+    { _name: "B", key: "B" },
+  ] as unknown as Parameters<typeof composeConstraintSpaces>[1];
+  const childSpaces: Parameters<typeof composeConstraintSpaces>[2] = [
+    [SIZE(Monotonic.linear(10, 0)), UNDEFINED],
+    [SIZE(Monotonic.linear(10, 0)), UNDEFINED],
+  ];
+  const distAB = distribute(["A", "B"]);
+  const pureInterval: PositionConstraint = {
+    type: "position",
+    y: [value(0), value(10)],
+    anchor: "middle",
+    override: false,
+    children: [A],
+  };
+  const pointPlusInterval: PositionConstraint = {
+    type: "position",
+    x: value(5),
+    y: [value(0), value(10)],
+    anchor: "middle",
+    override: false,
+    children: [A],
+  };
+  ok(
+    "pure-interval position composes with a distribute (span-like)",
+    composeConstraintSpaces(
+      [distAB, pureInterval],
+      childNodes,
+      childSpaces
+    ) !== undefined
+  );
+  ok(
+    "point+interval position bails composition (conservatively point-form)",
+    composeConstraintSpaces(
+      [distAB, pointPlusInterval],
+      childNodes,
+      childSpaces
+    ) === undefined
+  );
 }
 
 console.log("# constraint confluence: child scale factor planning");
@@ -1245,7 +1351,7 @@ console.log("# constraint confluence: contradictions are diagnosed");
 
   const spanA10_30 = span("A", 10, 30);
   const spanA10_40 = span("A", 10, 40);
-  const spanThrows = (constraints: SpanConstraint[]): boolean => {
+  const spanThrows = (constraints: PositionConstraint[]): boolean => {
     try {
       solvePlacementConstraints(
         constraints,
@@ -1267,7 +1373,7 @@ console.log("# constraint confluence: contradictions are diagnosed");
   );
 
   const spanPositionThrows = (
-    constraints: (SpanConstraint | PositionConstraint)[]
+    constraints: PositionConstraint[]
   ): boolean => {
     try {
       solvePlacementConstraints(

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -1163,7 +1163,7 @@ console.log("# constraint confluence: self-placement and override");
     ["A", makePlaceable()],
     ["B", makePlaceable()],
   ]);
-  targets.get("A")!.placementOn = () => ({ tag: "determined", at: 0 });
+  targets.get("A")!.placementOn = () => "determined";
   solvePlacementConstraints(
     [{ type: "align", x: "baseline", children: [A, B] }],
     targets,

--- a/packages/gofish-graphics/src/tests/space.test.ts
+++ b/packages/gofish-graphics/src/tests/space.test.ts
@@ -14,7 +14,7 @@ import {
   isPOSITION,
   isDIFFERENCE,
   isBaselineMagnitude,
-  placementOf,
+  anchorAt,
   spacePlacement,
   type CONTINUOUS_TYPE,
   type UnderlyingSpace,
@@ -100,15 +100,23 @@ console.log(
   "# space: the abstract placement lattice is total over origin (Phase A)"
 );
 {
-  // placementOf maps each of the three anchor states to a bare placement.
-  ok('anchor "free" → placement free', placementOf("free") === "free");
+  // The three placement cases ARE the three named constructors; anchorAt
+  // re-anchors while preserving the σ-affine width (the position operator's
+  // construction — a free width with slope must not collapse to a constant).
+  const freeSlope = SIZE(M.linear(10, 0)) as CONTINUOUS_TYPE; // width 10·σ
+  const anchored = anchorAt(freeSlope, 1955);
   ok(
-    'anchor "impossible" → placement conflict',
-    placementOf("impossible") === "conflict"
+    "anchorAt(free, 1955) → placement determined",
+    spacePlacement(anchored) === "determined"
   );
   ok(
-    "anchor <number> → placement determined (data coordinate lives in dataDomain)",
-    placementOf(1955) === "determined"
+    "anchorAt domain min is the anchor coordinate",
+    JSON.stringify(anchored.dataDomain) ===
+      JSON.stringify(interval(1955, 1955 + freeSlope.width.run(1)))
+  );
+  ok(
+    "anchorAt preserves the σ-affine width (slope not baked at σ=1)",
+    anchored.width.run(2) === 20
   );
 
   // Constructors carry dataDomain; placement is derived from its shape.

--- a/packages/gofish-graphics/src/tests/space.test.ts
+++ b/packages/gofish-graphics/src/tests/space.test.ts
@@ -15,7 +15,7 @@ import {
   isDIFFERENCE,
   isBaselineMagnitude,
   placementOf,
-  originOf,
+  spacePlacement,
   type CONTINUOUS_TYPE,
   type UnderlyingSpace,
 } from "../ast/underlyingSpace";
@@ -80,7 +80,7 @@ console.log("# space: baseline magnitude vs data axis anchored at 0");
   ok(
     "...and the forgotten composition is itself a baseline magnitude",
     composed !== undefined && isBaselineMagnitude(composed),
-    composed && `placement=${JSON.stringify((composed as any).placement)}`
+    composed && `dataDomain=${JSON.stringify((composed as any).dataDomain)}`
   );
 }
 
@@ -100,22 +100,18 @@ console.log(
   "# space: the abstract placement lattice is total over origin (Phase A)"
 );
 {
-  // placementOf maps each of the three origin states.
+  // placementOf maps each of the three anchor states to a bare placement.
+  ok('anchor "free" → placement free', placementOf("free") === "free");
   ok(
-    'origin "free" → placement free',
-    placementOf("free").tag === "free"
+    'anchor "impossible" → placement conflict',
+    placementOf("impossible") === "conflict"
   );
   ok(
-    'origin "impossible" → placement conflict',
-    placementOf("impossible").tag === "conflict"
-  );
-  const det = placementOf(1955);
-  ok(
-    "origin <number> → placement determined at that DATA coordinate",
-    det.tag === "determined" && det.at === 1955
+    "anchor <number> → placement determined (data coordinate lives in dataDomain)",
+    placementOf(1955) === "determined"
   );
 
-  // Constructors carry placement + dataDomain; originOf round-trips placement.
+  // Constructors carry dataDomain; placement is derived from its shape.
   const cases: [string, CONTINUOUS_TYPE, string, unknown][] = [
     ["SIZE", SIZE(M.linear(10, 0)) as CONTINUOUS_TYPE, "free", undefined],
     [
@@ -128,17 +124,12 @@ console.log(
   ];
   for (const [label, sp, expectedTag, expectedDomain] of cases) {
     ok(
-      `${label} carries placement.tag === "${expectedTag}"`,
-      sp.placement.tag === expectedTag
+      `${label} derives placement === "${expectedTag}"`,
+      spacePlacement(sp) === expectedTag
     );
     ok(
       `${label} carries the expected dataDomain`,
       JSON.stringify(sp.dataDomain) === JSON.stringify(expectedDomain)
-    );
-    ok(
-      `${label}: placementOf(originOf(sp)) round-trips placement`,
-      JSON.stringify(placementOf(originOf(sp))) ===
-        JSON.stringify(sp.placement)
     );
   }
 }


### PR DESCRIPTION
Advances #39. First tranche of the staged simplification mapped in the new design doc (committed here as `internals/design/sigma-affine-simplification.md`): unify sizing/positioning vocabulary around the σ-affine model `px(d) = pxMin + σ·(d − domainMin)`, and delete two constraint side-regimes from the public surface.

One commit per stage:

- **Stage 0+1 — placement becomes a derived view of `dataDomain`.** `Placement` is now the bare lattice `"free" | "determined" | "conflict"`, derived via `spacePlacement()` instead of stored in lockstep. The `at` payload was a fossil — it always equaled `dataDomain.min` (its sole reader, `positionNode`'s `offsetSpace`, now reads `continuousInterval`). `originOf` deleted (zero callers); builder type `Origin` renamed `Anchor` (the numeric case is the domain min, not a zero point). The underlying-space essay gains the one equation and the three-roles framing (alignment = constraint, placement = abstract value, intercept = concrete derived value). Follows up on the #586 collapse.
- **Stage 2 — `span` folds into `position`'s interval form.** `Constraint.position({x: [a, b]})` — two edges determine the size, exactly span's semantics; `Constraint.span`/`SpanConstraint`/`SpanOptions` deleted. Sole producer (scatter's `xMin`/`xMax` range channels) migrated. The internal edge-pin/extent lowering survives until the rank-2 solve (Stage 5), retyped. No wire-IR impact (span never crossed it).
- **Stage 3 — grid contained.** A grid layer used to half-apply sibling constraints (placement applied them; spaces/sizing saw only the grid). `selectGridConstraint` now throws on grid + any non-z-order constraint; `Constraint.grid` leaves the public factory (grid is `table`'s private elaboration target). The restriction lifts when grids become track equations (Stage 6e in the design doc).

The design doc also contains the detailed execution plans for the follow-up stages: 4 (one affine scale carrier), 5 (rank-2 placement solve), 6 (σ via the frame equation).

## Verification

- `pnpm capture-diff main` after **each** stage commit: **no layout changes, 260 stories identical** — the whole PR is pixel-equivalent, so no screenshots.
- Full package test suite green at each stage (confluence suite grew from 81 → 89 tests: interval-form position cases, grid mixing-throw, grid+z-order allowed).
- `typecheck`, `check-backlinks`, and `docs:build` clean at each stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)