### PR TITLE
σ-affine simplification, stage 6e: grid as track equations — one sizing rule

### DIFF
--- a/apps/docs/docs/internals/core/monotonic.md
+++ b/apps/docs/docs/internals/core/monotonic.md
@@ -125,6 +125,15 @@ Because the structure is preserved, a composed claim can be **printed as the equ
 represents** — `print` renders `40σ + 16`, or `max(160σ + 16, 90)` for an envelope —
 matching the forms in the [layout synthesis essay](/internals/design/layout-synthesis).
 
+`approxEqual(a, b, tol)` decides whether two claims are the same function. Two points pin a
+line, so the all-linear common case is exact from probes at σ = 0 and 1. A `max`-composed
+`Piecewise` needs more — two envelopes can agree at 0 and 1 yet differ on a middle segment
+— so when both operands are PWL it compares at 0, 1, and **every pairwise breakpoint** of
+the two envelopes' pieces (the only σ where a convex PWL can change slope); an `Unknown`
+operand falls back to a spread of sample points. This is what the `BBox` ledger uses to
+detect an over-determined key now that `table`'s content-sized tracks push piecewise claims
+into cells.
+
 ## Slope as a data-driven signal
 
 Because a `Linear` exposes its slope, the engine gets a cheap, exact predicate for

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -425,8 +425,8 @@ constraint overrides: union child spaces, apply `transform.scale` to free
 magnitudes, and merge datum-valued position/span domains with constraint
 measures taking precedence.
 `childLayoutSizeProposal` is the final per-child proposal priority before nest:
-grid cell size, else distribute slice for that named child, else the full layer
-box.
+the cell's own track extent (grid), else distribute slice for that named child,
+else the full layer box.
 `buildLayerConstraintLayoutPlan` packages the per-layer execution plan — which
 children skip baseline placement, nest source-before-derived order, and
 datum-position target axes — so the layer executes deterministic artifacts
@@ -439,17 +439,37 @@ out first. The bottom-up space pass applies only the inside-out portion via
 `applyNestSpacePlan`; once the source has concrete dimensions,
 `applyNestLayoutProposal` does the corresponding layout-time arithmetic on the
 derived axes.
-Grid is also selected through the proposal plan (`selectGridConstraint`):
-because a grid owns both track partitions for a layer — and bypasses the
-space/size fold entirely — it is a whole-layer layout mode, not a composable
-constraint. `selectGridConstraint` therefore enforces two exclusivity rules
-(it is the one site both the space pass and the layout pass flow through): more
-than one grid constraint is a proposal conflict rather than a declaration-order
-choice, and a grid mixed with any non-z-order constraint (align / distribute /
-position / nest) throws — that sibling would be applied by placement but never
-enter the space fold, so it would silently half-apply. z-order constraints
-(zAbove / zBelow) are render-time paint order and compose freely alongside a
-grid. Grid has no public factory; it is `table`'s private elaboration target.
+Grid is a **track equation** under the same unified sizing rule, not a separate
+layout regime (Stage 6e). Per axis, `resolveGridTracks` sets
+
+```
+track claim = Monotonic.max(claims of the cells in that track)      (max, +)
+grid claim  = Monotonic.add(track claims) + gaps                    (the σ-frame)
+```
+
+A claim-less ("fill") cell contributes nothing, so an all-fill grid has no track
+claims and the tracks split the leftover (allocated − gaps) equally — bit-for-bit
+the former `sliceExtent` box-division. Content-sized tracks emerge automatically
+when cells carry size claims: a track sizes to its widest cell, and fill tracks
+share whatever the claimed tracks leave. When every track carries a σ-dependent
+claim (no fill to absorb the slack), the grid claim is inverted against the
+allocated size by the same scope registry that solves any other frame equation.
+Because a categorical track axis cannot simultaneously be a SIZE magnitude, the
+grid's _reported_ space stays ORDINAL over the columns/rows (`gridSpaces`, for
+axis rendering) while the size claim is consumed at layout time by the track
+resolution. The layout budget sizes fill cells to their track extent; the
+authoritative **placement tracks** are recomputed from the actual laid-out cell
+sizes (`gridTracksFromSizes`) so each cell pins to the real geometry — one source
+the placement and the solver shadow both read, so they cannot drift.
+
+The grid now **genuinely composes** with sibling constraints: its per-track claim
+participates in the fold and its cell-center pins solve jointly with any align /
+position / z-order on the same layer (a `position` pin on a cell overrides its
+track centering — the authoritative-pin pattern). The Stage-3 containment throw
+is gone. `selectGridConstraint` keeps the one remaining rule: at most one grid
+per layer (two track partitions would be source-order-sensitive) is still a
+proposal conflict. Grid has no public factory; it is `table`'s private
+elaboration target.
 The same proposal plan marks datum-valued `position` targets
 (`buildPositionTargetDims`) so the layer does not also forward the consumed
 data→pixel scale to that child axis; literal pixel pins are not marked because

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -348,12 +348,16 @@ remaining divergences became what they really are:
 
 - **Nicing asymmetry (case 1) resolves to two scopes (case 3).** The corpus
   (`GOFISH_DUMP_SCOPES` + the 6b shadow) shows the only anchored-vs-size
