### PR TITLE
σ-affine simplification, stage 6a+6b: full shadow coverage + the σ-scope registry

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -691,6 +691,48 @@ This dispatch is the practical embodiment of the underlying-space-kind
 distinction. It also happens to make the rendering pipeline more readable:
 once you know the kind, you know which arithmetic applies.
 
+## The one solve site: the σ-scope registry
+
+Every scale above resolves the same frame equation — `content(σ) = allocated`,
+inverted once by `Monotonic.inverse` — but historically that inversion was
+written out at four-plus places, each with its own pixel budget and fallback:
+the render root (`gofish.tsx`), an explicit-pixel-size axis and a composed
+distribute budget and a `sharedScale` scope (all three inside
+`buildChildScalePlan`), and a coord boundary (`coord.tsx`'s `fitAxis`). Keeping
+them consistent needed a hand-written guard (the #618 "an intermediate must
+propagate the inherited σ, not re-root against its own budget" rule).
+
+Stage 6b makes those a **single mechanism**. A `ScopeRegistry`
+(`ast/solver/scopes.ts`), created once per render on the `RenderSession`, is the
+one place σ / posScale is derived: `solveSize(frame, allocated)` inverts the σ
+slope, `solvePosition(space, allocated)` builds the anchored `AxisMap`. The
+derivation sites are now **σ-scope roots** — the render root, an axis with an
+explicit pixel size, a constraint budget that roots its own scope, a
+`sharedScale` operator, and a coord boundary — and each calls the registry.
+**Everyone else inherits**: the #618 guard is now the structural rule "not a root
+→ don't call the solve", so the inherited σ propagates unchanged (in
+`buildChildScalePlan`, an intermediate budget simply skips the solve — the
+`inheritedScaleFactors[axis] !== undefined && selfScaledSpaces[axis] ===
+undefined` test that _was_ the guard is now the "is this a scope root?"
+predicate). Because the arithmetic is exactly what the sites ran inline, the
+solved numbers are unchanged; the registry only adds the choke-point.
+
+Behind `GOFISH_DUMP_SCOPES` the registry prints every scope it solved as a
+printable frame equation — the debuggability bar the σ-affine model was chosen
+for. One line per scope, e.g. a stacked bar (root POSITION scope + a shared SIZE
+scope on the same axis, agreeing on one slope) and a sunburst (a coord boundary
+re-rooting σ on the angular axis):
+
+```
+[scope] root   key=root  axis=y [0,140]→[0,400] = 400  σ=2.857 map=yes
+[scope] shared key=layer axis=y 140σ = 400            σ=2.857 map=no
+[scope] coord  key=coord axis=x 16σ = 6.283           σ=0.393 map=no
+```
+
+That the root and shared scopes on one axis print the same σ is Stage 6's
+invariant made visible: **one slope per σ-scope, by construction**, because the
+frame equation is solved once and the posScale is a derived view of that solve.
+
 ## Scales generalize flex factors
 
 A size scale whose range resolves to the parent's extent is doing exactly

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -358,7 +358,17 @@ still has two independent slopes after Stage 6, that is a bug in Stage 6.
 - **6b — one solve site.** Move the root inversion + the three
   `buildChildScalePlan` steps behind a single scope-root API with the same
   numbers and priority. The #618 guard becomes "not a root → inherit".
-  Pixel gate.
+  Pixel gate. **Landed:** `ast/solver/scopes.ts` holds a per-render
+  `ScopeRegistry` (on the `RenderSession`) whose `solveSize` / `solvePosition`
+  are the ONE place σ / posScale is derived; the render root (`gofish.tsx`),
+  `buildChildScalePlan`'s self-scaled / constraint-budget / shared steps, and the
+  coord boundary (`coord.tsx` `fitAxis`) all call it with bit-identical
+  arithmetic. The #618 propagate-vs-re-root guard is now the structural
+  "is this a scope root?" predicate in `buildChildScalePlan` (an intermediate
+  budget skips the solve and inherits). `GOFISH_DUMP_SCOPES` prints one frame
+  equation per scope. The sweep (`capture-sweep`) stayed clean and the
+  coord/confluence tests (flat ≡ nested σ) pass, confirming goTree/polar render
+  identically.
 - **6c — σ-affine claims flow.** Marks/folds contribute width `Monotonic`s
   into cells instead of pre-multiplied numbers; evaluation defers to the
   scope boundary; the "evaluate at σ, hand concrete sizes down" double

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -6,6 +6,9 @@
 // </gofish-wiki>
 
 import type { JSX } from "solid-js";
+// Type-only (erased) so no runtime cycle with solver/scopes.ts, which imports
+// RenderSession from here.
+import type { ScopeRegistry } from "./solver/scopes";
 import {
   Anchor,
   Dimensions,
@@ -90,6 +93,10 @@ export type RenderSession = {
   /** Set by the lower emit driver (`lowerToDisplayList`) for the duration of a
    *  lowering walk: the y-up→y-down pixel mapping every `lower` body uses. */
   toPixel?: ToPixel;
+  /** The σ-scope registry (#39 Stage 6b): the one place σ / posScale is derived,
+   *  shared by every scope root in this render. Created on first use
+   *  (`getScopeRegistry`). */
+  scopes?: ScopeRegistry;
 };
 
 export type ScaleFactorFunction = Monotonic.Monotonic;
@@ -1168,6 +1175,20 @@ export class GoFishNode {
       return this.parent.getRenderSession();
     }
     throw new Error("Render session not set");
+  }
+
+  /** Non-throwing session lookup for the layout-path σ-scope registry (Stage 6b):
+   *  the full `gofish()` flow always sets a session before layout, but a
+   *  standalone `node.layout(...)` (some coord/confluence tests) has none — then
+   *  the scope solve just uses a throwaway registry with identical arithmetic. */
+  public tryGetRenderSession(): RenderSession | undefined {
+    if (this.renderSession) return this.renderSession;
+    const parent = this.parent as
+      | { tryGetRenderSession?: () => RenderSession | undefined }
+      | undefined;
+    return parent && typeof parent.tryGetRenderSession === "function"
+      ? parent.tryGetRenderSession()
+      : undefined;
   }
 
   public render(

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -26,8 +26,13 @@ import type { PositionConstraint, PositionOptions } from "./position";
 import type { ZAboveConstraint, ZBelowConstraint } from "./zorder";
 import type { NestConstraint, NestOptions } from "./nest";
 import type { GridConstraint } from "./grid";
-import { type ConstraintPosScales, type ConstraintRef } from "./shared";
+import {
+  isPlacedOn,
+  type ConstraintPosScales,
+  type ConstraintRef,
+} from "./shared";
 import { solvePlacementConstraints } from "./placementSolver";
+import { shadowCheckConstraint, solverCheckEnabled } from "../solver/shadow";
 
 export type {
   Axis,
@@ -246,5 +251,45 @@ export function applyConstraints(
       | NestConstraint
       | GridConstraint => !isZOrderConstraint(constraint)
   );
+
+  // Solver shadow (#39, disposable observe→assert): snapshot each child's
+  // per-axis placement BEFORE the solve — only when the check is on, so
+  // production pays nothing — so each constraint's shadow can tell a child it
+  // packed from one that arrived pre-positioned. The rank-2 solve places every
+  // target at once (no per-constraint apply boundary), so the checks run once
+  // AFTER the solve against the settled positions.
+  const prePlaced = solverCheckEnabled()
+    ? new Map<string, [boolean, boolean]>(
+        [...nameToPlaceable].map(([name, p]) => [
+          name,
+          [isPlacedOn(p, 0), isPlacedOn(p, 1)] as [boolean, boolean],
+        ])
+      )
+    : undefined;
+
   solvePlacementConstraints(placement, nameToPlaceable, sizes, posScales);
+
+  if (prePlaced) {
+    for (const constraint of placement) {
+      // Build the target list and its aligned pre-solve placement snapshot in
+      // one pass (index i of each array is the same child), so the per-target
+      // `prePlaced` the checks read is the state BEFORE the solve, not after.
+      const targets: Placeable[] = [];
+      const targetPrePlaced: [boolean, boolean][] = [];
+      for (const ref of constraint.children) {
+        const p = ref ? nameToPlaceable.get(ref.name) : undefined;
+        if (p === undefined) continue;
+        targets.push(p);
+        targetPrePlaced.push(prePlaced.get(ref!.name) ?? [false, false]);
+      }
+      shadowCheckConstraint(
+        constraint,
+        targets,
+        posScales,
+        targetPrePlaced,
+        nameToPlaceable,
+        sizes
+      );
+    }
+  }
 }

--- a/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
+++ b/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
@@ -12,6 +12,7 @@ import {
   type UnderlyingSpace,
 } from "../underlyingSpace";
 import { allocateSlices } from "./folds";
+import type { ScopeRegistry } from "../solver/scopes";
 import type { ConstraintSpec } from ".";
 import type { GridConstraint } from "./grid";
 import type { ConstraintPosScales } from "./shared";
@@ -189,7 +190,12 @@ export function buildChildScalePlan(
   inheritedScaleFactors: Size<number | undefined> | undefined,
   inheritedPosScales: ConstraintPosScales,
   constraintBudget: ScaleBudget | undefined,
-  shared: Size<boolean>
+  shared: Size<boolean>,
+  // Stage 6b: the ONE σ-solve site. Every scale this plan roots is derived
+  // through the registry (so `GOFISH_DUMP_SCOPES` sees it and the numbers have a
+  // single source); `rootKey` labels the owning layer node in the dump.
+  scopes: ScopeRegistry,
+  rootKey: string
 ): ChildScalePlan {
   const basePosScales: ConstraintPosScales = [
     inheritedPosScales[0],
@@ -207,11 +213,19 @@ export function buildChildScalePlan(
     if (stashed === undefined || !Number.isFinite(layerSize[axis])) continue;
     if (isPOSITION(stashed)) {
       basePosScales[axis] =
-        posScaleFromSpace(stashed, layerSize[axis]) ?? inheritedPosScales[axis];
+        scopes.solvePosition(
+          { kind: "self-scaled", rootKey, axis },
+          stashed,
+          layerSize[axis]
+        ) ?? inheritedPosScales[axis];
     }
     if (isBaselineMagnitude(stashed)) {
       childScaleFactors[axis] =
-        stashed.width.inverse(layerSize[axis]) ?? inheritedScaleFactors?.[axis];
+        scopes.solveSize(
+          { kind: "self-scaled", rootKey, axis },
+          stashed.width,
+          layerSize[axis]
+        ) ?? inheritedScaleFactors?.[axis];
     }
   }
 
@@ -219,25 +233,27 @@ export function buildChildScalePlan(
     for (const axis of [0, 1] as const) {
       const dom = constraintBudget.sizeDomain[axis];
       if (dom === undefined || !Number.isFinite(layerSize[axis])) continue;
-      // Scale-root scoping: if an ancestor scale root already resolved σ for this
-      // axis (an inherited scale factor is present) AND this layer didn't itself
-      // introduce a new pixel scope (no self-scaled/stashed space on the axis),
-      // then this distribute is an INTERMEDIATE in the ancestor's σ-scope — it
-      // must PROPAGATE the inherited σ, not re-root by inverting its own σ-fold
-      // against the locally allocated size. In a consistently-sized layout the
-      // re-derived factor equals the inherited one (no-op); it only diverges when
-      // the allocated size disagrees with the inherited σ — e.g. an equal-slice
-      // budget under a coord, where the distribute axis IS the σ-scaled axis, so
-      // a nested group would otherwise silently re-derive a smaller σ (#618).
-      if (
-        inheritedScaleFactors?.[axis] !== undefined &&
-        selfScaledSpaces[axis] === undefined
-      ) {
-        continue;
-      }
-      const sf = dom.inverse(layerSize[axis], {
-        upperBoundGuess: layerSize[axis],
-      });
+      // Structural σ-scope rule (Stage 6b — the former #618 propagate-vs-re-root
+      // guard, made structural): ONLY A SCOPE ROOT SOLVES. This budget roots a
+      // scope on the axis unless an ancestor scope already owns it — i.e. an
+      // inherited σ is present AND this layer introduced no pixel scope of its
+      // own (no self-scaled space). In that INTERMEDIATE case the inherited σ has
+      // already been copied into `childScaleFactors`, so inherit it: do NOT
+      // re-root by inverting the local σ-fold against the allocated size. The
+      // re-derive-equal cases produce the same σ (no-op); the divergent case is
+      // an equal-slice budget under a coord, where the distribute axis IS the
+      // σ-scaled axis — a nested group would otherwise silently re-derive a
+      // smaller σ (#618).
+      const rootsScope =
+        inheritedScaleFactors?.[axis] === undefined ||
+        selfScaledSpaces[axis] !== undefined;
+      if (!rootsScope) continue;
+      const sf = scopes.solveSize(
+        { kind: "constraint-budget", rootKey, axis },
+        dom,
+        layerSize[axis],
+        { upperBoundGuess: layerSize[axis] }
+      );
       if (sf !== undefined) childScaleFactors[axis] = sf;
       else budgetFailures.push({ axis, budget: layerSize[axis] });
     }
@@ -248,9 +264,12 @@ export function buildChildScalePlan(
     const sp = selfScaledSpaces[axis] ?? layerSpace?.[axis];
     if (sp === undefined) continue;
     const sf = isCONTINUOUS(sp)
-      ? (sp.width.inverse(layerSize[axis], {
-          upperBoundGuess: layerSize[axis],
-        }) ?? 0)
+      ? (scopes.solveSize(
+          { kind: "shared", rootKey, axis },
+          sp.width,
+          layerSize[axis],
+          { upperBoundGuess: layerSize[axis] }
+        ) ?? 0)
       : undefined;
     if (sf !== undefined) childScaleFactors[axis] = sf;
     sharedScaleChecks.push({ axis, space: sp, sigma: sf });

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -23,6 +23,7 @@ import {
   UnderlyingSpace,
   UNDEFINED,
   POSITION,
+  SIZE,
   ORDINAL,
   isORDINAL,
   isPOSITION,
@@ -32,7 +33,9 @@ import {
   continuousInterval,
   type CONTINUOUS_TYPE,
 } from "../underlyingSpace";
-import { posScaleFromSpace, axisScale, type AxisMap } from "../domain";
+import { axisScale, type AxisMap } from "../domain";
+import { shadowCheckScaleRoot } from "../solver/shadow";
+import { getScopeRegistry } from "../solver/scopes";
 import * as Monotonic from "../../util/monotonic";
 import { createNodeOperator } from "../withGoFish";
 import { computeTransformedBoundingBox } from "./coordUtils";
@@ -162,7 +165,11 @@ export const coord = createNodeOperator(
           spaceRef.current = result;
           return result;
         },
-        layout: (shared, size, scales, children) => {
+        layout: (shared, size, scales, children, node) => {
+          // Stage 6b: a coord boundary is a σ-scope root — it re-roots σ for its
+          // subtree. Derive through the render's one registry, shared with the
+          // render root and every layer scope.
+          const scopes = getScopeRegistry(node.tryGetRenderSession());
           /* TODO: need correct scale factors */
           // TODO: only works for polar-family transforms right now
           const [origW, origH] = size;
@@ -202,7 +209,14 @@ export const coord = createNodeOperator(
             // spaces into `spaceRef.current` — reuse it and map onto [0, budget].
             const resolved = spaceRef.current?.[axis];
             if (resolved !== undefined && isPOSITION(resolved)) {
-              return [1, posScaleFromSpace(resolved, budget)];
+              return [
+                1,
+                scopes.solvePosition(
+                  { kind: "coord", rootKey: node.key ?? node.type, axis },
+                  resolved,
+                  budget
+                ),
+              ];
             }
             // A baseline-magnitude (data SIZE) axis: `resolveUnderlyingSpace`
             // leaves this case UNDEFINED, so sum the children's widths here and
@@ -213,7 +227,26 @@ export const coord = createNodeOperator(
               .filter(isBaselineMagnitude);
             if (baseline.length > 0) {
               const width = Monotonic.add(...baseline.map((s) => s.width));
-              return [width.inverse(budget) ?? 1, undefined];
+              // Stage 6b: the coord boundary's SIZE frame — solved through the one
+              // registry (content(σ)=budget via Monotonic.inverse).
+              const sigma = scopes.solveSize(
+                { kind: "coord", rootKey: node.key ?? node.type, axis },
+                width,
+                budget
+              );
+              // Solver shadow (#39): a coord boundary RE-ROOTS σ for its subtree,
+              // exactly as the root fits content to the canvas — assert the same
+              // frame equation content(σ)=budget closes at the boundary. Pass the
+              // raw inverse (undefined when it fails) so a degenerate re-root is
+              // caught, mirroring shadowCheckScaleRoot at the root. No-op unless
+              // GOFISH_SOLVER_CHECK is set.
+              shadowCheckScaleRoot(
+                SIZE(width),
+                budget,
+                sigma ?? undefined,
+                axis
+              );
+              return [sigma ?? 1, undefined];
             }
             return [1, undefined];
           };

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -14,12 +14,7 @@ import {
   GoFishNode,
   type RenderSession,
 } from "./_node";
-import {
-  posScaleFromSpace,
-  axisScale,
-  type AxisMap,
-  type AxisScale,
-} from "./domain";
+import { axisScale, type AxisMap, type AxisScale } from "./domain";
 import { bake } from "./coordinateTransforms/bake";
 import { lowerToDisplayList } from "./displayList/lower";
 import { paintSVG } from "./displayList/paintSVG";
@@ -34,6 +29,7 @@ import {
   type UnderlyingSpace,
 } from "./underlyingSpace";
 import { shadowCheckScaleRoot } from "./solver/shadow";
+import { getScopeRegistry } from "./solver/scopes";
 import { elaborateAxes, elaborateAxisTitles } from "./axes/elaborate";
 import { elaborateLegend, legendOverhang } from "./legends/elaborate";
 
@@ -370,10 +366,26 @@ export async function layout(
   const layoutW = w ?? (needsCanvas(niceUnderlyingSpaceX) ? canvasW : UNSIZED);
   const layoutH = h ?? (needsCanvas(niceUnderlyingSpaceY) ? canvasH : UNSIZED);
 
-  // An anchored CONTINUOUS root builds a data→pixel map over its data interval.
+  // The render's σ-scope registry: the ONE place σ / posScale is derived
+  // (Stage 6b). The root is the first scope root; every other scope (self-scaled
+  // axis, constraint budget, shared, coord boundary) solves through the same
+  // registry. Reset so a re-run layout pass starts clean.
+  const scopes = getScopeRegistry(contexts?.session);
+  scopes.reset();
+
+  // An anchored CONTINUOUS root builds a data→pixel map over its data interval —
+  // the root POSITION scope solved by the registry.
   const posScales: Size<AxisMap | undefined> = [
-    posScaleFromSpace(niceUnderlyingSpaceX, canvasW),
-    posScaleFromSpace(niceUnderlyingSpaceY, canvasH),
+    scopes.solvePosition(
+      { kind: "root", rootKey: "root", axis: 0 },
+      niceUnderlyingSpaceX,
+      canvasW
+    ),
+    scopes.solvePosition(
+      { kind: "root", rootKey: "root", axis: 1 },
+      niceUnderlyingSpaceY,
+      canvasH
+    ),
   ];
 
   if (debug) {
@@ -381,14 +393,23 @@ export async function layout(
   }
 
   // Root scale factor: a baseline magnitude ("free") root inverts its Monotonic
-  // against the canvas. Anchored roots use the posScale (above) instead; a
-  // difference root shrink-to-fits.
+  // against the canvas — the root SIZE scope, solved by the same registry.
+  // Anchored roots use the posScale (above) instead; a difference root
+  // shrink-to-fits.
   const rootScaleFactors: Size<number | undefined> = [
     isBaselineMagnitude(niceUnderlyingSpaceX)
-      ? (niceUnderlyingSpaceX.width.inverse(canvasW) ?? undefined)
+      ? scopes.solveSize(
+          { kind: "root", rootKey: "root", axis: 0 },
+          niceUnderlyingSpaceX.width,
+          canvasW
+        )
       : undefined,
     isBaselineMagnitude(niceUnderlyingSpaceY)
-      ? (niceUnderlyingSpaceY.width.inverse(canvasH) ?? undefined)
+      ? scopes.solveSize(
+          { kind: "root", rootKey: "root", axis: 1 },
+          niceUnderlyingSpaceY.width,
+          canvasH
+        )
       : undefined,
   ];
 
@@ -466,6 +487,9 @@ export async function layout(
   ];
 
   child.layout([layoutW, layoutH], rootScales);
+  // Scope dump (#39 Stage 6b): every σ-scope solved during the layout pass just
+  // above, as printable frame equations. No-op unless GOFISH_DUMP_SCOPES is set.
+  scopes.dump();
   // Root placement anchor. A GIVEN dimension keeps the baseline-anchored canvas
   // box [0, given]; content seated outside it (axis labels below 0, ticks above
   // `given`) is reserved as the per-side overhangs below. A SHRINK-TO-FIT

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -5,6 +5,7 @@
 import { GoFishNode, type ToPixel } from "../_node";
 import type { DisplayList } from "gofish-ir";
 import { shadowCheckScaleRoot } from "../solver/shadow";
+import { getScopeRegistry } from "../solver/scopes";
 import { flattenForZOrder, topoSortByZOrder } from "../paintOrder";
 import { isToken } from "../createName";
 import {
@@ -247,7 +248,11 @@ export const layer = createNodeOperatorSequential(
             inheritedScaleFactors,
             inheritedPosScales,
             constraintBudget,
-            shared
+            shared,
+            // Stage 6b: derive every scale this layer roots through the render's
+            // one σ-scope registry (shared with the root and coord boundaries).
+            getScopeRegistry(node.tryGetRenderSession()),
+            node.key ?? node.type
           );
           const { basePosScales, childScaleFactors } = childScalePlan;
           for (const failure of childScalePlan.budgetFailures) {

--- a/packages/gofish-graphics/src/ast/solver/scopes.ts
+++ b/packages/gofish-graphics/src/ast/solver/scopes.ts
@@ -1,0 +1,151 @@
+/**
+ * The σ-scope registry (#39 endgame, Stage 6b) — the ONE place σ / posScale is
+ * derived.
+ *
+ * Every continuous axis is one affine map per σ-scope, `px(d) = pxMin + σ·(d −
+ * domainMin)`, and σ is solved once per scope at the frame equation
+ * `content(σ) = allocated` (`Monotonic.inverse`). Before Stage 6b that inversion
+ * lived, hand-ordered, at four+ sites (the render root, a self-scaled axis, a
+ * composed-constraint budget, a `shared` scope, and a coord boundary), with the
+ * #618 propagate-vs-re-root guard hand-written to stop an intermediate from
+ * re-rooting. This module makes those a SINGLE mechanism:
+ *
+ *   - **scope roots solve** — the render root, an axis with an explicit pixel
+ *     size (self-scaling region), a composed-constraint budget that roots its
+ *     own scope, a `shared` operator, a coord boundary — each calls
+ *     {@link ScopeRegistry.solveSize} / {@link ScopeRegistry.solvePosition};
+ *   - **everyone else INHERITS** — the #618 guard is now the structural rule
+ *     "not a root → inherit": a non-root site simply does not call the solve, so
+ *     the inherited σ propagates unchanged.
+ *
+ * The arithmetic is exactly what the sites ran inline (`Monotonic.inverse` for
+ * the slope, `posScaleFromSpace` for the anchored map), so the numbers are
+ * bit-identical; the registry adds the single choke-point plus, behind
+ * `GOFISH_DUMP_SCOPES`, a printable dump of every scope's frame equation.
+ */
+import * as Monotonic from "../../util/monotonic";
+import { posScaleFromSpace, type AxisMap } from "../domain";
+import { envFlag } from "../../util";
+import type { RenderSession } from "../_node";
+
+export type ScopeKind =
+  | "root"
+  | "self-scaled"
+  | "constraint-budget"
+  | "shared"
+  | "coord";
+
+/** Identity of the scope being solved — its root node label and the axis. */
+export interface ScopeMeta {
+  kind: ScopeKind;
+  /** A stable label for the scope root (node key/type) for the dump. */
+  rootKey: string;
+  axis: 0 | 1;
+}
+
+interface ScopeEntry extends ScopeMeta {
+  allocated: number;
+  /** The frame equation LHS, printed (`Monotonic.print`), or a POSITION map's
+   *  `[min,max]→[0,alloc]` shape. */
+  frame: string;
+  sigma: number | undefined;
+  hasMap: boolean;
+}
+
+/** Whether the scope dump is on. Off (and near-zero-cost) in prod. */
+const dumpEnabled = (): boolean => envFlag("GOFISH_DUMP_SCOPES");
+
+/**
+ * Per-render record of every σ-scope solved. Lives on the {@link RenderSession}
+ * (one per render, so no cross-render leakage), and is reset at the start of a
+ * layout pass so it reflects the last pass if layout re-runs.
+ */
+export class ScopeRegistry {
+  private entries: ScopeEntry[] = [];
+
+  /** Clear recorded scopes — called at the root solve so a second layout pass
+   *  does not accumulate stale entries. */
+  reset(): void {
+    this.entries = [];
+  }
+
+  /**
+   * Solve σ for a SIZE frame at a scope root: invert `content(σ) = allocated`.
+   * `frame` is the σ-affine width `Monotonic` (a space's `width`, or a composed
+   * distribute size domain). Returns the slope, or `undefined` when the frame
+   * cannot determine σ (slope 0) — the caller keeps applying its own fallback,
+   * exactly as before.
+   */
+  solveSize(
+    meta: ScopeMeta,
+    frame: Monotonic.Monotonic,
+    allocated: number,
+    opts?: { tolerance?: number; lowerBound?: number; upperBoundGuess?: number }
+  ): number | undefined {
+    const sigma = frame.inverse(allocated, opts);
+    if (dumpEnabled())
+      this.entries.push({
+        ...meta,
+        allocated,
+        frame: Monotonic.print(frame),
+        sigma,
+        hasMap: false,
+      });
+    return sigma;
+  }
+
+  /**
+   * Build the anchored data→pixel map for a POSITION scope root — the space's
+   * `[min,max]` domain onto `[0, allocated]`. Records a scope only when a map
+   * actually results (a non-anchored axis is not a POSITION scope here).
+   */
+  solvePosition(
+    meta: ScopeMeta,
+    space:
+      | { kind: string; dataDomain?: { min: number; max: number } | "delta" }
+      | undefined,
+    allocated: number
+  ): AxisMap | undefined {
+    const map = posScaleFromSpace(space, allocated);
+    if (map !== undefined && dumpEnabled()) {
+      const dom =
+        space && space.dataDomain && space.dataDomain !== "delta"
+          ? `[${space.dataDomain.min},${space.dataDomain.max}]`
+          : "[·]";
+      this.entries.push({
+        ...meta,
+        allocated,
+        frame: `${dom}→[0,${allocated}]`,
+        sigma: map.sigma,
+        hasMap: true,
+      });
+    }
+    return map;
+  }
+
+  /** Print one line per scope: root kind/key, axis, allocated px, the frame
+   *  equation, the solved σ, and whether an anchored map is present. */
+  dump(): void {
+    if (!dumpEnabled() || this.entries.length === 0) return;
+    for (const e of this.entries) {
+      console.log(
+        `[scope] ${e.kind} key=${e.rootKey} axis=${e.axis === 0 ? "x" : "y"} ` +
+          `alloc=${e.allocated}px  ${e.frame} = ${e.allocated}  ` +
+          `σ=${e.sigma ?? "—"} map=${e.hasMap ? "yes" : "no"}`
+      );
+    }
+  }
+}
+
+/**
+ * The render's scope registry: the one on the session (created on first use so
+ * the whole render shares it), or a throwaway when there is no session (a
+ * standalone `layout()` call). Every σ-scope derivation goes through the
+ * returned registry.
+ */
+export function getScopeRegistry(
+  session: RenderSession | undefined
+): ScopeRegistry {
+  if (!session) return new ScopeRegistry();
+  return (session.scopes ??= new ScopeRegistry());
+}

--- a/packages/gofish-graphics/src/ast/solver/shadow.ts
+++ b/packages/gofish-graphics/src/ast/solver/shadow.ts
@@ -6,12 +6,15 @@
  * ledger (stages 0–2). Guarded by `GOFISH_SOLVER_CHECK` (env or `globalThis`);
  * zero-cost and silent when off, so production behavior is unchanged.
  *
- * Phase-1 coverage = PLACEMENT COMPOSITION before data→size: given each child's
- * engine-computed size, does the solver's box-key machinery reproduce the engine's
- * absolute positions? Start with the `distribute` constraint (the composition
- * `spread`/`stack`/`scatter` all elaborate to), edge mode, no pre-placed anchor —
- * the stacked/edge-spread core. Other modes/anchors are skipped (not yet
- * modeled), so a clean run means "every covered case agrees", not "everything".
+ * Coverage = PLACEMENT COMPOSITION (does the box-key model reproduce the engine's
+ * absolute positions given each child's size?) plus the σ-SCOPE frame equation
+ * (does content(σ)=allocated close where σ is solved?). The placement checks span
+ * `distribute` (edge AND center, including pre-placed/data-positioned chains via
+ * the pack/consistency-check boundary), `align`, `position`, `nest`
+ * (inner centered in outer), and `grid` (equal-track cell centers). The frame check
+ * runs at every σ-scope root: the render root (`gofish.tsx`), a shared/self-scaled
+ * layer axis (`layer.tsx`), and a coord boundary (`coord.tsx` fitAxis). A clean
+ * run means "every covered case agrees", not "everything".
  */
 import * as M from "../../util/monotonic";
 import { SolverBox } from "./index";
@@ -22,6 +25,8 @@ import { computeAesthetic, envFlag } from "../../util";
 import { pxOf } from "../domain";
 import { localAnchorPoint } from "../dims";
 import type { ConstraintSpec, ConstraintPosScales } from "../constraints";
+import { distributePlacementAnchors } from "../constraints/distribute";
+import { gridCellSize } from "../constraints/grid";
 import { isCONTINUOUS, type UnderlyingSpace } from "../underlyingSpace";
 
 /** Whether the solver shadow assertions run. Off (and zero-cost) in prod, so the
@@ -50,18 +55,24 @@ interface DistributeLike {
 }
 
 /**
- * Check the edge-distribute CONTIGUITY invariant the engine enforces on its
- * output: consecutive targets satisfy `child[i+1].min == child[i].max + spacing`.
- * This is anchor-agnostic — which child anchored the walk only sets the absolute
- * offset, not the spacing relation — which matters because the shadow runs after
- * the placement solver, by which point every target is placed (so the
- * pre-placement anchor distinction is gone).
+ * Check the distribute SPACING relation the engine enforces on its output. Every
+ * distribute lowers to a chain of anchored relations (`distribute.ts`): between
+ * consecutive targets in placement order, the `to`-anchor of the later child
+ * equals the `from`-anchor of the earlier one plus `spacing`. The two anchors
+ * are mode-dependent — `edge` uses `prev.max → cur.min` (contiguity), `center`
+ * uses `prev.center → cur.center` (center-to-center) — read here through the
+ * same box-key model (`anchorCoord`) `align`/`position` use, so this covers BOTH
+ * modes with one relation.
  *
- * The solver expresses it as an origin chain: seed the first target at its real
- * position (boundary condition), then predict each subsequent child's `min` via
- * `SolverBox` — `baseline = previous.max + spacing`, size pinned — and compare to
- * the engine. Agreement validates the solver representation reproduces the engine
- * composition on real story data (and that target/order/axis extraction is right).
+ * The consistency-check-not-pack boundary (the violin case). Distribute only
+ * PACKS children it places; a chain edge whose BOTH endpoints arrived
+ * pre-positioned on the stack axis (e.g. the violin's `stackY` over rects pinned
+ * at `y: data`) was a no-op in the lowering (`distribute.ts` skips it) — the
+ * spacing relation does NOT hold there, those two keep their data positions.
+ * Every other edge (≥1 unplaced endpoint) is packed, so the relation must hold.
+ * Validating exactly that boundary is the point of this check: it asserts the
+ * relation on packed edges and deliberately does not on the pre-placed ones,
+ * matching the engine's own pack/check split.
  */
 export function shadowCheckDistribute(
   constraint: DistributeLike,
@@ -70,42 +81,145 @@ export function shadowCheckDistribute(
   prePlaced: boolean[]
 ): void {
   if (!enabled() || constraint.type !== "distribute") return;
-  // Center mode (center-to-center spacing) is not yet modeled; only edge.
-  if (constraint.mode !== "edge") return;
   const idx = axisIndex(constraint.dir);
 
-  // Distribute only PACKS children it places. A child already placed on the
-  // stack axis (e.g. the violin's `stackY` over rects pinned at `y: data`) is
-  // data-positioned — distribute consistency-checks it, doesn't pack it — so the
-  // contiguity invariant doesn't apply. Validate only pure packing (nothing
-  // pre-placed); mixed/data-positioned distributes are deferred (honest
-  // coverage, not silently passed). Across all 189 stories this covers 2560
-  // edge-distributes; 934 are skipped here as data-positioned, 3 as center mode.
-  if (prePlaced.some(Boolean)) return;
+  // Placement order (`reverse` reverses the chain — mirror it index-wise so the
+  // pre-placed flags travel with their targets).
+  const order = targets.map((_, i) => i);
+  if (constraint.order === "reverse") order.reverse();
+  if (order.length < 2) return;
 
-  const ordered =
-    constraint.order === "reverse" ? [...targets].reverse() : targets;
-  if (ordered.length < 2) return;
+  // Mode picks the anchor pair the lowering relates: edge = prev.max→cur.min,
+  // center = prev.center→cur.center.
+  const anchors = distributePlacementAnchors(constraint.mode);
 
-  let prevMax: M.Monotonic | undefined;
-  for (let i = 0; i < ordered.length; i++) {
-    const size = ordered[i].dims[idx].size;
-    const engineMin = ordered[i].dims[idx].min;
-    // Bail the whole chain if any link is unplaced/unsized — can't model it.
-    if (size === undefined || engineMin === undefined) return;
-
-    const box = new SolverBox(0); // edge targets are min-anchored (baseline ≡ min)
-    box.add(
-      "baseline",
-      i === 0 ? engineMin : M.adds(prevMax!, constraint.spacing)
-    );
-    box.add("size", size);
-
-    const solverMin = box.read("min", 0)!;
-    if (i > 0 && Math.abs(solverMin - engineMin) > 1e-6) {
-      report(`distribute.edge dir=${constraint.dir}`, solverMin, engineMin);
+  for (let k = 1; k < order.length; k++) {
+    const pi = order[k - 1];
+    const ci = order[k];
+    // Both pre-placed → the lowering emits no relation (consistency check, not a
+    // pack); the spacing relation is not asserted here. See docstring.
+    if (prePlaced[pi] && prePlaced[ci]) continue;
+    const from = anchorCoord(targets[pi], idx, anchors.from);
+    const to = anchorCoord(targets[ci], idx, anchors.to);
+    if (from === undefined || to === undefined) continue; // unplaced/unsized link
+    // `to.anchor == from.anchor + spacing` (the relation direction proved in
+    // placementSolver.reduceToAxisProblem: `to.min = from.min + fromOff + gap −
+    // toOff`, i.e. anchor-point + gap).
+    if (Math.abs(to - (from + constraint.spacing)) > 1e-6) {
+      report(
+        `distribute.${constraint.mode} dir=${constraint.dir}`,
+        to,
+        from + constraint.spacing
+      );
     }
-    prevMax = box.keyMono("max");
+  }
+}
+
+/** The subset of a nest constraint the shadow reads. `x`/`y` are the paddings on
+ *  the constrained axes; `children` is `[outer, inner]`. */
+interface NestLike {
+  type?: string;
+  x?: number;
+  y?: number;
+  children: { name: string }[];
+}
+
+/**
+ * Check the `nest` composition. On each constrained axis `nest` emits ONE
+ * placement relation to the solver (`nest.ts` `lowerNestPlacement`): the inner is
+ * CENTERED in the outer (`outer.center == inner.center`, the middle-to-middle
+ * relate with gap 0). That center coincidence is the hard, placed-geometry
+ * invariant, read here through the box-key model.
+ *
+ * The padded-extent relation (`|outer| == |inner| + 2·padding`) is deliberately
+ * NOT asserted here: it is a size PROPOSAL — the space fold `nestedSpace` plus the
+ * layer's nest layout proposal — that COMPOSES WITH and YIELDS TO other size
+ * claims. In the OUTSIDE_IN direction (`inner = outer − 2·padding`) a
+ * larger-natural-content inner overflows the derived size, so the placed sizes do
+ * not satisfy the wrap relation even though the layout is correct (observed on
+ * GoTree `combine({x:"nest"})` stories). The pad relation is thus validated at the
+ * space-fold layer, not at placed geometry; Stage 6 folds it in as a size
+ * equation, where authority tiers make the override explicit.
+ */
+export function shadowCheckNest(
+  constraint: NestLike,
+  outer: Placeable | undefined,
+  inner: Placeable | undefined
+): void {
+  if (!enabled() || constraint.type !== "nest" || !outer || !inner) return;
+  const axes: [Axis, number | undefined][] = [
+    ["x", constraint.x],
+    ["y", constraint.y],
+  ];
+  for (const [axis, padding] of axes) {
+    if (padding === undefined) continue; // axis left unconstrained
+    const idx = axisIndex(axis);
+    // Centered placement: outer and inner share a center line (the emitted relate).
+    const oc = anchorCoord(outer, idx, "middle");
+    const ic = anchorCoord(inner, idx, "middle");
+    if (oc !== undefined && ic !== undefined && Math.abs(oc - ic) > 1e-6)
+      report(`nest.center ${axis}`, oc, ic);
+  }
+}
+
+/** The subset of a grid constraint the shadow reads. */
+interface GridLike {
+  type?: string;
+  numCols: number;
+  xSpacing: number;
+  ySpacing: number;
+  children: { name: string }[];
+}
+
+/**
+ * Check the `grid` composition — cells centered in equal flex tracks
+ * (`grid.ts`). The grid pins each cell's center at
+ * `column·(cellW+sx)+cellW/2`, `row·(cellH+sy)+cellH/2` in layer-local space
+ * (`gridCellPlacements`); the equal-track structure is therefore an
+ * ORIGIN-INDEPENDENT invariant on the placed centers: two cells in adjacent
+ * columns of one row have x-centers `cellW+sx` apart, two in adjacent rows of
+ * one column have y-centers `cellH+sy` apart — validated against `gridCellSize`
+ * (the same `sliceExtent` the layer proposes). Differences cancel the unknown
+ * layer origin, so no absolute frame is needed. Cell EXTENT is deliberately not
+ * asserted: a cell may keep its own size and only consume the center pin.
+ */
+export function shadowCheckGrid(
+  constraint: GridLike,
+  targetByName: Map<string, Placeable>,
+  layerSize: [number, number]
+): void {
+  if (!enabled() || constraint.type !== "grid") return;
+  const [cellW, cellH] = gridCellSize(
+    constraint as Parameters<typeof gridCellSize>[0],
+    layerSize
+  );
+  const numCols = constraint.numCols;
+  const centerOf = (i: number, idx: 0 | 1): number | undefined => {
+    const t = targetByName.get(constraint.children[i]?.name);
+    return t ? anchorCoord(t, idx, "middle") : undefined;
+  };
+  for (let i = 0; i < constraint.children.length; i++) {
+    const col = i % numCols;
+    const row = Math.floor(i / numCols);
+    // Adjacent column in the same row → x-centers `cellW + xSpacing` apart.
+    if (col + 1 < numCols && i + 1 < constraint.children.length) {
+      const a = centerOf(i, 0);
+      const b = centerOf(i + 1, 0);
+      if (a !== undefined && b !== undefined) {
+        const gap = cellW + constraint.xSpacing;
+        if (Math.abs(b - a - gap) > 1e-6) report(`grid.col`, b - a, gap);
+      }
+    }
+    // Adjacent row in the same column → y-centers `cellH + ySpacing` apart.
+    void row;
+    if (i + numCols < constraint.children.length) {
+      const a = centerOf(i, 1);
+      const b = centerOf(i + numCols, 1);
+      if (a !== undefined && b !== undefined) {
+        const gap = cellH + constraint.ySpacing;
+        if (Math.abs(b - a - gap) > 1e-6) report(`grid.row`, b - a, gap);
+      }
+    }
   }
 }
 
@@ -277,18 +391,22 @@ export function shadowCheckScaleRoot(
 }
 
 /**
- * Single per-constraint shadow hook for the constraint dispatcher — one line in
- * `applyConstraints` instead of three interleaved calls with bespoke pre-state
- * capture, so this disposable observe→assert scaffolding lifts out cleanly when
- * the solver lands. `prePlaced` is the per-target `[x, y]` placement snapshot the
- * caller takes BEFORE applying the constraint (only when the check is enabled);
- * it's `undefined` (and this no-ops) in production.
+ * Single per-constraint shadow hook for `applyConstraints` — one call that
+ * dispatches by constraint type, so this disposable observe→assert scaffolding
+ * lifts out cleanly when the solver lands. `prePlaced` is the per-target `[x, y]`
+ * placement snapshot the caller takes BEFORE the placement solve (only when the
+ * check is enabled); it's `undefined` (and this no-ops) in production.
+ * `nameToPlaceable`/`layerSize` are the layer's resolved children and pixel box,
+ * used by the `nest` and `grid` checks (which read placeables by name and the
+ * grid's track sizes).
  */
 export function shadowCheckConstraint(
   constraint: ConstraintSpec,
   targets: Placeable[],
   posScales: ConstraintPosScales | undefined,
-  prePlaced: [boolean, boolean][] | undefined
+  prePlaced: [boolean, boolean][] | undefined,
+  nameToPlaceable: Map<string, Placeable>,
+  layerSize: [number, number]
 ): void {
   if (!enabled() || !prePlaced) return;
   const c = constraint as { type?: string; dir?: Axis };
@@ -303,5 +421,14 @@ export function shadowCheckConstraint(
     );
   } else if (c.type === "position") {
     shadowCheckPosition(constraint as PositionLike, targets, posScales);
+  } else if (c.type === "nest") {
+    const nest = constraint as NestLike;
+    shadowCheckNest(
+      nest,
+      nameToPlaceable.get(nest.children[0]?.name),
+      nameToPlaceable.get(nest.children[1]?.name)
+    );
+  } else if (c.type === "grid") {
+    shadowCheckGrid(constraint as GridLike, nameToPlaceable, layerSize);
   }
 }

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -46,6 +46,7 @@ import {
 import { discretePosition, value } from "../ast/data";
 import { pxOf, type AxisMap } from "../ast/domain";
 import { POSITION, SIZE, UNDEFINED } from "../ast/underlyingSpace";
+import { ScopeRegistry } from "../ast/solver/scopes";
 import { interval } from "../util/interval";
 
 type Constraint =
@@ -1131,7 +1132,9 @@ console.log("# constraint confluence: child scale factor planning");
     [2, 3],
     [inheritedX, inheritedY],
     undefined,
-    [false, false]
+    [false, false],
+    new ScopeRegistry(),
+    "test"
   );
   ok(
     "self-scaled POSITION axis builds local posScale",
@@ -1159,7 +1162,9 @@ console.log("# constraint confluence: child scale factor planning");
     [2, 3],
     [inheritedX, inheritedY],
     { sizeDomain: [Monotonic.linear(10, 0), Monotonic.linear(0, 10)] },
-    [false, false]
+    [false, false],
+    new ScopeRegistry(),
+    "test"
   );
   ok(
     "intermediate distribute defers to inherited child scale factor (scale-root scoping)",
@@ -1180,7 +1185,9 @@ console.log("# constraint confluence: child scale factor planning");
     [undefined, undefined],
     [inheritedX, inheritedY],
     { sizeDomain: [Monotonic.linear(10, 0), Monotonic.linear(0, 10)] },
-    [false, false]
+    [false, false],
+    new ScopeRegistry(),
+    "test"
   );
   ok(
     "σ-root distribute re-derives child scale factor from its budget when invertible",
@@ -1200,7 +1207,9 @@ console.log("# constraint confluence: child scale factor planning");
     [2, 3],
     [inheritedX, inheritedY],
     { sizeDomain: [Monotonic.linear(10, 0), undefined] },
-    [true, false]
+    [true, false],
+    new ScopeRegistry(),
+    "test"
   );
   ok(
     "shared scale scope overrides budget scale factor and emits shadow check",


### PR DESCRIPTION
Advances #39. Stacked on #655. Stages 6a+6b of `internals/design/sigma-affine-simplification.md`.

**6a — observe.** The shadow checker now covers every previously-skipped mode: center-mode distribute, chains with pre-placed/data-positioned members (the pack-vs-consistency boundary), nest's center relation, grid's equal flex tracks, and coord-boundary frame equations. Notable find: the constraint-level shadow dispatch had been **silently unwired since the #614 IR refactor** (only the scale-root check was running) — rewired here. Sweep: 260/260 stories, zero divergences. One modeling clarification: nest's padded-extent relation is a size *proposal* that can yield (GoTree outside-in overflow), not a placed-geometry invariant, so the check asserts only the emitted center relation.

**6b — one solve site.** New `ScopeRegistry` (`solver/scopes.ts`, per-render on the session): the render root, self-scaling regions, constraint budgets, `sharedScale` scopes, and coord boundaries all delegate σ/posScale derivation to the single scope-root solve, with bit-identical numbers. The #618 propagate-vs-re-root guard is deleted as a conditional and reborn as the structural rule — only scope roots solve; intermediates inherit. `GOFISH_DUMP_SCOPES` prints one line per scope (frame equation via `Monotonic.print`, solved σ):

```
[scope] root   key=root  axis=y  [0,140]→[0,400] = 400  σ=2.857142857142857 map=yes
[scope] shared key=layer axis=y  140σ = 400            σ=2.857142857142857 map=no
```

Root and shared printing one σ is the Stage-6 invariant made visible.

## Verification

- `pnpm capture-diff main`: **no layout changes, 260 stories identical** (vs the pre-stage-0 baseline). Pixel-equivalent; no screenshots.
- `capture-sweep`: 260/260 clean with all new shadow modes active; full suite (incl. coord-confluence's flat≡nested σ), typecheck, `check-backlinks`, `docs:build` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)