### PR TITLE
σ-affine simplification, stage 4: one affine scale carrier per axis

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -113,16 +113,20 @@ carries its _own_ intercept — the σ-independent pixel part of an _extent_
 intercept`. That is an intercept of the size equation, not of the data→screen
 map; the two never mean the same thing.
 
-**The two scale carriers, honestly.** Layout currently threads two parallel
-per-axis channels downward (see [Layout dispatch](#layout-dispatch)).
-`scaleFactors` carries only the slope σ, for _unanchored_ extents — a free
-magnitude has no committed baseline, so its intercept is implicit in where its
-parent places it (baseline placement + `transform.translate`) and never needs to
-travel with the scale. `posScales` carries the _whole_ map `px(d)` for _anchored_
-extents, closing σ and the intercept together over one function. So "anchored"
-shows up operationally as "has a posScale"; "unanchored" as "has only a scale
-factor." Stage 4 of [the σ-affine plan](/internals/design/sigma-affine-simplification)
-folds these two into a single affine record.
+**The single scale carrier.** Layout threads one per-axis record downward (see
+[Layout dispatch](#layout-dispatch)): the `AxisScale` = `{ sigma?, map? }`
+(`domain.ts`). `sigma` is the slope σ for _unanchored_ extents — a free magnitude
+has no committed baseline, so its intercept is implicit in where its parent
+places it (baseline placement + `transform.translate`) and never travels with the
+scale. `map` is the _whole_ anchored map, with the intercept explicit as data
+rather than closed over a function: `px(d) = pxMin + sigma·(d − domainMin)`,
+evaluated by `pxOf` (the old `posScale(0)` intercept is `pxOf(map, 0)`). So
+"anchored" shows up operationally as "has a `map`"; "unanchored" as "has only a
+`sigma`." `map` carries its own slope, which need not equal the top-level
+`sigma` — a sub-budget layer scales a mark's size and its data position against
+different pixel extents. This single record replaced the former two parallel
+channels (`scaleFactors` = slope-only, `posScales` = whole map) in Stage 4 of
+[the σ-affine plan](/internals/design/sigma-affine-simplification).
 
 ## Why an explicit IR
 
@@ -648,10 +652,10 @@ reproduces both divisions, and the switch folds away:
 
 ```
 gofish.tsx (root):
