### PR TITLE
σ-affine simplification, stage 6d: baked-absolute child lowering

### DIFF
--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -151,16 +151,31 @@ scatter bubble's area) stays a flat point even under a coord.
 did. A node that reaches `INTERNAL_lower` is either a **leaf** (a bare shape) or a
 **bake boundary** — `coord`, `box`, `connect`, `arrow`, `enclose`, and the
 Porter-Duff compositors/mask. A boundary carries its own absolute transform and must
-re-walk its subtree with that transform composed in (via `flattenLayout`) so its
-descendants land in absolute coordinates _before_ `toPixel`. Pre-recursed,
-parent-relative child items would be mispositioned. This is the same
-boundary-recursive structure the bake itself has: each boundary flattens within its
-own scope, emits its warped primitives, and is treated as a unit by its parent.
+re-walk its subtree so its descendants land in absolute coordinates _before_
+`toPixel`. Pre-recursed, parent-relative child items would be mispositioned. This is
+the same boundary-recursive structure the bake itself has: each boundary flattens
+within its own scope, emits its warped primitives, and is treated as a unit by its
+parent.
 
-A `coord` operator is the archetype: it lowers its whole subtree into resolved
-`path`/`rect`/`ellipse` items whose coordinates are already warped through its
-coordinate transform (a petal becomes a `path`, a polar bar becomes a warped `path`),
-so the backend never sees the polar mapping — just absolute pixel paths.
+How the re-walk lands descendants in absolute coordinates splits by boundary kind
+(#39 stage 6d):
+
+- A **pure translate-only container** (`box`/`frame`, `offset`, `enclose`) flattens
+  its subtree with `bakeChildren` (`bake.ts`) — the same z-ordered flatten the root
+  bake uses, seeded at the container's own absolute translate — and lowers each
+  returned entry at its baked absolute transform (`INTERNAL_lower(coord, d.transform)`).
+  There is no per-container `toPixel` closure: the translate is baked into each
+  descendant's coordinates, not composed onto the session map. A non-identity `scale`
+  is the one part a flat list can't fold, so it stays a `group` wrapper around the
+  flattened items.
+- A **space remapper** (`coord`) genuinely warps its content, so it keeps a
+  `contentToPixel` map: it flattens its subtree (`flattenLayout`) and maps each
+  descendant through its coordinate transform then its own translate. A `coord` is the
+  archetype: it lowers its whole subtree into resolved `path`/`rect`/`ellipse` items
+  whose coordinates are already warped (a petal becomes a `path`, a polar bar a warped
+  `path`), so the backend never sees the polar mapping — just absolute pixel paths.
+- A **self-drawer** (`connect`, `arrow`) reads its own baked absolute translate
+  (`displayTranslate`) to place the geometry it draws from its children's anchors.
 
 ## The display list IR
 

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -412,11 +412,43 @@ on one axis is the sanctioned multi-scale reading.
   rather than flowing a `Monotonic` claim to the scope boundary. Making cells
   carry `Monotonic` claims (so evaluation defers to the boundary) is the larger
   6e-adjacent change and was held to keep the carrier landing pixel-clean.
-- **6d — translate retirement (#39 stage 3-D).** Render consumes baked
-  absolute coordinates through the `displayTranslate`/`translateString`
-  chokepoints (`dims.ts:268-294` was written to make this a one-function
-  change); the per-container `<g translate>` wrappers collapse. Expect benign
-  DOM reshuffles — this is precisely the pixel-not-DOM gate case.
+- **6d — translate retirement (#39 stage 3-D). Landed.** The per-container
+  translate-composition closures collapse: a pure translate-only bake boundary
+  (`box`/`frame`, `offset`, `enclose`) no longer composes its translate into a
+  child-local `toPixel` closure and lower its children parent-relative. Instead
+  it flattens its own subtree via the new `bakeChildren` (the root bake's
+  z-ordered children-flatten, factored out of `bake`) seeded at its absolute
+  translate, and lowers each descendant at its baked absolute transform
+  (`INTERNAL_lower(coord, d.transform)`) — the identical mechanism the root bake
+  already uses, so the two paths can't drift. The non-identity `scale` exception
+  stays a `group` wrapper (a flat list can't fold scale). The dead
+  `translateString` chokepoint (`dims.ts`) — every legacy `<g transform>` render
+  had already migrated to the display-list `toPixel` fold, leaving it imported
+  but never called — is deleted along with its four dead imports. `displayTranslate`
+  stays: it is the read of a baked absolute transform that the space-remap boundary
+  (`coord`'s `contentToPixel`) and the self-drawers (`connect`/`arrow`) apply to
+  their own geometry — those are NOT pure translate-only containers, so they keep
+  composing (the documented exception).
+
+  **No `transform.translate` write was retired.** Render/lower already reads the
+  ledger projection (`projectedTranslate`/`_displayTransform`), never the raw
+  written field; the surviving raw writes (`_pinAnchor`'s under-determined-axis
+  fallback, the `layout()` seed) feed `_projectTranslate`'s fallback, which
+  `ref`s and constraints also read — so none is render-only, and the
+  `translate === undefined` "parent may place me" sentinel is untouched.
+
+  **Gate — pixel, not DOM.** The zero-pixel gate is a new `capture-pixels`
+  script (`tests/scripts/capture-pixels.ts`): render every story to PNG at HEAD
+  and at the base ref in the SAME local Chromium, pixelmatch at threshold 0.
+  Result: **260/260 stories, 0 pixels moved.** Because the display-list path had
+  already inlined translate composition into coordinates (no `<g translate>`
+  wrappers survived for these boundaries — only the `scale` group), collapsing
+  the closures is byte-identical in the normalized DOM too: `capture-diff` and
+  `capture-sweep` (solver shadow) both report **260/260 identical / clean**. The
+  anticipated "benign DOM reshuffle" did not materialize — the reshuffle was
+  spent by the earlier `_render`→display-list migration, so 6d is pixel- AND
+  DOM-neutral.
+
 - **6e — grid as tracks.** A grid scope introduces `numCols + numRows` track
   cells; each cell(i, j) gets equations `cell.min = track.min` and
   `cell.size = track.size` per axis. Equal-flex is "all track sizes equal +

--- a/apps/docs/docs/internals/layout/coord-flattening.md
+++ b/apps/docs/docs/internals/layout/coord-flattening.md
@@ -118,6 +118,17 @@ which the render entry maps over directly.
   descends into each unit, so a component keeps its internal order. Transforms still
   compose all the way to the leaves; only the _ordering_ is per-layer.
 
+**`bakeChildren` — the same flatten, reused by boundaries.** `bake`'s per-transparent-layer
+children-flatten (the z-order resolution + transform composition) is factored into an
+exported `bakeChildren(node, translate, scale)`. A pure translate-only boundary
+(`box`/`frame`, `offset`, `enclose`) calls it on its _own_ subtree, seeded at the
+boundary's absolute translate, and lowers each returned entry at its baked absolute
+transform. This is stage 6d of [#39](https://github.com/gofish-graphics/gofish-graphics/issues/39):
+a translate-only boundary no longer composes its translate into a `toPixel` closure and
+lower its children parent-relative — it bakes them to absolute coordinates through the
+exact z-order-preserving path the root uses, so the two mechanisms can't drift. Only a
+non-identity `scale` (which a flat list can't fold) still needs a `group` wrapper.
+
 This root bake is the first step toward a serializable [display
 list](/internals/core/rendering) (the render IR): once each draw entry is a
 self-contained primitive rather than a `{ node, transform }` back-reference, the flat

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/bake.ts
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/bake.ts
@@ -163,72 +163,102 @@ const zOf = (node: GoFishAST): number =>
  * resolving each layer's own order and only then descending preserves the
  * legacy interleaving. Transforms still compose all the way to the leaves.
  */
+const walkNode = (
+  items: DisplayObject[],
+  node: GoFishAST,
+  transform: [number, number],
+  scale: [number, number]
+): void => {
+  const [ownTx, ownTy] = bakeTranslate(node);
+  const composedTranslate: [number, number] = [
+    ownTx + transform[0],
+    ownTy + transform[1],
+  ];
+  const composedScale: [number, number] = [
+    (node.transform?.scale?.[0] ?? 1) * scale[0],
+    (node.transform?.scale?.[1] ?? 1) * scale[1],
+  ];
+
+  if (!isTransparent(node)) {
+    items.push({
+      node,
+      transform: { translate: composedTranslate, scale: composedScale },
+    });
+    return;
+  }
+
+  walkChildren(items, node, composedTranslate, composedScale);
+};
+
+/** Flatten a transparent node's CHILDREN into `items` at the parent's already-
+ *  composed absolute `translate`/`scale` — resolving z hierarchically (the
+ *  z-constrained topo-sort, else the (local zOrder, index) order) exactly as
+ *  the root bake does. Shared so a bake boundary can flatten its own subtree to
+ *  absolute coordinates instead of composing its translate into a `toPixel`
+ *  closure (#39 stage 6d). */
+const walkChildren = (
+  items: DisplayObject[],
+  node: GoFishAST,
+  translate: [number, number],
+  scale: [number, number]
+): void => {
+  const children = (node as GoFishNode).children;
+  const zConstraints = ((node as GoFishNode).constraints ?? []).filter(
+    isZOrderConstraint
+  );
+
+  if (zConstraints.length > 0) {
+    // Resolve z WITHIN this layer over its component-granular flattened
+    // subtree (the same units the legacy layer render topo-sorted), then
+    // descend into each unit — components keep their internal order.
+    const sorted = topoSortByZOrder(flattenForZOrder(children), zConstraints, {
+      node: (it) => it.node,
+      z: (it) => it.defaultZ,
+      order: (it) => it.defaultOrder,
+    });
+    for (const unit of sorted) {
+      walkNode(
+        items,
+        unit.node,
+        [
+          translate[0] + unit.accTranslate[0],
+          translate[1] + unit.accTranslate[1],
+        ],
+        scale
+      );
+    }
+    return;
+  }
+
+  // Plain layer: paint children in (local zOrder, index) order.
+  const ordered = children
+    .map((child, index) => ({ child, index }))
+    .sort((a, b) => zOf(a.child) - zOf(b.child) || a.index - b.index);
+  for (const { child } of ordered) {
+    walkNode(items, child, translate, scale);
+  }
+};
+
 export const bake = (root: GoFishAST): DisplayObject[] => {
   const items: DisplayObject[] = [];
+  walkNode(items, root, [0, 0], [1, 1]);
+  return items;
+};
 
-  const walk = (
-    node: GoFishAST,
-    transform: [number, number],
-    scale: [number, number]
-  ): void => {
-    const [ownTx, ownTy] = bakeTranslate(node);
-    const composedTranslate: [number, number] = [
-      ownTx + transform[0],
-      ownTy + transform[1],
-    ];
-    const composedScale: [number, number] = [
-      (node.transform?.scale?.[0] ?? 1) * scale[0],
-      (node.transform?.scale?.[1] ?? 1) * scale[1],
-    ];
-
-    if (!isTransparent(node)) {
-      items.push({
-        node,
-        transform: { translate: composedTranslate, scale: composedScale },
-      });
-      return;
-    }
-
-    const children = (node as GoFishNode).children;
-    const zConstraints = ((node as GoFishNode).constraints ?? []).filter(
-      isZOrderConstraint
-    );
-
-    if (zConstraints.length > 0) {
-      // Resolve z WITHIN this layer over its component-granular flattened
-      // subtree (the same units the legacy layer render topo-sorted), then
-      // descend into each unit — components keep their internal order.
-      const sorted = topoSortByZOrder(
-        flattenForZOrder(children),
-        zConstraints,
-        {
-          node: (it) => it.node,
-          z: (it) => it.defaultZ,
-          order: (it) => it.defaultOrder,
-        }
-      );
-      for (const unit of sorted) {
-        walk(
-          unit.node,
-          [
-            composedTranslate[0] + unit.accTranslate[0],
-            composedTranslate[1] + unit.accTranslate[1],
-          ],
-          composedScale
-        );
-      }
-      return;
-    }
-
-    // Plain layer: paint children in (local zOrder, index) order.
-    const ordered = children
-      .map((child, index) => ({ child, index }))
-      .sort((a, b) => zOf(a.child) - zOf(b.child) || a.index - b.index);
-    for (const { child } of ordered) {
-      walk(child, composedTranslate, composedScale);
-    }
-  };
-
-  walk(root, [0, 0], [1, 1]);
+/**
+ * Flatten a bake boundary's own subtree into absolute-transform `DisplayObject`s,
+ * seeded at the boundary's already-absolute `translate`/`scale`. The boundary
+ * lowers each returned entry at its baked absolute transform (via
+ * `INTERNAL_lower(coord, d.transform)`) — the same mechanism the root bake uses —
+ * so a translate-only boundary needs no per-container `toPixel` closure (#39
+ * stage 6d). z-order is resolved identically to {@link bake}.
+ */
+export const bakeChildren = (
+  node: GoFishAST,
+  translate: [number, number] = [0, 0],
+  scale: [number, number] = [1, 1]
+): DisplayObject[] => {
+  const items: DisplayObject[] = [];
+  walkChildren(items, node, translate, scale);
   return items;
 };

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -14,7 +14,6 @@ import {
   FancyDims,
   Interval,
   Size,
-  translateString,
 } from "../dims";
 import { flattenLayout } from "./bake";
 import * as IntervalLib from "../../util/interval";

--- a/packages/gofish-graphics/src/ast/dims.ts
+++ b/packages/gofish-graphics/src/ast/dims.ts
@@ -267,11 +267,12 @@ export const displayDims = (
 
 /**
  * A node's render-side translate offset as a concrete `[tx, ty]` tuple, with the
- * `?? 0` fallback every shape/operator `_render` wants for drawing (an unplaced
- * axis draws at the origin). This is the single chokepoint for render's
- * `transform.translate` reads: making the move to baked absolute coordinates
- * (#39 stage 3-D) a one-function change rather than a ~15-site sweep. Scale is
- * left to the callers that compose it.
+ * `?? 0` fallback every shape/operator lower body wants for drawing (an unplaced
+ * axis draws at the origin). The read of a BAKED absolute transform each
+ * self-drawing boundary (coord, connect, enclose) applies to its own geometry;
+ * the pure translate-only containers (box/layer, offset) no longer compose it
+ * into a closure — they flatten their subtree to absolute coordinates via
+ * `bakeChildren` (#39 stage 6d). Scale is left to the callers that compose it.
  */
 export const displayTranslate = (transform?: {
   translate?: (number | undefined)[];
@@ -279,19 +280,6 @@ export const displayTranslate = (transform?: {
   transform?.translate?.[0] ?? 0,
   transform?.translate?.[1] ?? 0,
 ];
-
-/**
- * The SVG `translate(tx, ty)` attribute string for a node's transform — the
- * render-wrapper form of {@link displayTranslate}, shared by every container/mark
- * that emits a `<g transform="translate(...)">`. These wrappers are exactly the
- * ones #39 stage 3-D collapses once render consumes baked absolute coordinates.
- */
-export const translateString = (transform?: {
-  translate?: (number | undefined)[];
-}): string => {
-  const [tx, ty] = displayTranslate(transform);
-  return `translate(${tx}, ${ty})`;
-};
 
 /**
  * The `dims` getter body shared by {@link GoFishNode} and {@link GoFishRef}:

--- a/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
+++ b/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
@@ -10,8 +10,8 @@
 
 import type { DisplayList } from "gofish-ir";
 import type { GoFishNode, ToPixel } from "../_node";
-import type { GoFishAST } from "../_ast";
 import type { CoordinateTransform } from "../coordinateTransforms/coord";
+import { bakeChildren } from "../coordinateTransforms/bake";
 import { displayTranslate, type Transform } from "../dims";
 import { type Path, type Point, pathToSVGPath } from "../../path";
 
@@ -161,9 +161,13 @@ export const withToPixel = <T>(
   }
 };
 
-/** Lower a boundary's children under its own translate (the legacy
- *  `<g transform>`), plus an optional extra `(dx, dy)` shift — the shared body of
- *  the simple translate-only boundaries (offset, enclose, arrow). */
+/** Lower a translate-only boundary's children at BAKED ABSOLUTE coordinates,
+ *  plus an optional extra `(dx, dy)` shift — the shared body of the simple
+ *  translate-only boundaries (offset, enclose). #39 stage 6d: instead of
+ *  composing the boundary's translate into a child-local `toPixel` closure, the
+ *  subtree is flattened to absolute-transform display objects (seeded at the
+ *  boundary's own absolute translate) and each is lowered at that transform —
+ *  the same mechanism the root bake uses. */
 export const lowerChildrenOffset = (
   node: GoFishNode,
   transform: Transform | undefined,
@@ -172,11 +176,7 @@ export const lowerChildrenOffset = (
   dy = 0
 ): DisplayList.DisplayItem[] => {
   const [tx, ty] = displayTranslate(transform);
-  const outer = node.getRenderSession().toPixel!;
-  const composed: ToPixel = ([cx, cy]) => outer([tx + dx + cx, ty + dy + cy]);
-  return withToPixel(node, composed, () =>
-    (node.children as GoFishAST[]).flatMap((c) =>
-      c.INTERNAL_lower(coordinateTransform)
-    )
+  return bakeChildren(node, [tx + dx, ty + dy]).flatMap((d) =>
+    d.node.INTERNAL_lower(coordinateTransform, d.transform)
   );
 };

--- a/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
@@ -14,7 +14,6 @@ import {
   elaborateDirection,
   FancyDirection,
   Size,
-  translateString,
 } from "../dims";
 import { pairs } from "../../util";
 import { linear } from "../coordinateTransforms/linear";

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -2,11 +2,9 @@
 // @wiki Underlying Space — /internals/core/underlying-space
 // </gofish-wiki>
 
-import { GoFishNode, type ToPixel } from "../_node";
-import type { DisplayList } from "gofish-ir";
+import { GoFishNode } from "../_node";
 import { shadowCheckScaleRoot } from "../solver/shadow";
 import { getScopeRegistry } from "../solver/scopes";
-import { flattenForZOrder, topoSortByZOrder } from "../paintOrder";
 import { isToken } from "../createName";
 import {
   Size,
@@ -20,6 +18,7 @@ import { computeSize, foldFinite } from "../../util";
 import { axisScale } from "../domain";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
 import { coord } from "../coordinateTransforms/coord";
+import { bakeChildren } from "../coordinateTransforms/bake";
 import { createNodeOperatorSequential } from "../withGoFish";
 import { GoFishAST } from "../_ast";
 import {
@@ -27,7 +26,6 @@ import {
   collectPositionDomains,
   gridSpaces,
   gridCellSize,
-  isZOrderConstraint,
   type ConstraintSpec,
   type ZOrderConstraint,
 } from "../constraints";
@@ -450,95 +448,34 @@ export const layer = createNodeOperatorSequential(
             },
           };
         },
-        // IR lowering — mirror of the box/layer render. The box's translate is
-        // composed into a child-local `toPixel` (so children land in the right
-        // pixels); a non-identity scale can't be folded into coordinates, so it
-        // becomes a `group` item wrapping the children. Z-order mirrors render.
+        // IR lowering — mirror of the box/layer render. #39 stage 6d: the box's
+        // subtree is flattened to absolute-transform display objects (seeded at
+        // the box's own baked absolute translate) and each is lowered at that
+        // absolute transform — no per-container `toPixel` closure. z-order is
+        // resolved by the shared bake walk exactly as the root bake does. A
+        // non-identity scale can't fold into coordinates, so it stays a `group`
+        // item wrapping the children.
         lower: ({ transform, coordinateTransform }, _children, node) => {
           const scaleX = options.transform?.scale?.x ?? 1;
           const scaleY = options.transform?.scale?.y ?? 1;
           const [wrapTx, wrapTy] = displayTranslate(transform);
           // A `box` is a coordinate-transform barrier: its children render in
           // linear box-local space (the box positions itself in the parent
-          // coord, but its content does not warp). Mirror INTERNAL_render's
+          // coord, but its content does not warp). Mirror the render's
           // `this.type !== "box" ? coordinateTransform : undefined`.
           const childCoord =
             node.type === "box" ? undefined : coordinateTransform;
 
-          const session = node.getRenderSession();
-          const outer = session.toPixel!;
-          // Translate-only composition (scale handled by the group below).
-          const composed: ToPixel = ([cx, cy]) =>
-            outer([wrapTx + cx, wrapTy + cy]);
-
-          // Lower the (z-ordered) children under `composed`, restoring `toPixel`
-          // afterward. A per-child accTranslate (z-constraint flatten) is folded
-          // into the mapping for that child.
-          const lowerChildren = (): DisplayList.DisplayItem[] => {
-            const zConstraints = (node.constraints ?? []).filter(
-              isZOrderConstraint
-            );
-            const items: DisplayList.DisplayItem[] = [];
-            const withToPixel = (
-              fn: ToPixel,
-              run: () => DisplayList.DisplayItem[]
-            ) => {
-              session.toPixel = fn;
-              try {
-                return run();
-              } finally {
-                session.toPixel = composed;
-              }
-            };
-
-            if (zConstraints.length === 0) {
-              const ordered = node.children
-                .map((child, index) => ({
-                  child,
-                  index,
-                  zOrder: child instanceof GoFishNode ? child.getZOrder() : 0,
-                }))
-                .sort((a, b) => a.zOrder - b.zOrder || a.index - b.index);
-              session.toPixel = composed;
-              try {
-                for (const { child } of ordered)
-                  items.push(...child.INTERNAL_lower(childCoord));
-              } finally {
-                session.toPixel = outer;
-              }
-              return items;
-            }
-
-            const flat = flattenForZOrder(node.children);
-            const sorted = topoSortByZOrder(flat, zConstraints, {
-              node: (it) => it.node,
-              z: (it) => it.defaultZ,
-              order: (it) => it.defaultOrder,
-            });
-            try {
-              for (const item of sorted) {
-                const [ax, ay] = item.accTranslate;
-                const map: ToPixel =
-                  ax === 0 && ay === 0
-                    ? composed
-                    : ([cx, cy]) => composed([cx + ax, cy + ay]);
-                items.push(
-                  ...withToPixel(map, () =>
-                    item.node.INTERNAL_lower(childCoord)
-                  )
-                );
-              }
-            } finally {
-              session.toPixel = outer;
-            }
-            return items;
-          };
-
-          const childItems = lowerChildren();
+          // Seed the subtree bake at the box's absolute translate only — scale
+          // is applied by the group below, not folded into coordinates.
+          const childItems = bakeChildren(node, [wrapTx, wrapTy]).flatMap((d) =>
+            d.node.INTERNAL_lower(childCoord, d.transform)
+          );
 
           if (scaleX === 1 && scaleY === 1) return childItems;
 
           // Scale about the box's pixel origin: p ↦ origin + s·(p − origin).
+          const outer = node.getRenderSession().toPixel!;
           const [ox, oy] = outer([wrapTx, wrapTy]);
           return [
             {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
@@ -1,7 +1,7 @@
 import { computeAesthetic } from "../../util";
 import { posFn } from "../domain";
 import { GoFishNode } from "../_node";
-import { Size, translateString } from "../dims";
+import { Size } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import {
   anchorAt,

--- a/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
@@ -12,13 +12,7 @@ import type { HierarchyNode, HierarchyRectangularNode } from "d3-hierarchy";
 import { GoFishNode, Placeable } from "../_node";
 import { GoFishAST } from "../_ast";
 import { createNodeOperator } from "../withGoFish";
-import {
-  FancyDims,
-  Size,
-  Direction,
-  elaborateDims,
-  translateString,
-} from "../dims";
+import { FancyDims, Size, Direction, elaborateDims } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import { computeAesthetic, computeSize } from "../../util";
 import { posFn, pxOf } from "../domain";

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,6 +11,7 @@
     "capture-one": "tsx scripts/capture-one.ts",
     "capture-gallery": "tsx scripts/capture-gallery-thumbnails.ts",
     "capture-diff": "tsx scripts/capture-diff.ts",
+    "capture-pixels": "tsx scripts/capture-pixels.ts",
     "capture-sweep": "tsx scripts/capture-sweep.ts",
     "update-baselines": "tsx scripts/update-baselines.ts",
     "check-sync": "tsx scripts/check-python-sync.ts",

--- a/tests/scripts/capture-pixels.ts
+++ b/tests/scripts/capture-pixels.ts
@@ -1,0 +1,221 @@
+/**
+ * capture-pixels.ts
+ *
+ * PIXEL-exact regression gate for #39 stage 6d (translate retirement).
+ *
+ * Unlike `capture-diff.ts` (normalized-DOM geometry diff, platform-stable), this
+ * renders each story to a PNG at HEAD and at <base-ref> — BOTH in the SAME local
+ * Playwright/Chromium — and compares them pixel-for-pixel with pixelmatch at
+ * threshold 0. Because both refs rasterize on the identical browser/platform,
+ * text antialiasing is bit-identical, so a correct behavior-preserving refactor
+ * must yield ZERO differing pixels for every story. Any story with diffs is a
+ * real regression to investigate (do not paper over with tolerance).
+ *
+ * This is the 6d gate specifically: collapsing the per-container translate
+ * closures reshuffles the DOM (see capture-diff) but must not move a single
+ * pixel — a DOM diff there is benign, a pixel diff here is not.
+ *
+ * Usage:
+ *   tsx scripts/capture-pixels.ts <base-ref> [filter]
+ *
+ *   tsx scripts/capture-pixels.ts HEAD           # whole suite vs HEAD (pre-edit self-check)
+ *   tsx scripts/capture-pixels.ts 70d281b4       # vs the 6c tip
+ *   tsx scripts/capture-pixels.ts 70d281b4 bar   # only stories matching "bar"
+ *
+ * Output:
+ *   tests/tmp/capture-pixels/head/<path>.png   PNG at HEAD (edited worktree)
+ *   tests/tmp/capture-pixels/base/<path>.png   PNG at <base-ref>
+ *   tests/tmp/capture-pixels/diff/<path>.png   pixelmatch diff (only for stories that moved)
+ *
+ * Exit code 0 = every story pixel-identical, 1 = at least one story moved (or a
+ * render failed / a story exists in only one ref).
+ */
+
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync, rmSync, mkdirSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { PNG } from "pngjs";
+import pixelmatch from "pixelmatch";
+import { captureStories } from "./capture-core.js";
+import { git, removeWorktree } from "./snapshot-branch.js";
+
+const TESTS_DIR = join(import.meta.dirname, "..");
+const HARNESS_DIR = join(TESTS_DIR, "harness");
+const OUT_DIR = join(TESTS_DIR, "tmp/capture-pixels");
+const HEAD_DIR = join(OUT_DIR, "head");
+const BASE_DIR = join(OUT_DIR, "base");
+const DIFF_DIR = join(OUT_DIR, "diff");
+
+const HEAD_PORT = 3005;
+const BASE_PORT = 3006;
+
+/** Compare two PNGs at threshold 0. Returns differing-pixel count and (when > 0)
+ *  the diff image. Mismatched dimensions are themselves a hard difference. */
+function comparePng(
+  basePath: string,
+  headPath: string
+): { numDiff: number; total: number; diff?: Buffer; note?: string } {
+  const base = PNG.sync.read(readFileSync(basePath));
+  const head = PNG.sync.read(readFileSync(headPath));
+  if (base.width !== head.width || base.height !== head.height) {
+    return {
+      numDiff: base.width * base.height,
+      total: base.width * base.height,
+      note: `dimensions differ: base ${base.width}x${base.height} vs head ${head.width}x${head.height}`,
+    };
+  }
+  const { width, height } = base;
+  const diff = new PNG({ width, height });
+  const numDiff = pixelmatch(base.data, head.data, diff.data, width, height, {
+    threshold: 0,
+  });
+  return {
+    numDiff,
+    total: width * height,
+    diff: numDiff > 0 ? PNG.sync.write(diff) : undefined,
+  };
+}
+
+async function main() {
+  const baseRef = process.argv[2];
+  const filter = process.argv[3];
+
+  if (!baseRef) {
+    console.error(
+      "Usage: tsx scripts/capture-pixels.ts <base-ref> [filter]\n" +
+        "  e.g. tsx scripts/capture-pixels.ts 70d281b4\n" +
+        "       tsx scripts/capture-pixels.ts HEAD bar"
+    );
+    process.exit(2);
+  }
+
+  const baseSha = git(`git rev-parse "${baseRef}"`, { ignoreError: true });
+  if (!baseSha) {
+    console.error(`Cannot resolve base ref "${baseRef}".`);
+    process.exit(2);
+  }
+  const baseShort = baseSha.slice(0, 9);
+
+  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  // 1. HEAD (current, possibly-edited worktree) → PNGs.
+  console.log(`=== Capturing HEAD (current worktree) → PNG ===\n`);
+  const headResult = await captureStories({
+    harnessDir: HARNESS_DIR,
+    port: HEAD_PORT,
+    outDir: HEAD_DIR,
+    filter,
+    screenshot: true,
+  });
+
+  // 2. <base-ref> from a throwaway worktree → PNGs (same process/browser).
+  const wtPath = join("/tmp", `gofish-capture-pixels-${process.pid}`);
+  removeWorktree(wtPath);
+  let baseResult;
+  try {
+    console.log(
+      `\n=== Checking out ${baseRef} (${baseShort}) into a temp worktree ===`
+    );
+    git(`git worktree add --detach "${wtPath}" ${baseSha}`);
+    console.log(`Installing dependencies in the temp worktree...`);
+    execSync("pnpm install --ignore-scripts", {
+      cwd: wtPath,
+      stdio: "inherit",
+    });
+
+    console.log(`\n=== Capturing ${baseRef} (${baseShort}) → PNG ===\n`);
+    baseResult = await captureStories({
+      harnessDir: join(wtPath, "tests/harness"),
+      port: BASE_PORT,
+      outDir: BASE_DIR,
+      filter,
+      screenshot: true,
+    });
+  } finally {
+    removeWorktree(wtPath);
+  }
+
+  // 3. Pixel-compare per story.
+  const headSet = new Set(
+    headResult.captured.map((p) => p.replace(/\.html$/, ""))
+  );
+  const baseSet = new Set(
+    baseResult.captured.map((p) => p.replace(/\.html$/, ""))
+  );
+  const all = Array.from(new Set([...headSet, ...baseSet])).sort();
+
+  let compared = 0;
+  const moved: {
+    path: string;
+    numDiff: number;
+    total: number;
+    note?: string;
+  }[] = [];
+  const onlyOne: { path: string; where: string }[] = [];
+
+  for (const path of all) {
+    if (!headSet.has(path)) {
+      onlyOne.push({ path, where: baseRef });
+      continue;
+    }
+    if (!baseSet.has(path)) {
+      onlyOne.push({ path, where: "HEAD" });
+      continue;
+    }
+    const headPng = join(HEAD_DIR, `${path}.png`);
+    const basePng = join(BASE_DIR, `${path}.png`);
+    if (!existsSync(headPng) || !existsSync(basePng)) {
+      onlyOne.push({ path, where: existsSync(headPng) ? "HEAD" : baseRef });
+      continue;
+    }
+    compared++;
+    const { numDiff, total, diff, note } = comparePng(basePng, headPng);
+    if (numDiff > 0) {
+      moved.push({ path, numDiff, total, note });
+      if (diff) {
+        const diffPath = join(DIFF_DIR, `${path}.png`);
+        mkdirSync(dirname(diffPath), { recursive: true });
+        writeFileSync(diffPath, diff);
+      }
+    }
+  }
+
+  // 4. Report.
+  console.log(`\n=== Pixel result: HEAD vs ${baseRef} (${baseShort}) ===\n`);
+  console.log(`  Stories compared: ${compared}`);
+  console.log(`  Stories with differing pixels: ${moved.length}`);
+  if (moved.length) {
+    for (const m of moved)
+      console.log(
+        `    ~ ${m.path}: ${m.numDiff}/${m.total} px differ${m.note ? ` (${m.note})` : ""}`
+      );
+    console.log(`\n  Diff PNGs: ${DIFF_DIR}`);
+  }
+  if (onlyOne.length) {
+    console.log(`\n  ${onlyOne.length} story(ies) present in only one ref:`);
+    for (const o of onlyOne)
+      console.log(`    ! ${o.path} (only in ${o.where})`);
+  }
+  const renderFailures = [
+    ...headResult.failed.map((f) => ({ ...f, ref: "HEAD" })),
+    ...baseResult.failed.map((f) => ({ ...f, ref: baseRef })),
+  ];
+  if (renderFailures.length) {
+    console.log(`\n  ${renderFailures.length} render failure(s):`);
+    for (const f of renderFailures)
+      console.log(`    ! [${f.ref}] ${f.path}: ${f.error}`);
+  }
+
+  const clean =
+    moved.length === 0 && onlyOne.length === 0 && renderFailures.length === 0;
+  console.log(
+    `\n  ${clean ? "CLEAN — zero pixels moved." : "PIXELS MOVED / failures — investigate."}`
+  );
+  process.exit(clean ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(2);
+});


### PR DESCRIPTION
Advances #39 (stage 3-D's render half). Stacked on #658. Stage 6d of `internals/design/sigma-affine-simplification.md`.

Boundary `lower` bodies — layer/box/frame, and offset/enclose via `lowerHelpers` — now consume baked absolute coordinates through a shared `bakeChildren` (factored from the root bake) instead of composing per-container translate closures into `toPixel`. That deletes the duplicated in-lower z-order machinery (~95 → 40 lines in layer's lower, including the `withToPixel` swap dance) and the dead `translateString` chokepoint plus four dead imports. The documented exceptions stay: a non-identity scale keeps its `group` wrapper, `coord`'s `contentToPixel` is a genuine space remap, and `connect`/`arrow` are self-drawers.

Two findings worth recording:

- **No `transform.translate` write could be retired** — none is render-only. Render already reads the ledger projection; the surviving raw writes feed the fallback that refs and constraints consume, and the layout-side `undefined` sentinel is untouched. The "retire the writes" half of stage 3-D was, it turns out, already complete.
- **Zero DOM churn**, contrary to the plan's expectation of benign reshuffles — the `<g translate>` collapse was already spent by the earlier display-list migration, so 6d is a pure internal refactor of coordinate computation.

New tooling: `capture-pixels` — renders every story to PNG at HEAD and at a base ref (throwaway worktree, same local Chromium) and compares via pixelmatch at **threshold 0**.

## Verification

- `capture-pixels`: **260/260 stories, zero differing pixels** at threshold 0.
- `pnpm capture-diff main`: no layout changes, 260 identical (vs the pre-stage-0 baseline).
- `capture-sweep` 260/260 clean (nothing leaked into layout); full suite, typecheck, `check-backlinks`, `docs:build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)