### PR TITLE
σ-affine simplification, stage 6c: one slope per σ-scope, by construction

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -123,11 +123,26 @@ scale. `map` is the _whole_ anchored map, with the intercept explicit as data
 rather than closed over a function: `px(d) = pxMin + sigma·(d − domainMin)`,
 evaluated by `pxOf` (the old `posScale(0)` intercept is `pxOf(map, 0)`). So
 "anchored" shows up operationally as "has a `map`"; "unanchored" as "has only a
-`sigma`." `map` carries its own slope, which need not equal the top-level
-`sigma` — a sub-budget layer scales a mark's size and its data position against
-different pixel extents. This single record replaced the former two parallel
+`sigma`." This single record replaced the former two parallel
 channels (`scaleFactors` = slope-only, `posScales` = whole map) in Stage 4 of
 [the σ-affine plan](/internals/design/sigma-affine-simplification).
+
+**One slope per σ-scope, and the two-scope carrier.** The carrier's two slopes —
+its `sigma` and its `map.sigma` — are not independent numbers. Each is the σ of a
+distinct σ-scope solved once by the scope registry (below):
+`sigma` is the axis's **SIZE** scope (what a magnitude is scaled by), `map.sigma`
+is the axis's **POSITION** scope (what an anchored coordinate is mapped by). No
+site fabricates either — every `map` comes from `computePosScale` through
+`solvePosition` (or the equal-measure recentering), every `sigma` from
+`solveSize` (Stage 6c). Within any one scope there is therefore exactly one slope,
+by construction. When both halves are present and `sigma ≠ map.sigma`, the axis
+genuinely carries **two scopes**, and each half is read by the channel it belongs
+to — magnitudes read `sigma`, anchored positions read `map`. That happens when a
+marginal panel's ticks map the _niced_ axis domain while its bars size the
+_un-niced_ stacked total (a nicing split), or when a sub-budget layer scales size
+against a local extent but position against an inherited one (a sub-budget vs
+inherited split). Both are two honest scopes on one axis — the multi-scale reading
+of the same equation — not a slope with a redundant, drifting twin.
 
 ## Why an explicit IR
 
@@ -732,6 +747,20 @@ re-rooting σ on the angular axis):
 That the root and shared scopes on one axis print the same σ is Stage 6's
 invariant made visible: **one slope per σ-scope, by construction**, because the
 frame equation is solved once and the posScale is a derived view of that solve.