-  if root[axis] is a free magnitude            → scale factor = width.inverse(canvas)
-  if root[axis].dataDomain is an interval       → build a posScale over it
-  pass both downward as (scaleFactors, posScales) — a child reads whichever
-  it needs
+  if root[axis] is a free magnitude            → sigma = width.inverse(canvas)
+  if root[axis].dataDomain is an interval       → map = an AxisMap over it
+  pass one `AxisScale` = { sigma?, map? } downward per axis — a child reads
+  `sigma` for size, `map` for data position (they're mutually exclusive at root)
 
 layer.layout, on an axis the node scopes (node.shared[axis] — set by
 `spread`/`stack`'s `sharedScale`; default [false, false] is a no-op):
@@ -659,19 +663,21 @@ layer.layout, on an axis the node scopes (node.shared[axis] — set by
     else → undefined (ORDINAL/UNDEFINED don't need a continuous scale factor)
 ```
 
-Leaf shapes never need to compute their own scale factors — they receive
-them via the `scaleFactors` parameter and apply them in `computeSize`.
+Leaf shapes never need to compute their own scale factors — they receive the
+per-axis `AxisScale` via the `scales` parameter and read its `sigma` in
+`computeSize` (and its `map` via `pxOf` for data position).
 
 `spread`/`stack` no longer have their own `layout` — they **elaborate to
 `layer + align + distribute`** (`spread.tsx`), so the dispatch above lives
 entirely in `layer.layout`. `buildChildScalePlan` is the shared layout-time
-planner: explicit self-scaled axes first derive local posScales/scale factors, a
+planner: explicit self-scaled axes first derive local maps/scale factors, a
 layer whose constraints fold to a SIZE claim then inverts that fold against its
 allotted size (`fold.inverse(size[axis])`) to derive a local scale factor for
 its constrained children (returning failures so `layer` can warn before falling
 back), and a `sharedScale` scope finally runs the per-axis solve in the
-pseudocode above. The result is a **fresh `childScaleFactors` array** handed to
-descendants — **no node ever mutates the inherited `scaleFactors`**. That is the
+pseudocode above. `layer` recombines the per-axis σ and `map` into one
+`AxisScale` per child at `child.layout`. The result is a **fresh `childScaleFactors`
+array** handed to descendants — **no node ever mutates the inherited σ**. That is the
 claim-hoisting form of `sharedScale` (#549): a scale solves at the lowest node
 where its measure stops being shared, and the result flows to descendants only,
 never leaking to siblings.

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -310,6 +310,20 @@ posScale and σ are _views_ of the solved system (the Stage-4 `AxisScale`
 record becomes exactly this view: σ = slope, `map` = anchored min facet +
 pixel min; the intercept is `posScale(0)`, derived, never stored).
 
+**The dual slope is transitional debt, eliminated here — not a keeper.**
+Stage 4's `AxisScale.map` carries its own slope because today σ is solved in
+the four+ places above against four different pixel budgets, so a mark can
+read size-σ and position-slope from different extents on one axis (nicing
+asymmetry, spacing's slope-vs-secant, sub-budget scopes vs an inherited map).
+Stage 6's invariant is **one slope per σ-scope, by construction**: the frame
+equation solves σ once at the scope root and the posScale is a derived view
+of the same solve, so within a scope the two cannot disagree. The divergences
+that remain must then become what they really are — two scopes on one axis
+(keyed by measure: the multi-scale/dual-axis design), or explicit non-data
+pixels (spacing as a piecewise gap, not a secant that papers over it).
+`AxisScale` collapses back to a single-slope view when 6b/6c land; if it
+still has two independent slopes after Stage 6, that is a bug in Stage 6.
+
 ### Sub-stages, each gated
 
 - **6a — observe.** Extend `solver/shadow.ts` coverage to the modes it skips:

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -59,6 +59,7 @@ import {
   UnderlyingSpace,
 } from "./underlyingSpace";
 import { toJSON, interval } from "../util/interval";
+import type { AxisScale } from "./domain";
 import { envFlag } from "../util";
 import { nice } from "d3-array";
 import type { ScaleContext } from "./gofish";
@@ -143,17 +144,17 @@ export type Placeable = {
   pinAnchor?: (axis: FancyDirection, value: number, anchor: Anchor) => void;
 };
 
-// `scaleFactors` is the σ (pixels-per-data-unit) handed down per axis. A node
-// MUST NOT mutate this array: to establish a local scale for its descendants
-// (the `shared` scoping annotation, below) it copies into a fresh array and
-// passes that down — never writing back to the parent's, so a solved σ can't
-// leak to the node's siblings (see spread.tsx / layer.tsx).
+// `scales` is the per-axis data→pixel affine scale handed down (the single
+// {@link AxisScale} carrier: `sigma` = pixels-per-data-unit for size, `map` =
+// the anchored data→pixel map). A node MUST NOT mutate this array: to establish
+// a local scale for its descendants (the `shared` scoping annotation, below) it
+// copies into a fresh array and passes that down — never writing back to the
+// parent's, so a solved σ can't leak to the node's siblings (see layer.tsx).
 export type Layout = (
   shared: Size<boolean>,
   size: Size,
-  scaleFactors: Size<number | undefined>,
+  scales: Size<AxisScale | undefined>,
   children: GoFishAST[],
-  posScales: Size<((pos: number) => number) | undefined>,
   node: GoFishNode
 ) => { intrinsicDims: FancyDims; transform: FancyTransform; renderData?: any };
 
@@ -264,7 +265,7 @@ export class GoFishNode {
    *  σ from its own box and hands it to descendants via a fresh array — claim
    *  hoisting, #549); `false` (default) = pass-through, inheriting σ from above.
    *  It is NOT a mutation flag — no node writes back to the parent's
-   *  `scaleFactors`. Currently set only by `spread`/`stack` (`sharedScale`). */
+   *  `scales`. Currently set only by `spread`/`stack` (`sharedScale`). */
   public shared: Size<boolean>;
   public renderData?: any;
   public coordinateTransform?: CoordinateTransform;
@@ -743,20 +744,15 @@ export class GoFishNode {
     });
   }
 
-  public layout(
-    size: Size,
-    scaleFactors: Size<number | undefined>,
-    posScales: Size<((pos: number) => number) | undefined>
-  ): Placeable {
+  public layout(size: Size, scales: Size<AxisScale | undefined>): Placeable {
     // Axes are no longer drawn here: they are elaborated into ordinary shapes +
     // constraints by `elaborateAxes` (src/ast/axes/elaborate.tsx) before layout,
     // so the layout engine has no axis-specific budget/baseline machinery.
     const { intrinsicDims, transform, renderData } = this._layout(
       this.shared,
       size,
-      scaleFactors,
+      scales,
       this.children,
-      posScales,
       this
     );
 

--- a/packages/gofish-graphics/src/ast/_ref.tsx
+++ b/packages/gofish-graphics/src/ast/_ref.tsx
@@ -19,7 +19,7 @@ import {
   Size,
   Transform,
 } from "./dims";
-import { Domain } from "./domain";
+import { Domain, type AxisScale } from "./domain";
 import { GoFishNode } from "./_node";
 import { GoFishAST } from "./_ast";
 import { MaybeValue } from "./data";
@@ -276,11 +276,7 @@ export class GoFishRef {
     return measurement;
   }
 
-  public layout(
-    size: Size,
-    scaleFactors: Size<number | undefined>,
-    _posScales?: Size<((pos: number) => number) | undefined>
-  ): Placeable {
+  public layout(size: Size, _scales?: Size<AxisScale | undefined>): Placeable {
     if (!this.selectedNode) {
       throw new Error("Selected node not found");
     }

--- a/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
@@ -25,6 +25,7 @@ import { isPositionInterval, lowerPositionPlacement } from "./position";
 import type { SpanExtent } from "./span";
 import { collectSpanExtents, lowerSpanEdgePins } from "./span";
 import { axisIndex, type Axis, type ConstraintPosScales } from "./shared";
+import { pxOf, type AxisMap } from "../domain";
 import type { PlacementProgram } from "./placementFacts";
 
 export type PlacementConstraint =
@@ -52,7 +53,7 @@ const placementKey = (axis: Axis, name: string): string => `${axis}:${name}`;
 
 export function compilePlacementCoordinate(
   coordinate: PositionValue,
-  scale: ((value: number) => number) | undefined,
+  scale: AxisMap | undefined,
   axisSize?: number
 ): PlacementCoordinate {
   if (isDiscretePosition(coordinate)) {
@@ -61,12 +62,12 @@ export function compilePlacementCoordinate(
   }
   if (!isValue(coordinate)) return coordinate;
   if (scale === undefined) return undefined;
-  return scale(getValue(coordinate)!) + getValueOffset(coordinate);
+  return pxOf(scale, getValue(coordinate)!) + getValueOffset(coordinate);
 }
 
 function resolveCoordinate(
   coordinate: PositionValue,
-  scale: ((value: number) => number) | undefined,
+  scale: AxisMap | undefined,
   axisSize?: number
 ): number | undefined {
   return compilePlacementCoordinate(coordinate, scale, axisSize);

--- a/packages/gofish-graphics/src/ast/constraints/shared.ts
+++ b/packages/gofish-graphics/src/ast/constraints/shared.ts
@@ -1,6 +1,7 @@
 import { GoFishNode, type Placeable } from "../_node";
 import { GoFishRef } from "../_ref";
 import type { GoFishAST } from "../_ast";
+import type { AxisMap } from "../domain";
 import { isToken } from "../createName";
 
 export type Axis = "x" | "y";
@@ -15,13 +16,12 @@ export type AlignAnchor = Alignment | "baseline";
 /** Lightweight handle for referencing a named child inside .constrain() */
 export type ConstraintRef = { readonly name: string };
 
-/** Per-axis data→pixel position scales, as built by `layer.tsx` and consumed
+/** Per-axis data→pixel position maps, as built by `layer.tsx` and consumed
  *  by `Constraint.position` (a literal coordinate is a raw pixel; a `datum`
- *  coordinate is mapped through the matching scale). */
-export type ConstraintPosScales = [
-  ((value: number) => number) | undefined,
-  ((value: number) => number) | undefined,
-];
+ *  coordinate is mapped through the matching map via `pxOf`). An entry is
+ *  `undefined` exactly when the axis is unanchored — the position half of the
+ *  single {@link AxisScale} carrier. */
+export type ConstraintPosScales = [AxisMap | undefined, AxisMap | undefined];
 
 /** Convert axis name to dimension index (0 = x, 1 = y) */
 export const axisIndex = (axis: Axis): 0 | 1 => (axis === "x" ? 0 : 1);

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -32,7 +32,7 @@ import {
   continuousInterval,
   type CONTINUOUS_TYPE,
 } from "../underlyingSpace";
-import { posScaleFromSpace } from "../domain";
+import { posScaleFromSpace, axisScale, type AxisMap } from "../domain";
 import * as Monotonic from "../../util/monotonic";
 import { createNodeOperator } from "../withGoFish";
 import { computeTransformedBoundingBox } from "./coordUtils";
@@ -162,7 +162,7 @@ export const coord = createNodeOperator(
           spaceRef.current = result;
           return result;
         },
-        layout: (shared, size, scaleFactors, children, posScales) => {
+        layout: (shared, size, scales, children) => {
           /* TODO: need correct scale factors */
           // TODO: only works for polar-family transforms right now
           const [origW, origH] = size;
@@ -188,15 +188,15 @@ export const coord = createNodeOperator(
           // fits content to the canvas (gofish.tsx) — here the budget plays the
           // role of the canvas. A baseline-magnitude (data SIZE) axis scales by
           // budget/total via `width.inverse(budget)` so the children fill the
-          // ring; an anchored (data POSITION) axis maps onto [0, budget] via a
-          // posScale. Only DATA-bound channels consume these — a plain number
-          // bypasses both scaleFactor and posScale (see `computeAesthetic`) — so
+          // ring; an anchored (data POSITION) axis maps onto [0, budget] via an
+          // anchored map. Only DATA-bound channels consume the scale — a plain
+          // number bypasses both σ and the map (see `computeAesthetic`) — so
           // hand-sized (radian/pixel) stories are unchanged. This is what lets a
           // mark say `thetaSize: datum(count)` and have the ring auto-fit.
           const fitAxis = (
             axis: 0 | 1,
             budget: number
-          ): [number, ((p: number) => number) | undefined] => {
+          ): [number, AxisMap | undefined] => {
             // An anchored (data POSITION) axis: the coord's own
             // `resolveUnderlyingSpace` already unioned the children's POSITION
             // spaces into `spaceRef.current` — reuse it and map onto [0, budget].
@@ -220,7 +220,7 @@ export const coord = createNodeOperator(
           const [sfX, psX] = fitAxis(0, angularBudget);
           const [sfY, psY] = fitAxis(1, outerR - innerR);
           const childPlaceables = children.map((child) =>
-            child.layout(size, [sfX, sfY], [psX, psY])
+            child.layout(size, [axisScale(sfX, psX), axisScale(sfY, psY)])
           );
           childPlaceables.forEach((c) => {
             c.place("x", 0, "baseline");

--- a/packages/gofish-graphics/src/ast/domain.ts
+++ b/packages/gofish-graphics/src/ast/domain.ts
@@ -53,16 +53,56 @@ export const unifyContinuousDomains = (
   });
 };
 
-// creates an affine scale transforming the domain to [0, size] or [size, 0] if reverse is true
+/** One continuous axis's data→pixel affine map, with the intercept explicit
+ *  instead of closed over a function: `px(d) = pxMin + sigma·(d − domainMin)`.
+ *  `sigma` is the map's own slope (px per data unit); it need NOT equal an
+ *  {@link AxisScale}'s top-level `sigma` — a sub-budget layer can scale a mark's
+ *  size and its data position against different pixel extents. Evaluated by
+ *  {@link pxOf}; the old `posScale(0)` intercept is `pxOf(map, 0)`. */
+export type AxisMap = { sigma: number; domainMin: number; pxMin: number };
+
+/** One axis's data→pixel affine scale — the single carrier that replaced the
+ *  parallel `scaleFactors` (slope-only) and `posScales` (whole map) channels.
+ *  `sigma` is px per data unit for UNANCHORED size consumers (the old
+ *  `scaleFactor`); `map` is the anchored data→pixel map (the old `posScale`),
+ *  present iff the axis is anchored. */
+export type AxisScale = { sigma?: number; map?: AxisMap };
+
+/** Evaluate an anchored map at a data value. */
+export const pxOf = (map: AxisMap, d: number): number =>
+  map.pxMin + map.sigma * (d - map.domainMin);
+
+/** Function view of an anchored map, for consumers that take a `(d)=>px`
+ *  callback (`computeAesthetic`). A local derivation at the consumption site —
+ *  never threaded between nodes. Undefined when the axis is unanchored. */
+export const posFn = (
+  map: AxisMap | undefined
+): ((d: number) => number) | undefined =>
+  map === undefined ? undefined : (d) => pxOf(map, d);
+
+/** Assemble one axis's {@link AxisScale} from its σ (size slope) and anchored
+ *  map, collapsing "neither present" to `undefined` so a bare axis stays
+ *  undefined (not an empty record). */
+export const axisScale = (
+  sigma: number | undefined,
+  map: AxisMap | undefined
+): AxisScale | undefined =>
+  sigma === undefined && map === undefined ? undefined : { sigma, map };
+
+// creates an affine map transforming the domain to [0, size] or [size, 0] if reverse is true
 export const computePosScale = (
   domain: ContinuousDomain,
   size: number,
   reverse: boolean = false
-) => {
+): AxisMap => {
   const [min, max] = domain.value;
   const scale = size / (max - min);
-  return (pos: number) =>
-    reverse ? size - (pos - min) * scale : (pos - min) * scale;
+  // px(d) = pxMin + sigma·(d − domainMin) reproduces the former closure exactly:
+  // forward  `(d − min)·scale`         → pxMin 0,    sigma  scale;
+  // reverse  `size − (d − min)·scale`  → pxMin size, sigma −scale.
+  return reverse
+    ? { sigma: -scale, domainMin: min, pxMin: size }
+    : { sigma: scale, domainMin: min, pxMin: 0 };
 };
 
 /**
@@ -83,7 +123,7 @@ export const posScaleFromSpace = (
       }
     | undefined,
   size: number
-): ((pos: number) => number) | undefined =>
+): AxisMap | undefined =>
   space &&
   space.kind === "continuous" &&
   space.dataDomain !== undefined &&

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -14,7 +14,12 @@ import {
   GoFishNode,
   type RenderSession,
 } from "./_node";
-import { posScaleFromSpace } from "./domain";
+import {
+  posScaleFromSpace,
+  axisScale,
+  type AxisMap,
+  type AxisScale,
+} from "./domain";
 import { bake } from "./coordinateTransforms/bake";
 import { lowerToDisplayList } from "./displayList/lower";
 import { paintSVG } from "./displayList/paintSVG";
@@ -156,10 +161,7 @@ export async function layout(
   underlyingSpaceX: UnderlyingSpace;
   underlyingSpaceY: UnderlyingSpace;
   yUp: boolean;
-  posScales: [
-    ((pos: number) => number) | undefined,
-    ((pos: number) => number) | undefined,
-  ];
+  scales: Size<AxisScale | undefined>;
   child: GoFishNode;
   width: number;
   height: number;
@@ -368,11 +370,8 @@ export async function layout(
   const layoutW = w ?? (needsCanvas(niceUnderlyingSpaceX) ? canvasW : UNSIZED);
   const layoutH = h ?? (needsCanvas(niceUnderlyingSpaceY) ? canvasH : UNSIZED);
 
-  // An anchored CONTINUOUS root builds a posScale over its data interval.
-  const posScales: [
-    ((pos: number) => number) | undefined,
-    ((pos: number) => number) | undefined,
-  ] = [
+  // An anchored CONTINUOUS root builds a data→pixel map over its data interval.
+  const posScales: Size<AxisMap | undefined> = [
     posScaleFromSpace(niceUnderlyingSpaceX, canvasW),
     posScaleFromSpace(niceUnderlyingSpaceY, canvasH),
   ];
@@ -433,8 +432,12 @@ export async function layout(
         const info = axisInfo[axis]!;
         if (info.kind === "position") {
           const offset = (info.canvas - shared * info.range) / 2; // center slack
-          const min = info.min;
-          posScales[axis] = (pos: number) => (pos - min) * shared + offset;
+          // Same affine map as `(pos − min)·shared + offset`, intercept explicit.
+          posScales[axis] = {
+            sigma: shared,
+            domainMin: info.min,
+            pxMin: offset,
+          };
         } else {
           rootScaleFactors[axis] = shared;
         }
@@ -454,7 +457,15 @@ export async function layout(
   // tree, before layout/render consume the flag. See _node.resolveEmbedding.
   child.resolveEmbedding();
 
-  child.layout([layoutW, layoutH], rootScaleFactors, posScales);
+  // Merge the two half-channels into the single per-axis scale carrier handed
+  // to layout: σ (size slope) from `rootScaleFactors`, the anchored map from
+  // `posScales`. They are mutually exclusive per axis at the root.
+  const rootScales: Size<AxisScale | undefined> = [
+    axisScale(rootScaleFactors[0], posScales[0]),
+    axisScale(rootScaleFactors[1], posScales[1]),
+  ];
+
+  child.layout([layoutW, layoutH], rootScales);
   // Root placement anchor. A GIVEN dimension keeps the baseline-anchored canvas
   // box [0, given]; content seated outside it (axis labels below 0, ticks above
   // `given`) is reserved as the per-side overhangs below. A SHRINK-TO-FIT
@@ -523,7 +534,7 @@ export async function layout(
     underlyingSpaceX: niceUnderlyingSpaceX,
     underlyingSpaceY: niceUnderlyingSpaceY,
     yUp: effYUp,
-    posScales,
+    scales: rootScales,
     child,
     width: finalW,
     height: finalH,
@@ -572,10 +583,7 @@ type LayoutData = {
   underlyingSpaceY: UnderlyingSpace;
   /** Whether the root renders y-UP (continuous y / coord scope). See #143/#16. */
   yUp: boolean;
-  posScales: [
-    ((pos: number) => number) | undefined,
-    ((pos: number) => number) | undefined,
-  ];
+  scales: Size<AxisScale | undefined>;
   child: GoFishNode;
   width: number;
   height: number;

--- a/packages/gofish-graphics/src/ast/graphicalOperators/arrow.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/arrow.tsx
@@ -4,6 +4,7 @@ import { Size, displayTranslate } from "../dims";
 import type { DisplayList } from "gofish-ir";
 import { lowerStyle, withToPixel } from "../displayList/lowerHelpers";
 import { UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
+import { axisScale } from "../domain";
 import { createNodeOperator } from "../withGoFish";
 import { type ArrowOptions, getBoxToBoxArrow } from "perfect-arrows";
 import { bbox, union } from "../../util/bbox";
@@ -55,7 +56,7 @@ export const arrow = createNodeOperator(
           _childSpaces: Size<UnderlyingSpace>[],
           _childNodes: GoFishAST[]
         ) => [UNDEFINED, UNDEFINED],
-        layout: (shared, size, scaleFactors, layoutChildren) => {
+        layout: (shared, size, scales, layoutChildren) => {
           if (layoutChildren.length < 2) {
             return {
               intrinsicDims: [
@@ -67,8 +68,13 @@ export const arrow = createNodeOperator(
             };
           }
 
+          // Forward σ (size slope) but not the anchored map: arrow anchors to
+          // its endpoints' bboxes, not to data position.
           const childPlaceables = layoutChildren.map((child) =>
-            child.layout(size, scaleFactors, [undefined, undefined])
+            child.layout(size, [
+              axisScale(scales?.[0]?.sigma, undefined),
+              axisScale(scales?.[1]?.sigma, undefined),
+            ])
           );
           const fromDims = childPlaceables[0].dims;
           const toDims = childPlaceables[1].dims;

--- a/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
@@ -19,7 +19,7 @@ import {
 import { pairs } from "../../util";
 import { linear } from "../coordinateTransforms/linear";
 import { MaybeValue } from "../data";
-import { Domain } from "../domain";
+import { Domain, axisScale } from "../domain";
 import { UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
 import { createNodeOperator } from "../withGoFish";
 
@@ -113,7 +113,7 @@ export const connect = createNodeOperator(
         ) => {
           return [UNDEFINED, UNDEFINED];
         },
-        layout: (shared, size, scaleFactors, children) => {
+        layout: (shared, size, scales, children) => {
           const defaultColor = children[0]?.color ?? "black";
 
           const paths: Path[] = [];
@@ -128,8 +128,13 @@ export const connect = createNodeOperator(
             }
           }
 
+          // Forward σ (size slope) but not the anchored map: connect places
+          // endpoints by their own bboxes, not by data position.
           const childPlaceables = children.map((child) =>
-            child.layout(size, scaleFactors, [undefined, undefined])
+            child.layout(size, [
+              axisScale(scales?.[0]?.sigma, undefined),
+              axisScale(scales?.[1]?.sigma, undefined),
+            ])
           );
           const bboxPairs = pairs(childPlaceables.map((child) => child.dims));
 

--- a/packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx
@@ -31,11 +31,11 @@ export const enclose = createNodeOperator(
         ) => {
           return [UNDEFINED, UNDEFINED];
         },
-        layout: (shared, size, scaleFactors, children, posScales) => {
+        layout: (shared, size, scales, children) => {
           const childPlaceables = [];
 
           for (const child of children) {
-            const childPlaceable = child.layout(size, scaleFactors, posScales);
+            const childPlaceable = child.layout(size, scales);
             childPlaceable.place("x", 0, "baseline");
             childPlaceable.place("y", 0, "baseline");
             childPlaceables.push(childPlaceable);

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -16,6 +16,7 @@ import {
 } from "../dims";
 import { UNDEFINED, UnderlyingSpace, hasBaseline } from "../underlyingSpace";
 import { computeSize, foldFinite } from "../../util";
+import { axisScale } from "../domain";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
 import { coord } from "../coordinateTransforms/coord";
 import { createNodeOperatorSequential } from "../withGoFish";
@@ -29,7 +30,7 @@ import {
   type ConstraintSpec,
   type ZOrderConstraint,
 } from "../constraints";
-import { childNameKey } from "../constraints/shared";
+import { childNameKey, type ConstraintPosScales } from "../constraints/shared";
 import {
   applyNestLayoutProposal,
   applyNestSpacePlan,
@@ -198,11 +199,25 @@ export const layer = createNodeOperatorSequential(
           }
           return resolved;
         },
-        layout: (shared, size, scaleFactors, children, posScales, node) => {
+        layout: (shared, size, scales, children, node) => {
+          // Split the incoming single-carrier scale into its two half-channels
+          // for the proposal planning below: σ (size slope) feeds sizing and the
+          // child σ forwarding; the anchored map feeds `position` constraints and
+          // per-child map forwarding. They recombine per child at `child.layout`.
+          const inheritedScaleFactors: Size<number | undefined> = [
+            scales?.[0]?.sigma,
+            scales?.[1]?.sigma,
+          ];
+          const inheritedPosScales: ConstraintPosScales = [
+            scales?.[0]?.map,
+            scales?.[1]?.map,
+          ];
           // Compute size using dims (w and h) before passing to children
           size = [
-            computeSize(dims[0].size, scaleFactors?.[0]!, size[0]) ?? size[0],
-            computeSize(dims[1].size, scaleFactors?.[1]!, size[1]) ?? size[1],
+            computeSize(dims[0].size, inheritedScaleFactors[0]!, size[0]) ??
+              size[0],
+            computeSize(dims[1].size, inheritedScaleFactors[1]!, size[1]) ??
+              size[1],
           ];
 
           // Grid budget: a grid layer is exclusively cells (table elaboration),
@@ -223,14 +238,14 @@ export const layer = createNodeOperatorSequential(
           // `basePosScales` is reused below as the floor for `effectivePosScales`
           // and the per-child forwarding (`childScalesFor`), so the override
           // applies regardless of `ownsPositionAxis`. `childScaleFactors` is a
-          // fresh array — never mutate the parent's `scaleFactors` (unlike
+          // fresh array — never mutate the parent's inherited σ (unlike
           // spread, which mutates intentionally for sibling sharing).
           const childScalePlan = buildChildScalePlan(
             selfScaledSpaces,
             node._underlyingSpace,
             size,
-            scaleFactors,
-            posScales,
+            inheritedScaleFactors,
+            inheritedPosScales,
             constraintBudget,
             shared
           );
@@ -322,17 +337,21 @@ export const layer = createNodeOperatorSequential(
               layoutPlan.nestPlan?.byDerived.get(i),
               childPlaceables
             );
-            const childPlaceable = child.layout(
-              layoutSize,
-              childScaleFactors,
-              childPosScalesFor(
-                (children[i] as GoFishNode)._underlyingSpace,
-                targetDims,
-                ownsAxis,
-                basePosScales,
-                effectivePosScales
-              )
+            // Recombine the two forwarding decisions into the single carrier: σ
+            // forwards uniformly (childScaleFactors), the anchored map forwards
+            // per child (childPosScalesFor — stripped where a constraint consumed
+            // the scale). A stripped map keeps the child's σ.
+            const childMaps = childPosScalesFor(
+              (children[i] as GoFishNode)._underlyingSpace,
+              targetDims,
+              ownsAxis,
+              basePosScales,
+              effectivePosScales
             );
+            const childPlaceable = child.layout(layoutSize, [
+              axisScale(childScaleFactors[0], childMaps[0]),
+              axisScale(childScaleFactors[1], childMaps[1]),
+            ]);
             if (!childName || !layoutPlan.constrainedNames.has(childName)) {
               childPlaceable.place("x", 0, "baseline");
               childPlaceable.place("y", 0, "baseline");

--- a/packages/gofish-graphics/src/ast/graphicalOperators/offset.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/offset.tsx
@@ -36,8 +36,8 @@ export const offset = createNodeOperator<{ x?: number; y?: number }, GoFishAST>(
         type: "offset",
         shared: [false, false],
         resolveUnderlyingSpace: (childSpaces) => childSpaces[0] ?? [],
-        layout: (_shared, size, scaleFactors, layoutChildren, posScales) => {
-          const child = layoutChildren[0].layout(size, scaleFactors, posScales);
+        layout: (_shared, size, scales, layoutChildren) => {
+          const child = layoutChildren[0].layout(size, scales);
           child.place("x", 0, "baseline");
           child.place("y", 0, "baseline");
           return {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
@@ -52,18 +52,11 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
             children: Size<UnderlyingSpace>[],
             _childNodes: GoFishAST[]
           ) => [unionChildSpaces(children, 0), unionChildSpaces(children, 1)],
-          layout: (
-            _shared,
-            size,
-            scaleFactors,
-            layoutChildren,
-            posScales,
-            _node
-          ) => {
+          layout: (_shared, size, scales, layoutChildren) => {
             requireTwoChildren(layoutChildren);
 
             const childPlaceables = layoutChildren.map((child) =>
-              child.layout(size, scaleFactors, posScales)
+              child.layout(size, scales)
             );
             childPlaceables.forEach((child) => {
               child.place("x", 0, "baseline");
@@ -231,18 +224,11 @@ export const mask = createNodeOperator(
           children: Size<UnderlyingSpace>[],
           _childNodes: GoFishAST[]
         ) => [unionChildSpaces(children, 0), unionChildSpaces(children, 1)],
-        layout: (
-          _shared,
-          size,
-          scaleFactors,
-          layoutChildren,
-          posScales,
-          _node
-        ) => {
+        layout: (_shared, size, scales, layoutChildren) => {
           requireTwoChildren(layoutChildren);
 
           const childPlaceables = layoutChildren.map((child) =>
-            child.layout(size, scaleFactors, posScales)
+            child.layout(size, scales)
           );
           childPlaceables.forEach((child) => {
             child.place("x", 0, "baseline");

--- a/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
@@ -1,4 +1,5 @@
 import { computeAesthetic } from "../../util";
+import { posFn } from "../domain";
 import { GoFishNode } from "../_node";
 import { Size, translateString } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
@@ -51,13 +52,13 @@ export const positionNode = (
           offsetSpace(child[1], options.y),
         ];
       },
-      layout: (shared, size, scaleFactors, children, posScales, _node) => {
+      layout: (shared, size, scales, children) => {
         if (children.length !== 1) {
           throw new Error("Position operator expects exactly one child");
         }
 
         const child = children[0];
-        const childPlaceable = child.layout(size, scaleFactors, posScales);
+        const childPlaceable = child.layout(size, scales);
 
         if (childPlaceable.dims[0].min === undefined) {
           childPlaceable.place("x", 0, "baseline");
@@ -69,11 +70,11 @@ export const positionNode = (
         const offsetX =
           options.x === undefined
             ? undefined
-            : (computeAesthetic(options.x, posScales[0]!, 0) ?? 0);
+            : (computeAesthetic(options.x, posFn(scales[0]?.map)!, 0) ?? 0);
         const offsetY =
           options.y === undefined
             ? undefined
-            : (computeAesthetic(options.y, posScales[1]!, 0) ?? 0);
+            : (computeAesthetic(options.y, posFn(scales[1]?.map)!, 0) ?? 0);
 
         return {
           intrinsicDims: [

--- a/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
@@ -21,6 +21,7 @@ import {
 } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import { computeAesthetic, computeSize } from "../../util";
+import { posFn, pxOf } from "../domain";
 import {
   POSITION,
   SIZE,
@@ -139,15 +140,15 @@ export const Treemap = createNodeOperator(
               : POSITION(interval(0, 1));
           return [axisSpace(0), axisSpace(1)];
         },
-        layout: (_shared, size, scaleFactors, childAsts, posScales, node) => {
+        layout: (_shared, size, scales, childAsts, node) => {
           const xPos = computeAesthetic(
             dims[0].min,
-            posScales?.[0]!,
+            posFn(scales?.[0]?.map)!,
             undefined
           );
           const yPos = computeAesthetic(
             dims[1].min,
-            posScales?.[1]!,
+            posFn(scales?.[1]?.map)!,
             undefined
           );
 
@@ -180,21 +181,21 @@ export const Treemap = createNodeOperator(
             if (!isValue(declared)) {
               return computeSize(
                 declared,
-                scaleFactors?.[dir] ?? 1,
+                scales?.[dir]?.sigma ?? 1,
                 size[dir]
               ) as number;
             }
             const v = getValue(declared)!;
-            const posScale = posScales?.[dir];
-            if (posScale) return posScale(v) - posScale(0);
-            const sf = scaleFactors?.[dir] ?? localScaleFactor(dir) ?? 1;
+            const map = scales?.[dir]?.map;
+            if (map) return pxOf(map, v) - pxOf(map, 0);
+            const sf = scales?.[dir]?.sigma ?? localScaleFactor(dir) ?? 1;
             return v * sf;
           };
 
           const resolvedSize: Size = [resolveAxisSize(0), resolveAxisSize(1)];
 
-          const sfX = scaleFactors?.[0] ?? localScaleFactor(0) ?? 1;
-          const sfY = scaleFactors?.[1] ?? localScaleFactor(1) ?? 1;
+          const sfX = scales?.[0]?.sigma ?? localScaleFactor(0) ?? 1;
+          const sfY = scales?.[1]?.sigma ?? localScaleFactor(1) ?? 1;
 
           const session = node.getRenderSession();
           const scaleContext = session.scaleContext;
@@ -286,7 +287,7 @@ export const Treemap = createNodeOperator(
                 lh = side;
               }
             }
-            const placeable = child.layout([lw, lh], scaleFactors, posScales);
+            const placeable = child.layout([lw, lh], scales);
             placeable.place(0, x0 + w / 2, "center");
             const cy = flipY ? resolvedSize[1] - (y0 + h / 2) : y0 + h / 2;
             placeable.place(1, cy, "center");

--- a/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
@@ -16,7 +16,7 @@ import {
   Size,
   Transform,
 } from "../dims";
-import { aesthetic, continuous } from "../domain";
+import { aesthetic, continuous, posFn } from "../domain";
 import { interval } from "../../util/interval";
 import {
   ORDINAL,
@@ -103,12 +103,12 @@ export const Ellipse = ({
 
         return [resolveAxis(0, wDomain), resolveAxis(1, hDomain)];
       },
-      layout: (shared, size, scaleFactors, children, posScales) => {
+      layout: (shared, size, scales, children) => {
         let w = isValue(dims[0].size)
-          ? getValue(dims[0].size!) * scaleFactors[0]!
+          ? getValue(dims[0].size!) * scales[0]?.sigma!
           : (dims[0].size ?? size[0]);
         let h = isValue(dims[1].size)
-          ? getValue(dims[1].size!) * scaleFactors[1]!
+          ? getValue(dims[1].size!) * scales[1]?.sigma!
           : (dims[1].size ?? size[1]);
 
         if (aspectRatio !== undefined && aspectRatio > 0) {
@@ -126,8 +126,16 @@ export const Ellipse = ({
           }
         }
 
-        const x = computeAesthetic(dims[0].min, posScales[0]!, undefined);
-        const y = computeAesthetic(dims[1].min, posScales[1]!, undefined);
+        const x = computeAesthetic(
+          dims[0].min,
+          posFn(scales[0]?.map)!,
+          undefined
+        );
+        const y = computeAesthetic(
+          dims[1].min,
+          posFn(scales[1]?.map)!,
+          undefined
+        );
 
         return {
           intrinsicDims: [

--- a/packages/gofish-graphics/src/ast/shapes/image.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/image.tsx
@@ -1,5 +1,6 @@
 import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic } from "../../util";
+import { posFn, pxOf } from "../domain";
 import { interval } from "../../util/interval";
 import { GoFishNode } from "../_node";
 import { getMeasure, getValue, isAesthetic, isValue } from "../data";
@@ -284,16 +285,16 @@ export const Image = ({
 
         return [resolveAxis(0, xPos), resolveAxis(1, yPos)];
       },
-      layout: (shared, size, scaleFactors, children, posScales) => {
+      layout: (shared, size, scales, children) => {
         // For data-bound (Value-wrapped) dims, map from data units to pixels via
-        // posScale when available — this keeps image sizing consistent with
-        // rect's data-driven sizing. For literal-number dims, treat as pixels.
+        // the anchored map when available — this keeps image sizing consistent
+        // with rect's data-driven sizing. For literal-number dims, treat as pixels.
         const pixelSize = (dim: 0 | 1): number | undefined => {
           const raw = dims[dim].size;
           if (isValue(raw)) {
             const dataSize = getValue(raw)!;
-            const scale = posScales?.[dim];
-            return scale ? scale(dataSize) - scale(0) : dataSize;
+            const map = scales?.[dim]?.map;
+            return map ? pxOf(map, dataSize) - pxOf(map, 0) : dataSize;
           }
           return raw;
         };
@@ -307,11 +308,19 @@ export const Image = ({
         );
 
         const positionX =
-          computeAesthetic(dims[0].center, posScales?.[0]!, undefined) ??
-          computeAesthetic(dims[0].min, posScales?.[0]!, undefined);
+          computeAesthetic(
+            dims[0].center,
+            posFn(scales?.[0]?.map)!,
+            undefined
+          ) ??
+          computeAesthetic(dims[0].min, posFn(scales?.[0]?.map)!, undefined);
         const positionY =
-          computeAesthetic(dims[1].center, posScales?.[1]!, undefined) ??
-          computeAesthetic(dims[1].min, posScales?.[1]!, undefined);
+          computeAesthetic(
+            dims[1].center,
+            posFn(scales?.[1]?.map)!,
+            undefined
+          ) ??
+          computeAesthetic(dims[1].min, posFn(scales?.[1]?.map)!, undefined);
 
         return {
           intrinsicDims: [

--- a/packages/gofish-graphics/src/ast/shapes/petal.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/petal.tsx
@@ -90,12 +90,12 @@ export const Petal = ({
 
         return [resolveAxis(0), resolveAxis(1)];
       },
-      layout: (shared, size, scaleFactors, children) => {
+      layout: (shared, size, scales, children) => {
         const w = isValue(dims[0].size)
-          ? getValue(dims[0].size!) * scaleFactors[0]!
+          ? getValue(dims[0].size!) * scales[0]?.sigma!
           : (dims[0].size ?? size[0]);
         const h = isValue(dims[1].size)
-          ? getValue(dims[1].size!) * scaleFactors[1]!
+          ? getValue(dims[1].size!) * scales[1]?.sigma!
           : (dims[1].size ?? size[1]);
 
         return {

--- a/packages/gofish-graphics/src/ast/shapes/rect.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/rect.tsx
@@ -26,7 +26,7 @@ import {
   Size,
   Transform,
 } from "../dims";
-import { aesthetic, continuous, Domain } from "../domain";
+import { aesthetic, continuous, Domain, posFn, pxOf } from "../domain";
 import * as Monotonic from "../../util/monotonic";
 import { computeAesthetic, computeSize } from "../../util";
 import {
@@ -164,41 +164,53 @@ export const Rect = ({
 
         return [resolveAxis(0, wDomain), resolveAxis(1, hDomain)];
       },
-      layout: (shared, size, scaleFactors, children, posScales) => {
-        let x = computeAesthetic(dims[0].min, posScales?.[0]!, undefined);
-        let y = computeAesthetic(dims[1].min, posScales?.[1]!, undefined);
+      layout: (shared, size, scales, children) => {
+        let x = computeAesthetic(
+          dims[0].min,
+          posFn(scales?.[0]?.map)!,
+          undefined
+        );
+        let y = computeAesthetic(
+          dims[1].min,
+          posFn(scales?.[1]?.map)!,
+          undefined
+        );
 
         let w: number | undefined;
         if (isValue(dims[0].min) && isValue(dims[0].max)) {
           // Both min and max are values -> width spans [min, max] in data space
-          x = computeAesthetic(dims[0].min, posScales?.[0]!, undefined);
-          const xMax = computeAesthetic(
-            dims[0].max,
-            posScales?.[0]!,
+          x = computeAesthetic(
+            dims[0].min,
+            posFn(scales?.[0]?.map)!,
             undefined
           );
-          // posScales[0]! above guarantees a defined scale, so
-          // computeAesthetic returns a number here.
+          const xMax = computeAesthetic(
+            dims[0].max,
+            posFn(scales?.[0]?.map)!,
+            undefined
+          );
+          // the map above guarantees a defined scale, so computeAesthetic
+          // returns a number here.
           w = xMax! - x!;
         } else if (isValue(dims[0].min) && isValue(dims[0].size)) {
-          // If posScales for x exists, scale min and min+size, then subtract
+          // If a map for x exists, scale min and min+size, then subtract
           const min = x;
           const max = computeAesthetic(
             value(getValue(dims[0].min)! + getValue(dims[0].size)!),
-            posScales[0]!,
+            posFn(scales?.[0]?.map)!,
             undefined
           );
-          // Same invariant as the min/max branch: posScales[0]! above
+          // Same invariant as the min/max branch: the map above
           // guarantees a defined scale.
           w = max! - min!;
-        } else if (isValue(dims[0].size) && posScales?.[0]) {
-          // If we have size but no min, and posScales exists, use position scale
+        } else if (isValue(dims[0].size) && scales?.[0]?.map) {
+          // If we have size but no min, and a map exists, use position scale
           // Treat min as 0 (baseline) and compute width from position scale
-          const minPos = posScales[0](0);
-          const maxPos = posScales[0](getValue(dims[0].size)!);
+          const minPos = pxOf(scales[0]!.map!, 0);
+          const maxPos = pxOf(scales[0]!.map!, getValue(dims[0].size)!);
           w = maxPos - minPos;
         } else {
-          w = computeSize(dims[0].size, scaleFactors?.[0]!, size[0]);
+          w = computeSize(dims[0].size, scales?.[0]?.sigma!, size[0]);
         }
         // When parent constraints are unresolved and rect width is unspecified,
         // keep a visible default instead of propagating undefined.
@@ -209,34 +221,38 @@ export const Rect = ({
         let h: number | undefined;
         if (isValue(dims[1].min) && isValue(dims[1].max)) {
           // Both min and max are values -> height spans [min, max] in data space
-          y = computeAesthetic(dims[1].min, posScales?.[1]!, undefined);
-          const yMax = computeAesthetic(
-            dims[1].max,
-            posScales?.[1]!,
+          y = computeAesthetic(
+            dims[1].min,
+            posFn(scales?.[1]?.map)!,
             undefined
           );
-          // posScales[1]! above guarantees a defined scale, so
-          // computeAesthetic returns a number here.
+          const yMax = computeAesthetic(
+            dims[1].max,
+            posFn(scales?.[1]?.map)!,
+            undefined
+          );
+          // the map above guarantees a defined scale, so computeAesthetic
+          // returns a number here.
           h = yMax! - y!;
         } else if (isValue(dims[1].min) && isValue(dims[1].size)) {
-          // If posScales for y exists, scale min and min+size, then subtract
+          // If a map for y exists, scale min and min+size, then subtract
           const min = y;
           const max = computeAesthetic(
             value(getValue(dims[1].min)! + getValue(dims[1].size)!),
-            posScales[1]!,
+            posFn(scales?.[1]?.map)!,
             undefined
           );
-          // Same invariant as the min/max branch: posScales[1]! above
+          // Same invariant as the min/max branch: the map above
           // guarantees a defined scale.
           h = max! - min!;
-        } else if (isValue(dims[1].size) && posScales?.[1]) {
-          // If we have size but no min, and posScales exists, use position scale
+        } else if (isValue(dims[1].size) && scales?.[1]?.map) {
+          // If we have size but no min, and a map exists, use position scale
           // Treat min as 0 (baseline) and compute height from position scale
-          const minPos = posScales[1](0);
-          const maxPos = posScales[1](getValue(dims[1].size)!);
+          const minPos = pxOf(scales[1]!.map!, 0);
+          const maxPos = pxOf(scales[1]!.map!, getValue(dims[1].size)!);
           h = maxPos - minPos;
         } else {
-          h = computeSize(dims[1].size, scaleFactors?.[1]!, size[1]);
+          h = computeSize(dims[1].size, scales?.[1]?.sigma!, size[1]);
         }
         if (h === undefined || !Number.isFinite(h)) {
           h = DEFAULT_RECT_SIZE;

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -1,6 +1,7 @@
 import * as Monotonic from "../../util/monotonic";
 import { resolveColorChannel } from "../../color";
 import { computeAesthetic } from "../../util";
+import { posFn } from "../domain";
 import { interval } from "../../util/interval";
 import { GoFishNode } from "../_node";
 import {
@@ -248,7 +249,7 @@ export const Text = ({
 
         return [resolveAxis(0, xPos), resolveAxis(1, yPos)];
       },
-      layout: (shared, size, scaleFactors, children, posScales) => {
+      layout: (shared, size, scales, children) => {
         const finalText = isValue(textContent)
           ? getValue(textContent)
           : textContent;
@@ -277,11 +278,19 @@ export const Text = ({
           : relRaw;
 
         const positionX =
-          computeAesthetic(dims[0].center, posScales?.[0]!, undefined) ??
-          computeAesthetic(dims[0].min, posScales?.[0]!, undefined);
+          computeAesthetic(
+            dims[0].center,
+            posFn(scales?.[0]?.map)!,
+            undefined
+          ) ??
+          computeAesthetic(dims[0].min, posFn(scales?.[0]?.map)!, undefined);
         const positionY =
-          computeAesthetic(dims[1].center, posScales?.[1]!, undefined) ??
-          computeAesthetic(dims[1].min, posScales?.[1]!, undefined);
+          computeAesthetic(
+            dims[1].center,
+            posFn(scales?.[1]?.map)!,
+            undefined
+          ) ??
+          computeAesthetic(dims[1].min, posFn(scales?.[1]?.map)!, undefined);
 
         return {
           intrinsicDims: [

--- a/packages/gofish-graphics/src/ast/solver/shadow.ts
+++ b/packages/gofish-graphics/src/ast/solver/shadow.ts
@@ -19,6 +19,7 @@ import type { Placeable } from "../_node";
 import { axisIndex, isPlacedOn, type Axis } from "../constraints/shared";
 import { getValue, isValue, type MaybeValue } from "../data";
 import { computeAesthetic, envFlag } from "../../util";
+import { pxOf } from "../domain";
 import { localAnchorPoint } from "../dims";
 import type { ConstraintSpec, ConstraintPosScales } from "../constraints";
 import { isCONTINUOUS, type UnderlyingSpace } from "../underlyingSpace";
@@ -210,7 +211,7 @@ interface PositionLike {
 export function shadowCheckPosition(
   constraint: PositionLike,
   targets: Placeable[],
-  posScales: (((v: number) => number) | undefined)[] | undefined
+  posScales: ConstraintPosScales | undefined
 ): void {
   if (!enabled() || constraint.type !== "position") return;
   // Across all 189 stories this covers 5753 datum→position mappings with zero
@@ -222,8 +223,9 @@ export function shadowCheckPosition(
   for (const [axis, coord] of axes) {
     if (coord === undefined || !isValue(coord)) continue; // datum only
     const idx = axisIndex(axis);
-    const scale = posScales?.[idx];
-    if (scale === undefined) continue; // datum w/o scale is an engine no-op
+    const map = posScales?.[idx];
+    if (map === undefined) continue; // datum w/o scale is an engine no-op
+    const scale = (v: number) => pxOf(map, v);
     const d = getValue(coord)!;
 
     // 1. POSITION scale must be affine (origin + σ·data).

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -47,6 +47,7 @@ import {
   selectGridConstraint,
 } from "../ast/constraints/proposalPlan";
 import { discretePosition, value } from "../ast/data";
+import { pxOf, type AxisMap } from "../ast/domain";
 import { POSITION, SIZE, UNDEFINED } from "../ast/underlyingSpace";
 import { interval } from "../util/interval";
 
@@ -717,10 +718,11 @@ console.log("# constraint confluence: position scale ownership planning");
 
 console.log("# constraint confluence: child posScale forwarding");
 {
-  const baseX = (v: number) => v + 1;
-  const baseY = (v: number) => v + 2;
-  const effectiveX = (v: number) => v * 10;
-  const effectiveY = (v: number) => v * 20;
+  // AxisMaps standing in for the former closures: pxOf(map, v) reproduces them.
+  const baseX: AxisMap = { sigma: 1, domainMin: 0, pxMin: 1 }; // v + 1
+  const baseY: AxisMap = { sigma: 1, domainMin: 0, pxMin: 2 }; // v + 2
+  const effectiveX: AxisMap = { sigma: 10, domainMin: 0, pxMin: 0 }; // v * 10
+  const effectiveY: AxisMap = { sigma: 20, domainMin: 0, pxMin: 0 }; // v * 20
   const positionSpace = POSITION(interval(0, 10));
 
   const noOwnedAxisPlan = buildPositionScalePlan(
@@ -746,7 +748,7 @@ console.log("# constraint confluence: child posScale forwarding");
     ownedAxisPlan.ownsAxis[0] === true &&
       ownedAxisPlan.ownsAxis[1] === false &&
       ownedAxisPlan.effectivePosScales[0] === baseX &&
-      ownedAxisPlan.effectivePosScales[1]?.(5) === 100
+      pxOf(ownedAxisPlan.effectivePosScales[1]!, 5) === 100
   );
 
   const unowned = childPosScalesFor(
@@ -807,7 +809,11 @@ console.log("# constraint confluence: raw placement coordinates");
   ok(
     "datum placement coordinate elaborates through posScale before raw facts",
     compilePlacementCoordinate(value(5).offset(3), undefined) === undefined &&
-      compilePlacementCoordinate(value(5).offset(3), (v) => v * 10) === 53
+      compilePlacementCoordinate(value(5).offset(3), {
+        sigma: 10,
+        domainMin: 0,
+        pxMin: 0,
+      }) === 53
   );
   ok(
     "discrete placement coordinate resolves from containing axis size",
@@ -1097,8 +1103,8 @@ console.log("# constraint confluence: interval vs point compose bail");
 
 console.log("# constraint confluence: child scale factor planning");
 {
-  const inheritedX = (v: number) => v + 1;
-  const inheritedY = (v: number) => v + 2;
+  const inheritedX: AxisMap = { sigma: 1, domainMin: 0, pxMin: 1 }; // v + 1
+  const inheritedY: AxisMap = { sigma: 1, domainMin: 0, pxMin: 2 }; // v + 2
   const positionSpace = POSITION(interval(0, 10));
   const sizeSpace = SIZE(Monotonic.linear(20, 0));
 
@@ -1113,7 +1119,7 @@ console.log("# constraint confluence: child scale factor planning");
   );
   ok(
     "self-scaled POSITION axis builds local posScale",
-    selfScaled.basePosScales[0]?.(5) === 50 &&
+    pxOf(selfScaled.basePosScales[0]!, 5) === 50 &&
       selfScaled.basePosScales[1] === inheritedY
   );
   ok(

--- a/packages/gofish-graphics/src/tests/coordConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/coordConfluence.test.ts
@@ -57,7 +57,7 @@ async function leafThetaSizes(child: any): Promise<number[]> {
   root.resolveAliases();
   root.resolveUnderlyingSpace();
   root.resolveEmbedding();
-  root.layout([400, 400], [undefined, undefined], [undefined, undefined]);
+  root.layout([400, 400], [undefined, undefined]);
   const out: number[] = [];
   const walk = (n: any) => {
     if (n.type === "rect") out.push(n.intrinsicDims?.[0]?.size ?? NaN);


### PR DESCRIPTION
Advances #39. Stacked on #652. Stage 4 of the plan in `internals/design/sigma-affine-simplification.md`: the two half-channels threaded side by side through every layout call —

```
scaleFactors: Size<number | undefined>                    // slope only
posScales:    Size<((pos: number) => number) | undefined> // whole map, opaque closure
```

— become one per-axis record:

```ts
type AxisMap   = { sigma: number; domainMin: number; pxMin: number };
type AxisScale = { sigma?: number; map?: AxisMap };
// px(d) = map.pxMin + map.sigma · (d − map.domainMin)   — evaluated via pxOf()
```

The intercept is now explicit data instead of being closed over (`posScale(0)` = `pxOf(map, 0)`), "anchored" = `map` present, and the slope is readable alone for unanchored size consumers. One deliberate shape decision: **`map` carries its own slope** rather than sharing the top-level `sigma` — a mark can legitimately read size-σ and position-slope against different pixel extents on the same axis (`rect` does exactly this), so collapsing them would have changed pixels.

Strictly mechanical (24 files): the `Layout` signature takes one `scales` param; every forwarding decision — `buildChildScalePlan`'s four-step priority, the #618 inherited-σ guard, `childPosScalesFor`'s three-way pick — is bit-identical, restated on the record. A pre-change audit verified every posScale constructor in the codebase is affine (six construction sites; none piecewise/log), and closure→record conversions preserve IEEE operation order.

## Verification

- `pnpm capture-diff main`: **no layout changes, 260 stories identical** — pixel-equivalent, no screenshots.
- Full package test suite green (all 9 suites); `typecheck`, `check-backlinks`, `docs:build` clean.
- Essay's carrier description updated in the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)