-  disagreement is a marginal panel whose ticks map the _niced_ axis domain
-  (`[0,44]→[0,80]`, σ=1.818, the POSITION scope) while its bars size the
-  _un-niced_ stacked total (`45σ=80`, σ=1.778, the SIZE scope). These are two
-  distinct scopes on one axis, each read by its own channel (ticks read the map,
-  bars read σ) — exactly the sub-budget-vs-inherited shape, so case 1 needs no
-  separate machinery.
+  disagreement is a marginal panel whose count axis is a **self-scaled region**:
+  it carries an explicit pixel size, so it stashes its own space and builds a
+  LOCAL scale against its own box (`buildChildScalePlan` step 2). That stashed
+  space **escapes the nicing** applied to the shared/outer axis domain (#659), so
+  the panel's own count scale (`45σ=80`, σ=1.778, the SIZE scope) and the shared
+  niced map read by the ticks (`[0,44]→[0,80]`, σ=1.818, the POSITION scope) are
+  two distinct scopes, each consumed by its own channel — exactly the
+  self-scaled-vs-inherited shape, so case 1 needs no separate machinery. (It is
+  NOT one axis whose ticks are niced and whose bars are un-niced; it is the
+  self-scaled stash sidestepping nicing entirely.)
 - **Spacing / non-data pixels (case 2)** are already the Monotonic intercept in
   the frame equation (`width.inverse(allocated)`), so the per-segment slope is the
   scope σ, not a secant. No change needed.
@@ -449,16 +453,47 @@ on one axis is the sanctioned multi-scale reading.
   spent by the earlier `_render`→display-list migration, so 6d is pixel- AND
   DOM-neutral.
 
-- **6e — grid as tracks.** A grid scope introduces `numCols + numRows` track
-  cells; each cell(i, j) gets equations `cell.min = track.min` and
-  `cell.size = track.size` per axis. Equal-flex is "all track sizes equal +
-  Σ tracks + gaps = W" (today's `sliceExtent`, as equations); content-sized
-  tracks are `track.size ≥ max(cell claims)` — note `max` leaves the linear
-  fragment (piecewise claims; see the `monoEqual` two-point-probe caveat in
-  `bbox.ts`), so this lands as an iterate-or-piecewise extension, and is the
-  point where `table` gains content-sized tracks. The Stage-3 layer bypasses
-  (space-fold early return, cell-budget special case, mixing throw) delete;
-  `gridSpaces`' ORDINAL axes contribution stays but composes.
+- **6e — grid as tracks. Landed.** A grid resolves its tracks under the ONE
+  unified sizing rule — the same (max, +) fold every other operator uses:
+
+  ```
+  track claim = Monotonic.max(claims of the cells in that track)
+  grid claim  = Monotonic.add(track claims) + gaps          (the σ-frame LHS)
+  ```
+
+  A claim-less (fill) cell contributes nothing, so an all-fill grid has no track
+  claims and the leftover (allocated − gaps) splits equally — bit-identical to
+  the former `sliceExtent` box-division. Content-sized tracks emerge
+  automatically when cells carry claims (a track sizes to its widest cell; fill
+  tracks share the remainder). `max` and `add` are BOTH closed over the convex
+  piecewise-linear (max, +) algebra — the composed claim stays a `Monotonic`, so
+  when every track is claimed with a σ-dependent claim the grid claim inverts
+  against the allocated size through the scope registry exactly like any other
+  frame equation (the common all-constant, fixed-px case is σ-independent and
+  reads back its intercept). Because piecewise claims now flow into cells, the
+  `monoEqual` two-point probe in `bbox.ts` was upgraded to `Monotonic.approxEqual`
+  — structural (compare at 0, 1, and every pairwise breakpoint) for piecewise
+  operands, the same cheap two-point line probe for the all-linear common case.
+
+  **Design choice — pre-resolution, not tracks-in-the-graph.** Tracks are
+  resolved by `resolveGridTracks` (the sizing budget for fill cells) and, for
+  placement, by `gridTracksFromSizes` from the ACTUAL laid-out cell sizes, so the
+  cell-center pins match the real geometry and the solver shadow cannot drift
+  from what rendered. This reuses the rank-2 placement solver as-is (cells pin to
+  their track-intersection centers) — the equations are identical to naming each
+  track a cell in the difference graph, but lighter. The Stage-3 layer bypasses
+  are deleted (space-fold early return, the whole-layer cell-budget special case,
+  the mixing throw); grid now GENUINELY composes — its per-track claim
+  participates in the fold and its cell pins solve jointly with align / position
+  / z-order (a `position` pin on a cell overrides its track centering, the
+  authoritative-pin pattern). `gridSpaces`' ORDINAL track axes stay for axis
+  rendering (a categorical axis can't also be a SIZE magnitude), composing
+  through the same return path rather than an early exit. The at-most-one-grid
+  rule and `__grid_cell_i` naming stay. **Gate:** all-fill tables pixel-identical
+  (heatmaps unchanged); one intended mover — the Titanic facet unit grid, whose
+  cells carry intrinsic waffle-size claims, now content-sizes its tracks (facets
+  pack to content instead of stretching to equal box-division).
+
 - **6f — determinacy from rank.** The Stage-1 `spacePlacement` view retires:
   free/determined/conflict is read off the scope system's baseline-subsystem
   rank/consistency. Space resolution keeps only data facts
@@ -477,8 +512,13 @@ on one axis is the sanctioned multi-scale reading.
   scope registry is keyed that way from the start.
 - **Where scope state lives:** on the render session (like `toPixel`) vs a
   map keyed by scope-root uid; must survive resume/re-layout.
-- **Piecewise claims:** `max`-composition (6e) and any future clamp break the
-  two-point `monoEqual` probe; decide the claim representation before 6e.
+- **Piecewise claims (resolved in 6e):** `max`-composition keeps claims in the
+  convex piecewise-linear (max, +) algebra (both `max` and `add` are closed over
+  it), so the representation is unchanged — the only fix needed was the equality
+  probe: `monoEqual` now delegates to `Monotonic.approxEqual`, which compares
+  piecewise operands structurally (at 0, 1, and every breakpoint) and keeps the
+  cheap two-point line probe for the all-linear case. A future non-monotone clamp
+  would still need more.
 
 ### Debuggability requirement
 

--- a/apps/docs/docs/js/api/operators/table.md
+++ b/apps/docs/docs/js/api/operators/table.md
@@ -64,3 +64,14 @@ chart(data, { color: gradient(["#ffffcc", "#fd8d3c", "#bd0026"]), axes: true })
 - Data insertion order determines column and row ordering. Sort your data first if you need a specific order.
 - Unlike nested `spread` calls, `table` correctly exposes ordinal axes on both dimensions so axis labels render on both x and y.
 - Pair with `gradient()` on the chart color option and `fill: "fieldName"` on the mark for heatmap coloring.
+
+### Cell sizing
+
+Tracks size by one rule: a column (or row) is as wide (or tall) as its widest
+(or tallest) cell — `track = max(cell size claims)`. Cells that carry no size
+claim ("fill" cells, like a plain `rect({ fill })` in a heatmap) contribute
+nothing, so an **all-fill table divides its box into equal tracks** exactly as
+before — heatmaps are unchanged. When cells DO carry a size claim (for example a
+nested chart whose own content has an intrinsic size), each track sizes to its
+widest cell and the table shrinks to fit its content, rather than stretching
+every cell to an equal share of the box.

--- a/apps/docs/docs/python/api/operators/table.md
+++ b/apps/docs/docs/python/api/operators/table.md
@@ -68,3 +68,14 @@ chart(data).flow(table(by={"x": "col", "y": "row"}, spacing=(2, 8)))
   ordinal axes on **both** dimensions, so axis labels render on x and y.
 - Pair `gradient()` on the chart `color` option with `fill="fieldName"` on the
   mark for heatmap coloring.
+
+### Cell sizing
+
+Tracks size by one rule: a column (or row) is as wide (or tall) as its widest
+(or tallest) cell — `track = max(cell size claims)`. Cells that carry no size
+claim ("fill" cells, like a plain `rect(fill=...)` in a heatmap) contribute
+nothing, so an **all-fill table divides its box into equal tracks** exactly as
+before — heatmaps are unchanged. When cells DO carry a size claim (for example a
+nested chart with intrinsic content size), each track sizes to its widest cell
+and the table shrinks to fit its content instead of stretching every cell to an
+equal share of the box.

--- a/packages/gofish-graphics/src/ast/constraints/bbox.ts
+++ b/packages/gofish-graphics/src/ast/constraints/bbox.ts
@@ -59,17 +59,14 @@ const COEFFS: Record<BBoxKey, [number, number]> = {
 const asMono = (v: BBoxValue): Monotonic.Monotonic =>
   typeof v === "number" ? Monotonic.linear(0, v) : v;
 
-/** Equality of two σ-affine claims, by probing at two distinct σ (two points
- *  pin a line). v1 limitation: exact only for linear claims; a piecewise claim
- *  agreeing at 0 and 1 but differing on another segment would read as equal —
- *  acceptable until a size-setting constraint produces a piecewise key. */
+/** Equality of two σ-affine claims. Linear claims are pinned exactly by two
+ *  probes; piecewise claims (Stage 6e's `max`-composed track claims) are
+ *  compared structurally at every breakpoint. See `Monotonic.approxEqual`. */
 const monoEqual = (
   a: Monotonic.Monotonic,
   b: Monotonic.Monotonic,
   tolerance: number
-): boolean =>
-  Math.abs(a.run(0) - b.run(0)) <= tolerance &&
-  Math.abs(a.run(1) - b.run(1)) <= tolerance;
+): boolean => Monotonic.approxEqual(a, b, tolerance);
 
 export interface BBoxConflict {
   key: BBoxKey;

--- a/packages/gofish-graphics/src/ast/constraints/grid.ts
+++ b/packages/gofish-graphics/src/ast/constraints/grid.ts
@@ -6,31 +6,49 @@
 //
 // A grid is the symmetric 2-D layout: cells partitioned into `numCols` columns
 // (a track per column on x) and the implied rows (a track per row on y), every
-// cell filling its (column, row) track intersection. It's the elaboration
+// cell pinned to its (column, row) track intersection. It's the elaboration
 // target for `table` — `layer(cells).constrain(grid(...))`.
 //
-// The per-axis size equation is the flex-track form from layout-synthesis.md:
+// **The unified sizing rule (Stage 6e).** Per axis, a track's extent is set by
+// ONE rule — the (max, +) fold every other operator already uses:
 //
-//   W = numCols · cellW + sx·(numCols−1)        →  cellW = (W − sx·(numCols−1)) / numCols
-//   H = numRows · cellH + sy·(numRows−1)        →  cellH = (H − sy·(numRows−1)) / numRows
+//   track claim   = Monotonic.max(claims of the cells in that track)
+//   grid claim    = Monotonic.add(track claims) + gaps          (the σ-frame LHS)
 //
-// For a uniform grid every track is one flex unit, so solving the equation is
-// the box-division `cellExtent` below — the table is the flex scope root (it
-// solves its tracks against its own box; nothing bubbles). The general
-// Σ-over-max-of-cells (content-sized tracks, variable flex) is a later
-// generalization; v1 is equal tracks with the cells filling them.
+// A claim-less ("fill") cell contributes nothing to its track. This subsumes
+// today's equal-flex box-division: an all-fill grid has no track claims, so the
+// leftover (allocated − gaps) splits equally among the tracks — bit-identical to
+// the former `sliceExtent`. Content-sized tracks emerge automatically when cells
+// carry size claims (a track sizes to its widest cell). Fill tracks share
+// whatever the claimed tracks leave over, equally.
+//
+// `resolveGridTracks` is the single site that runs this rule; both the layout
+// budget (each cell is proposed its track's extent) and the placement (each cell
+// pinned to its track-intersection center) read the SAME resolved tracks, so the
+// two cannot drift. When every track carries a σ-dependent claim (no fill to
+// absorb slack) the grid claim is inverted against the allocated size by the
+// scope registry, exactly like any other frame equation; the common all-constant
+// case (fixed-px cells) is σ-independent and reads back its intercept.
 //
 // The grid is interpreted by the Layer after `selectGridConstraint` has
-// established that there is at most one grid owner for the layer: `gridSpaces`
-// gives the ORDINAL axes (categorical columns/rows, for axis rendering), the
-// Layer's budget sizes each cell to `cellExtent`, and `placementSolver.ts`
-// centers each cell in its track.
+// established that there is at most one grid owner for the layer. `gridSpaces`
+// gives the categorical track axes (ORDINAL over columns/rows) for axis
+// rendering — a categorical axis cannot simultaneously be a SIZE magnitude, so
+// the grid's size claim is consumed at layout time (track resolution) rather than
+// reported as the axis space.
 
+import * as Monotonic from "../../util/monotonic";
 import { GoFishNode } from "../_node";
 import type { GoFishAST } from "../_ast";
 import { type ConstraintRef } from "./shared";
 import { sliceExtent } from "./folds";
-import { ORDINAL, UNDEFINED, type UnderlyingSpace } from "../underlyingSpace";
+import {
+  ORDINAL,
+  UNDEFINED,
+  isBaselineMagnitude,
+  type UnderlyingSpace,
+} from "../underlyingSpace";
+import type { ScopeRegistry } from "../solver/scopes";
 import type { PlacementFactEmitter } from "./placementFacts";
 
 export interface GridOptions {
@@ -74,58 +92,273 @@ export const isGridConstraint = (c: { type: string }): c is GridConstraint =>
 const numRowsOf = (c: GridConstraint): number =>
   Math.ceil(c.children.length / c.numCols);
 
-/** Per-cell proposed size `[cellW, cellH]` for a grid laid into `size` — each
- *  axis split into equal flex tracks via the shared `sliceExtent` (folds.ts). */
-export const gridCellSize = (
+/** The resolved geometry of one axis's tracks: each track's start (low edge, in
+ *  the layer's local pixel frame) and extent. `starts[i] + extents[i]/2` is the
+ *  center a cell in track `i` pins to. */
+export type TrackLayout = { starts: number[]; extents: number[] };
+
+/** A cell's size claim on `axis`: the SIZE-magnitude width Monotonic it reports,
+ *  or undefined when the cell fills (no size claim — a plain `rect({fill})`, a
+ *  literal-pixel cell, or an ORDINAL/POSITION axis). */
+const cellClaim = (
+  cell: GoFishAST | undefined,
+  axis: 0 | 1
+): Monotonic.Monotonic | undefined => {
+  if (!(cell instanceof GoFishNode)) return undefined;
+  const sp = cell._underlyingSpace?.[axis];
+  return sp !== undefined && isBaselineMagnitude(sp) ? sp.width : undefined;
+};
+
+/** Per-axis track claims: for each track (a column on x, a row on y), the max
+ *  over its cells' claims — the (max, +) rule. A track with no claiming cell is
+ *  `undefined` (a fill track). */
+export function gridTrackClaims(
   c: GridConstraint,
-  size: readonly [number, number]
-): [number, number] => [
-  sliceExtent(size[0], c.xSpacing, c.numCols),
-  sliceExtent(size[1], c.ySpacing, numRowsOf(c)),
-];
+  cells: readonly GoFishAST[]
+): [(Monotonic.Monotonic | undefined)[], (Monotonic.Monotonic | undefined)[]] {
+  const numRows = numRowsOf(c);
+  const colClaims = Array.from({ length: c.numCols }, (_, col) => {
+    const claims: Monotonic.Monotonic[] = [];
+    for (let row = 0; row < numRows; row++) {
+      const claim = cellClaim(cells[row * c.numCols + col], 0);
+      if (claim !== undefined) claims.push(claim);
+    }
+    return claims.length > 0 ? Monotonic.max(...claims) : undefined;
+  });
+  const rowClaims = Array.from({ length: numRows }, (_, row) => {
+    const claims: Monotonic.Monotonic[] = [];
+    for (let col = 0; col < c.numCols; col++) {
+      const claim = cellClaim(cells[row * c.numCols + col], 1);
+      if (claim !== undefined) claims.push(claim);
+    }
+    return claims.length > 0 ? Monotonic.max(...claims) : undefined;
+  });
+  return [colClaims, rowClaims];
+}
+
+/** Solve one axis of tracks against `allocated` pixels under the unified rule.
+ *
+ *  - No claims (all fill): the leftover after gaps splits equally — today's
+ *    `sliceExtent`, bit-identical.
+ *  - Some claims: each claimed track takes its claim (evaluated at the solved σ,
+ *    or its constant intercept when σ-independent); the remaining fill tracks
+ *    share whatever is left, equally. When EVERY track is claimed and a claim is
+ *    σ-dependent, σ is solved by inverting `Σ claims + gaps = allocated` through
+ *    the scope registry (the same frame equation as any other size scope). */
+function resolveAxisTracks(
+  claims: (Monotonic.Monotonic | undefined)[],
+  allocated: number,
+  spacing: number,
+  scopes?: ScopeRegistry,
+  meta?: { rootKey: string; axis: 0 | 1 }
+): TrackLayout {
+  const n = claims.length;
+  const gaps = spacing * Math.max(0, n - 1);
+  const nFill = claims.filter((c) => c === undefined).length;
+
+  let extents: number[];
+  if (nFill === n) {
+    const e = sliceExtent(allocated, spacing, n);
+    extents = claims.map(() => e);
+  } else {
+    // Solve σ only when every track is claimed (no fill absorbs the slack) and a
+    // claim is genuinely σ-dependent; otherwise claims are constants and σ is
+    // irrelevant (read back the intercept at σ=0).
+    let sigma = 0;
+    if (nFill === 0 && scopes !== undefined && meta !== undefined) {
+      const claimed = claims.filter(
+        (c): c is Monotonic.Monotonic => c !== undefined
+      );
+      const gridClaim = Monotonic.adds(Monotonic.add(...claimed), gaps);
+      if (!Monotonic.isConstant(gridClaim)) {
+        sigma =
+          scopes.solveSize(
+            { kind: "grid", rootKey: meta.rootKey, axis: meta.axis },
+            gridClaim,
+            allocated,
+            { upperBoundGuess: allocated }
+          ) ?? 0;
+      }
+    }
+    const claimedExtents = claims.map((c) =>
+      c === undefined ? undefined : Math.max(0, c.run(sigma))
+    );
+    const claimedTotal =
+      claimedExtents.reduce((s: number, e) => s + (e ?? 0), 0) + gaps;
+    const fillShare =
+      nFill > 0 ? Math.max(0, (allocated - claimedTotal) / nFill) : 0;
+    extents = claims.map((c, i) =>
+      c === undefined ? fillShare : claimedExtents[i]!
+    );
+  }
+
+  const starts: number[] = [];
+  let cursor = 0;
+  for (let i = 0; i < n; i++) {
+    starts.push(cursor);
+    cursor += extents[i] + spacing;
+  }
+  return { starts, extents };
+}
+
+/** Resolve both axes' tracks for a grid laid into `size`, under the unified
+ *  (max, +) sizing rule. The one site the rule runs; the layout budget and the
+ *  placement both read the result, so cell proposals and cell centers agree by
+ *  construction. */
+export function resolveGridTracks(
+  c: GridConstraint,
+  cells: readonly GoFishAST[],
+  size: readonly [number, number],
+  scopes?: ScopeRegistry,
+  rootKey = "grid"
+): [TrackLayout, TrackLayout] {
+  const [colClaims, rowClaims] = gridTrackClaims(c, cells);
+  return [
+    resolveAxisTracks(colClaims, size[0], c.xSpacing, scopes, {
+      rootKey,
+      axis: 0,
+    }),
+    resolveAxisTracks(rowClaims, size[1], c.ySpacing, scopes, {
+      rootKey,
+      axis: 1,
+    }),
+  ];
+}
+
+/** Lay out a run of track extents into `{ starts, extents }`: cumulative starts
+ *  with `spacing` reserved between adjacent tracks. */
+function layoutTrack(extents: number[], spacing: number): TrackLayout {
+  const starts: number[] = [];
+  let cursor = 0;
+  for (const e of extents) {
+    starts.push(cursor);
+    cursor += e + spacing;
+  }
+  return { starts, extents };
+}
+
+/** The AUTHORITATIVE placement tracks: each track's extent is the max of its
+ *  cells' ACTUAL laid-out sizes (a filled cell equals the budgeted extent; a
+ *  claim cell equals its content). Computed post-layout so the cell centers pin
+ *  to the real geometry — this is the single source both the placement and the
+ *  solver shadow read, so they cannot drift from what rendered. */
+export function gridTracksFromSizes(
+  c: GridConstraint,
+  cellSizes: (readonly [number, number] | undefined)[]
+): [TrackLayout, TrackLayout] {
+  const numRows = numRowsOf(c);
+  const colExtents = Array.from({ length: c.numCols }, (_, col) => {
+    let m = 0;
+    for (let row = 0; row < numRows; row++)
+      m = Math.max(m, cellSizes[row * c.numCols + col]?.[0] ?? 0);
+    return m;
+  });
+  const rowExtents = Array.from({ length: numRows }, (_, row) => {
+    let m = 0;
+    for (let col = 0; col < c.numCols; col++)
+      m = Math.max(m, cellSizes[row * c.numCols + col]?.[1] ?? 0);
+    return m;
+  });
+  return [
+    layoutTrack(colExtents, c.xSpacing),
+    layoutTrack(rowExtents, c.ySpacing),
+  ];
+}
+
+/** Per-cell proposed size `[cellW, cellH]`, keyed by cell name: each cell is
+ *  proposed its (column, row) track's extent. A fill cell fills that extent; a
+ *  claim cell keeps its own (equal or smaller) size and is centered in it. */
+export function gridCellSizeByName(
+  c: GridConstraint,
+  tracks: [TrackLayout, TrackLayout]
+): Map<string, [number, number]> {
+  const [cols, rows] = tracks;
+  const out = new Map<string, [number, number]>();
+  c.children.forEach((child, index) => {
+    if (child === undefined) return;
+    const col = index % c.numCols;
+    const row = Math.floor(index / c.numCols);
+    out.set(child.name, [cols.extents[col], rows.extents[row]]);
+  });
+  return out;
+}
 
 export type GridCellPlacement = {
   child: ConstraintRef;
   center: [number, number];
 };
 
+/** Cell centers from resolved tracks (Stage 6e) — or, when `tracks` is omitted,
+ *  the equal box-division fallback used by the direct-solver tests. */
 export function gridCellPlacements(
   c: GridConstraint,
-  size: readonly [number, number]
+  size: readonly [number, number],
+  tracks?: [TrackLayout, TrackLayout]
 ): GridCellPlacement[] {
-  const [cellWidth, cellHeight] = gridCellSize(c, size);
+  const [cols, rows] =
+    tracks ??
+    ([
+      {
+        extents: Array.from({ length: c.numCols }, () =>
+          sliceExtent(size[0], c.xSpacing, c.numCols)
+        ),
+        starts: Array.from(
+          { length: c.numCols },
+          (_, j) =>
+            j * (sliceExtent(size[0], c.xSpacing, c.numCols) + c.xSpacing)
+        ),
+      },
+      {
+        extents: Array.from({ length: numRowsOf(c) }, () =>
+          sliceExtent(size[1], c.ySpacing, numRowsOf(c))
+        ),
+        starts: Array.from(
+          { length: numRowsOf(c) },
+          (_, r) =>
+            r * (sliceExtent(size[1], c.ySpacing, numRowsOf(c)) + c.ySpacing)
+        ),
+      },
+    ] as [TrackLayout, TrackLayout]);
   return c.children.map((child, index) => {
     const column = index % c.numCols;
     const row = Math.floor(index / c.numCols);
     return {
       child,
       center: [
-        column * (cellWidth + c.xSpacing) + cellWidth / 2,
-        row * (cellHeight + c.ySpacing) + cellHeight / 2,
+        cols.starts[column] + cols.extents[column] / 2,
+        rows.starts[row] + rows.extents[row] / 2,
       ],
     };
   });
 }
 
+/** Emit the per-cell center pins for a grid. A cell whose center on an axis is
+ *  claimed by a `position` pin is skipped on that axis — the explicit pin
+ *  overrides the track centering (the authoritative-pin pattern). */
 export function lowerGridPlacement(
   c: GridConstraint,
   owner: string,
   size: readonly [number, number],
-  emitter: PlacementFactEmitter
+  emitter: PlacementFactEmitter,
+  tracks?: [TrackLayout, TrackLayout],
+  pinnedByPosition?: Map<string, Set<0 | 1>>
 ): void {
-  for (const { child, center } of gridCellPlacements(c, size)) {
-    emitter.pin({
-      axis: "x",
-      target: { name: child.name, anchor: "middle" },
-      value: center[0],
-      owner,
-    });
-    emitter.pin({
-      axis: "y",
-      target: { name: child.name, anchor: "middle" },
-      value: center[1],
-      owner,
-    });
+  for (const { child, center } of gridCellPlacements(c, size, tracks)) {
+    const overridden = pinnedByPosition?.get(child.name);
+    if (!overridden?.has(0))
+      emitter.pin({
+        axis: "x",
+        target: { name: child.name, anchor: "middle" },
+        value: center[0],
+        owner,
+      });
+    if (!overridden?.has(1))
+      emitter.pin({
+        axis: "y",
+        target: { name: child.name, anchor: "middle" },
+        value: center[1],
+        owner,
+      });
   }
 }
 

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -25,7 +25,7 @@ import type { DistributeConstraint, DistributeOptions } from "./distribute";
 import type { PositionConstraint, PositionOptions } from "./position";
 import type { ZAboveConstraint, ZBelowConstraint } from "./zorder";
 import type { NestConstraint, NestOptions } from "./nest";
-import type { GridConstraint } from "./grid";
+import type { GridConstraint, TrackLayout } from "./grid";
 import {
   isPlacedOn,
   type ConstraintPosScales,
@@ -60,7 +60,14 @@ export type { NestConstraint, NestOptions } from "./nest";
 export type { GridConstraint } from "./grid";
 export { isZOrderConstraint } from "./zorder";
 export { isNestConstraint, nestedSpace } from "./nest";
-export { isGridConstraint, gridSpaces, gridCellSize } from "./grid";
+export {
+  isGridConstraint,
+  gridSpaces,
+  resolveGridTracks,
+  gridCellSizeByName,
+  gridTracksFromSizes,
+  type TrackLayout,
+} from "./grid";
 export { getPositioningConstraintRefs } from "./proposalPlan";
 export { BBox } from "./bbox";
 
@@ -239,7 +246,8 @@ export function applyConstraints(
   constraints: ConstraintSpec[],
   nameToPlaceable: Map<string, Placeable>,
   sizes: [number, number],
-  posScales?: ConstraintPosScales
+  posScales?: ConstraintPosScales,
+  gridTracks?: [TrackLayout, TrackLayout]
 ): void {
   const placement = constraints.filter(
     (
@@ -267,7 +275,13 @@ export function applyConstraints(
       )
     : undefined;
 
-  solvePlacementConstraints(placement, nameToPlaceable, sizes, posScales);
+  solvePlacementConstraints(
+    placement,
+    nameToPlaceable,
+    sizes,
+    posScales,
+    gridTracks
+  );
 
   if (prePlaced) {
     for (const constraint of placement) {

--- a/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
@@ -14,7 +14,7 @@ import type { AlignConstraint } from "./align";
 import { lowerAlignPlacement } from "./align";
 import type { DistributeConstraint } from "./distribute";
 import { lowerDistributePlacement } from "./distribute";
-import type { GridConstraint } from "./grid";
+import type { GridConstraint, TrackLayout } from "./grid";
 import { lowerGridPlacement } from "./grid";
 import type { NestConstraint } from "./nest";
 import { lowerNestPlacement } from "./nest";
@@ -154,8 +154,23 @@ export function lowerPlacementConstraints(
   constraints: PlacementConstraint[],
   targets: Map<string, Placeable>,
   sizes: [number, number],
-  posScales?: ConstraintPosScales
+  posScales?: ConstraintPosScales,
+  gridTracks?: [TrackLayout, TrackLayout]
 ): LoweredPlacement {
+  // A `position` pin on a grid cell overrides that cell's track centering on the
+  // pinned axis (the authoritative-pin pattern) — collect which (cell, axis) a
+  // position constraint owns so the grid skips its center pin there.
+  const pinnedByPosition = new Map<string, Set<0 | 1>>();
+  for (const constraint of constraints) {
+    if (constraint.type !== "position") continue;
+    for (const ref of constraint.children) {
+      if (!ref) continue;
+      const axes = pinnedByPosition.get(ref.name) ?? new Set<0 | 1>();
+      if (constraint.x !== undefined) axes.add(0);
+      if (constraint.y !== undefined) axes.add(1);
+      if (axes.size > 0) pinnedByPosition.set(ref.name, axes);
+    }
+  }
   const ownership = new PlacementOwnershipPlan(
     targets,
     constraints,
@@ -226,7 +241,14 @@ export function lowerPlacementConstraints(
       return;
     }
 
-    lowerGridPlacement(constraint, owner, sizes, lowerer);
+    lowerGridPlacement(
+      constraint,
+      owner,
+      sizes,
+      lowerer,
+      gridTracks,
+      pinnedByPosition
+    );
   });
 
   return { anchorProgram: lowerer.anchorProgram };

--- a/packages/gofish-graphics/src/ast/constraints/placementSolver.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementSolver.ts
@@ -8,6 +8,7 @@ import {
   lowerPlacementConstraints,
   type PlacementConstraint,
 } from "./placementLowering";
+import type { TrackLayout } from "./grid";
 import {
   axisIndex,
   type AlignAnchor,
@@ -226,13 +227,15 @@ export function solvePlacementConstraints(
   constraints: PlacementConstraint[],
   targets: Map<string, Placeable>,
   sizes: [number, number],
-  posScales?: ConstraintPosScales
+  posScales?: ConstraintPosScales,
+  gridTracks?: [TrackLayout, TrackLayout]
 ): PlacementConflict[] {
   const lowered = lowerPlacementConstraints(
     constraints,
     targets,
     sizes,
-    posScales
+    posScales,
+    gridTracks
   );
 
   const solved = [

--- a/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
+++ b/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
@@ -131,7 +131,8 @@ export function buildDistributeSliceMap(
 /** Choose the concrete size proposed to one child in a layer.
  *
  * Priority is explicit and single-owner:
- *   1. grid: owns the whole layer proposal, so every child gets the cell size;
+ *   1. grid: each cell is proposed ITS (column, row) track's extent (Stage 6e —
+ *      resolved by the unified max rule in `resolveGridTracks`), keyed by name;
  *   2. distribute: owns only the named child axes it sliced;
  *   3. default layer box: unconstrained/fill proposal is the full layer size.
  *
@@ -140,10 +141,16 @@ export function buildDistributeSliceMap(
 export function childLayoutSizeProposal(
   childName: string | undefined,
   layerSize: Size,
-  gridCell: Size | undefined,
+  gridCellByName: Map<string, Size> | undefined,
   sliceByName: Map<string, Size> | undefined
 ): Size {
-  if (gridCell !== undefined) return gridCell;
+  if (
+    gridCellByName !== undefined &&
+    childName !== undefined &&
+    gridCellByName.has(childName)
+  ) {
+    return gridCellByName.get(childName)!;
+  }
   if (
     sliceByName === undefined ||
     childName === undefined ||
@@ -283,10 +290,16 @@ export function buildChildScalePlan(
   };
 }
 
-/** A grid owns the whole two-axis proposal scope for its layer. Multiple grids
- * would otherwise be source-order-sensitive because space resolution and
- * proposal sizing can only choose one track partition while placement would see
- * all pins. */
+/** Select the layer's single grid constraint, if any.
+ *
+ * A grid resolves its tracks under the unified max rule (`resolveGridTracks`)
+ * and now GENUINELY COMPOSES with sibling constraints (Stage 6e): its per-track
+ * claim participates in sizing, and its cell-center pins solve jointly with any
+ * align/position/z-order on the same layer. The Stage-3 containment throw (which
+ * rejected any non-z-order sibling because the grid used to bypass the space and
+ * size folds) is therefore gone. The at-most-one-grid rule stays: two track
+ * partitions on one layer would be source-order-sensitive, so it is still an
+ * error. */
 export function selectGridConstraint(
   constraints: readonly ConstraintSpec[]
 ): GridConstraint | undefined {
@@ -299,24 +312,6 @@ export function selectGridConstraint(
       );
     }
     selected = constraint;
-  }
-  // A grid is a whole-layer layout mode, not a composable constraint: it owns
-  // both track partitions and bypasses the space/size fold, while placement
-  // still applies every sibling constraint — so a grid mixed with any other
-  // positioning constraint silently half-applies (its facts never enter the
-  // space fold). Reject non-z-order siblings; z-order (zAbove/zBelow) is
-  // render-time paint order and composes. This lifts when grids become track
-  // equations (Stage 6e, design/sigma-affine-simplification.md).
-  if (selected !== undefined) {
-    for (const constraint of constraints) {
-      if (constraint.type === "grid" || isZOrderConstraint(constraint)) {
-        continue;
-      }
-      throw new Error(
-        `Constraint.grid cannot be combined with a '${constraint.type}' constraint on the same layer. ` +
-          `Put the grid in its own layer, or nest layers, so each layout mode owns its own scope.`
-      );
-    }
   }
   return selected;
 }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -13,7 +13,12 @@ import {
   FancyDims,
   displayTranslate,
 } from "../dims";
-import { UNDEFINED, UnderlyingSpace, hasBaseline } from "../underlyingSpace";
+import {
+  UNDEFINED,
+  UnderlyingSpace,
+  hasBaseline,
+  isUNDEFINED,
+} from "../underlyingSpace";
 import { computeSize, foldFinite } from "../../util";
 import { axisScale } from "../domain";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
@@ -25,7 +30,9 @@ import {
   applyConstraints,
   collectPositionDomains,
   gridSpaces,
-  gridCellSize,
+  resolveGridTracks,
+  gridCellSizeByName,
+  gridTracksFromSizes,
   type ConstraintSpec,
   type ZOrderConstraint,
 } from "../constraints";
@@ -128,11 +135,15 @@ export const layer = createNodeOperatorSequential(
           _shared: Size<boolean>,
           constraints
         ) => {
-          // A grid constraint makes this layer a grid: its axes are categorical
-          // (ORDINAL over columns / rows) and the cells fill flex tracks (sized
-          // in `layout`). It's exclusive — no union/nest/position fold applies.
+          // A grid constraint makes this layer a grid. Stage 6e: the grid no
+          // longer bypasses the fold — it participates. Its categorical track
+          // axes (ORDINAL over columns / rows, for axis rendering) are composed
+          // in at the END of this function, overriding the covered axes, while
+          // any sibling constraint (align / position) still contributes to the
+          // fold below. Its size claim (Σ max-of-cell-claims + gaps) is consumed
+          // at layout time by `resolveGridTracks`, not reported as the axis space
+          // — a categorical axis cannot also be a SIZE magnitude.
           const gridC = selectGridConstraint(constraints ?? []);
-          if (gridC !== undefined) return gridSpaces(gridC, _childNodes);
 
           // Nest space fold: only INSIDE_OUT edges (`dir: 'in'`) derive a
           // space — `outer = inner + 2·padding` when inner is SIZE — so a
@@ -181,6 +192,19 @@ export const layer = createNodeOperatorSequential(
             }
           }
 
+          // Grid track axes compose LAST, overriding the covered axes with the
+          // categorical ORDINAL space (columns on x, rows on y) that axis
+          // rendering consumes — the grid's contribution to the fold. A pure
+          // grid therefore reports exactly `gridSpaces` (as before); a grid mixed
+          // with a sibling constraint keeps that sibling's fold on any axis the
+          // grid leaves UNDEFINED (no keys).
+          if (gridC !== undefined) {
+            const gridAxes = gridSpaces(gridC, _childNodes);
+            for (const axis of [0, 1] as const) {
+              if (!isUNDEFINED(gridAxes[axis])) resolved[axis] = gridAxes[axis];
+            }
+          }
+
           // Stash the absorbed anchored extent and report UNDEFINED upward for
           // any dim with an explicit pixel size — self-scaling region; see
           // selfScaledSpaces above. (last write wins — may run more than once.)
@@ -219,11 +243,26 @@ export const layer = createNodeOperatorSequential(
               size[1],
           ];
 
-          // Grid budget: a grid layer is exclusively cells (table elaboration),
-          // and every cell fills its flex track — so all children get the equal
-          // track size (box-division); the placement solver then centers them.
+          // Grid budget (Stage 6e): resolve the tracks under the unified max rule
+          // from the cells' pre-layout size claims — each track sizes to the max
+          // claim of its cells, fill tracks split the leftover equally. This
+          // sizes only the FILL cells (a claim cell keeps its own size); the
+          // authoritative PLACEMENT tracks are recomputed from the actual
+          // laid-out cell sizes after the child loop (`gridTracksFromSizes`), so
+          // cell centers pin to the real geometry.
           const gridC = selectGridConstraint(node.constraints);
-          const gridCell = gridC ? gridCellSize(gridC, size) : undefined;
+          const gridCellByName = gridC
+            ? gridCellSizeByName(
+                gridC,
+                resolveGridTracks(
+                  gridC,
+                  node.children,
+                  size,
+                  getScopeRegistry(node.tryGetRenderSession()),
+                  node.key ?? node.type
+                )
+              )
+            : undefined;
 
           // Build the LOCAL scale for each self-scaled (stashed) dim against our
           // own pixel box — see selfScaledSpaces above. The recipe (cf. the
@@ -336,7 +375,12 @@ export const layer = createNodeOperatorSequential(
             // proposal, so nest composes with — and wins on its derived axes
             // over — any budget slice.
             const layoutSize = applyNestLayoutProposal(
-              childLayoutSizeProposal(childName, size, gridCell, sliceByName),
+              childLayoutSizeProposal(
+                childName,
+                size,
+                gridCellByName,
+                sliceByName
+              ),
               layoutPlan.nestPlan?.byDerived.get(i),
               childPlaceables
             );
@@ -379,11 +423,29 @@ export const layer = createNodeOperatorSequential(
             // Compose and solve placement constraints as one per-axis relational
             // problem. Declaration order does not choose an anchor; unanchored
             // components receive a deterministic weak origin.
+            // Placement tracks from the ACTUAL laid-out cell sizes (Stage 6e):
+            // each track's extent is the max of its cells' real geometry, so the
+            // cell-center pins match what rendered (and the solver shadow agrees).
+            const gridTracks = gridC
+              ? gridTracksFromSizes(
+                  gridC,
+                  childPlaceables.map((cp) =>
+                    cp
+                      ? ([
+                          Math.abs(cp.dims[0].size ?? 0),
+                          Math.abs(cp.dims[1].size ?? 0),
+                        ] as [number, number])
+                      : undefined
+                  )
+                )
+              : undefined;
+
             applyConstraints(
               node.constraints,
               nameToPlaceable,
               size,
-              effectivePosScales
+              effectivePosScales,
+              gridTracks
             );
 
             // Place any child the constraints left unplaced at the layer's

--- a/packages/gofish-graphics/src/ast/solver/scopes.ts
+++ b/packages/gofish-graphics/src/ast/solver/scopes.ts
@@ -34,6 +34,7 @@ export type ScopeKind =
   | "constraint-budget"
   | "shared"
   | "coord"
+  | "grid"
   | "recenter";
 
 /** One axis's contribution to the #582 equal-measure recentering: either an

--- a/packages/gofish-graphics/src/ast/solver/shadow.ts
+++ b/packages/gofish-graphics/src/ast/solver/shadow.ts
@@ -26,7 +26,6 @@ import { pxOf } from "../domain";
 import { localAnchorPoint } from "../dims";
 import type { ConstraintSpec, ConstraintPosScales } from "../constraints";
 import { distributePlacementAnchors } from "../constraints/distribute";
-import { gridCellSize } from "../constraints/grid";
 import { isCONTINUOUS, type UnderlyingSpace } from "../underlyingSpace";
 
 /** Whether the solver shadow assertions run. Off (and zero-cost) in prod, so the
@@ -172,16 +171,16 @@ interface GridLike {
 }
 
 /**
- * Check the `grid` composition — cells centered in equal flex tracks
- * (`grid.ts`). The grid pins each cell's center at
- * `column·(cellW+sx)+cellW/2`, `row·(cellH+sy)+cellH/2` in layer-local space
- * (`gridCellPlacements`); the equal-track structure is therefore an
- * ORIGIN-INDEPENDENT invariant on the placed centers: two cells in adjacent
- * columns of one row have x-centers `cellW+sx` apart, two in adjacent rows of
- * one column have y-centers `cellH+sy` apart — validated against `gridCellSize`
- * (the same `sliceExtent` the layer proposes). Differences cancel the unknown
- * layer origin, so no absolute frame is needed. Cell EXTENT is deliberately not
- * asserted: a cell may keep its own size and only consume the center pin.
+ * Check the `grid` composition — cells centered in their (column, row) tracks
+ * (`grid.ts`). Stage 6e: tracks are content-sized under the unified max rule, so
+ * the gap between two adjacent cells is no longer a uniform `cellExtent+spacing`
+ * — it is `extent(col)/2 + spacing + extent(col+1)/2`, where a track's extent is
+ * the max laid-out size of its cells (a cell that fills equals the extent; a
+ * smaller claim cell is centered, and the column's widest cell pins the extent).
+ * Recovering the track extents from the placed cell sizes and asserting the
+ * center-to-center gaps is the ORIGIN-INDEPENDENT invariant (differences cancel
+ * the unknown layer origin). Cell EXTENT is deliberately not asserted; a cell
+ * whose center is overridden by a `position` pin is skipped on that axis.
  */
 export function shadowCheckGrid(
   constraint: GridLike,
@@ -189,34 +188,53 @@ export function shadowCheckGrid(
   layerSize: [number, number]
 ): void {
   if (!enabled() || constraint.type !== "grid") return;
-  const [cellW, cellH] = gridCellSize(
-    constraint as Parameters<typeof gridCellSize>[0],
-    layerSize
-  );
+  void layerSize;
   const numCols = constraint.numCols;
+  const numRows = Math.ceil(constraint.children.length / numCols);
+  const targetOf = (i: number): Placeable | undefined =>
+    targetByName.get(constraint.children[i]?.name);
   const centerOf = (i: number, idx: 0 | 1): number | undefined => {
-    const t = targetByName.get(constraint.children[i]?.name);
+    const t = targetOf(i);
     return t ? anchorCoord(t, idx, "middle") : undefined;
+  };
+  const sizeOf = (i: number, idx: 0 | 1): number | undefined => {
+    const t = targetOf(i);
+    const s = t?.dims[idx].size;
+    return s === undefined ? undefined : Math.abs(s);
+  };
+  // A track's extent is the max laid-out cell size across the track.
+  const colExtent = (col: number): number => {
+    let m = 0;
+    for (let row = 0; row < numRows; row++)
+      m = Math.max(m, sizeOf(row * numCols + col, 0) ?? 0);
+    return m;
+  };
+  const rowExtent = (row: number): number => {
+    let m = 0;
+    for (let col = 0; col < numCols; col++)
+      m = Math.max(m, sizeOf(row * numCols + col, 1) ?? 0);
+    return m;
   };
   for (let i = 0; i < constraint.children.length; i++) {
     const col = i % numCols;
-    const row = Math.floor(i / numCols);
-    // Adjacent column in the same row → x-centers `cellW + xSpacing` apart.
+    // Adjacent column in the same row → centers half-extents + spacing apart.
     if (col + 1 < numCols && i + 1 < constraint.children.length) {
       const a = centerOf(i, 0);
       const b = centerOf(i + 1, 0);
       if (a !== undefined && b !== undefined) {
-        const gap = cellW + constraint.xSpacing;
+        const gap =
+          colExtent(col) / 2 + constraint.xSpacing + colExtent(col + 1) / 2;
         if (Math.abs(b - a - gap) > 1e-6) report(`grid.col`, b - a, gap);
       }
     }
-    // Adjacent row in the same column → y-centers `cellH + ySpacing` apart.
-    void row;
+    // Adjacent row in the same column → centers half-extents + spacing apart.
+    const row = Math.floor(i / numCols);
     if (i + numCols < constraint.children.length) {
       const a = centerOf(i, 1);
       const b = centerOf(i + numCols, 1);
       if (a !== undefined && b !== undefined) {
-        const gap = cellH + constraint.ySpacing;
+        const gap =
+          rowExtent(row) / 2 + constraint.ySpacing + rowExtent(row + 1) / 2;
         if (Math.abs(b - a - gap) > 1e-6) report(`grid.row`, b - a, gap);
       }
     }

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -8,7 +8,8 @@ import type { Placeable } from "../ast/_node";
 import * as Monotonic from "../util/monotonic";
 import type { AlignConstraint } from "../ast/constraints/align";
 import type { DistributeConstraint } from "../ast/constraints/distribute";
-import type { GridConstraint } from "../ast/constraints/grid";
+import type { GridConstraint, TrackLayout } from "../ast/constraints/grid";
+import { gridCellSizeByName, gridTracksFromSizes } from "../ast/constraints/grid";
 import type { NestConstraint } from "../ast/constraints/nest";
 import {
   compilePlacementCoordinate,
@@ -409,6 +410,107 @@ console.log("# constraint confluence: nest and grid placement");
   );
 }
 
+console.log("# constraint confluence: grid content-sized tracks (Stage 6e)");
+{
+  // Two columns of DIFFERENT extent (content-sized): col0=40, col1=100,
+  // xSpacing=10 → starts [0, 50]; centers col0=20, col1=50+50=100.
+  const grid: GridConstraint = {
+    type: "grid",
+    numCols: 2,
+    xSpacing: 10,
+    ySpacing: 0,
+    children: [A, B],
+  };
+  const tracks: [TrackLayout, TrackLayout] = [
+    { starts: [0, 50], extents: [40, 100] },
+    { starts: [0], extents: [30] },
+  ];
+
+  // The per-cell budget map hands each cell its own track's extent.
+  const cellSizes = gridCellSizeByName(grid, tracks);
+  ok(
+    "grid cell budget = per-cell track extents",
+    JSON.stringify(cellSizes.get("A")) === "[40,30]" &&
+      JSON.stringify(cellSizes.get("B")) === "[100,30]"
+  );
+
+  const contentTargets = () =>
+    new Map<string, Placeable>([
+      ["A", makePlaceable(40, 30)],
+      ["B", makePlaceable(100, 30)],
+    ]);
+  {
+    const t = contentTargets();
+    solvePlacementConstraints([grid], t, [300, 200], undefined, tracks);
+    ok(
+      "content-sized grid centers each cell in its own track",
+      t.get("A")!.dims[0].center === 20 && t.get("B")!.dims[0].center === 100
+    );
+  }
+
+  // grid + align on a NON-cell child C: C's center is aligned (middle x) to the
+  // grid cell A. The two constraints compose and are order-independent.
+  const alignAC: AlignConstraint = { type: "align", x: "middle", children: [A, C] };
+  const withAlign = (order: Constraint[]) => {
+    const t = contentTargets();
+    t.set("C", makePlaceable(10, 10));
+    solvePlacementConstraints(order, t, [300, 200], undefined, tracks);
+    return {
+      A: t.get("A")!.dims[0].center,
+      C: t.get("C")!.dims[0].center,
+    };
+  };
+  const af = withAlign([grid, alignAC]);
+  const as = withAlign([alignAC, grid]);
+  ok(
+    "grid + align on a non-cell composes, order-independent",
+    JSON.stringify(af) === JSON.stringify(as) && af.A === 20 && af.C === 20
+  );
+
+  // grid + position pin of a CELL: the pin overrides that cell's track
+  // centering on the pinned axis; the other cell keeps its track center.
+  const pinB = position("B", 250);
+  const withPin = (order: Constraint[]) => {
+    const t = contentTargets();
+    solvePlacementConstraints(order, t, [300, 200], undefined, tracks);
+    return { A: t.get("A")!.dims[0].center, B: t.get("B")!.dims[0].center };
+  };
+  const pf = withPin([grid, pinB]);
+  const ps = withPin([pinB, grid]);
+  ok(
+    "position pin on a cell overrides its track centering, order-independent",
+    JSON.stringify(pf) === JSON.stringify(ps) && pf.A === 20 && pf.B === 250
+  );
+
+  // Authoritative placement tracks are recomputed from ACTUAL laid-out cell
+  // sizes: a track sizes to the MAX of its cells (a claim cell wider than a
+  // sibling pins the track; a mixed fill/claim track = the claim). 2 cols × 2
+  // rows, xSpacing=10: col0 max(40,20)=40, col1 max(100,60)=100.
+  const grid2x2: GridConstraint = {
+    type: "grid",
+    numCols: 2,
+    xSpacing: 10,
+    ySpacing: 5,
+    children: [A, B, C, child("D")],
+  };
+  const fromSizes = gridTracksFromSizes(grid2x2, [
+    [40, 30],
+    [100, 30],
+    [20, 12],
+    [60, 8],
+  ]);
+  ok(
+    "placement tracks take the max laid-out size per track",
+    JSON.stringify(fromSizes[0].extents) === "[40,100]" &&
+      JSON.stringify(fromSizes[0].starts) === "[0,50]"
+  );
+  ok(
+    "placement track rows take the max height and cumulate with spacing",
+    JSON.stringify(fromSizes[1].extents) === "[30,12]" &&
+      JSON.stringify(fromSizes[1].starts) === "[0,35]"
+  );
+}
+
 console.log("# constraint confluence: nest size dependency planning");
 {
   const nestAB: NestConstraint = {
@@ -584,15 +686,17 @@ console.log("# constraint confluence: distribute size proposals");
 
   const layerSize: [number, number] = [300, 200];
   const gridCell: [number, number] = [90, 40];
+  const gridCellByName = new Map<string, [number, number]>([["A", gridCell]]);
   const sliceByName = new Map<string, [number, number]>([
     ["A", [100, 200]],
   ]);
   ok(
-    "grid proposal overrides distribute slice",
-    childLayoutSizeProposal("A", layerSize, gridCell, sliceByName) === gridCell
+    "grid cell proposal (its track extent) overrides distribute slice",
+    childLayoutSizeProposal("A", layerSize, gridCellByName, sliceByName) ===
+      gridCell
   );
   ok(
-    "named distribute child receives sliced proposal",
+    "a non-cell named child still receives its distribute slice",
     childLayoutSizeProposal("A", layerSize, undefined, sliceByName) ===
       sliceByName.get("A")
   );
@@ -644,23 +748,18 @@ console.log("# constraint confluence: grid proposal ownership");
       throwsWith([grid1, grid2], "Constraint.grid proposal conflict")
   );
 
-  // grid mixed with any non-z-order constraint half-applies (placement sees it,
-  // the space/size fold does not), so selectGridConstraint rejects it.
+  // Stage 6e: grid now GENUINELY composes with sibling constraints, so
+  // selectGridConstraint no longer throws on a non-z-order sibling — it just
+  // selects the one grid (the mixing is exercised for real at placement below).
   const alignMix: AlignConstraint = {
     type: "align",
     y: "middle",
     children: [A, B],
   };
   ok(
-    "grid mixed with align throws in either order",
-    throwsWith(
-      [grid2, alignMix],
-      "Constraint.grid cannot be combined with a 'align' constraint"
-    ) &&
-      throwsWith(
-        [alignMix, grid2],
-        "Constraint.grid cannot be combined with a 'align' constraint"
-      )
+    "grid alongside an align is allowed (composes) in either order",
+    selectGridConstraint([grid2, alignMix]) === grid2 &&
+      selectGridConstraint([alignMix, grid2]) === grid2
   );
 
   // z-order (zAbove/zBelow) is render-time paint order and composes with grid.

--- a/packages/gofish-graphics/src/util/monotonic.ts
+++ b/packages/gofish-graphics/src/util/monotonic.ts
@@ -224,6 +224,48 @@ export const max = (...args: Monotonic[]): Monotonic => {
   return unknown((x: number) => Math.max(...args.map((arg) => arg.run(x))));
 };
 
+/**
+ * Structural equality of two σ-affine claims within an absolute `tolerance`.
+ *
+ * Two points pin a line, so the all-linear common case is exact from probes at
+ * σ = 0 and 1 (the former `monoEqual` in bbox.ts, kept cheap). Once a claim is
+ * piecewise (the `max`-composed track claims of Stage 6e), two probes no longer
+ * suffice: two envelopes can agree at 0 and 1 yet differ on a middle segment. So
+ * when both operands are linear/piecewise (no `unknown`), compare at 0, 1, and
+ * every pairwise breakpoint of the two envelopes' pieces — the only σ where a
+ * convex PWL can change slope. An `unknown` operand has no closed envelope, so
+ * fall back to a spread of multi-point probes.
+ */
+export const approxEqual = (
+  a: Monotonic,
+  b: Monotonic,
+  tolerance = 1e-6
+): boolean => {
+  const close = (x: number, y: number): boolean => Math.abs(x - y) <= tolerance;
+  // All-linear fast path: identical to the two-point probe it replaces.
+  if (isLinear(a) && isLinear(b))
+    return close(a.run(0), b.run(0)) && close(a.run(1), b.run(1));
+
+  const pa = piecesOf(a);
+  const pb = piecesOf(b);
+  if (pa !== undefined && pb !== undefined) {
+    const xs = new Set<number>([0, 1]);
+    const all = [...pa, ...pb];
+    for (let i = 0; i < all.length; i++) {
+      for (let j = i + 1; j < all.length; j++) {
+        const ds = all[i].slope - all[j].slope;
+        if (Math.abs(ds) < 1e-12) continue;
+        const x = (all[j].intercept - all[i].intercept) / ds;
+        if (Number.isFinite(x) && x > 0) xs.add(x);
+      }
+    }
+    return [...xs].every((x) => close(a.run(x), b.run(x)));
+  }
+
+  // An `unknown` (opaque closure) operand: probe a spread of points.
+  return [0, 0.5, 1, 2, 10].every((x) => close(a.run(x), b.run(x)));
+};
+
 /** Pretty-print a Monotonic as the equation it represents — `40σ + 16`,
  *  `max(40σ + 16, 90)`, or `f(σ)` for an opaque closure. Matches the forms in
  *  the layout-synthesis essay; for debugging composed size claims. */

--- a/packages/gofish-graphics/stories/atom/TitanicFacet.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/TitanicFacet.stories.tsx
@@ -43,6 +43,11 @@ export const Default: StoryObj<Args> = {
      chart(titanicPassengers, { color: palette(["#2b8cbe", "#ff8408"]), axes: true })
         .flow(table({
                 by: {x: "pclass", y: "sex"},
+                // Content-sized tracks (σ-affine 6e) pack facets to their dot
+                // blocks; declared gutters replace the equal-split slack the
+                // old box-division provided by accident. The Atom-faithful
+                // semantics (equal cells, fit-derived unit size) is #663.
+                spacing: 32,
               }))
       .mark((d) => chart(d)
             .flow(


### PR DESCRIPTION
Advances #39. Stacked on #660. Stage 6e of `internals/design/sigma-affine-simplification.md` — grid stops being a layout regime and becomes claim equations. Screenshots below (one story legitimately moved, adjudicated by Josh).

**The unified rule (no mode, no option):** `track claim = Monotonic.max(cell claims)`, fill cells contributing nothing; `grid claim = Σ tracks + gaps`, solved by the scope registry like any other frame equation. All-fill grids reduce to the equal `sliceExtent` split **bit-identically**; content-sized tracks emerge automatically when cells carry claims. Placement pins derive from *actual laid-out* cell sizes, so the solver shadow cannot drift from rendered geometry.

**Deletions:** the layer space-fold early-return (grid was exclusive; it now composes with nest/position/spread folds, ORDINAL axes contribution intact), the uniform cell-budget special case, and Stage 3's mixing throw — grid + align/position now genuinely compose (a position pin overrides a cell's track centering on the pinned axis; confluence tests cover both orders). `Monotonic.approxEqual` replaces the linear-only two-point `monoEqual` probe (structural piecewise compare, linear fast path). The at-most-one-grid rule stays.

**Movers (full-corpus enumeration — exactly one genuine):**
- `atom/TitanicFacet` — cells are waffle charts of fixed `r:4` dots (intrinsic per-facet claims), so tracks now size to content instead of stretching every facet to an equal share. **Adjudicated: accepted**, with declared `spacing: 32` replacing the old equal-split slack (a follow-up commit here). The Atom-faithful semantics this story *should* eventually have — equal cells with fit-derived unit size — is #663.
- `forward-syntax-v3/heatmap` — container width attribute differs by 0.0001px (summation-order float artifact); every rect/label byte-identical.

The CI `visual-test` baseline for TitanicFacet will fail until the Linux baseline regenerates — that's the adjudicated mover reaching the pixel authority, expected.

## Screenshots

| before (equal box-division) | after (content tracks, packed) | after + declared spacing (shipped) |
|---|---|---|
| ![before](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-664/before.png) | ![packed](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-664/after-packed.png) | ![spacing](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-664/after-spacing32.png) |

## Verification

- Full-corpus `capture-diff`: exactly the two stories above; all-fill tables (Activity Heatmap, Labeled Heatmap) byte-identical.
- `capture-sweep` 260/260 clean; confluence 92 → 98; full suite, typecheck, `check-backlinks`, `docs:build` green.
- Python parity: no wire changes (grid is JS-internal elaboration; `table` opts unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