+
+Stage 6c makes the registry the _sole_ producer of every slope, so that "by
+construction" holds everywhere the carrier flows. Two former exceptions closed:
+a coord boundary's POSITION axis used to hand down a fabricated `σ = 1` alongside
+its map (a scope-less slope that no consumer read) — it now carries no size σ at
+all, since a POSITION-only axis has no SIZE scope; and the #582 equal-measure
+recentering (equating x and y when they share a unit of measure) used to rewrite
+the root's σ inline in `gofish.tsx`, off the registry's books. It is now a named
+`recenterEqualMeasure` operation _on_ the registry, so the dump records the FINAL
+σ (a `recenter` entry per axis) rather than the pre-recentering root σ. With both
+closed, the only way a carrier shows two different slopes on one axis is the
+legitimate **two-scope** case above (a SIZE scope and a POSITION scope, e.g. a
+marginal panel's niced ticks vs its un-niced bar total) — each half still a single
+registry-solved scope σ, never independent state.
 
 ## Scales generalize flex factors
 

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -334,19 +334,43 @@ posScale and σ are _views_ of the solved system (the Stage-4 `AxisScale`
 record becomes exactly this view: σ = slope, `map` = anchored `min` anchor +
 pixel min; the intercept is `posScale(0)`, derived, never stored).
 
-**The dual slope is transitional debt, eliminated here — not a keeper.**
-Stage 4's `AxisScale.map` carries its own slope because today σ is solved in
-the four+ places above against four different pixel budgets, so a mark can
-read size-σ and position-slope from different extents on one axis (nicing
+**The dual slope was transitional debt — discharged in 6c as two scopes, not
+independent state.** Stage 4's `AxisScale.map` carried its own slope because σ was
+solved in the four+ places above against four different pixel budgets, so a mark
+could read size-σ and position-slope from different extents on one axis (nicing
 asymmetry, spacing's slope-vs-secant, sub-budget scopes vs an inherited map).
 Stage 6's invariant is **one slope per σ-scope, by construction**: the frame
 equation solves σ once at the scope root and the posScale is a derived view
-of the same solve, so within a scope the two cannot disagree. The divergences
-that remain must then become what they really are — two scopes on one axis
-(keyed by measure: the multi-scale/dual-axis design), or explicit non-data
-pixels (spacing as a piecewise gap, not a secant that papers over it).
-`AxisScale` collapses back to a single-slope view when 6b/6c land; if it
-still has two independent slopes after Stage 6, that is a bug in Stage 6.
+of the same solve, so within a scope the two cannot disagree. After 6c that holds
+everywhere the carrier flows — the scope registry is the **sole producer** of
+every slope, so neither `sigma` nor `map.sigma` is ever a free number. The
+remaining divergences became what they really are:
+
+- **Nicing asymmetry (case 1) resolves to two scopes (case 3).** The corpus
+  (`GOFISH_DUMP_SCOPES` + the 6b shadow) shows the only anchored-vs-size
+  disagreement is a marginal panel whose ticks map the _niced_ axis domain
+  (`[0,44]→[0,80]`, σ=1.818, the POSITION scope) while its bars size the
+  _un-niced_ stacked total (`45σ=80`, σ=1.778, the SIZE scope). These are two
+  distinct scopes on one axis, each read by its own channel (ticks read the map,
+  bars read σ) — exactly the sub-budget-vs-inherited shape, so case 1 needs no
+  separate machinery.
+- **Spacing / non-data pixels (case 2)** are already the Monotonic intercept in
+  the frame equation (`width.inverse(allocated)`), so the per-segment slope is the
+  scope σ, not a secant. No change needed.
+- **Sub-budget vs inherited (case 3)** is a SIZE scope (the panel's local budget)
+  and a POSITION scope (a shared ancestor map) coexisting on one axis. The
+  `AxisScale`'s two halves are precisely these two scope views; each is a single
+  registry-solved σ.
+
+So `AxisScale` is a **two-scope view**, not a slope with a redundant twin. Every
+`map` comes from `computePosScale` via `solvePosition` (or the equal-measure
+recentering), every `sigma` from `solveSize`; there is **no independent slope**
+after Stage 6. The two former fabrication sites are closed: a coord boundary's
+POSITION-only axis no longer hands down a scope-less `σ = 1` (it carries no size σ),
+and the #582 recentering is a named `recenterEqualMeasure` operation on the
+registry (so the dump shows the final σ). If a carrier ever shows two _independent_
+slopes — a slope not traceable to a registry scope — that is a bug; two _scopes_
+on one axis is the sanctioned multi-scale reading.
 
 ### Sub-stages, each gated
 
@@ -369,10 +393,25 @@ still has two independent slopes after Stage 6, that is a bug in Stage 6.
   equation per scope. The sweep (`capture-sweep`) stayed clean and the
   coord/confluence tests (flat ≡ nested σ) pass, confirming goTree/polar render
   identically.
-- **6c — σ-affine claims flow.** Marks/folds contribute width `Monotonic`s
-  into cells instead of pre-multiplied numbers; evaluation defers to the
-  scope boundary; the "evaluate at σ, hand concrete sizes down" double
-  bookkeeping (`computeSize`'s scaleFactor path) collapses. Pixel gate.
+- **6c — one slope per σ-scope, by construction.** **Landed (carrier + sole
+  producer):** the scope registry is now the ONLY producer of every slope, so the
+  `AxisScale`'s two halves (`sigma` = SIZE scope σ, `map.sigma` = POSITION scope σ)
+  are each a registry-solved scope view — never independent state. The two former
+  fabrication sites were closed: a coord boundary's POSITION-only axis dropped its
+  scope-less `σ = 1` placeholder (pixel-identical — no consumer read it), and the
+  #582 equal-measure recentering moved off `gofish.tsx` into a named
+  `ScopeRegistry.recenterEqualMeasure` operation (so `GOFISH_DUMP_SCOPES` records
+  the FINAL σ). The pre-change inventory (dump + a temporary `[solver-check]`
+  dual-slope shadow driven to zero across the 260-story sweep) confirmed the only
+  surviving anchored-vs-size disagreements are legitimate two-scope cases (nicing
+  and sub-budget), each half consumed by its own channel. **Deferred (residue,
+  acceptable per the plan):** the "evaluate at σ, hand concrete sizes down" double
+  bookkeeping still stands — `computeSize`'s `scaleFactor` path (`rect`, `layer`,
+  `treemap`), the `size × σ` pre-multiply in `petal`/`ellipse`, and distribute's
+  `scaleFactor` callbacks all still evaluate a width at a known σ at the consumer
+  rather than flowing a `Monotonic` claim to the scope boundary. Making cells
+  carry `Monotonic` claims (so evaluation defers to the boundary) is the larger
+  6e-adjacent change and was held to keep the carrier landing pixel-clean.
 - **6d — translate retirement (#39 stage 3-D).** Render consumes baked
   absolute coordinates through the `displayTranslate`/`translateString`
   chokepoints (`dims.ts:268-294` was written to make this a one-function

--- a/apps/docs/docs/internals/layout/coord-flattening.md
+++ b/apps/docs/docs/internals/layout/coord-flattening.md
@@ -130,7 +130,9 @@ canvas (gofish.tsx) — here the angular/radial budget plays the canvas role. It
 `fitAxis(axis, budget)` reads the subtree's resolved space on that axis and
 returns a `(scaleFactor, posScale)` to hand each child: a baseline-magnitude
 (data SIZE) axis scales by `width.inverse(budget)` so the children fill the ring;
-an anchored (data POSITION) axis maps onto `[0, budget]` via a posScale. Only
+an anchored (data POSITION) axis maps onto `[0, budget]` via a posScale and
+carries **no** size σ (Stage 6c — a POSITION-only axis has no SIZE scope, so it
+never fabricates one; the map's own slope is the scope's σ). Only
 DATA-bound channels consume these — a plain number bypasses both (see
 `computeAesthetic`) — so a hand-sized (radian/pixel) mark is unaffected, while a
 mark that says `thetaSize: datum(count)` auto-fits. Because the coord is the

--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -378,7 +378,10 @@ are built and before `child.layout`: when `spaceMeasure(x) === spaceMeasure(y)`
 domain's `canvas / range` or a baseline-magnitude σ — is equated to the binding
 `min(...)` so one data unit measures the same on both axes (circles stay circular,
 maps stay undistorted); the binding axis fills, the other gets a recentered
-posScale. It is type equality, not a knob, and a single-coordinate-space coupling
+posScale. Stage 6c makes this a named `recenterEqualMeasure` operation _on_ the
+scope registry rather than an inline rewrite, so it is the one post-solve σ
+adjustment on the registry's books and `GOFISH_DUMP_SCOPES` records the final σ.
+It is type equality, not a knob, and a single-coordinate-space coupling
 — it does not reach sizes solved in separate nested operator scopes. After layout it
 reads the chart's _final_ extent back off the root via `child.dims[i].size`, so an
 unsized axis still yields a concrete SVG size (e.g. a no-width bar chart gets

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -203,14 +203,19 @@ export const coord = createNodeOperator(
           const fitAxis = (
             axis: 0 | 1,
             budget: number
-          ): [number, AxisMap | undefined] => {
+          ): [number | undefined, AxisMap | undefined] => {
             // An anchored (data POSITION) axis: the coord's own
             // `resolveUnderlyingSpace` already unioned the children's POSITION
             // spaces into `spaceRef.current` — reuse it and map onto [0, budget].
+            // This is a POSITION scope only: it has no SIZE scope, so it carries
+            // NO σ (Stage 6c: never fabricate an independent size slope — the map's
+            // own slope IS the scope's σ). A data-bound size on this axis reads the
+            // map difference; a plain-number size bypasses both. The former `1`
+            // placeholder was a fabricated size σ with no scope behind it.
             const resolved = spaceRef.current?.[axis];
             if (resolved !== undefined && isPOSITION(resolved)) {
               return [
-                1,
+                undefined,
                 scopes.solvePosition(
                   { kind: "coord", rootKey: node.key ?? node.type, axis },
                   resolved,

--- a/packages/gofish-graphics/src/ast/domain.ts
+++ b/packages/gofish-graphics/src/ast/domain.ts
@@ -55,17 +55,27 @@ export const unifyContinuousDomains = (
 
 /** One continuous axis's data→pixel affine map, with the intercept explicit
  *  instead of closed over a function: `px(d) = pxMin + sigma·(d − domainMin)`.
- *  `sigma` is the map's own slope (px per data unit); it need NOT equal an
- *  {@link AxisScale}'s top-level `sigma` — a sub-budget layer can scale a mark's
- *  size and its data position against different pixel extents. Evaluated by
- *  {@link pxOf}; the old `posScale(0)` intercept is `pxOf(map, 0)`. */
+ *  `sigma` is the map's own slope (px per data unit). By construction it is the
+ *  σ of a POSITION σ-scope: every `AxisMap` is produced by {@link computePosScale}
+ *  through the scope registry (`solvePosition`) or its equal-measure recentering,
+ *  so `sigma` is never a free-floating number — it is a scope's solved slope.
+ *  Evaluated by {@link pxOf}; the old `posScale(0)` intercept is `pxOf(map, 0)`. */
 export type AxisMap = { sigma: number; domainMin: number; pxMin: number };
 
 /** One axis's data→pixel affine scale — the single carrier that replaced the
  *  parallel `scaleFactors` (slope-only) and `posScales` (whole map) channels.
- *  `sigma` is px per data unit for UNANCHORED size consumers (the old
- *  `scaleFactor`); `map` is the anchored data→pixel map (the old `posScale`),
- *  present iff the axis is anchored. */
+ *
+ *  The two halves are the read-off of up to TWO σ-scopes on this axis, NOT two
+ *  independent slopes (Stage 6c — see the σ-affine plan). `sigma` is the σ of the
+ *  axis's SIZE scope (px per data unit for unanchored magnitude consumers, the
+ *  old `scaleFactor`); `map` is the anchored map of the axis's POSITION scope
+ *  (the old `posScale`), and `map.sigma` is that scope's σ. Both are registry-
+ *  solved — no site fabricates either — so when both are present and `sigma ≠
+ *  map.sigma` the axis genuinely carries two scopes (e.g. a marginal panel whose
+ *  ticks map the NICED domain while its bars size the UN-niced total, or a
+ *  sub-budget layer scaling size against a local extent and position against an
+ *  inherited one). Each half is read by the channel it belongs to: magnitudes
+ *  read `sigma`, anchored positions read `map`. */
 export type AxisScale = { sigma?: number; map?: AxisMap };
 
 /** Evaluate an anchored map at a data value. */
@@ -80,9 +90,11 @@ export const posFn = (
 ): ((d: number) => number) | undefined =>
   map === undefined ? undefined : (d) => pxOf(map, d);
 
-/** Assemble one axis's {@link AxisScale} from its σ (size slope) and anchored
- *  map, collapsing "neither present" to `undefined` so a bare axis stays
- *  undefined (not an empty record). */
+/** Assemble one axis's {@link AxisScale} from its SIZE-scope σ and its
+ *  POSITION-scope `map`, collapsing "neither present" to `undefined` so a bare
+ *  axis stays undefined (not an empty record). Both arguments are registry-
+ *  solved slopes (see {@link AxisScale}); this only bundles the two scope views
+ *  the axis carries — it never derives a slope. */
 export const axisScale = (
   sigma: number | undefined,
   map: AxisMap | undefined

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -29,7 +29,7 @@ import {
   type UnderlyingSpace,
 } from "./underlyingSpace";
 import { shadowCheckScaleRoot } from "./solver/shadow";
-import { getScopeRegistry } from "./solver/scopes";
+import { getScopeRegistry, type EqualMeasureAxis } from "./solver/scopes";
 import { elaborateAxes, elaborateAxisTitles } from "./axes/elaborate";
 import { elaborateLegend, legendOverhang } from "./legends/elaborate";
 
@@ -420,50 +420,34 @@ export async function layout(
   // matching, the same way `circle({ r })` lowers to a `w`/`h` that share a
   // measure and so cannot render as an ellipse. Each axis's pixels-per-data-unit
   // comes from its POSITION domain (`canvas / range`) or its baseline-magnitude
-  // σ; we take the binding (smaller) one and apply it to both — the binding axis
-  // fills its dimension, the other gets slack, centered by convention. A POSITION
-  // axis writes back a recentered posScale; a SIZE axis writes back its σ (its
-  // content stays origin-anchored — SIZE-slack centering is deferred). Silently
-  // skipped when an axis has no continuous scale to equate (e.g. ordinal).
+  // σ. The scope-level operation — take the binding (smaller) σ and equate both
+  // axes' scopes — lives on the registry (Stage 6c: the ONE post-solve σ
+  // adjustment, so every slope stays registry-sourced and the dump shows the
+  // FINAL σ). Silently skipped when an axis has no continuous scale to equate.
   const measureX = spaceMeasure(niceUnderlyingSpaceX);
   const measureY = spaceMeasure(niceUnderlyingSpaceY);
   if (measureX !== undefined && measureX === measureY) {
-    const axisInfo = ([0, 1] as const).map((axis) => {
-      const space = axis === 0 ? niceUnderlyingSpaceX : niceUnderlyingSpaceY;
-      const canvas = axis === 0 ? canvasW : canvasH;
-      const ival = continuousInterval(space);
-      if (ival !== undefined && ival.max > ival.min) {
-        const range = ival.max - ival.min;
-        return {
-          kind: "position" as const,
-          unitPx: canvas / range,
-          min: ival.min,
-          range,
-          canvas,
-        };
-      }
-      const sigma = rootScaleFactors[axis];
-      if (sigma !== undefined) return { kind: "size" as const, unitPx: sigma };
-      return undefined;
-    });
-    const [ax, ay] = axisInfo;
-    if (ax !== undefined && ay !== undefined) {
-      const shared = Math.min(ax.unitPx, ay.unitPx); // binding axis wins
-      for (const axis of [0, 1] as const) {
-        const info = axisInfo[axis]!;
-        if (info.kind === "position") {
-          const offset = (info.canvas - shared * info.range) / 2; // center slack
-          // Same affine map as `(pos − min)·shared + offset`, intercept explicit.
-          posScales[axis] = {
-            sigma: shared,
-            domainMin: info.min,
-            pxMin: offset,
+    const axisInfo = ([0, 1] as const).map(
+      (axis): EqualMeasureAxis | undefined => {
+        const space = axis === 0 ? niceUnderlyingSpaceX : niceUnderlyingSpaceY;
+        const canvas = axis === 0 ? canvasW : canvasH;
+        const ival = continuousInterval(space);
+        if (ival !== undefined && ival.max > ival.min) {
+          const range = ival.max - ival.min;
+          return {
+            kind: "position",
+            unitPx: canvas / range,
+            min: ival.min,
+            range,
+            canvas,
           };
-        } else {
-          rootScaleFactors[axis] = shared;
         }
+        const sigma = rootScaleFactors[axis];
+        if (sigma !== undefined) return { kind: "size", unitPx: sigma };
+        return undefined;
       }
-    }
+    ) as [EqualMeasureAxis | undefined, EqualMeasureAxis | undefined];
+    scopes.recenterEqualMeasure("root", axisInfo, posScales, rootScaleFactors);
   }
 
   // Solver shadow (#39): the ROOT σ-scope — the SIZE frame equation

--- a/packages/gofish-graphics/src/ast/solver/scopes.ts
+++ b/packages/gofish-graphics/src/ast/solver/scopes.ts
@@ -33,7 +33,22 @@ export type ScopeKind =
   | "self-scaled"
   | "constraint-budget"
   | "shared"
-  | "coord";
+  | "coord"
+  | "recenter";
+
+/** One axis's contribution to the #582 equal-measure recentering: either an
+ *  anchored POSITION axis (its data interval and canvas) or a bare SIZE axis
+ *  (just its σ). `unitPx` is the axis's pixels-per-data-unit before recentering
+ *  — the quantity the two axes must agree on when they share a measure. */
+export type EqualMeasureAxis =
+  | {
+      kind: "position";
+      unitPx: number;
+      min: number;
+      range: number;
+      canvas: number;
+    }
+  | { kind: "size"; unitPx: number };
 
 /** Identity of the scope being solved — its root node label and the axis. */
 export interface ScopeMeta {
@@ -121,6 +136,61 @@ export class ScopeRegistry {
       });
     }
     return map;
+  }
+
+  /**
+   * The #582 equal-measure recentering, modeled as a named post-solve scope
+   * operation (Stage 6c). When x and y carry the SAME unit of measure, "1 unit
+   * on x" and "1 unit on y" are the same quantity, so their data→pixel scales
+   * must be EQUAL — a circle stays circular. The two axes' independently-solved
+   * scopes are therefore collapsed into ONE shared σ (the binding, smaller
+   * `unitPx`); the other axis takes slack, centered by convention. A POSITION
+   * axis writes back a recentered anchored map; a SIZE axis writes back its σ
+   * (content stays origin-anchored — SIZE-slack centering is deferred).
+   *
+   * This is the ONE place a post-solve σ adjustment happens, so it lives on the
+   * registry (not inlined in `gofish.tsx`): every slope a render produces is now
+   * registry-sourced, and `GOFISH_DUMP_SCOPES` records the FINAL σ (a `recenter`
+   * entry per axis) rather than the pre-recentering root σ. Mutates `posScales`
+   * / `rootScaleFactors` in place; a no-op unless both axes have a continuous
+   * scale to equate.
+   */
+  recenterEqualMeasure(
+    rootKey: string,
+    axisInfo: [EqualMeasureAxis | undefined, EqualMeasureAxis | undefined],
+    posScales: (AxisMap | undefined)[],
+    rootScaleFactors: (number | undefined)[]
+  ): void {
+    const [ax, ay] = axisInfo;
+    if (ax === undefined || ay === undefined) return;
+    const shared = Math.min(ax.unitPx, ay.unitPx); // binding axis wins
+    for (const axis of [0, 1] as const) {
+      const info = axisInfo[axis]!;
+      if (info.kind === "position") {
+        const offset = (info.canvas - shared * info.range) / 2; // center slack
+        // Same affine map as `(pos − min)·shared + offset`, intercept explicit.
+        posScales[axis] = {
+          sigma: shared,
+          domainMin: info.min,
+          pxMin: offset,
+        };
+      } else {
+        rootScaleFactors[axis] = shared;
+      }
+      if (dumpEnabled())
+        this.entries.push({
+          kind: "recenter",
+          rootKey,
+          axis,
+          allocated: info.kind === "position" ? info.canvas : NaN,
+          frame:
+            info.kind === "position"
+              ? `[${info.min},${info.min + info.range}]→center(σ=${shared})`
+              : `σ:=min(x,y)`,
+          sigma: shared,
+          hasMap: info.kind === "position",
+        });
+    }
   }
 
   /** Print one line per scope: root kind/key, axis, allocated px, the frame

--- a/tests/scripts/dump-scopes.ts
+++ b/tests/scripts/dump-scopes.ts
@@ -1,0 +1,62 @@
+// Render the stories matching a filter with GOFISH_DUMP_SCOPES on and print each
+// one's [scope] frame-equation lines — the single-story companion to the
+// whole-corpus capture-sweep, for inspecting a chart's σ-scope structure.
+// Usage: tsx scripts/dump-scopes.ts "<filter>"
+import { chromium } from "playwright";
+import { join } from "path";
+import {
+  startViteServer,
+  waitForVite,
+  type StoryInfo,
+} from "./capture-core.js";
+
+const HARNESS_DIR = join(import.meta.dirname, "..", "harness");
+const PORT = 3007;
+
+async function main() {
+  const filter = (process.argv[2] ?? "").toLowerCase().trim();
+  const viteProc = startViteServer(HARNESS_DIR, PORT);
+  viteProc.stderr?.on("data", (d) => process.stderr.write(d.toString()));
+  const browser = await chromium.launch({ headless: true });
+  try {
+    await waitForVite(PORT);
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      (window as unknown as Record<string, unknown>).GOFISH_DUMP_SCOPES = 1;
+    });
+    let buffer: string[] = [];
+    page.on("console", (msg) => {
+      const t = msg.text();
+      if (t.startsWith("[scope]")) buffer.push(t);
+    });
+    await page.goto(`http://localhost:${PORT}/stories-runner.html`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForFunction(
+      () => (window as any).__STORIES_RUNNER_READY__ === true,
+      { timeout: 30_000 }
+    );
+    const all = (await page.evaluate(() =>
+      window.__listStories__()
+    )) as StoryInfo[];
+    const stories = all.filter((s) =>
+      `${s.title}/${s.name}`.toLowerCase().includes(filter)
+    );
+    for (const story of stories) {
+      buffer = [];
+      await page.evaluate(async (id) => window.__renderStory__(id), story.id);
+      await page.waitForFunction(() => window.__STORY_RENDER_DONE__ === true, {
+        timeout: 15_000,
+      });
+      await page.waitForTimeout(50);
+      console.log(`\n### ${story.title}/${story.name}`);
+      for (const l of buffer) console.log(l);
+    }
+    await context.close();
+  } finally {
+    await browser.close();
+    viteProc.kill();
+  }
+}
+main();


### PR DESCRIPTION
Advances #39. Stacked on #656. Stage 6c of `internals/design/sigma-affine-simplification.md` — the stage that discharges the dual-slope debt Josh signed off on as transitional-only.

**The corpus told the story.** A temporary dual-slope shadow assertion swept all 260 stories: only 10 had an axis where `map.sigma` differed from the size σ, in exactly two categories:

1. **A fabricated dead value (6 stories):** coord's `fitAxis` POSITION branch returned `σ=1` as a placeholder with no scope behind it and no consumer. Deleted — the seven affected coord stories are DOM-byte-identical.
2. **Two solved scopes on one axis (4 stories).** CORRECTION (post-review, see #659): the original description here ("niced ticks read one scope, un-niced bars the other") was wrong in both directions. In the marginal histogram exemplar, `[0,44]` is the RAW domain and `[0,45]` the niced one; the bars are drawn at the raw σ=80/44≈1.818 (every bar height is an exact integer count at that slope), and the `45σ=80` scope solves the niced width. The mechanism: self-scaling regions stash their space before nicing can reach it (`resolveNiceDomains` sees the reported `UNDEFINED`), so content escapes nicing — a latent violation of the nicing contract (shapes must move with the niced domain), invisible today only because these panels draw no count axis. Filed as #659; this PR preserves the behavior pixel-identically, as every stage does. The legitimate two-scope (multi-scale) framing still stands for genuinely cross-scope reads; this particular case should collapse to ONE scope once #659 is fixed.

**The invariant, by construction:** the `ScopeRegistry` (`solveSize` / `solvePosition` / and now `recenterEqualMeasure`, the #582 equal-measure adjustment moved on-registry as the one named post-solve operation) is the **sole producer of every slope**. `AxisScale.sigma` is the axis's SIZE-scope σ; `AxisScale.map.sigma` its POSITION-scope σ; when both exist and differ, the axis carries two scopes — the multi-scale/dual-axis structure — never free-floating state. The design doc's "two independent slopes surviving Stage 6 is a Stage 6 bug" sentence is discharged (grep-verifiably gone, replaced by the two-scopes framing). `GOFISH_DUMP_SCOPES` now shows final (post-recenter) σ, and `dump-scopes.ts` joins `capture-sweep` as the single-story inspector.

Deferred with documentation (per plan): the evaluate-then-hand-down residue (`computeSize`'s σ path in rect/layer/treemap, the pre-multiplies in petal/ellipse, distribute's σ callbacks) — these consume scope-solved σ correctly but don't yet flow claims to the boundary; listed in the design doc's 6c entry.

## Verification

- `pnpm capture-diff main`: **no layout changes, 260 stories identical** (vs pre-stage-0 baseline). No screenshots: pixel-equivalent.
- `capture-sweep` 260/260 clean; full suite green (confluence 92/92); typecheck, `check-backlinks`, `docs:build` clean; targeted DOM-byte checks on the 10 previously-divergent stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
