### PR TITLE
σ-affine simplification, stage 6: scope registry, one slope, grid tracks, solver-sourced guards

### DIFF
--- a/apps/docs/docs/internals/core/monotonic.md
+++ b/apps/docs/docs/internals/core/monotonic.md
@@ -125,6 +125,15 @@ Because the structure is preserved, a composed claim can be **printed as the equ
 represents** — `print` renders `40σ + 16`, or `max(160σ + 16, 90)` for an envelope —
 matching the forms in the [layout synthesis essay](/internals/design/layout-synthesis).
 
+`approxEqual(a, b, tol)` decides whether two claims are the same function. Two points pin a
+line, so the all-linear common case is exact from probes at σ = 0 and 1. A `max`-composed
+`Piecewise` needs more — two envelopes can agree at 0 and 1 yet differ on a middle segment
+— so when both operands are PWL it compares at 0, 1, and **every pairwise breakpoint** of
+the two envelopes' pieces (the only σ where a convex PWL can change slope); an `Unknown`
+operand falls back to a spread of sample points. This is what the `BBox` ledger uses to
+detect an over-determined key now that `table`'s content-sized tracks push piecewise claims
+into cells.
+
 ## Slope as a data-driven signal
 
 Because a `Linear` exposes its slope, the engine gets a cheap, exact predicate for

--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -151,16 +151,31 @@ scatter bubble's area) stays a flat point even under a coord.
 did. A node that reaches `INTERNAL_lower` is either a **leaf** (a bare shape) or a
 **bake boundary** — `coord`, `box`, `connect`, `arrow`, `enclose`, and the
 Porter-Duff compositors/mask. A boundary carries its own absolute transform and must
-re-walk its subtree with that transform composed in (via `flattenLayout`) so its
-descendants land in absolute coordinates _before_ `toPixel`. Pre-recursed,
-parent-relative child items would be mispositioned. This is the same
-boundary-recursive structure the bake itself has: each boundary flattens within its
-own scope, emits its warped primitives, and is treated as a unit by its parent.
+re-walk its subtree so its descendants land in absolute coordinates _before_
+`toPixel`. Pre-recursed, parent-relative child items would be mispositioned. This is
+the same boundary-recursive structure the bake itself has: each boundary flattens
+within its own scope, emits its warped primitives, and is treated as a unit by its
+parent.
 
-A `coord` operator is the archetype: it lowers its whole subtree into resolved
-`path`/`rect`/`ellipse` items whose coordinates are already warped through its
-coordinate transform (a petal becomes a `path`, a polar bar becomes a warped `path`),
-so the backend never sees the polar mapping — just absolute pixel paths.
+How the re-walk lands descendants in absolute coordinates splits by boundary kind
+(#39 stage 6d):
+
+- A **pure translate-only container** (`box`/`frame`, `offset`, `enclose`) flattens
+  its subtree with `bakeChildren` (`bake.ts`) — the same z-ordered flatten the root
+  bake uses, seeded at the container's own absolute translate — and lowers each
+  returned entry at its baked absolute transform (`INTERNAL_lower(coord, d.transform)`).
+  There is no per-container `toPixel` closure: the translate is baked into each
+  descendant's coordinates, not composed onto the session map. A non-identity `scale`
+  is the one part a flat list can't fold, so it stays a `group` wrapper around the
+  flattened items.
+- A **space remapper** (`coord`) genuinely warps its content, so it keeps a
+  `contentToPixel` map: it flattens its subtree (`flattenLayout`) and maps each
+  descendant through its coordinate transform then its own translate. A `coord` is the
+  archetype: it lowers its whole subtree into resolved `path`/`rect`/`ellipse` items
+  whose coordinates are already warped (a petal becomes a `path`, a polar bar a warped
+  `path`), so the backend never sees the polar mapping — just absolute pixel paths.
+- A **self-drawer** (`connect`, `arrow`) reads its own baked absolute translate
+  (`displayTranslate`) to place the geometry it draws from its children's anchors.
 
 ## The display list IR
 

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -123,11 +123,26 @@ scale. `map` is the _whole_ anchored map, with the intercept explicit as data
 rather than closed over a function: `px(d) = pxMin + sigma·(d − domainMin)`,
 evaluated by `pxOf` (the old `posScale(0)` intercept is `pxOf(map, 0)`). So
 "anchored" shows up operationally as "has a `map`"; "unanchored" as "has only a
-`sigma`." `map` carries its own slope, which need not equal the top-level
-`sigma` — a sub-budget layer scales a mark's size and its data position against
-different pixel extents. This single record replaced the former two parallel
+`sigma`." This single record replaced the former two parallel
 channels (`scaleFactors` = slope-only, `posScales` = whole map) in Stage 4 of
 [the σ-affine plan](/internals/design/sigma-affine-simplification).
+
+**One slope per σ-scope, and the two-scope carrier.** The carrier's two slopes —
+its `sigma` and its `map.sigma` — are not independent numbers. Each is the σ of a
+distinct σ-scope solved once by the scope registry (below):
+`sigma` is the axis's **SIZE** scope (what a magnitude is scaled by), `map.sigma`
+is the axis's **POSITION** scope (what an anchored coordinate is mapped by). No
+site fabricates either — every `map` comes from `computePosScale` through
+`solvePosition` (or the equal-measure recentering), every `sigma` from
+`solveSize` (Stage 6c). Within any one scope there is therefore exactly one slope,
+by construction. When both halves are present and `sigma ≠ map.sigma`, the axis
+genuinely carries **two scopes**, and each half is read by the channel it belongs
+to — magnitudes read `sigma`, anchored positions read `map`. That happens when a
+marginal panel's ticks map the _niced_ axis domain while its bars size the
+_un-niced_ stacked total (a nicing split), or when a sub-budget layer scales size
+against a local extent but position against an inherited one (a sub-budget vs
+inherited split). Both are two honest scopes on one axis — the multi-scale reading
+of the same equation — not a slope with a redundant, drifting twin.
 
 ## Why an explicit IR
 
@@ -732,6 +747,20 @@ re-rooting σ on the angular axis):
 That the root and shared scopes on one axis print the same σ is Stage 6's
 invariant made visible: **one slope per σ-scope, by construction**, because the
 frame equation is solved once and the posScale is a derived view of that solve.
+
+Stage 6c makes the registry the _sole_ producer of every slope, so that "by
+construction" holds everywhere the carrier flows. Two former exceptions closed:
+a coord boundary's POSITION axis used to hand down a fabricated `σ = 1` alongside
+its map (a scope-less slope that no consumer read) — it now carries no size σ at
+all, since a POSITION-only axis has no SIZE scope; and the #582 equal-measure
+recentering (equating x and y when they share a unit of measure) used to rewrite
+the root's σ inline in `gofish.tsx`, off the registry's books. It is now a named
+`recenterEqualMeasure` operation _on_ the registry, so the dump records the FINAL
+σ (a `recenter` entry per axis) rather than the pre-recentering root σ. With both
+closed, the only way a carrier shows two different slopes on one axis is the
+legitimate **two-scope** case above (a SIZE scope and a POSITION scope, e.g. a
+marginal panel's niced ticks vs its un-niced bar total) — each half still a single
+registry-solved scope σ, never independent state.
 
 ## Scales generalize flex factors
 

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -541,26 +541,42 @@ needs the aligned system to appear at a particular place must say so explicitly
 with a placement constraint.
 
 That normalization is also what keeps data-positioned children safe. A faceted
-scatter panel over `[1955, 2010]`, whose `placement` is `determined`, should not
-be pulled to `posScale(0)` (data-zero, far below 1955). So the placement solver
-reads `Placeable.placementOn(dir)`: **a target whose subtree already commits a
-data position (`placement` `determined`/`conflict`) on a posScale axis, with a
-non-`middle` anchor, is left alone** — `align` shares the frame (it still unions
-the children's `dataDomain`) but supplies no baseline. When alignment does write
-an anchor relation, it asks
+scatter panel over `[1955, 2010]`, anchored to the shared y data scale, should
+not be pulled to `posScale(0)` (data-zero, far below 1955). So `align` leaves it
+alone: **a target anchored to a data (POSITION) scope on a posScale axis, with a
+non-`middle` anchor, is not moved** — `align` shares the frame (it still unions
+the children's `dataDomain`) but supplies no baseline. Its baseline is already
+`posScale(0)` of the shared scope, so all such panels co-locate by construction.
+
+**The guard asks the solver, not the space pass (Stage 6f).** This is the
+blindingly-obvious final form the whole design arc was reaching for. The question
+"is this target already positioned?" is answered by the placement solve's own
+authority record — the `PlacementOwnershipPlan` — through one predicate,
+`isDataPositioned(axis, name)`. The fact it reads (which children are anchored to
+a POSITION scope on each axis) is a pure **data/scope** fact — a child's
+`dataDomain` is present on that axis — collected _once_ at the layer boundary and
+handed to the solve as an explicit ownership input. The constraint path no longer
+reconstructs the space pass's `free`/`determined`/`conflict` lattice by calling a
+`placementOn` method on the target mid-lowering; there is no layout fact derived
+from the space pass in the guards anymore. (`spacePlacement` still computes that
+lattice for the space folds themselves — the `union`/`middle`/anchored decisions —
+which is where a determinacy read belongs.)
+
+When alignment does write an anchor relation, it asks
 `Placeable.localAnchor(axis, anchor)` for the anchor's coordinate in the
 target's local box. `GoFishNode.localAnchor()` derives that from the node's
 intrinsic dimensions (including baseline/min/center/max), so relation solving
 can handle asymmetric boxes such as text and negative bars without relying on
 the display transform.
 
-Because placement is first-class, this is the _whole_ mechanism — no flag, no
-scoping. (Historically the same effect needed a `guardDataPositioned` flag on
-spread/scatter aligns plus a per-axis `fromSize` boolean reconstructed from the
-pre-fold child spaces in the layer; the flag was a _proxy_ for the placement
-fact, and the reconstruction read it indirectly. Both are gone — the per-child
-placement read is strictly more general, handling a mix of positioned and free
-children that the old all-or-nothing axis guard could not.) See
+Because the fact is a single scope-membership input to the solve, this is the
+_whole_ mechanism — no flag, no scoping. (Historically the same effect needed a
+`guardDataPositioned` flag on spread/scatter aligns plus a per-axis `fromSize`
+boolean reconstructed from the pre-fold child spaces in the layer; then a
+`placementOn` method reconstructing the placement lattice per target during
+lowering. All are gone — the ownership plan's per-child scope-membership read is
+strictly more general, handling a mix of positioned and free children that the
+old all-or-nothing axis guard could not.) See
 [the spec](/internals/design/size-difference-unification) for the
 "space as abstract interpretation" framing this falls out of.
 

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -425,8 +425,8 @@ constraint overrides: union child spaces, apply `transform.scale` to free
 magnitudes, and merge datum-valued position/span domains with constraint
 measures taking precedence.
 `childLayoutSizeProposal` is the final per-child proposal priority before nest:
-grid cell size, else distribute slice for that named child, else the full layer
-box.
+the cell's own track extent (grid), else distribute slice for that named child,
+else the full layer box.
 `buildLayerConstraintLayoutPlan` packages the per-layer execution plan — which
 children skip baseline placement, nest source-before-derived order, and
 datum-position target axes — so the layer executes deterministic artifacts
@@ -439,17 +439,37 @@ out first. The bottom-up space pass applies only the inside-out portion via
 `applyNestSpacePlan`; once the source has concrete dimensions,
 `applyNestLayoutProposal` does the corresponding layout-time arithmetic on the
 derived axes.
-Grid is also selected through the proposal plan (`selectGridConstraint`):
-because a grid owns both track partitions for a layer — and bypasses the
-space/size fold entirely — it is a whole-layer layout mode, not a composable
-constraint. `selectGridConstraint` therefore enforces two exclusivity rules
-(it is the one site both the space pass and the layout pass flow through): more
-than one grid constraint is a proposal conflict rather than a declaration-order
-choice, and a grid mixed with any non-z-order constraint (align / distribute /
-position / nest) throws — that sibling would be applied by placement but never
-enter the space fold, so it would silently half-apply. z-order constraints
-(zAbove / zBelow) are render-time paint order and compose freely alongside a
-grid. Grid has no public factory; it is `table`'s private elaboration target.
+Grid is a **track equation** under the same unified sizing rule, not a separate
+layout regime (Stage 6e). Per axis, `resolveGridTracks` sets
+
+```
+track claim = Monotonic.max(claims of the cells in that track)      (max, +)
+grid claim  = Monotonic.add(track claims) + gaps                    (the σ-frame)
+```
+
+A claim-less ("fill") cell contributes nothing, so an all-fill grid has no track
+claims and the tracks split the leftover (allocated − gaps) equally — bit-for-bit
+the former `sliceExtent` box-division. Content-sized tracks emerge automatically
+when cells carry size claims: a track sizes to its widest cell, and fill tracks
+share whatever the claimed tracks leave. When every track carries a σ-dependent
+claim (no fill to absorb the slack), the grid claim is inverted against the
+allocated size by the same scope registry that solves any other frame equation.
+Because a categorical track axis cannot simultaneously be a SIZE magnitude, the
+grid's _reported_ space stays ORDINAL over the columns/rows (`gridSpaces`, for
+axis rendering) while the size claim is consumed at layout time by the track
+resolution. The layout budget sizes fill cells to their track extent; the
+authoritative **placement tracks** are recomputed from the actual laid-out cell
+sizes (`gridTracksFromSizes`) so each cell pins to the real geometry — one source
+the placement and the solver shadow both read, so they cannot drift.
+
+The grid now **genuinely composes** with sibling constraints: its per-track claim
+participates in the fold and its cell-center pins solve jointly with any align /
+position / z-order on the same layer (a `position` pin on a cell overrides its
+track centering — the authoritative-pin pattern). The Stage-3 containment throw
+is gone. `selectGridConstraint` keeps the one remaining rule: at most one grid
+per layer (two track partitions would be source-order-sensitive) is still a
+proposal conflict. Grid has no public factory; it is `table`'s private
+elaboration target.
 The same proposal plan marks datum-valued `position` targets
 (`buildPositionTargetDims`) so the layer does not also forward the consumed
 data→pixel scale to that child axis; literal pixel pins are not marked because

--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -691,6 +691,48 @@ This dispatch is the practical embodiment of the underlying-space-kind
 distinction. It also happens to make the rendering pipeline more readable:
 once you know the kind, you know which arithmetic applies.
 
+## The one solve site: the σ-scope registry
+
+Every scale above resolves the same frame equation — `content(σ) = allocated`,
+inverted once by `Monotonic.inverse` — but historically that inversion was
+written out at four-plus places, each with its own pixel budget and fallback:
+the render root (`gofish.tsx`), an explicit-pixel-size axis and a composed
+distribute budget and a `sharedScale` scope (all three inside
+`buildChildScalePlan`), and a coord boundary (`coord.tsx`'s `fitAxis`). Keeping
+them consistent needed a hand-written guard (the #618 "an intermediate must
+propagate the inherited σ, not re-root against its own budget" rule).
+
+Stage 6b makes those a **single mechanism**. A `ScopeRegistry`
+(`ast/solver/scopes.ts`), created once per render on the `RenderSession`, is the
+one place σ / posScale is derived: `solveSize(frame, allocated)` inverts the σ
+slope, `solvePosition(space, allocated)` builds the anchored `AxisMap`. The
+derivation sites are now **σ-scope roots** — the render root, an axis with an
+explicit pixel size, a constraint budget that roots its own scope, a
+`sharedScale` operator, and a coord boundary — and each calls the registry.
+**Everyone else inherits**: the #618 guard is now the structural rule "not a root
+→ don't call the solve", so the inherited σ propagates unchanged (in
+`buildChildScalePlan`, an intermediate budget simply skips the solve — the
+`inheritedScaleFactors[axis] !== undefined && selfScaledSpaces[axis] ===
+undefined` test that _was_ the guard is now the "is this a scope root?"
+predicate). Because the arithmetic is exactly what the sites ran inline, the
+solved numbers are unchanged; the registry only adds the choke-point.
+
+Behind `GOFISH_DUMP_SCOPES` the registry prints every scope it solved as a
+printable frame equation — the debuggability bar the σ-affine model was chosen
+for. One line per scope, e.g. a stacked bar (root POSITION scope + a shared SIZE
+scope on the same axis, agreeing on one slope) and a sunburst (a coord boundary
+re-rooting σ on the angular axis):
+
+```
+[scope] root   key=root  axis=y [0,140]→[0,400] = 400  σ=2.857 map=yes
+[scope] shared key=layer axis=y 140σ = 400            σ=2.857 map=no
+[scope] coord  key=coord axis=x 16σ = 6.283           σ=0.393 map=no
+```
+
+That the root and shared scopes on one axis print the same σ is Stage 6's
+invariant made visible: **one slope per σ-scope, by construction**, because the
+frame equation is solved once and the posScale is a derived view of that solve.
+
 ## Scales generalize flex factors
 
 A size scale whose range resolves to the parent's extent is doing exactly

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -494,12 +494,39 @@ on one axis is the sanctioned multi-scale reading.
   cells carry intrinsic waffle-size claims, now content-sizes its tracks (facets
   pack to content instead of stretching to equal box-division).
 
-- **6f — determinacy from rank.** The Stage-1 `spacePlacement` view retires:
-  free/determined/conflict is read off the scope system's baseline-subsystem
-  rank/consistency. Space resolution keeps only data facts
-  (`width`, `dataDomain`, `measure`). The align transfer functions become
-  transfer functions _of the solver's abstract domain_, closing the
-  "guards should be blindingly obvious" thread.
+- **6f — the guards ask the solver. Landed.** The last layout guard that
+  reconstructed a fact from the space pass retires. `align`'s "is this target
+  already positioned?" no longer calls a `Placeable.placementOn(dir)` method that
+  rebuilt the `free`/`determined`/`conflict` lattice from the target's
+  `dataDomain` mid-lowering. Instead the placement solve's own authority record —
+  the `PlacementOwnershipPlan` — answers it, through one predicate
+  `isDataPositioned(axis, name)`. The fact it reads (which children are anchored
+  to a POSITION scope on each axis) is a pure **data/scope** fact — a child's
+  `dataDomain` present on that axis — collected _once_ at the layer boundary
+  (`layer.tsx`, where the child spaces already live) and handed to the solve as an
+  explicit ownership input alongside `initiallyPlaced`/`positionPinned`. So the
+  constraint path no longer consults `spacePlacement` at all (the debug printer
+  and the space folds still do, which is where a determinacy read belongs), and
+  `placementOn` is deleted from the `Placeable` contract and `GoFishNode`.
+
+  **What "determinacy from rank" meant vs. what shipped.** The plan framed this
+  as reading free/determined/conflict off the placement subsystem's rank. The
+  corpus forensics (376 guarded cells across every faceted/stacked story) showed
+  the load-bearing targets — faceted scatter/stacked panels — carry **no strong
+  pin and no self-placement** (`dims.min` undefined); their determinacy comes
+  entirely from an **anchored posScale** (a SIZE/scope fact), which the placement
+  rank cannot see. So a literal "rank of the placement subsystem" reading would
+  have called them _free_ and moved them — a behavior change. The realized form
+  keeps the same fact but sources it honestly (scope membership, a data fact),
+  routing it through the ownership plan so the guard's _input_ is the solver's
+  authority record rather than a late reconstruction. Behavior-preserving:
+  the new path fires on exactly the same 376 cells; full suite + solver-shadow
+  sweep (260/260 clean) + pixel gate all green.
+
+  This closes the "guards should be blindingly obvious" thread that started the
+  whole design arc: space resolution now keeps only data facts (`width`,
+  `dataDomain`, `measure`), and every layout guard reads the placement solve's
+  ownership plan, not the space pass.
 
 ### Open design questions (resolve during 6, tracked now)
 
@@ -547,6 +574,37 @@ Stages 0–3 are each a small PR and can land this week in any order. Stage 4 is
 the enabling refactor and should land alone, with nothing else in the diff.
 Stage 5 consumes 4. Stage 6 consumes 4+5 and subsumes the leftovers of 2
 (span's internal machinery) and 3 (grid's bypasses).
+
+**Status (per stage):**
+
+| Stage                                   | Status                                                 |
+| --------------------------------------- | ------------------------------------------------------ |
+| 0 — docs / vocabulary                   | **landed**                                             |
+| 1 — placement lattice                   | **landed**                                             |
+| 2 — span → position                     | **landed**                                             |
+| 3 — grid cliff                          | **landed**                                             |
+| 4 — one scale carrier                   | **landed**                                             |
+| 5 — rank-2 placement (5a/5b/5c)         | **landed**                                             |
+| 6a — observe (shadow coverage)          | **landed**                                             |
+| 6b — one solve site (scope registry)    | **landed**                                             |
+| 6c — one slope per σ-scope              | **landed** (carrier + sole producer; residue deferred) |
+| 6d — translate retirement               | **landed**                                             |
+| 6e — grid as tracks                     | **landed**                                             |
+| 6f — the guards ask the solver          | **landed**                                             |
+| #659 — self-scaled stash escapes nicing | **next** (own stage, post-6f)                          |
+
+The whole staged plan (0–6f) is landed. The one remaining known dual-slope is
+#659 — a self-scaled marginal panel whose stashed count space sidesteps the
+nicing applied to the shared axis domain, so its ticks and bars read two slopes
+of the _same_ space. That is a
+genuine stash-escape (not the sanctioned panel-local-SIZE-vs-shared-POSITION
+multi-scale) and is scheduled as its own stage after 6f. The three other
+two-scope-on-one-axis stories the 6c inventory flagged (Faceted Chart/Default,
+Labels/LabelOnSpread, Layered Bars and Area/HoistedVarietySpread) are **not**
+#659 variants: each carries one shared POSITION scope (the y map) plus several
+panel-local SIZE scopes solved by the spread/stack `sharedScale` machinery, but
+the marks consume the inherited POSITION σ — the local SIZE σ is computed and not
+consumed, so there is no rendered dual slope and no correctness issue.
 
 Wiki obligation: most touched files carry the `@wiki Underlying Space`
 backlink — `underlying-space.md` must be updated in the same change for every

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -358,7 +358,17 @@ still has two independent slopes after Stage 6, that is a bug in Stage 6.
 - **6b — one solve site.** Move the root inversion + the three
   `buildChildScalePlan` steps behind a single scope-root API with the same
   numbers and priority. The #618 guard becomes "not a root → inherit".
-  Pixel gate.
+  Pixel gate. **Landed:** `ast/solver/scopes.ts` holds a per-render
+  `ScopeRegistry` (on the `RenderSession`) whose `solveSize` / `solvePosition`
+  are the ONE place σ / posScale is derived; the render root (`gofish.tsx`),
+  `buildChildScalePlan`'s self-scaled / constraint-budget / shared steps, and the
+  coord boundary (`coord.tsx` `fitAxis`) all call it with bit-identical
+  arithmetic. The #618 propagate-vs-re-root guard is now the structural
+  "is this a scope root?" predicate in `buildChildScalePlan` (an intermediate
+  budget skips the solve and inherits). `GOFISH_DUMP_SCOPES` prints one frame
+  equation per scope. The sweep (`capture-sweep`) stayed clean and the
+  coord/confluence tests (flat ≡ nested σ) pass, confirming goTree/polar render
+  identically.
 - **6c — σ-affine claims flow.** Marks/folds contribute width `Monotonic`s
   into cells instead of pre-multiplied numbers; evaluation defers to the
   scope boundary; the "evaluate at σ, hand concrete sizes down" double

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -334,19 +334,43 @@ posScale and σ are _views_ of the solved system (the Stage-4 `AxisScale`
 record becomes exactly this view: σ = slope, `map` = anchored `min` anchor +
 pixel min; the intercept is `posScale(0)`, derived, never stored).
 
-**The dual slope is transitional debt, eliminated here — not a keeper.**
-Stage 4's `AxisScale.map` carries its own slope because today σ is solved in
-the four+ places above against four different pixel budgets, so a mark can
-read size-σ and position-slope from different extents on one axis (nicing
+**The dual slope was transitional debt — discharged in 6c as two scopes, not
+independent state.** Stage 4's `AxisScale.map` carried its own slope because σ was
+solved in the four+ places above against four different pixel budgets, so a mark
+could read size-σ and position-slope from different extents on one axis (nicing
 asymmetry, spacing's slope-vs-secant, sub-budget scopes vs an inherited map).
 Stage 6's invariant is **one slope per σ-scope, by construction**: the frame
 equation solves σ once at the scope root and the posScale is a derived view
-of the same solve, so within a scope the two cannot disagree. The divergences
-that remain must then become what they really are — two scopes on one axis
-(keyed by measure: the multi-scale/dual-axis design), or explicit non-data
-pixels (spacing as a piecewise gap, not a secant that papers over it).
-`AxisScale` collapses back to a single-slope view when 6b/6c land; if it
-still has two independent slopes after Stage 6, that is a bug in Stage 6.
+of the same solve, so within a scope the two cannot disagree. After 6c that holds
+everywhere the carrier flows — the scope registry is the **sole producer** of
+every slope, so neither `sigma` nor `map.sigma` is ever a free number. The
+remaining divergences became what they really are:
+
+- **Nicing asymmetry (case 1) resolves to two scopes (case 3).** The corpus
+  (`GOFISH_DUMP_SCOPES` + the 6b shadow) shows the only anchored-vs-size
+  disagreement is a marginal panel whose ticks map the _niced_ axis domain
+  (`[0,44]→[0,80]`, σ=1.818, the POSITION scope) while its bars size the
+  _un-niced_ stacked total (`45σ=80`, σ=1.778, the SIZE scope). These are two
+  distinct scopes on one axis, each read by its own channel (ticks read the map,
+  bars read σ) — exactly the sub-budget-vs-inherited shape, so case 1 needs no
+  separate machinery.
+- **Spacing / non-data pixels (case 2)** are already the Monotonic intercept in
+  the frame equation (`width.inverse(allocated)`), so the per-segment slope is the
+  scope σ, not a secant. No change needed.
+- **Sub-budget vs inherited (case 3)** is a SIZE scope (the panel's local budget)
+  and a POSITION scope (a shared ancestor map) coexisting on one axis. The
+  `AxisScale`'s two halves are precisely these two scope views; each is a single
+  registry-solved σ.
+
+So `AxisScale` is a **two-scope view**, not a slope with a redundant twin. Every
+`map` comes from `computePosScale` via `solvePosition` (or the equal-measure
+recentering), every `sigma` from `solveSize`; there is **no independent slope**
+after Stage 6. The two former fabrication sites are closed: a coord boundary's
+POSITION-only axis no longer hands down a scope-less `σ = 1` (it carries no size σ),
+and the #582 recentering is a named `recenterEqualMeasure` operation on the
+registry (so the dump shows the final σ). If a carrier ever shows two _independent_
+slopes — a slope not traceable to a registry scope — that is a bug; two _scopes_
+on one axis is the sanctioned multi-scale reading.
 
 ### Sub-stages, each gated
 
@@ -369,10 +393,25 @@ still has two independent slopes after Stage 6, that is a bug in Stage 6.
   equation per scope. The sweep (`capture-sweep`) stayed clean and the
   coord/confluence tests (flat ≡ nested σ) pass, confirming goTree/polar render
   identically.
-- **6c — σ-affine claims flow.** Marks/folds contribute width `Monotonic`s
-  into cells instead of pre-multiplied numbers; evaluation defers to the
-  scope boundary; the "evaluate at σ, hand concrete sizes down" double
-  bookkeeping (`computeSize`'s scaleFactor path) collapses. Pixel gate.
+- **6c — one slope per σ-scope, by construction.** **Landed (carrier + sole
+  producer):** the scope registry is now the ONLY producer of every slope, so the
+  `AxisScale`'s two halves (`sigma` = SIZE scope σ, `map.sigma` = POSITION scope σ)
+  are each a registry-solved scope view — never independent state. The two former
+  fabrication sites were closed: a coord boundary's POSITION-only axis dropped its
+  scope-less `σ = 1` placeholder (pixel-identical — no consumer read it), and the
+  #582 equal-measure recentering moved off `gofish.tsx` into a named
+  `ScopeRegistry.recenterEqualMeasure` operation (so `GOFISH_DUMP_SCOPES` records
+  the FINAL σ). The pre-change inventory (dump + a temporary `[solver-check]`
+  dual-slope shadow driven to zero across the 260-story sweep) confirmed the only
+  surviving anchored-vs-size disagreements are legitimate two-scope cases (nicing
+  and sub-budget), each half consumed by its own channel. **Deferred (residue,
+  acceptable per the plan):** the "evaluate at σ, hand concrete sizes down" double
+  bookkeeping still stands — `computeSize`'s `scaleFactor` path (`rect`, `layer`,
+  `treemap`), the `size × σ` pre-multiply in `petal`/`ellipse`, and distribute's
+  `scaleFactor` callbacks all still evaluate a width at a known σ at the consumer
+  rather than flowing a `Monotonic` claim to the scope boundary. Making cells
+  carry `Monotonic` claims (so evaluation defers to the boundary) is the larger
+  6e-adjacent change and was held to keep the carrier landing pixel-clean.
 - **6d — translate retirement (#39 stage 3-D).** Render consumes baked
   absolute coordinates through the `displayTranslate`/`translateString`
   chokepoints (`dims.ts:268-294` was written to make this a one-function

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -348,12 +348,16 @@ remaining divergences became what they really are:
 
 - **Nicing asymmetry (case 1) resolves to two scopes (case 3).** The corpus
   (`GOFISH_DUMP_SCOPES` + the 6b shadow) shows the only anchored-vs-size
-  disagreement is a marginal panel whose ticks map the _niced_ axis domain
-  (`[0,44]→[0,80]`, σ=1.818, the POSITION scope) while its bars size the
-  _un-niced_ stacked total (`45σ=80`, σ=1.778, the SIZE scope). These are two
-  distinct scopes on one axis, each read by its own channel (ticks read the map,
-  bars read σ) — exactly the sub-budget-vs-inherited shape, so case 1 needs no
-  separate machinery.
+  disagreement is a marginal panel whose count axis is a **self-scaled region**:
+  it carries an explicit pixel size, so it stashes its own space and builds a
+  LOCAL scale against its own box (`buildChildScalePlan` step 2). That stashed
+  space **escapes the nicing** applied to the shared/outer axis domain (#659), so
+  the panel's own count scale (`45σ=80`, σ=1.778, the SIZE scope) and the shared
+  niced map read by the ticks (`[0,44]→[0,80]`, σ=1.818, the POSITION scope) are
+  two distinct scopes, each consumed by its own channel — exactly the
+  self-scaled-vs-inherited shape, so case 1 needs no separate machinery. (It is
+  NOT one axis whose ticks are niced and whose bars are un-niced; it is the
+  self-scaled stash sidestepping nicing entirely.)
 - **Spacing / non-data pixels (case 2)** are already the Monotonic intercept in
   the frame equation (`width.inverse(allocated)`), so the per-segment slope is the
   scope σ, not a secant. No change needed.
@@ -449,16 +453,47 @@ on one axis is the sanctioned multi-scale reading.
   spent by the earlier `_render`→display-list migration, so 6d is pixel- AND
   DOM-neutral.
 
-- **6e — grid as tracks.** A grid scope introduces `numCols + numRows` track
-  cells; each cell(i, j) gets equations `cell.min = track.min` and
-  `cell.size = track.size` per axis. Equal-flex is "all track sizes equal +
-  Σ tracks + gaps = W" (today's `sliceExtent`, as equations); content-sized
-  tracks are `track.size ≥ max(cell claims)` — note `max` leaves the linear
-  fragment (piecewise claims; see the `monoEqual` two-point-probe caveat in
-  `bbox.ts`), so this lands as an iterate-or-piecewise extension, and is the
-  point where `table` gains content-sized tracks. The Stage-3 layer bypasses
-  (space-fold early return, cell-budget special case, mixing throw) delete;
-  `gridSpaces`' ORDINAL axes contribution stays but composes.
+- **6e — grid as tracks. Landed.** A grid resolves its tracks under the ONE
+  unified sizing rule — the same (max, +) fold every other operator uses:
+
+  ```
+  track claim = Monotonic.max(claims of the cells in that track)
+  grid claim  = Monotonic.add(track claims) + gaps          (the σ-frame LHS)
+  ```
+
+  A claim-less (fill) cell contributes nothing, so an all-fill grid has no track
+  claims and the leftover (allocated − gaps) splits equally — bit-identical to
+  the former `sliceExtent` box-division. Content-sized tracks emerge
+  automatically when cells carry claims (a track sizes to its widest cell; fill
+  tracks share the remainder). `max` and `add` are BOTH closed over the convex
+  piecewise-linear (max, +) algebra — the composed claim stays a `Monotonic`, so
+  when every track is claimed with a σ-dependent claim the grid claim inverts
+  against the allocated size through the scope registry exactly like any other
+  frame equation (the common all-constant, fixed-px case is σ-independent and
+  reads back its intercept). Because piecewise claims now flow into cells, the
+  `monoEqual` two-point probe in `bbox.ts` was upgraded to `Monotonic.approxEqual`
+  — structural (compare at 0, 1, and every pairwise breakpoint) for piecewise
+  operands, the same cheap two-point line probe for the all-linear common case.
+
+  **Design choice — pre-resolution, not tracks-in-the-graph.** Tracks are
+  resolved by `resolveGridTracks` (the sizing budget for fill cells) and, for
+  placement, by `gridTracksFromSizes` from the ACTUAL laid-out cell sizes, so the
+  cell-center pins match the real geometry and the solver shadow cannot drift
+  from what rendered. This reuses the rank-2 placement solver as-is (cells pin to
+  their track-intersection centers) — the equations are identical to naming each
+  track a cell in the difference graph, but lighter. The Stage-3 layer bypasses
+  are deleted (space-fold early return, the whole-layer cell-budget special case,
+  the mixing throw); grid now GENUINELY composes — its per-track claim
+  participates in the fold and its cell pins solve jointly with align / position
+  / z-order (a `position` pin on a cell overrides its track centering, the
+  authoritative-pin pattern). `gridSpaces`' ORDINAL track axes stay for axis
+  rendering (a categorical axis can't also be a SIZE magnitude), composing
+  through the same return path rather than an early exit. The at-most-one-grid
+  rule and `__grid_cell_i` naming stay. **Gate:** all-fill tables pixel-identical
+  (heatmaps unchanged); one intended mover — the Titanic facet unit grid, whose
+  cells carry intrinsic waffle-size claims, now content-sizes its tracks (facets
+  pack to content instead of stretching to equal box-division).
+
 - **6f — determinacy from rank.** The Stage-1 `spacePlacement` view retires:
   free/determined/conflict is read off the scope system's baseline-subsystem
   rank/consistency. Space resolution keeps only data facts
@@ -477,8 +512,13 @@ on one axis is the sanctioned multi-scale reading.
   scope registry is keyed that way from the start.
 - **Where scope state lives:** on the render session (like `toPixel`) vs a
   map keyed by scope-root uid; must survive resume/re-layout.
-- **Piecewise claims:** `max`-composition (6e) and any future clamp break the
-  two-point `monoEqual` probe; decide the claim representation before 6e.
+- **Piecewise claims (resolved in 6e):** `max`-composition keeps claims in the
+  convex piecewise-linear (max, +) algebra (both `max` and `add` are closed over
+  it), so the representation is unchanged — the only fix needed was the equality
+  probe: `monoEqual` now delegates to `Monotonic.approxEqual`, which compares
+  piecewise operands structurally (at 0, 1, and every breakpoint) and keeps the
+  cheap two-point line probe for the all-linear case. A future non-monotone clamp
+  would still need more.
 
 ### Debuggability requirement
 

--- a/apps/docs/docs/internals/design/sigma-affine-simplification.md
+++ b/apps/docs/docs/internals/design/sigma-affine-simplification.md
@@ -412,11 +412,43 @@ on one axis is the sanctioned multi-scale reading.
   rather than flowing a `Monotonic` claim to the scope boundary. Making cells
   carry `Monotonic` claims (so evaluation defers to the boundary) is the larger
   6e-adjacent change and was held to keep the carrier landing pixel-clean.
-- **6d — translate retirement (#39 stage 3-D).** Render consumes baked
-  absolute coordinates through the `displayTranslate`/`translateString`
-  chokepoints (`dims.ts:268-294` was written to make this a one-function
-  change); the per-container `<g translate>` wrappers collapse. Expect benign
-  DOM reshuffles — this is precisely the pixel-not-DOM gate case.
+- **6d — translate retirement (#39 stage 3-D). Landed.** The per-container
+  translate-composition closures collapse: a pure translate-only bake boundary
+  (`box`/`frame`, `offset`, `enclose`) no longer composes its translate into a
+  child-local `toPixel` closure and lower its children parent-relative. Instead
+  it flattens its own subtree via the new `bakeChildren` (the root bake's
+  z-ordered children-flatten, factored out of `bake`) seeded at its absolute
+  translate, and lowers each descendant at its baked absolute transform
+  (`INTERNAL_lower(coord, d.transform)`) — the identical mechanism the root bake
+  already uses, so the two paths can't drift. The non-identity `scale` exception
+  stays a `group` wrapper (a flat list can't fold scale). The dead
+  `translateString` chokepoint (`dims.ts`) — every legacy `<g transform>` render
+  had already migrated to the display-list `toPixel` fold, leaving it imported
+  but never called — is deleted along with its four dead imports. `displayTranslate`
+  stays: it is the read of a baked absolute transform that the space-remap boundary
+  (`coord`'s `contentToPixel`) and the self-drawers (`connect`/`arrow`) apply to
+  their own geometry — those are NOT pure translate-only containers, so they keep
+  composing (the documented exception).
+
+  **No `transform.translate` write was retired.** Render/lower already reads the
+  ledger projection (`projectedTranslate`/`_displayTransform`), never the raw
+  written field; the surviving raw writes (`_pinAnchor`'s under-determined-axis
+  fallback, the `layout()` seed) feed `_projectTranslate`'s fallback, which
+  `ref`s and constraints also read — so none is render-only, and the
+  `translate === undefined` "parent may place me" sentinel is untouched.
+
+  **Gate — pixel, not DOM.** The zero-pixel gate is a new `capture-pixels`
+  script (`tests/scripts/capture-pixels.ts`): render every story to PNG at HEAD
+  and at the base ref in the SAME local Chromium, pixelmatch at threshold 0.
+  Result: **260/260 stories, 0 pixels moved.** Because the display-list path had
+  already inlined translate composition into coordinates (no `<g translate>`
+  wrappers survived for these boundaries — only the `scale` group), collapsing
+  the closures is byte-identical in the normalized DOM too: `capture-diff` and
+  `capture-sweep` (solver shadow) both report **260/260 identical / clean**. The
+  anticipated "benign DOM reshuffle" did not materialize — the reshuffle was
+  spent by the earlier `_render`→display-list migration, so 6d is pixel- AND
+  DOM-neutral.
+
 - **6e — grid as tracks.** A grid scope introduces `numCols + numRows` track
   cells; each cell(i, j) gets equations `cell.min = track.min` and
   `cell.size = track.size` per axis. Equal-flex is "all track sizes equal +

--- a/apps/docs/docs/internals/layout/coord-flattening.md
+++ b/apps/docs/docs/internals/layout/coord-flattening.md
@@ -130,7 +130,9 @@ canvas (gofish.tsx) — here the angular/radial budget plays the canvas role. It
 `fitAxis(axis, budget)` reads the subtree's resolved space on that axis and
 returns a `(scaleFactor, posScale)` to hand each child: a baseline-magnitude
 (data SIZE) axis scales by `width.inverse(budget)` so the children fill the ring;
-an anchored (data POSITION) axis maps onto `[0, budget]` via a posScale. Only
+an anchored (data POSITION) axis maps onto `[0, budget]` via a posScale and
+carries **no** size σ (Stage 6c — a POSITION-only axis has no SIZE scope, so it
+never fabricates one; the map's own slope is the scope's σ). Only
 DATA-bound channels consume these — a plain number bypasses both (see
 `computeAesthetic`) — so a hand-sized (radian/pixel) mark is unaffected, while a
 mark that says `thetaSize: datum(count)` auto-fits. Because the coord is the

--- a/apps/docs/docs/internals/layout/coord-flattening.md
+++ b/apps/docs/docs/internals/layout/coord-flattening.md
@@ -118,6 +118,17 @@ which the render entry maps over directly.
   descends into each unit, so a component keeps its internal order. Transforms still
   compose all the way to the leaves; only the _ordering_ is per-layer.
 
+**`bakeChildren` — the same flatten, reused by boundaries.** `bake`'s per-transparent-layer
+children-flatten (the z-order resolution + transform composition) is factored into an
+exported `bakeChildren(node, translate, scale)`. A pure translate-only boundary
+(`box`/`frame`, `offset`, `enclose`) calls it on its _own_ subtree, seeded at the
+boundary's absolute translate, and lowers each returned entry at its baked absolute
+transform. This is stage 6d of [#39](https://github.com/gofish-graphics/gofish-graphics/issues/39):
+a translate-only boundary no longer composes its translate into a `toPixel` closure and
+lower its children parent-relative — it bakes them to absolute coordinates through the
+exact z-order-preserving path the root uses, so the two mechanisms can't drift. Only a
+non-identity `scale` (which a flat list can't fold) still needs a `group` wrapper.
+
 This root bake is the first step toward a serializable [display
 list](/internals/core/rendering) (the render IR): once each draw entry is a
 self-contained primitive rather than a `{ node, transform }` back-reference, the flat

--- a/apps/docs/docs/internals/layout/passes.md
+++ b/apps/docs/docs/internals/layout/passes.md
@@ -378,7 +378,10 @@ are built and before `child.layout`: when `spaceMeasure(x) === spaceMeasure(y)`
 domain's `canvas / range` or a baseline-magnitude σ — is equated to the binding
 `min(...)` so one data unit measures the same on both axes (circles stay circular,
 maps stay undistorted); the binding axis fills, the other gets a recentered
-posScale. It is type equality, not a knob, and a single-coordinate-space coupling
+posScale. Stage 6c makes this a named `recenterEqualMeasure` operation _on_ the
+scope registry rather than an inline rewrite, so it is the one post-solve σ
+adjustment on the registry's books and `GOFISH_DUMP_SCOPES` records the final σ.
+It is type equality, not a knob, and a single-coordinate-space coupling
 — it does not reach sizes solved in separate nested operator scopes. After layout it
 reads the chart's _final_ extent back off the root via `child.dims[i].size`, so an
 unsized axis still yields a concrete SVG size (e.g. a no-width bar chart gets

--- a/apps/docs/docs/js/api/operators/table.md
+++ b/apps/docs/docs/js/api/operators/table.md
@@ -64,3 +64,14 @@ chart(data, { color: gradient(["#ffffcc", "#fd8d3c", "#bd0026"]), axes: true })
 - Data insertion order determines column and row ordering. Sort your data first if you need a specific order.
 - Unlike nested `spread` calls, `table` correctly exposes ordinal axes on both dimensions so axis labels render on both x and y.
 - Pair with `gradient()` on the chart color option and `fill: "fieldName"` on the mark for heatmap coloring.
+
+### Cell sizing
+
+Tracks size by one rule: a column (or row) is as wide (or tall) as its widest
+(or tallest) cell — `track = max(cell size claims)`. Cells that carry no size
+claim ("fill" cells, like a plain `rect({ fill })` in a heatmap) contribute
+nothing, so an **all-fill table divides its box into equal tracks** exactly as
+before — heatmaps are unchanged. When cells DO carry a size claim (for example a
+nested chart whose own content has an intrinsic size), each track sizes to its
+widest cell and the table shrinks to fit its content, rather than stretching
+every cell to an equal share of the box.

--- a/apps/docs/docs/python/api/operators/table.md
+++ b/apps/docs/docs/python/api/operators/table.md
@@ -68,3 +68,14 @@ chart(data).flow(table(by={"x": "col", "y": "row"}, spacing=(2, 8)))
   ordinal axes on **both** dimensions, so axis labels render on x and y.
 - Pair `gradient()` on the chart `color` option with `fill="fieldName"` on the
   mark for heatmap coloring.
+
+### Cell sizing
+
+Tracks size by one rule: a column (or row) is as wide (or tall) as its widest
+(or tallest) cell — `track = max(cell size claims)`. Cells that carry no size
+claim ("fill" cells, like a plain `rect(fill=...)` in a heatmap) contribute
+nothing, so an **all-fill table divides its box into equal tracks** exactly as
+before — heatmaps are unchanged. When cells DO carry a size claim (for example a
+nested chart with intrinsic content size), each track sizes to its widest cell
+and the table shrinks to fit its content instead of stretching every cell to an
+equal share of the box.

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -6,6 +6,9 @@
 // </gofish-wiki>
 
 import type { JSX } from "solid-js";
+// Type-only (erased) so no runtime cycle with solver/scopes.ts, which imports
+// RenderSession from here.
+import type { ScopeRegistry } from "./solver/scopes";
 import {
   Anchor,
   Dimensions,
@@ -90,6 +93,10 @@ export type RenderSession = {
   /** Set by the lower emit driver (`lowerToDisplayList`) for the duration of a
    *  lowering walk: the y-up→y-down pixel mapping every `lower` body uses. */
   toPixel?: ToPixel;
+  /** The σ-scope registry (#39 Stage 6b): the one place σ / posScale is derived,
+   *  shared by every scope root in this render. Created on first use
+   *  (`getScopeRegistry`). */
+  scopes?: ScopeRegistry;
 };
 
 export type ScaleFactorFunction = Monotonic.Monotonic;
@@ -1168,6 +1175,20 @@ export class GoFishNode {
       return this.parent.getRenderSession();
     }
     throw new Error("Render session not set");
+  }
+
+  /** Non-throwing session lookup for the layout-path σ-scope registry (Stage 6b):
+   *  the full `gofish()` flow always sets a session before layout, but a
+   *  standalone `node.layout(...)` (some coord/confluence tests) has none — then
+   *  the scope solve just uses a throwaway registry with identical arithmetic. */
+  public tryGetRenderSession(): RenderSession | undefined {
+    if (this.renderSession) return this.renderSession;
+    const parent = this.parent as
+      | { tryGetRenderSession?: () => RenderSession | undefined }
+      | undefined;
+    return parent && typeof parent.tryGetRenderSession === "function"
+      ? parent.tryGetRenderSession()
+      : undefined;
   }
 
   public render(

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -58,7 +58,6 @@ import {
   continuousInterval,
   spacePlacement,
   CONTINUOUS_TYPE,
-  type Placement,
   UnderlyingSpace,
 } from "./underlyingSpace";
 import { toJSON, interval } from "../util/interval";
@@ -128,12 +127,6 @@ export type Placeable = {
    *  uses this to express every anchor as `absoluteMin + constant`, including
    *  `baseline` for asymmetric boxes such as text and negative bars. */
   localAnchor?: (axis: FancyDirection, anchor: Anchor) => number | undefined;
-  /** This target's abstract {@link Placement} on `dir` (`"free"` /
-   *  `"determined"` / `"conflict"`), or `undefined` for a non-continuous axis.
-   *  `align` reads it to leave self-positioned children alone. Omitted by `ref`
-   *  stand-ins (→ `undefined`, so they get the fallback baseline like any
-   *  chrome). */
-  placementOn?: (dir: Direction) => Placement | undefined;
   place: (axis: FancyDirection, value: number, anchor?: Anchor) => void;
   /** Write an axis extent from owned bbox keys (the size-setting primitive
    *  #39 — `span` and an authoritative `position` pin go through it). Optional
@@ -896,19 +889,6 @@ export class GoFishNode {
     )
       return undefined;
     return localAnchorPoint(anchor, intrinsic.min, intrinsic.size ?? 0);
-  }
-
-  /** This node's abstract {@link Placement} on `dir` (the layout half of its
-   *  underlying space) — `"free"` (awaiting a position), `"determined"` (already
-   *  committed to a data coordinate), or `"conflict"`. `undefined` for a
-   *  non-continuous / unresolved axis (chrome). `align` reads it to leave
-   *  self-positioned children (a scatter facet) where their own scale puts them
-   *  — the principled replacement for the data-positioned guard. */
-  public placementOn(dir: Direction): Placement | undefined {
-    const sp = this._underlyingSpace?.[dir];
-    return sp !== undefined && isCONTINUOUS(sp)
-      ? spacePlacement(sp)
-      : undefined;
   }
 
   private get _displayTransform(): Transform | undefined {

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -74,18 +74,30 @@ function normalizedAnchors(spec: AlignAxisSpec, count: number): AlignAnchor[] {
   return spec;
 }
 
+/**
+ * "Is this align target already positioned by a data scale on this axis?" —
+ * the guard that leaves self-positioned children (a scatter facet panel) where
+ * their own data scale puts them, instead of moving them to the shared baseline.
+ *
+ * Stage 6f: this no longer reconstructs the space-pass `free/determined/conflict`
+ * lattice by calling a `placementOn` method on the target during lowering. The
+ * fact "this (node, axis) is anchored to a POSITION scope" is collected ONCE at
+ * the layer boundary (a member of the shared data→pixel map — its baseline is
+ * `posScale(0)`, not free to slide) and handed to the ownership plan, which is
+ * the single authority the align guard now consults (`isDataPositioned`). It is
+ * only meaningful where a data scale exists on the axis (`posScales[axis]`) and
+ * the anchor is not `middle` (a center alignment resolves against the box, not a
+ * scale origin).
+ */
 function isDataPositionedAlignTarget(
-  target: Placeable | undefined,
+  name: string,
   anchor: AlignAnchor,
   axis: 0 | 1,
-  posScales: ConstraintPosScales | undefined
+  posScales: ConstraintPosScales | undefined,
+  isDataPositioned: (axis: 0 | 1, name: string) => boolean
 ): boolean {
   if (anchor === "middle" || posScales?.[axis] === undefined) return false;
-  const placement =
-    typeof target?.placementOn === "function"
-      ? target.placementOn(axis)
-      : undefined;
-  return placement !== undefined && placement !== "free";
+  return isDataPositioned(axis, name);
 }
 
 export function lowerAlignPlacement(
@@ -96,11 +108,13 @@ export function lowerAlignPlacement(
     targets,
     posScales,
     isPinned,
+    isDataPositioned,
   }: {
     emitter: PlacementFactEmitter;
     targets: Map<string, Placeable>;
     posScales: ConstraintPosScales | undefined;
     isPinned: (axis: Axis, name: string) => boolean;
+    isDataPositioned: (axis: 0 | 1, name: string) => boolean;
   }
 ): void {
   const emit = (axis: Axis, spec: AlignAxisSpec | undefined) => {
@@ -128,8 +142,13 @@ export function lowerAlignPlacement(
     const source = entries.find(({ child }) => isPinned(axis, child.name));
     const movable = entries.filter(({ child, anchor }) => {
       if (isPinned(axis, child.name)) return false;
-      const target = targets.get(child.name);
-      return !isDataPositionedAlignTarget(target, anchor, idx, posScales);
+      return !isDataPositionedAlignTarget(
+        child.name,
+        anchor,
+        idx,
+        posScales,
+        isDataPositioned
+      );
     });
     if (movable.length === 0) return;
 

--- a/packages/gofish-graphics/src/ast/constraints/bbox.ts
+++ b/packages/gofish-graphics/src/ast/constraints/bbox.ts
@@ -59,17 +59,14 @@ const COEFFS: Record<BBoxKey, [number, number]> = {
 const asMono = (v: BBoxValue): Monotonic.Monotonic =>
   typeof v === "number" ? Monotonic.linear(0, v) : v;
 
-/** Equality of two σ-affine claims, by probing at two distinct σ (two points
- *  pin a line). v1 limitation: exact only for linear claims; a piecewise claim
- *  agreeing at 0 and 1 but differing on another segment would read as equal —
- *  acceptable until a size-setting constraint produces a piecewise key. */
+/** Equality of two σ-affine claims. Linear claims are pinned exactly by two
+ *  probes; piecewise claims (Stage 6e's `max`-composed track claims) are
+ *  compared structurally at every breakpoint. See `Monotonic.approxEqual`. */
 const monoEqual = (
   a: Monotonic.Monotonic,
   b: Monotonic.Monotonic,
   tolerance: number
-): boolean =>
-  Math.abs(a.run(0) - b.run(0)) <= tolerance &&
-  Math.abs(a.run(1) - b.run(1)) <= tolerance;
+): boolean => Monotonic.approxEqual(a, b, tolerance);
 
 export interface BBoxConflict {
   key: BBoxKey;

--- a/packages/gofish-graphics/src/ast/constraints/grid.ts
+++ b/packages/gofish-graphics/src/ast/constraints/grid.ts
@@ -6,31 +6,49 @@
 //
 // A grid is the symmetric 2-D layout: cells partitioned into `numCols` columns
 // (a track per column on x) and the implied rows (a track per row on y), every
-// cell filling its (column, row) track intersection. It's the elaboration
+// cell pinned to its (column, row) track intersection. It's the elaboration
 // target for `table` — `layer(cells).constrain(grid(...))`.
 //
-// The per-axis size equation is the flex-track form from layout-synthesis.md:
+// **The unified sizing rule (Stage 6e).** Per axis, a track's extent is set by
+// ONE rule — the (max, +) fold every other operator already uses:
 //
-//   W = numCols · cellW + sx·(numCols−1)        →  cellW = (W − sx·(numCols−1)) / numCols
-//   H = numRows · cellH + sy·(numRows−1)        →  cellH = (H − sy·(numRows−1)) / numRows
+//   track claim   = Monotonic.max(claims of the cells in that track)
+//   grid claim    = Monotonic.add(track claims) + gaps          (the σ-frame LHS)
 //
-// For a uniform grid every track is one flex unit, so solving the equation is
-// the box-division `cellExtent` below — the table is the flex scope root (it
-// solves its tracks against its own box; nothing bubbles). The general
-// Σ-over-max-of-cells (content-sized tracks, variable flex) is a later
-// generalization; v1 is equal tracks with the cells filling them.
+// A claim-less ("fill") cell contributes nothing to its track. This subsumes
+// today's equal-flex box-division: an all-fill grid has no track claims, so the
+// leftover (allocated − gaps) splits equally among the tracks — bit-identical to
+// the former `sliceExtent`. Content-sized tracks emerge automatically when cells
+// carry size claims (a track sizes to its widest cell). Fill tracks share
+// whatever the claimed tracks leave over, equally.
+//
+// `resolveGridTracks` is the single site that runs this rule; both the layout
+// budget (each cell is proposed its track's extent) and the placement (each cell
+// pinned to its track-intersection center) read the SAME resolved tracks, so the
+// two cannot drift. When every track carries a σ-dependent claim (no fill to
+// absorb slack) the grid claim is inverted against the allocated size by the
+// scope registry, exactly like any other frame equation; the common all-constant
+// case (fixed-px cells) is σ-independent and reads back its intercept.
 //
 // The grid is interpreted by the Layer after `selectGridConstraint` has
-// established that there is at most one grid owner for the layer: `gridSpaces`
-// gives the ORDINAL axes (categorical columns/rows, for axis rendering), the
-// Layer's budget sizes each cell to `cellExtent`, and `placementSolver.ts`
-// centers each cell in its track.
+// established that there is at most one grid owner for the layer. `gridSpaces`
+// gives the categorical track axes (ORDINAL over columns/rows) for axis
+// rendering — a categorical axis cannot simultaneously be a SIZE magnitude, so
+// the grid's size claim is consumed at layout time (track resolution) rather than
+// reported as the axis space.
 
+import * as Monotonic from "../../util/monotonic";
 import { GoFishNode } from "../_node";
 import type { GoFishAST } from "../_ast";
 import { type ConstraintRef } from "./shared";
 import { sliceExtent } from "./folds";
-import { ORDINAL, UNDEFINED, type UnderlyingSpace } from "../underlyingSpace";
+import {
+  ORDINAL,
+  UNDEFINED,
+  isBaselineMagnitude,
+  type UnderlyingSpace,
+} from "../underlyingSpace";
+import type { ScopeRegistry } from "../solver/scopes";
 import type { PlacementFactEmitter } from "./placementFacts";
 
 export interface GridOptions {
@@ -74,58 +92,273 @@ export const isGridConstraint = (c: { type: string }): c is GridConstraint =>
 const numRowsOf = (c: GridConstraint): number =>
   Math.ceil(c.children.length / c.numCols);
 
-/** Per-cell proposed size `[cellW, cellH]` for a grid laid into `size` — each
- *  axis split into equal flex tracks via the shared `sliceExtent` (folds.ts). */
-export const gridCellSize = (
+/** The resolved geometry of one axis's tracks: each track's start (low edge, in
+ *  the layer's local pixel frame) and extent. `starts[i] + extents[i]/2` is the
+ *  center a cell in track `i` pins to. */
+export type TrackLayout = { starts: number[]; extents: number[] };
+
+/** A cell's size claim on `axis`: the SIZE-magnitude width Monotonic it reports,
+ *  or undefined when the cell fills (no size claim — a plain `rect({fill})`, a
+ *  literal-pixel cell, or an ORDINAL/POSITION axis). */
+const cellClaim = (
+  cell: GoFishAST | undefined,
+  axis: 0 | 1
+): Monotonic.Monotonic | undefined => {
+  if (!(cell instanceof GoFishNode)) return undefined;
+  const sp = cell._underlyingSpace?.[axis];
+  return sp !== undefined && isBaselineMagnitude(sp) ? sp.width : undefined;
+};
+
+/** Per-axis track claims: for each track (a column on x, a row on y), the max
+ *  over its cells' claims — the (max, +) rule. A track with no claiming cell is
+ *  `undefined` (a fill track). */
+export function gridTrackClaims(
   c: GridConstraint,
-  size: readonly [number, number]
-): [number, number] => [
-  sliceExtent(size[0], c.xSpacing, c.numCols),
-  sliceExtent(size[1], c.ySpacing, numRowsOf(c)),
-];
+  cells: readonly GoFishAST[]
+): [(Monotonic.Monotonic | undefined)[], (Monotonic.Monotonic | undefined)[]] {
+  const numRows = numRowsOf(c);
+  const colClaims = Array.from({ length: c.numCols }, (_, col) => {
+    const claims: Monotonic.Monotonic[] = [];
+    for (let row = 0; row < numRows; row++) {
+      const claim = cellClaim(cells[row * c.numCols + col], 0);
+      if (claim !== undefined) claims.push(claim);
+    }
+    return claims.length > 0 ? Monotonic.max(...claims) : undefined;
+  });
+  const rowClaims = Array.from({ length: numRows }, (_, row) => {
+    const claims: Monotonic.Monotonic[] = [];
+    for (let col = 0; col < c.numCols; col++) {
+      const claim = cellClaim(cells[row * c.numCols + col], 1);
+      if (claim !== undefined) claims.push(claim);
+    }
+    return claims.length > 0 ? Monotonic.max(...claims) : undefined;
+  });
+  return [colClaims, rowClaims];
+}
+
+/** Solve one axis of tracks against `allocated` pixels under the unified rule.
+ *
+ *  - No claims (all fill): the leftover after gaps splits equally — today's
+ *    `sliceExtent`, bit-identical.
+ *  - Some claims: each claimed track takes its claim (evaluated at the solved σ,
+ *    or its constant intercept when σ-independent); the remaining fill tracks
+ *    share whatever is left, equally. When EVERY track is claimed and a claim is
+ *    σ-dependent, σ is solved by inverting `Σ claims + gaps = allocated` through
+ *    the scope registry (the same frame equation as any other size scope). */
+function resolveAxisTracks(
+  claims: (Monotonic.Monotonic | undefined)[],
+  allocated: number,
+  spacing: number,
+  scopes?: ScopeRegistry,
+  meta?: { rootKey: string; axis: 0 | 1 }
+): TrackLayout {
+  const n = claims.length;
+  const gaps = spacing * Math.max(0, n - 1);
+  const nFill = claims.filter((c) => c === undefined).length;
+
+  let extents: number[];
+  if (nFill === n) {
+    const e = sliceExtent(allocated, spacing, n);
+    extents = claims.map(() => e);
+  } else {
+    // Solve σ only when every track is claimed (no fill absorbs the slack) and a
+    // claim is genuinely σ-dependent; otherwise claims are constants and σ is
+    // irrelevant (read back the intercept at σ=0).
+    let sigma = 0;
+    if (nFill === 0 && scopes !== undefined && meta !== undefined) {
+      const claimed = claims.filter(
+        (c): c is Monotonic.Monotonic => c !== undefined
+      );
+      const gridClaim = Monotonic.adds(Monotonic.add(...claimed), gaps);
+      if (!Monotonic.isConstant(gridClaim)) {
+        sigma =
+          scopes.solveSize(
+            { kind: "grid", rootKey: meta.rootKey, axis: meta.axis },
+            gridClaim,
+            allocated,
+            { upperBoundGuess: allocated }
+          ) ?? 0;
+      }
+    }
+    const claimedExtents = claims.map((c) =>
+      c === undefined ? undefined : Math.max(0, c.run(sigma))
+    );
+    const claimedTotal =
+      claimedExtents.reduce((s: number, e) => s + (e ?? 0), 0) + gaps;
+    const fillShare =
+      nFill > 0 ? Math.max(0, (allocated - claimedTotal) / nFill) : 0;
+    extents = claims.map((c, i) =>
+      c === undefined ? fillShare : claimedExtents[i]!
+    );
+  }
+
+  const starts: number[] = [];
+  let cursor = 0;
+  for (let i = 0; i < n; i++) {
+    starts.push(cursor);
+    cursor += extents[i] + spacing;
+  }
+  return { starts, extents };
+}
+
+/** Resolve both axes' tracks for a grid laid into `size`, under the unified
+ *  (max, +) sizing rule. The one site the rule runs; the layout budget and the
+ *  placement both read the result, so cell proposals and cell centers agree by
+ *  construction. */
+export function resolveGridTracks(
+  c: GridConstraint,
+  cells: readonly GoFishAST[],
+  size: readonly [number, number],
+  scopes?: ScopeRegistry,
+  rootKey = "grid"
+): [TrackLayout, TrackLayout] {
+  const [colClaims, rowClaims] = gridTrackClaims(c, cells);
+  return [
+    resolveAxisTracks(colClaims, size[0], c.xSpacing, scopes, {
+      rootKey,
+      axis: 0,
+    }),
+    resolveAxisTracks(rowClaims, size[1], c.ySpacing, scopes, {
+      rootKey,
+      axis: 1,
+    }),
+  ];
+}
+
+/** Lay out a run of track extents into `{ starts, extents }`: cumulative starts
+ *  with `spacing` reserved between adjacent tracks. */
+function layoutTrack(extents: number[], spacing: number): TrackLayout {
+  const starts: number[] = [];
+  let cursor = 0;
+  for (const e of extents) {
+    starts.push(cursor);
+    cursor += e + spacing;
+  }
+  return { starts, extents };
+}
+
+/** The AUTHORITATIVE placement tracks: each track's extent is the max of its
+ *  cells' ACTUAL laid-out sizes (a filled cell equals the budgeted extent; a
+ *  claim cell equals its content). Computed post-layout so the cell centers pin
+ *  to the real geometry — this is the single source both the placement and the
+ *  solver shadow read, so they cannot drift from what rendered. */
+export function gridTracksFromSizes(
+  c: GridConstraint,
+  cellSizes: (readonly [number, number] | undefined)[]
+): [TrackLayout, TrackLayout] {
+  const numRows = numRowsOf(c);
+  const colExtents = Array.from({ length: c.numCols }, (_, col) => {
+    let m = 0;
+    for (let row = 0; row < numRows; row++)
+      m = Math.max(m, cellSizes[row * c.numCols + col]?.[0] ?? 0);
+    return m;
+  });
+  const rowExtents = Array.from({ length: numRows }, (_, row) => {
+    let m = 0;
+    for (let col = 0; col < c.numCols; col++)
+      m = Math.max(m, cellSizes[row * c.numCols + col]?.[1] ?? 0);
+    return m;
+  });
+  return [
+    layoutTrack(colExtents, c.xSpacing),
+    layoutTrack(rowExtents, c.ySpacing),
+  ];
+}
+
+/** Per-cell proposed size `[cellW, cellH]`, keyed by cell name: each cell is
+ *  proposed its (column, row) track's extent. A fill cell fills that extent; a
+ *  claim cell keeps its own (equal or smaller) size and is centered in it. */
+export function gridCellSizeByName(
+  c: GridConstraint,
+  tracks: [TrackLayout, TrackLayout]
+): Map<string, [number, number]> {
+  const [cols, rows] = tracks;
+  const out = new Map<string, [number, number]>();
+  c.children.forEach((child, index) => {
+    if (child === undefined) return;
+    const col = index % c.numCols;
+    const row = Math.floor(index / c.numCols);
+    out.set(child.name, [cols.extents[col], rows.extents[row]]);
+  });
+  return out;
+}
 
 export type GridCellPlacement = {
   child: ConstraintRef;
   center: [number, number];
 };
 
+/** Cell centers from resolved tracks (Stage 6e) — or, when `tracks` is omitted,
+ *  the equal box-division fallback used by the direct-solver tests. */
 export function gridCellPlacements(
   c: GridConstraint,
-  size: readonly [number, number]
+  size: readonly [number, number],
+  tracks?: [TrackLayout, TrackLayout]
 ): GridCellPlacement[] {
-  const [cellWidth, cellHeight] = gridCellSize(c, size);
+  const [cols, rows] =
+    tracks ??
+    ([
+      {
+        extents: Array.from({ length: c.numCols }, () =>
+          sliceExtent(size[0], c.xSpacing, c.numCols)
+        ),
+        starts: Array.from(
+          { length: c.numCols },
+          (_, j) =>
+            j * (sliceExtent(size[0], c.xSpacing, c.numCols) + c.xSpacing)
+        ),
+      },
+      {
+        extents: Array.from({ length: numRowsOf(c) }, () =>
+          sliceExtent(size[1], c.ySpacing, numRowsOf(c))
+        ),
+        starts: Array.from(
+          { length: numRowsOf(c) },
+          (_, r) =>
+            r * (sliceExtent(size[1], c.ySpacing, numRowsOf(c)) + c.ySpacing)
+        ),
+      },
+    ] as [TrackLayout, TrackLayout]);
   return c.children.map((child, index) => {
     const column = index % c.numCols;
     const row = Math.floor(index / c.numCols);
     return {
       child,
       center: [
-        column * (cellWidth + c.xSpacing) + cellWidth / 2,
-        row * (cellHeight + c.ySpacing) + cellHeight / 2,
+        cols.starts[column] + cols.extents[column] / 2,
+        rows.starts[row] + rows.extents[row] / 2,
       ],
     };
   });
 }
 
+/** Emit the per-cell center pins for a grid. A cell whose center on an axis is
+ *  claimed by a `position` pin is skipped on that axis — the explicit pin
+ *  overrides the track centering (the authoritative-pin pattern). */
 export function lowerGridPlacement(
   c: GridConstraint,
   owner: string,
   size: readonly [number, number],
-  emitter: PlacementFactEmitter
+  emitter: PlacementFactEmitter,
+  tracks?: [TrackLayout, TrackLayout],
+  pinnedByPosition?: Map<string, Set<0 | 1>>
 ): void {
-  for (const { child, center } of gridCellPlacements(c, size)) {
-    emitter.pin({
-      axis: "x",
-      target: { name: child.name, anchor: "middle" },
-      value: center[0],
-      owner,
-    });
-    emitter.pin({
-      axis: "y",
-      target: { name: child.name, anchor: "middle" },
-      value: center[1],
-      owner,
-    });
+  for (const { child, center } of gridCellPlacements(c, size, tracks)) {
+    const overridden = pinnedByPosition?.get(child.name);
+    if (!overridden?.has(0))
+      emitter.pin({
+        axis: "x",
+        target: { name: child.name, anchor: "middle" },
+        value: center[0],
+        owner,
+      });
+    if (!overridden?.has(1))
+      emitter.pin({
+        axis: "y",
+        target: { name: child.name, anchor: "middle" },
+        value: center[1],
+        owner,
+      });
   }
 }
 

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -25,7 +25,7 @@ import type { DistributeConstraint, DistributeOptions } from "./distribute";
 import type { PositionConstraint, PositionOptions } from "./position";
 import type { ZAboveConstraint, ZBelowConstraint } from "./zorder";
 import type { NestConstraint, NestOptions } from "./nest";
-import type { GridConstraint } from "./grid";
+import type { GridConstraint, TrackLayout } from "./grid";
 import {
   isPlacedOn,
   type ConstraintPosScales,
@@ -60,7 +60,14 @@ export type { NestConstraint, NestOptions } from "./nest";
 export type { GridConstraint } from "./grid";
 export { isZOrderConstraint } from "./zorder";
 export { isNestConstraint, nestedSpace } from "./nest";
-export { isGridConstraint, gridSpaces, gridCellSize } from "./grid";
+export {
+  isGridConstraint,
+  gridSpaces,
+  resolveGridTracks,
+  gridCellSizeByName,
+  gridTracksFromSizes,
+  type TrackLayout,
+} from "./grid";
 export { getPositioningConstraintRefs } from "./proposalPlan";
 export { BBox } from "./bbox";
 
@@ -239,7 +246,8 @@ export function applyConstraints(
   constraints: ConstraintSpec[],
   nameToPlaceable: Map<string, Placeable>,
   sizes: [number, number],
-  posScales?: ConstraintPosScales
+  posScales?: ConstraintPosScales,
+  gridTracks?: [TrackLayout, TrackLayout]
 ): void {
   const placement = constraints.filter(
     (
@@ -267,7 +275,13 @@ export function applyConstraints(
       )
     : undefined;
 
-  solvePlacementConstraints(placement, nameToPlaceable, sizes, posScales);
+  solvePlacementConstraints(
+    placement,
+    nameToPlaceable,
+    sizes,
+    posScales,
+    gridTracks
+  );
 
   if (prePlaced) {
     for (const constraint of placement) {

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -241,13 +241,17 @@ export function collectPositionDomains(constraints: ConstraintSpec[]): {
  * @param nameToPlaceable - Map from child name to its Placeable
  * @param sizes - The layer's box size `[w, h]`, used by grid placement
  * @param posScales - Per-axis data→pixel scales for `position` constraints
+ * @param dataPositioned - Per-axis sets of child names anchored to a data scale
+ *   (baseline fixed at `posScale(0)`); `align` leaves these where their own scale
+ *   puts them. The space/scope fact that replaced the `placementOn` guard read.
  */
 export function applyConstraints(
   constraints: ConstraintSpec[],
   nameToPlaceable: Map<string, Placeable>,
   sizes: [number, number],
   posScales?: ConstraintPosScales,
-  gridTracks?: [TrackLayout, TrackLayout]
+  gridTracks?: [TrackLayout, TrackLayout],
+  dataPositioned?: [Set<string>, Set<string>]
 ): void {
   const placement = constraints.filter(
     (
@@ -280,7 +284,8 @@ export function applyConstraints(
     nameToPlaceable,
     sizes,
     posScales,
-    gridTracks
+    gridTracks,
+    dataPositioned
   );
 
   if (prePlaced) {

--- a/packages/gofish-graphics/src/ast/constraints/index.ts
+++ b/packages/gofish-graphics/src/ast/constraints/index.ts
@@ -26,8 +26,13 @@ import type { PositionConstraint, PositionOptions } from "./position";
 import type { ZAboveConstraint, ZBelowConstraint } from "./zorder";
 import type { NestConstraint, NestOptions } from "./nest";
 import type { GridConstraint } from "./grid";
-import { type ConstraintPosScales, type ConstraintRef } from "./shared";
+import {
+  isPlacedOn,
+  type ConstraintPosScales,
+  type ConstraintRef,
+} from "./shared";
 import { solvePlacementConstraints } from "./placementSolver";
+import { shadowCheckConstraint, solverCheckEnabled } from "../solver/shadow";
 
 export type {
   Axis,
@@ -246,5 +251,45 @@ export function applyConstraints(
       | NestConstraint
       | GridConstraint => !isZOrderConstraint(constraint)
   );
+
+  // Solver shadow (#39, disposable observe→assert): snapshot each child's
+  // per-axis placement BEFORE the solve — only when the check is on, so
+  // production pays nothing — so each constraint's shadow can tell a child it
+  // packed from one that arrived pre-positioned. The rank-2 solve places every
+  // target at once (no per-constraint apply boundary), so the checks run once
+  // AFTER the solve against the settled positions.
+  const prePlaced = solverCheckEnabled()
+    ? new Map<string, [boolean, boolean]>(
+        [...nameToPlaceable].map(([name, p]) => [
+          name,
+          [isPlacedOn(p, 0), isPlacedOn(p, 1)] as [boolean, boolean],
+        ])
+      )
+    : undefined;
+
   solvePlacementConstraints(placement, nameToPlaceable, sizes, posScales);
+
+  if (prePlaced) {
+    for (const constraint of placement) {
+      // Build the target list and its aligned pre-solve placement snapshot in
+      // one pass (index i of each array is the same child), so the per-target
+      // `prePlaced` the checks read is the state BEFORE the solve, not after.
+      const targets: Placeable[] = [];
+      const targetPrePlaced: [boolean, boolean][] = [];
+      for (const ref of constraint.children) {
+        const p = ref ? nameToPlaceable.get(ref.name) : undefined;
+        if (p === undefined) continue;
+        targets.push(p);
+        targetPrePlaced.push(prePlaced.get(ref!.name) ?? [false, false]);
+      }
+      shadowCheckConstraint(
+        constraint,
+        targets,
+        posScales,
+        targetPrePlaced,
+        nameToPlaceable,
+        sizes
+      );
+    }
+  }
 }

--- a/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
@@ -75,15 +75,18 @@ class PlacementOwnershipPlan {
   private readonly authoritative = new Set<string>();
   private readonly initiallyPlaced = new Set<string>();
   private readonly positionPinned = new Set<string>();
+  private readonly dataPositionedSet: [Set<string>, Set<string>];
   private readonly sizes: [number, number];
 
   constructor(
     targets: Map<string, Placeable>,
     constraints: PlacementConstraint[],
     posScales: ConstraintPosScales | undefined,
-    sizes: [number, number]
+    sizes: [number, number],
+    dataPositioned?: [Set<string>, Set<string>]
   ) {
     this.sizes = sizes;
+    this.dataPositionedSet = dataPositioned ?? [new Set(), new Set()];
     for (const [name, target] of targets) {
       for (const axis of AXIS_INDICES) {
         if (target.dims[axis].min !== undefined)
@@ -104,6 +107,16 @@ class PlacementOwnershipPlan {
   isPinned(axis: Axis, name: string): boolean {
     const key = placementKey(axis, name);
     return this.initiallyPlaced.has(key) || this.positionPinned.has(key);
+  }
+
+  /** Whether this (node, axis) is anchored to a data (POSITION) scope — its
+   *  baseline is fixed at `posScale(0)` by the shared map, so `align` must leave
+   *  it where its own scale puts it (a scatter facet panel). Collected at the
+   *  layer boundary (a SPACE/scope fact) and handed in; the ownership plan is the
+   *  single authority the align guard consults, in place of the retired
+   *  space-pass `placementOn` reconstruction (Stage 6f). */
+  isDataPositioned(axis: 0 | 1, name: string): boolean {
+    return this.dataPositionedSet[axis].has(name);
   }
 
   shouldPinSelfPlacement(axis: 0 | 1, name: string): boolean {
@@ -155,7 +168,8 @@ export function lowerPlacementConstraints(
   targets: Map<string, Placeable>,
   sizes: [number, number],
   posScales?: ConstraintPosScales,
-  gridTracks?: [TrackLayout, TrackLayout]
+  gridTracks?: [TrackLayout, TrackLayout],
+  dataPositioned?: [Set<string>, Set<string>]
 ): LoweredPlacement {
   // A `position` pin on a grid cell overrides that cell's track centering on the
   // pinned axis (the authoritative-pin pattern) — collect which (cell, axis) a
@@ -175,7 +189,8 @@ export function lowerPlacementConstraints(
     targets,
     constraints,
     posScales,
-    sizes
+    sizes,
+    dataPositioned
   );
 
   const lowerer = new PlacementProgramLowerer(targets);
@@ -185,6 +200,7 @@ export function lowerPlacementConstraints(
   };
   const isInitiallyPlaced = ownership.isInitiallyPlaced.bind(ownership);
   const isPinned = ownership.isPinned.bind(ownership);
+  const isDataPositioned = ownership.isDataPositioned.bind(ownership);
 
   // A node that self-placed during its own layout is a hard boundary condition,
   // except where an authoritative position constraint explicitly owns the axis.
@@ -223,6 +239,7 @@ export function lowerPlacementConstraints(
         targets,
         posScales,
         isPinned,
+        isDataPositioned,
       });
       return;
     }

--- a/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementLowering.ts
@@ -14,7 +14,7 @@ import type { AlignConstraint } from "./align";
 import { lowerAlignPlacement } from "./align";
 import type { DistributeConstraint } from "./distribute";
 import { lowerDistributePlacement } from "./distribute";
-import type { GridConstraint } from "./grid";
+import type { GridConstraint, TrackLayout } from "./grid";
 import { lowerGridPlacement } from "./grid";
 import type { NestConstraint } from "./nest";
 import { lowerNestPlacement } from "./nest";
@@ -154,8 +154,23 @@ export function lowerPlacementConstraints(
   constraints: PlacementConstraint[],
   targets: Map<string, Placeable>,
   sizes: [number, number],
-  posScales?: ConstraintPosScales
+  posScales?: ConstraintPosScales,
+  gridTracks?: [TrackLayout, TrackLayout]
 ): LoweredPlacement {
+  // A `position` pin on a grid cell overrides that cell's track centering on the
+  // pinned axis (the authoritative-pin pattern) — collect which (cell, axis) a
+  // position constraint owns so the grid skips its center pin there.
+  const pinnedByPosition = new Map<string, Set<0 | 1>>();
+  for (const constraint of constraints) {
+    if (constraint.type !== "position") continue;
+    for (const ref of constraint.children) {
+      if (!ref) continue;
+      const axes = pinnedByPosition.get(ref.name) ?? new Set<0 | 1>();
+      if (constraint.x !== undefined) axes.add(0);
+      if (constraint.y !== undefined) axes.add(1);
+      if (axes.size > 0) pinnedByPosition.set(ref.name, axes);
+    }
+  }
   const ownership = new PlacementOwnershipPlan(
     targets,
     constraints,
@@ -226,7 +241,14 @@ export function lowerPlacementConstraints(
       return;
     }
 
-    lowerGridPlacement(constraint, owner, sizes, lowerer);
+    lowerGridPlacement(
+      constraint,
+      owner,
+      sizes,
+      lowerer,
+      gridTracks,
+      pinnedByPosition
+    );
   });
 
   return { anchorProgram: lowerer.anchorProgram };

--- a/packages/gofish-graphics/src/ast/constraints/placementSolver.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementSolver.ts
@@ -8,6 +8,7 @@ import {
   lowerPlacementConstraints,
   type PlacementConstraint,
 } from "./placementLowering";
+import type { TrackLayout } from "./grid";
 import {
   axisIndex,
   type AlignAnchor,
@@ -226,13 +227,15 @@ export function solvePlacementConstraints(
   constraints: PlacementConstraint[],
   targets: Map<string, Placeable>,
   sizes: [number, number],
-  posScales?: ConstraintPosScales
+  posScales?: ConstraintPosScales,
+  gridTracks?: [TrackLayout, TrackLayout]
 ): PlacementConflict[] {
   const lowered = lowerPlacementConstraints(
     constraints,
     targets,
     sizes,
-    posScales
+    posScales,
+    gridTracks
   );
 
   const solved = [

--- a/packages/gofish-graphics/src/ast/constraints/placementSolver.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementSolver.ts
@@ -228,14 +228,16 @@ export function solvePlacementConstraints(
   targets: Map<string, Placeable>,
   sizes: [number, number],
   posScales?: ConstraintPosScales,
-  gridTracks?: [TrackLayout, TrackLayout]
+  gridTracks?: [TrackLayout, TrackLayout],
+  dataPositioned?: [Set<string>, Set<string>]
 ): PlacementConflict[] {
   const lowered = lowerPlacementConstraints(
     constraints,
     targets,
     sizes,
     posScales,
-    gridTracks
+    gridTracks,
+    dataPositioned
   );
 
   const solved = [

--- a/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
+++ b/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
@@ -131,7 +131,8 @@ export function buildDistributeSliceMap(
 /** Choose the concrete size proposed to one child in a layer.
  *
  * Priority is explicit and single-owner:
- *   1. grid: owns the whole layer proposal, so every child gets the cell size;
+ *   1. grid: each cell is proposed ITS (column, row) track's extent (Stage 6e —
+ *      resolved by the unified max rule in `resolveGridTracks`), keyed by name;
  *   2. distribute: owns only the named child axes it sliced;
  *   3. default layer box: unconstrained/fill proposal is the full layer size.
  *
@@ -140,10 +141,16 @@ export function buildDistributeSliceMap(
 export function childLayoutSizeProposal(
   childName: string | undefined,
   layerSize: Size,
-  gridCell: Size | undefined,
+  gridCellByName: Map<string, Size> | undefined,
   sliceByName: Map<string, Size> | undefined
 ): Size {
-  if (gridCell !== undefined) return gridCell;
+  if (
+    gridCellByName !== undefined &&
+    childName !== undefined &&
+    gridCellByName.has(childName)
+  ) {
+    return gridCellByName.get(childName)!;
+  }
   if (
     sliceByName === undefined ||
     childName === undefined ||
@@ -283,10 +290,16 @@ export function buildChildScalePlan(
   };
 }
 
-/** A grid owns the whole two-axis proposal scope for its layer. Multiple grids
- * would otherwise be source-order-sensitive because space resolution and
- * proposal sizing can only choose one track partition while placement would see
- * all pins. */
+/** Select the layer's single grid constraint, if any.
+ *
+ * A grid resolves its tracks under the unified max rule (`resolveGridTracks`)
+ * and now GENUINELY COMPOSES with sibling constraints (Stage 6e): its per-track
+ * claim participates in sizing, and its cell-center pins solve jointly with any
+ * align/position/z-order on the same layer. The Stage-3 containment throw (which
+ * rejected any non-z-order sibling because the grid used to bypass the space and
+ * size folds) is therefore gone. The at-most-one-grid rule stays: two track
+ * partitions on one layer would be source-order-sensitive, so it is still an
+ * error. */
 export function selectGridConstraint(
   constraints: readonly ConstraintSpec[]
 ): GridConstraint | undefined {
@@ -299,24 +312,6 @@ export function selectGridConstraint(
       );
     }
     selected = constraint;
-  }
-  // A grid is a whole-layer layout mode, not a composable constraint: it owns
-  // both track partitions and bypasses the space/size fold, while placement
-  // still applies every sibling constraint — so a grid mixed with any other
-  // positioning constraint silently half-applies (its facts never enter the
-  // space fold). Reject non-z-order siblings; z-order (zAbove/zBelow) is
-  // render-time paint order and composes. This lifts when grids become track
-  // equations (Stage 6e, design/sigma-affine-simplification.md).
-  if (selected !== undefined) {
-    for (const constraint of constraints) {
-      if (constraint.type === "grid" || isZOrderConstraint(constraint)) {
-        continue;
-      }
-      throw new Error(
-        `Constraint.grid cannot be combined with a '${constraint.type}' constraint on the same layer. ` +
-          `Put the grid in its own layer, or nest layers, so each layout mode owns its own scope.`
-      );
-    }
   }
   return selected;
 }

--- a/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
+++ b/packages/gofish-graphics/src/ast/constraints/proposalPlan.ts
@@ -12,6 +12,7 @@ import {
   type UnderlyingSpace,
 } from "../underlyingSpace";
 import { allocateSlices } from "./folds";
+import type { ScopeRegistry } from "../solver/scopes";
 import type { ConstraintSpec } from ".";
 import type { GridConstraint } from "./grid";
 import type { ConstraintPosScales } from "./shared";
@@ -189,7 +190,12 @@ export function buildChildScalePlan(
   inheritedScaleFactors: Size<number | undefined> | undefined,
   inheritedPosScales: ConstraintPosScales,
   constraintBudget: ScaleBudget | undefined,
-  shared: Size<boolean>
+  shared: Size<boolean>,
+  // Stage 6b: the ONE σ-solve site. Every scale this plan roots is derived
+  // through the registry (so `GOFISH_DUMP_SCOPES` sees it and the numbers have a
+  // single source); `rootKey` labels the owning layer node in the dump.
+  scopes: ScopeRegistry,
+  rootKey: string
 ): ChildScalePlan {
   const basePosScales: ConstraintPosScales = [
     inheritedPosScales[0],
@@ -207,11 +213,19 @@ export function buildChildScalePlan(
     if (stashed === undefined || !Number.isFinite(layerSize[axis])) continue;
     if (isPOSITION(stashed)) {
       basePosScales[axis] =
-        posScaleFromSpace(stashed, layerSize[axis]) ?? inheritedPosScales[axis];
+        scopes.solvePosition(
+          { kind: "self-scaled", rootKey, axis },
+          stashed,
+          layerSize[axis]
+        ) ?? inheritedPosScales[axis];
     }
     if (isBaselineMagnitude(stashed)) {
       childScaleFactors[axis] =
-        stashed.width.inverse(layerSize[axis]) ?? inheritedScaleFactors?.[axis];
+        scopes.solveSize(
+          { kind: "self-scaled", rootKey, axis },
+          stashed.width,
+          layerSize[axis]
+        ) ?? inheritedScaleFactors?.[axis];
     }
   }
 
@@ -219,25 +233,27 @@ export function buildChildScalePlan(
     for (const axis of [0, 1] as const) {
       const dom = constraintBudget.sizeDomain[axis];
       if (dom === undefined || !Number.isFinite(layerSize[axis])) continue;
-      // Scale-root scoping: if an ancestor scale root already resolved σ for this
-      // axis (an inherited scale factor is present) AND this layer didn't itself
-      // introduce a new pixel scope (no self-scaled/stashed space on the axis),
-      // then this distribute is an INTERMEDIATE in the ancestor's σ-scope — it
-      // must PROPAGATE the inherited σ, not re-root by inverting its own σ-fold
-      // against the locally allocated size. In a consistently-sized layout the
-      // re-derived factor equals the inherited one (no-op); it only diverges when
-      // the allocated size disagrees with the inherited σ — e.g. an equal-slice
-      // budget under a coord, where the distribute axis IS the σ-scaled axis, so
-      // a nested group would otherwise silently re-derive a smaller σ (#618).
-      if (
-        inheritedScaleFactors?.[axis] !== undefined &&
-        selfScaledSpaces[axis] === undefined
-      ) {
-        continue;
-      }
-      const sf = dom.inverse(layerSize[axis], {
-        upperBoundGuess: layerSize[axis],
-      });
+      // Structural σ-scope rule (Stage 6b — the former #618 propagate-vs-re-root
+      // guard, made structural): ONLY A SCOPE ROOT SOLVES. This budget roots a
+      // scope on the axis unless an ancestor scope already owns it — i.e. an
+      // inherited σ is present AND this layer introduced no pixel scope of its
+      // own (no self-scaled space). In that INTERMEDIATE case the inherited σ has
+      // already been copied into `childScaleFactors`, so inherit it: do NOT
+      // re-root by inverting the local σ-fold against the allocated size. The
+      // re-derive-equal cases produce the same σ (no-op); the divergent case is
+      // an equal-slice budget under a coord, where the distribute axis IS the
+      // σ-scaled axis — a nested group would otherwise silently re-derive a
+      // smaller σ (#618).
+      const rootsScope =
+        inheritedScaleFactors?.[axis] === undefined ||
+        selfScaledSpaces[axis] !== undefined;
+      if (!rootsScope) continue;
+      const sf = scopes.solveSize(
+        { kind: "constraint-budget", rootKey, axis },
+        dom,
+        layerSize[axis],
+        { upperBoundGuess: layerSize[axis] }
+      );
       if (sf !== undefined) childScaleFactors[axis] = sf;
       else budgetFailures.push({ axis, budget: layerSize[axis] });
     }
@@ -248,9 +264,12 @@ export function buildChildScalePlan(
     const sp = selfScaledSpaces[axis] ?? layerSpace?.[axis];
     if (sp === undefined) continue;
     const sf = isCONTINUOUS(sp)
-      ? (sp.width.inverse(layerSize[axis], {
-          upperBoundGuess: layerSize[axis],
-        }) ?? 0)
+      ? (scopes.solveSize(
+          { kind: "shared", rootKey, axis },
+          sp.width,
+          layerSize[axis],
+          { upperBoundGuess: layerSize[axis] }
+        ) ?? 0)
       : undefined;
     if (sf !== undefined) childScaleFactors[axis] = sf;
     sharedScaleChecks.push({ axis, space: sp, sigma: sf });

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/bake.ts
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/bake.ts
@@ -163,72 +163,102 @@ const zOf = (node: GoFishAST): number =>
  * resolving each layer's own order and only then descending preserves the
  * legacy interleaving. Transforms still compose all the way to the leaves.
  */
+const walkNode = (
+  items: DisplayObject[],
+  node: GoFishAST,
+  transform: [number, number],
+  scale: [number, number]
+): void => {
+  const [ownTx, ownTy] = bakeTranslate(node);
+  const composedTranslate: [number, number] = [
+    ownTx + transform[0],
+    ownTy + transform[1],
+  ];
+  const composedScale: [number, number] = [
+    (node.transform?.scale?.[0] ?? 1) * scale[0],
+    (node.transform?.scale?.[1] ?? 1) * scale[1],
+  ];
+
+  if (!isTransparent(node)) {
+    items.push({
+      node,
+      transform: { translate: composedTranslate, scale: composedScale },
+    });
+    return;
+  }
+
+  walkChildren(items, node, composedTranslate, composedScale);
+};
+
+/** Flatten a transparent node's CHILDREN into `items` at the parent's already-
+ *  composed absolute `translate`/`scale` — resolving z hierarchically (the
+ *  z-constrained topo-sort, else the (local zOrder, index) order) exactly as
+ *  the root bake does. Shared so a bake boundary can flatten its own subtree to
+ *  absolute coordinates instead of composing its translate into a `toPixel`
+ *  closure (#39 stage 6d). */
+const walkChildren = (
+  items: DisplayObject[],
+  node: GoFishAST,
+  translate: [number, number],
+  scale: [number, number]
+): void => {
+  const children = (node as GoFishNode).children;
+  const zConstraints = ((node as GoFishNode).constraints ?? []).filter(
+    isZOrderConstraint
+  );
+
+  if (zConstraints.length > 0) {
+    // Resolve z WITHIN this layer over its component-granular flattened
+    // subtree (the same units the legacy layer render topo-sorted), then
+    // descend into each unit — components keep their internal order.
+    const sorted = topoSortByZOrder(flattenForZOrder(children), zConstraints, {
+      node: (it) => it.node,
+      z: (it) => it.defaultZ,
+      order: (it) => it.defaultOrder,
+    });
+    for (const unit of sorted) {
+      walkNode(
+        items,
+        unit.node,
+        [
+          translate[0] + unit.accTranslate[0],
+          translate[1] + unit.accTranslate[1],
+        ],
+        scale
+      );
+    }
+    return;
+  }
+
+  // Plain layer: paint children in (local zOrder, index) order.
+  const ordered = children
+    .map((child, index) => ({ child, index }))
+    .sort((a, b) => zOf(a.child) - zOf(b.child) || a.index - b.index);
+  for (const { child } of ordered) {
+    walkNode(items, child, translate, scale);
+  }
+};
+
 export const bake = (root: GoFishAST): DisplayObject[] => {
   const items: DisplayObject[] = [];
+  walkNode(items, root, [0, 0], [1, 1]);
+  return items;
+};
 
-  const walk = (
-    node: GoFishAST,
-    transform: [number, number],
-    scale: [number, number]
-  ): void => {
-    const [ownTx, ownTy] = bakeTranslate(node);
-    const composedTranslate: [number, number] = [
-      ownTx + transform[0],
-      ownTy + transform[1],
-    ];
-    const composedScale: [number, number] = [
-      (node.transform?.scale?.[0] ?? 1) * scale[0],
-      (node.transform?.scale?.[1] ?? 1) * scale[1],
-    ];
-
-    if (!isTransparent(node)) {
-      items.push({
-        node,
-        transform: { translate: composedTranslate, scale: composedScale },
-      });
-      return;
-    }
-
-    const children = (node as GoFishNode).children;
-    const zConstraints = ((node as GoFishNode).constraints ?? []).filter(
-      isZOrderConstraint
-    );
-
-    if (zConstraints.length > 0) {
-      // Resolve z WITHIN this layer over its component-granular flattened
-      // subtree (the same units the legacy layer render topo-sorted), then
-      // descend into each unit — components keep their internal order.
-      const sorted = topoSortByZOrder(
-        flattenForZOrder(children),
-        zConstraints,
-        {
-          node: (it) => it.node,
-          z: (it) => it.defaultZ,
-          order: (it) => it.defaultOrder,
-        }
-      );
-      for (const unit of sorted) {
-        walk(
-          unit.node,
-          [
-            composedTranslate[0] + unit.accTranslate[0],
-            composedTranslate[1] + unit.accTranslate[1],
-          ],
-          composedScale
-        );
-      }
-      return;
-    }
-
-    // Plain layer: paint children in (local zOrder, index) order.
-    const ordered = children
-      .map((child, index) => ({ child, index }))
-      .sort((a, b) => zOf(a.child) - zOf(b.child) || a.index - b.index);
-    for (const { child } of ordered) {
-      walk(child, composedTranslate, composedScale);
-    }
-  };
-
-  walk(root, [0, 0], [1, 1]);
+/**
+ * Flatten a bake boundary's own subtree into absolute-transform `DisplayObject`s,
+ * seeded at the boundary's already-absolute `translate`/`scale`. The boundary
+ * lowers each returned entry at its baked absolute transform (via
+ * `INTERNAL_lower(coord, d.transform)`) — the same mechanism the root bake uses —
+ * so a translate-only boundary needs no per-container `toPixel` closure (#39
+ * stage 6d). z-order is resolved identically to {@link bake}.
+ */
+export const bakeChildren = (
+  node: GoFishAST,
+  translate: [number, number] = [0, 0],
+  scale: [number, number] = [1, 1]
+): DisplayObject[] => {
+  const items: DisplayObject[] = [];
+  walkChildren(items, node, translate, scale);
   return items;
 };

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -14,7 +14,6 @@ import {
   FancyDims,
   Interval,
   Size,
-  translateString,
 } from "../dims";
 import { flattenLayout } from "./bake";
 import * as IntervalLib from "../../util/interval";

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -203,14 +203,19 @@ export const coord = createNodeOperator(
           const fitAxis = (
             axis: 0 | 1,
             budget: number
-          ): [number, AxisMap | undefined] => {
+          ): [number | undefined, AxisMap | undefined] => {
             // An anchored (data POSITION) axis: the coord's own
             // `resolveUnderlyingSpace` already unioned the children's POSITION
             // spaces into `spaceRef.current` — reuse it and map onto [0, budget].
+            // This is a POSITION scope only: it has no SIZE scope, so it carries
+            // NO σ (Stage 6c: never fabricate an independent size slope — the map's
+            // own slope IS the scope's σ). A data-bound size on this axis reads the
+            // map difference; a plain-number size bypasses both. The former `1`
+            // placeholder was a fabricated size σ with no scope behind it.
             const resolved = spaceRef.current?.[axis];
             if (resolved !== undefined && isPOSITION(resolved)) {
               return [
-                1,
+                undefined,
                 scopes.solvePosition(
                   { kind: "coord", rootKey: node.key ?? node.type, axis },
                   resolved,

--- a/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
+++ b/packages/gofish-graphics/src/ast/coordinateTransforms/coord.tsx
@@ -23,6 +23,7 @@ import {
   UnderlyingSpace,
   UNDEFINED,
   POSITION,
+  SIZE,
   ORDINAL,
   isORDINAL,
   isPOSITION,
@@ -32,7 +33,9 @@ import {
   continuousInterval,
   type CONTINUOUS_TYPE,
 } from "../underlyingSpace";
-import { posScaleFromSpace, axisScale, type AxisMap } from "../domain";
+import { axisScale, type AxisMap } from "../domain";
+import { shadowCheckScaleRoot } from "../solver/shadow";
+import { getScopeRegistry } from "../solver/scopes";
 import * as Monotonic from "../../util/monotonic";
 import { createNodeOperator } from "../withGoFish";
 import { computeTransformedBoundingBox } from "./coordUtils";
@@ -162,7 +165,11 @@ export const coord = createNodeOperator(
           spaceRef.current = result;
           return result;
         },
-        layout: (shared, size, scales, children) => {
+        layout: (shared, size, scales, children, node) => {
+          // Stage 6b: a coord boundary is a σ-scope root — it re-roots σ for its
+          // subtree. Derive through the render's one registry, shared with the
+          // render root and every layer scope.
+          const scopes = getScopeRegistry(node.tryGetRenderSession());
           /* TODO: need correct scale factors */
           // TODO: only works for polar-family transforms right now
           const [origW, origH] = size;
@@ -202,7 +209,14 @@ export const coord = createNodeOperator(
             // spaces into `spaceRef.current` — reuse it and map onto [0, budget].
             const resolved = spaceRef.current?.[axis];
             if (resolved !== undefined && isPOSITION(resolved)) {
-              return [1, posScaleFromSpace(resolved, budget)];
+              return [
+                1,
+                scopes.solvePosition(
+                  { kind: "coord", rootKey: node.key ?? node.type, axis },
+                  resolved,
+                  budget
+                ),
+              ];
             }
             // A baseline-magnitude (data SIZE) axis: `resolveUnderlyingSpace`
             // leaves this case UNDEFINED, so sum the children's widths here and
@@ -213,7 +227,26 @@ export const coord = createNodeOperator(
               .filter(isBaselineMagnitude);
             if (baseline.length > 0) {
               const width = Monotonic.add(...baseline.map((s) => s.width));
-              return [width.inverse(budget) ?? 1, undefined];
+              // Stage 6b: the coord boundary's SIZE frame — solved through the one
+              // registry (content(σ)=budget via Monotonic.inverse).
+              const sigma = scopes.solveSize(
+                { kind: "coord", rootKey: node.key ?? node.type, axis },
+                width,
+                budget
+              );
+              // Solver shadow (#39): a coord boundary RE-ROOTS σ for its subtree,
+              // exactly as the root fits content to the canvas — assert the same
+              // frame equation content(σ)=budget closes at the boundary. Pass the
+              // raw inverse (undefined when it fails) so a degenerate re-root is
+              // caught, mirroring shadowCheckScaleRoot at the root. No-op unless
+              // GOFISH_SOLVER_CHECK is set.
+              shadowCheckScaleRoot(
+                SIZE(width),
+                budget,
+                sigma ?? undefined,
+                axis
+              );
+              return [sigma ?? 1, undefined];
             }
             return [1, undefined];
           };

--- a/packages/gofish-graphics/src/ast/dims.ts
+++ b/packages/gofish-graphics/src/ast/dims.ts
@@ -267,11 +267,12 @@ export const displayDims = (
 
 /**
  * A node's render-side translate offset as a concrete `[tx, ty]` tuple, with the
- * `?? 0` fallback every shape/operator `_render` wants for drawing (an unplaced
- * axis draws at the origin). This is the single chokepoint for render's
- * `transform.translate` reads: making the move to baked absolute coordinates
- * (#39 stage 3-D) a one-function change rather than a ~15-site sweep. Scale is
- * left to the callers that compose it.
+ * `?? 0` fallback every shape/operator lower body wants for drawing (an unplaced
+ * axis draws at the origin). The read of a BAKED absolute transform each
+ * self-drawing boundary (coord, connect, enclose) applies to its own geometry;
+ * the pure translate-only containers (box/layer, offset) no longer compose it
+ * into a closure — they flatten their subtree to absolute coordinates via
+ * `bakeChildren` (#39 stage 6d). Scale is left to the callers that compose it.
  */
 export const displayTranslate = (transform?: {
   translate?: (number | undefined)[];
@@ -279,19 +280,6 @@ export const displayTranslate = (transform?: {
   transform?.translate?.[0] ?? 0,
   transform?.translate?.[1] ?? 0,
 ];
-
-/**
- * The SVG `translate(tx, ty)` attribute string for a node's transform — the
- * render-wrapper form of {@link displayTranslate}, shared by every container/mark
- * that emits a `<g transform="translate(...)">`. These wrappers are exactly the
- * ones #39 stage 3-D collapses once render consumes baked absolute coordinates.
- */
-export const translateString = (transform?: {
-  translate?: (number | undefined)[];
-}): string => {
-  const [tx, ty] = displayTranslate(transform);
-  return `translate(${tx}, ${ty})`;
-};
 
 /**
  * The `dims` getter body shared by {@link GoFishNode} and {@link GoFishRef}:

--- a/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
+++ b/packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
@@ -10,8 +10,8 @@
 
 import type { DisplayList } from "gofish-ir";
 import type { GoFishNode, ToPixel } from "../_node";
-import type { GoFishAST } from "../_ast";
 import type { CoordinateTransform } from "../coordinateTransforms/coord";
+import { bakeChildren } from "../coordinateTransforms/bake";
 import { displayTranslate, type Transform } from "../dims";
 import { type Path, type Point, pathToSVGPath } from "../../path";
 
@@ -161,9 +161,13 @@ export const withToPixel = <T>(
   }
 };
 
-/** Lower a boundary's children under its own translate (the legacy
- *  `<g transform>`), plus an optional extra `(dx, dy)` shift — the shared body of
- *  the simple translate-only boundaries (offset, enclose, arrow). */
+/** Lower a translate-only boundary's children at BAKED ABSOLUTE coordinates,
+ *  plus an optional extra `(dx, dy)` shift — the shared body of the simple
+ *  translate-only boundaries (offset, enclose). #39 stage 6d: instead of
+ *  composing the boundary's translate into a child-local `toPixel` closure, the
+ *  subtree is flattened to absolute-transform display objects (seeded at the
+ *  boundary's own absolute translate) and each is lowered at that transform —
+ *  the same mechanism the root bake uses. */
 export const lowerChildrenOffset = (
   node: GoFishNode,
   transform: Transform | undefined,
@@ -172,11 +176,7 @@ export const lowerChildrenOffset = (
   dy = 0
 ): DisplayList.DisplayItem[] => {
   const [tx, ty] = displayTranslate(transform);
-  const outer = node.getRenderSession().toPixel!;
-  const composed: ToPixel = ([cx, cy]) => outer([tx + dx + cx, ty + dy + cy]);
-  return withToPixel(node, composed, () =>
-    (node.children as GoFishAST[]).flatMap((c) =>
-      c.INTERNAL_lower(coordinateTransform)
-    )
+  return bakeChildren(node, [tx + dx, ty + dy]).flatMap((d) =>
+    d.node.INTERNAL_lower(coordinateTransform, d.transform)
   );
 };

--- a/packages/gofish-graphics/src/ast/domain.ts
+++ b/packages/gofish-graphics/src/ast/domain.ts
@@ -55,17 +55,27 @@ export const unifyContinuousDomains = (
 
 /** One continuous axis's data→pixel affine map, with the intercept explicit
  *  instead of closed over a function: `px(d) = pxMin + sigma·(d − domainMin)`.
- *  `sigma` is the map's own slope (px per data unit); it need NOT equal an
- *  {@link AxisScale}'s top-level `sigma` — a sub-budget layer can scale a mark's
- *  size and its data position against different pixel extents. Evaluated by
- *  {@link pxOf}; the old `posScale(0)` intercept is `pxOf(map, 0)`. */
+ *  `sigma` is the map's own slope (px per data unit). By construction it is the
+ *  σ of a POSITION σ-scope: every `AxisMap` is produced by {@link computePosScale}
+ *  through the scope registry (`solvePosition`) or its equal-measure recentering,
+ *  so `sigma` is never a free-floating number — it is a scope's solved slope.
+ *  Evaluated by {@link pxOf}; the old `posScale(0)` intercept is `pxOf(map, 0)`. */
 export type AxisMap = { sigma: number; domainMin: number; pxMin: number };
 
 /** One axis's data→pixel affine scale — the single carrier that replaced the
  *  parallel `scaleFactors` (slope-only) and `posScales` (whole map) channels.
- *  `sigma` is px per data unit for UNANCHORED size consumers (the old
- *  `scaleFactor`); `map` is the anchored data→pixel map (the old `posScale`),
- *  present iff the axis is anchored. */
+ *
+ *  The two halves are the read-off of up to TWO σ-scopes on this axis, NOT two
+ *  independent slopes (Stage 6c — see the σ-affine plan). `sigma` is the σ of the
+ *  axis's SIZE scope (px per data unit for unanchored magnitude consumers, the
+ *  old `scaleFactor`); `map` is the anchored map of the axis's POSITION scope
+ *  (the old `posScale`), and `map.sigma` is that scope's σ. Both are registry-
+ *  solved — no site fabricates either — so when both are present and `sigma ≠
+ *  map.sigma` the axis genuinely carries two scopes (e.g. a marginal panel whose
+ *  ticks map the NICED domain while its bars size the UN-niced total, or a
+ *  sub-budget layer scaling size against a local extent and position against an
+ *  inherited one). Each half is read by the channel it belongs to: magnitudes
+ *  read `sigma`, anchored positions read `map`. */
 export type AxisScale = { sigma?: number; map?: AxisMap };
 
 /** Evaluate an anchored map at a data value. */
@@ -80,9 +90,11 @@ export const posFn = (
 ): ((d: number) => number) | undefined =>
   map === undefined ? undefined : (d) => pxOf(map, d);
 
-/** Assemble one axis's {@link AxisScale} from its σ (size slope) and anchored
- *  map, collapsing "neither present" to `undefined` so a bare axis stays
- *  undefined (not an empty record). */
+/** Assemble one axis's {@link AxisScale} from its SIZE-scope σ and its
+ *  POSITION-scope `map`, collapsing "neither present" to `undefined` so a bare
+ *  axis stays undefined (not an empty record). Both arguments are registry-
+ *  solved slopes (see {@link AxisScale}); this only bundles the two scope views
+ *  the axis carries — it never derives a slope. */
 export const axisScale = (
   sigma: number | undefined,
   map: AxisMap | undefined

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -29,7 +29,7 @@ import {
   type UnderlyingSpace,
 } from "./underlyingSpace";
 import { shadowCheckScaleRoot } from "./solver/shadow";
-import { getScopeRegistry } from "./solver/scopes";
+import { getScopeRegistry, type EqualMeasureAxis } from "./solver/scopes";
 import { elaborateAxes, elaborateAxisTitles } from "./axes/elaborate";
 import { elaborateLegend, legendOverhang } from "./legends/elaborate";
 
@@ -420,50 +420,34 @@ export async function layout(
   // matching, the same way `circle({ r })` lowers to a `w`/`h` that share a
   // measure and so cannot render as an ellipse. Each axis's pixels-per-data-unit
   // comes from its POSITION domain (`canvas / range`) or its baseline-magnitude
-  // σ; we take the binding (smaller) one and apply it to both — the binding axis
-  // fills its dimension, the other gets slack, centered by convention. A POSITION
-  // axis writes back a recentered posScale; a SIZE axis writes back its σ (its
-  // content stays origin-anchored — SIZE-slack centering is deferred). Silently
-  // skipped when an axis has no continuous scale to equate (e.g. ordinal).
+  // σ. The scope-level operation — take the binding (smaller) σ and equate both
+  // axes' scopes — lives on the registry (Stage 6c: the ONE post-solve σ
+  // adjustment, so every slope stays registry-sourced and the dump shows the
+  // FINAL σ). Silently skipped when an axis has no continuous scale to equate.
   const measureX = spaceMeasure(niceUnderlyingSpaceX);
   const measureY = spaceMeasure(niceUnderlyingSpaceY);
   if (measureX !== undefined && measureX === measureY) {
-    const axisInfo = ([0, 1] as const).map((axis) => {
-      const space = axis === 0 ? niceUnderlyingSpaceX : niceUnderlyingSpaceY;
-      const canvas = axis === 0 ? canvasW : canvasH;
-      const ival = continuousInterval(space);
-      if (ival !== undefined && ival.max > ival.min) {
-        const range = ival.max - ival.min;
-        return {
-          kind: "position" as const,
-          unitPx: canvas / range,
-          min: ival.min,
-          range,
-          canvas,
-        };
-      }
-      const sigma = rootScaleFactors[axis];
-      if (sigma !== undefined) return { kind: "size" as const, unitPx: sigma };
-      return undefined;
-    });
-    const [ax, ay] = axisInfo;
-    if (ax !== undefined && ay !== undefined) {
-      const shared = Math.min(ax.unitPx, ay.unitPx); // binding axis wins
-      for (const axis of [0, 1] as const) {
-        const info = axisInfo[axis]!;
-        if (info.kind === "position") {
-          const offset = (info.canvas - shared * info.range) / 2; // center slack
-          // Same affine map as `(pos − min)·shared + offset`, intercept explicit.
-          posScales[axis] = {
-            sigma: shared,
-            domainMin: info.min,
-            pxMin: offset,
+    const axisInfo = ([0, 1] as const).map(
+      (axis): EqualMeasureAxis | undefined => {
+        const space = axis === 0 ? niceUnderlyingSpaceX : niceUnderlyingSpaceY;
+        const canvas = axis === 0 ? canvasW : canvasH;
+        const ival = continuousInterval(space);
+        if (ival !== undefined && ival.max > ival.min) {
+          const range = ival.max - ival.min;
+          return {
+            kind: "position",
+            unitPx: canvas / range,
+            min: ival.min,
+            range,
+            canvas,
           };
-        } else {
-          rootScaleFactors[axis] = shared;
         }
+        const sigma = rootScaleFactors[axis];
+        if (sigma !== undefined) return { kind: "size", unitPx: sigma };
+        return undefined;
       }
-    }
+    ) as [EqualMeasureAxis | undefined, EqualMeasureAxis | undefined];
+    scopes.recenterEqualMeasure("root", axisInfo, posScales, rootScaleFactors);
   }
 
   // Solver shadow (#39): the ROOT σ-scope — the SIZE frame equation

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -14,12 +14,7 @@ import {
   GoFishNode,
   type RenderSession,
 } from "./_node";
-import {
-  posScaleFromSpace,
-  axisScale,
-  type AxisMap,
-  type AxisScale,
-} from "./domain";
+import { axisScale, type AxisMap, type AxisScale } from "./domain";
 import { bake } from "./coordinateTransforms/bake";
 import { lowerToDisplayList } from "./displayList/lower";
 import { paintSVG } from "./displayList/paintSVG";
@@ -34,6 +29,7 @@ import {
   type UnderlyingSpace,
 } from "./underlyingSpace";
 import { shadowCheckScaleRoot } from "./solver/shadow";
+import { getScopeRegistry } from "./solver/scopes";
 import { elaborateAxes, elaborateAxisTitles } from "./axes/elaborate";
 import { elaborateLegend, legendOverhang } from "./legends/elaborate";
 
@@ -370,10 +366,26 @@ export async function layout(
   const layoutW = w ?? (needsCanvas(niceUnderlyingSpaceX) ? canvasW : UNSIZED);
   const layoutH = h ?? (needsCanvas(niceUnderlyingSpaceY) ? canvasH : UNSIZED);
 
-  // An anchored CONTINUOUS root builds a data→pixel map over its data interval.
+  // The render's σ-scope registry: the ONE place σ / posScale is derived
+  // (Stage 6b). The root is the first scope root; every other scope (self-scaled
+  // axis, constraint budget, shared, coord boundary) solves through the same
+  // registry. Reset so a re-run layout pass starts clean.
+  const scopes = getScopeRegistry(contexts?.session);
+  scopes.reset();
+
+  // An anchored CONTINUOUS root builds a data→pixel map over its data interval —
+  // the root POSITION scope solved by the registry.
   const posScales: Size<AxisMap | undefined> = [
-    posScaleFromSpace(niceUnderlyingSpaceX, canvasW),
-    posScaleFromSpace(niceUnderlyingSpaceY, canvasH),
+    scopes.solvePosition(
+      { kind: "root", rootKey: "root", axis: 0 },
+      niceUnderlyingSpaceX,
+      canvasW
+    ),
+    scopes.solvePosition(
+      { kind: "root", rootKey: "root", axis: 1 },
+      niceUnderlyingSpaceY,
+      canvasH
+    ),
   ];
 
   if (debug) {
@@ -381,14 +393,23 @@ export async function layout(
   }
 
   // Root scale factor: a baseline magnitude ("free") root inverts its Monotonic
-  // against the canvas. Anchored roots use the posScale (above) instead; a
-  // difference root shrink-to-fits.
+  // against the canvas — the root SIZE scope, solved by the same registry.
+  // Anchored roots use the posScale (above) instead; a difference root
+  // shrink-to-fits.
   const rootScaleFactors: Size<number | undefined> = [
     isBaselineMagnitude(niceUnderlyingSpaceX)
-      ? (niceUnderlyingSpaceX.width.inverse(canvasW) ?? undefined)
+      ? scopes.solveSize(
+          { kind: "root", rootKey: "root", axis: 0 },
+          niceUnderlyingSpaceX.width,
+          canvasW
+        )
       : undefined,
     isBaselineMagnitude(niceUnderlyingSpaceY)
-      ? (niceUnderlyingSpaceY.width.inverse(canvasH) ?? undefined)
+      ? scopes.solveSize(
+          { kind: "root", rootKey: "root", axis: 1 },
+          niceUnderlyingSpaceY.width,
+          canvasH
+        )
       : undefined,
   ];
 
@@ -466,6 +487,9 @@ export async function layout(
   ];
 
   child.layout([layoutW, layoutH], rootScales);
+  // Scope dump (#39 Stage 6b): every σ-scope solved during the layout pass just
+  // above, as printable frame equations. No-op unless GOFISH_DUMP_SCOPES is set.
+  scopes.dump();
   // Root placement anchor. A GIVEN dimension keeps the baseline-anchored canvas
   // box [0, given]; content seated outside it (axis labels below 0, ticks above
   // `given`) is reserved as the per-side overhangs below. A SHRINK-TO-FIT

--- a/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/connect.tsx
@@ -14,7 +14,6 @@ import {
   elaborateDirection,
   FancyDirection,
   Size,
-  translateString,
 } from "../dims";
 import { pairs } from "../../util";
 import { linear } from "../coordinateTransforms/linear";

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -5,6 +5,7 @@
 import { GoFishNode, type ToPixel } from "../_node";
 import type { DisplayList } from "gofish-ir";
 import { shadowCheckScaleRoot } from "../solver/shadow";
+import { getScopeRegistry } from "../solver/scopes";
 import { flattenForZOrder, topoSortByZOrder } from "../paintOrder";
 import { isToken } from "../createName";
 import {
@@ -247,7 +248,11 @@ export const layer = createNodeOperatorSequential(
             inheritedScaleFactors,
             inheritedPosScales,
             constraintBudget,
-            shared
+            shared,
+            // Stage 6b: derive every scale this layer roots through the render's
+            // one σ-scope registry (shared with the root and coord boundaries).
+            getScopeRegistry(node.tryGetRenderSession()),
+            node.key ?? node.type
           );
           const { basePosScales, childScaleFactors } = childScalePlan;
           for (const failure of childScalePlan.budgetFailures) {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -2,11 +2,9 @@
 // @wiki Underlying Space — /internals/core/underlying-space
 // </gofish-wiki>
 
-import { GoFishNode, type ToPixel } from "../_node";
-import type { DisplayList } from "gofish-ir";
+import { GoFishNode } from "../_node";
 import { shadowCheckScaleRoot } from "../solver/shadow";
 import { getScopeRegistry } from "../solver/scopes";
-import { flattenForZOrder, topoSortByZOrder } from "../paintOrder";
 import { isToken } from "../createName";
 import {
   Size,
@@ -20,6 +18,7 @@ import { computeSize, foldFinite } from "../../util";
 import { axisScale } from "../domain";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
 import { coord } from "../coordinateTransforms/coord";
+import { bakeChildren } from "../coordinateTransforms/bake";
 import { createNodeOperatorSequential } from "../withGoFish";
 import { GoFishAST } from "../_ast";
 import {
@@ -27,7 +26,6 @@ import {
   collectPositionDomains,
   gridSpaces,
   gridCellSize,
-  isZOrderConstraint,
   type ConstraintSpec,
   type ZOrderConstraint,
 } from "../constraints";
@@ -450,95 +448,34 @@ export const layer = createNodeOperatorSequential(
             },
           };
         },
-        // IR lowering — mirror of the box/layer render. The box's translate is
-        // composed into a child-local `toPixel` (so children land in the right
-        // pixels); a non-identity scale can't be folded into coordinates, so it
-        // becomes a `group` item wrapping the children. Z-order mirrors render.
+        // IR lowering — mirror of the box/layer render. #39 stage 6d: the box's
+        // subtree is flattened to absolute-transform display objects (seeded at
+        // the box's own baked absolute translate) and each is lowered at that
+        // absolute transform — no per-container `toPixel` closure. z-order is
+        // resolved by the shared bake walk exactly as the root bake does. A
+        // non-identity scale can't fold into coordinates, so it stays a `group`
+        // item wrapping the children.
         lower: ({ transform, coordinateTransform }, _children, node) => {
           const scaleX = options.transform?.scale?.x ?? 1;
           const scaleY = options.transform?.scale?.y ?? 1;
           const [wrapTx, wrapTy] = displayTranslate(transform);
           // A `box` is a coordinate-transform barrier: its children render in
           // linear box-local space (the box positions itself in the parent
-          // coord, but its content does not warp). Mirror INTERNAL_render's
+          // coord, but its content does not warp). Mirror the render's
           // `this.type !== "box" ? coordinateTransform : undefined`.
           const childCoord =
             node.type === "box" ? undefined : coordinateTransform;
 
-          const session = node.getRenderSession();
-          const outer = session.toPixel!;
-          // Translate-only composition (scale handled by the group below).
-          const composed: ToPixel = ([cx, cy]) =>
-            outer([wrapTx + cx, wrapTy + cy]);
-
-          // Lower the (z-ordered) children under `composed`, restoring `toPixel`
-          // afterward. A per-child accTranslate (z-constraint flatten) is folded
-          // into the mapping for that child.
-          const lowerChildren = (): DisplayList.DisplayItem[] => {
-            const zConstraints = (node.constraints ?? []).filter(
-              isZOrderConstraint
-            );
-            const items: DisplayList.DisplayItem[] = [];
-            const withToPixel = (
-              fn: ToPixel,
-              run: () => DisplayList.DisplayItem[]
-            ) => {
-              session.toPixel = fn;
-              try {
-                return run();
-              } finally {
-                session.toPixel = composed;
-              }
-            };
-
-            if (zConstraints.length === 0) {
-              const ordered = node.children
-                .map((child, index) => ({
-                  child,
-                  index,
-                  zOrder: child instanceof GoFishNode ? child.getZOrder() : 0,
-                }))
-                .sort((a, b) => a.zOrder - b.zOrder || a.index - b.index);
-              session.toPixel = composed;
-              try {
-                for (const { child } of ordered)
-                  items.push(...child.INTERNAL_lower(childCoord));
-              } finally {
-                session.toPixel = outer;
-              }
-              return items;
-            }
-
-            const flat = flattenForZOrder(node.children);
-            const sorted = topoSortByZOrder(flat, zConstraints, {
-              node: (it) => it.node,
-              z: (it) => it.defaultZ,
-              order: (it) => it.defaultOrder,
-            });
-            try {
-              for (const item of sorted) {
-                const [ax, ay] = item.accTranslate;
-                const map: ToPixel =
-                  ax === 0 && ay === 0
-                    ? composed
-                    : ([cx, cy]) => composed([cx + ax, cy + ay]);
-                items.push(
-                  ...withToPixel(map, () =>
-                    item.node.INTERNAL_lower(childCoord)
-                  )
-                );
-              }
-            } finally {
-              session.toPixel = outer;
-            }
-            return items;
-          };
-
-          const childItems = lowerChildren();
+          // Seed the subtree bake at the box's absolute translate only — scale
+          // is applied by the group below, not folded into coordinates.
+          const childItems = bakeChildren(node, [wrapTx, wrapTy]).flatMap((d) =>
+            d.node.INTERNAL_lower(childCoord, d.transform)
+          );
 
           if (scaleX === 1 && scaleY === 1) return childItems;
 
           // Scale about the box's pixel origin: p ↦ origin + s·(p − origin).
+          const outer = node.getRenderSession().toPixel!;
           const [ox, oy] = outer([wrapTx, wrapTy]);
           return [
             {

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -17,6 +17,7 @@ import {
   UNDEFINED,
   UnderlyingSpace,
   hasBaseline,
+  isCONTINUOUS,
   isUNDEFINED,
 } from "../underlyingSpace";
 import { computeSize, foldFinite } from "../../util";
@@ -440,12 +441,40 @@ export const layer = createNodeOperatorSequential(
                 )
               : undefined;
 
+            // Which (constrained child, axis) is anchored to a data scale — its
+            // baseline is fixed at `posScale(0)` by the shared map, so `align`
+            // leaves it where its own scale puts it (a scatter facet panel).
+            // This is the SPACE/scope fact that used to be reconstructed inside
+            // the align guard via a `placementOn` method on the target; Stage 6f
+            // collects it ONCE here, at the layer boundary, reading the pure DATA
+            // fact (`dataDomain` present on a continuous axis) and hands it to the
+            // placement solve's ownership plan — the constraint path no longer
+            // consults the space pass's free/determined/conflict lattice.
+            const dataPositioned: [Set<string>, Set<string>] = [
+              new Set(),
+              new Set(),
+            ];
+            for (const [name, cp] of nameToPlaceable) {
+              const childSpace = (cp as GoFishNode)._underlyingSpace;
+              if (childSpace === undefined) continue;
+              for (const axis of [0, 1] as const) {
+                const s = childSpace[axis];
+                if (
+                  s !== undefined &&
+                  isCONTINUOUS(s) &&
+                  s.dataDomain !== undefined
+                )
+                  dataPositioned[axis].add(name);
+              }
+            }
+
             applyConstraints(
               node.constraints,
               nameToPlaceable,
               size,
               effectivePosScales,
-              gridTracks
+              gridTracks,
+              dataPositioned
             );
 
             // Place any child the constraints left unplaced at the layer's

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -13,7 +13,12 @@ import {
   FancyDims,
   displayTranslate,
 } from "../dims";
-import { UNDEFINED, UnderlyingSpace, hasBaseline } from "../underlyingSpace";
+import {
+  UNDEFINED,
+  UnderlyingSpace,
+  hasBaseline,
+  isUNDEFINED,
+} from "../underlyingSpace";
 import { computeSize, foldFinite } from "../../util";
 import { axisScale } from "../domain";
 import { CoordinateTransform } from "../coordinateTransforms/coord";
@@ -25,7 +30,9 @@ import {
   applyConstraints,
   collectPositionDomains,
   gridSpaces,
-  gridCellSize,
+  resolveGridTracks,
+  gridCellSizeByName,
+  gridTracksFromSizes,
   type ConstraintSpec,
   type ZOrderConstraint,
 } from "../constraints";
@@ -128,11 +135,15 @@ export const layer = createNodeOperatorSequential(
           _shared: Size<boolean>,
           constraints
         ) => {
-          // A grid constraint makes this layer a grid: its axes are categorical
-          // (ORDINAL over columns / rows) and the cells fill flex tracks (sized
-          // in `layout`). It's exclusive — no union/nest/position fold applies.
+          // A grid constraint makes this layer a grid. Stage 6e: the grid no
+          // longer bypasses the fold — it participates. Its categorical track
+          // axes (ORDINAL over columns / rows, for axis rendering) are composed
+          // in at the END of this function, overriding the covered axes, while
+          // any sibling constraint (align / position) still contributes to the
+          // fold below. Its size claim (Σ max-of-cell-claims + gaps) is consumed
+          // at layout time by `resolveGridTracks`, not reported as the axis space
+          // — a categorical axis cannot also be a SIZE magnitude.
           const gridC = selectGridConstraint(constraints ?? []);
-          if (gridC !== undefined) return gridSpaces(gridC, _childNodes);
 
           // Nest space fold: only INSIDE_OUT edges (`dir: 'in'`) derive a
           // space — `outer = inner + 2·padding` when inner is SIZE — so a
@@ -181,6 +192,19 @@ export const layer = createNodeOperatorSequential(
             }
           }
 
+          // Grid track axes compose LAST, overriding the covered axes with the
+          // categorical ORDINAL space (columns on x, rows on y) that axis
+          // rendering consumes — the grid's contribution to the fold. A pure
+          // grid therefore reports exactly `gridSpaces` (as before); a grid mixed
+          // with a sibling constraint keeps that sibling's fold on any axis the
+          // grid leaves UNDEFINED (no keys).
+          if (gridC !== undefined) {
+            const gridAxes = gridSpaces(gridC, _childNodes);
+            for (const axis of [0, 1] as const) {
+              if (!isUNDEFINED(gridAxes[axis])) resolved[axis] = gridAxes[axis];
+            }
+          }
+
           // Stash the absorbed anchored extent and report UNDEFINED upward for
           // any dim with an explicit pixel size — self-scaling region; see
           // selfScaledSpaces above. (last write wins — may run more than once.)
@@ -219,11 +243,26 @@ export const layer = createNodeOperatorSequential(
               size[1],
           ];
 
-          // Grid budget: a grid layer is exclusively cells (table elaboration),
-          // and every cell fills its flex track — so all children get the equal
-          // track size (box-division); the placement solver then centers them.
+          // Grid budget (Stage 6e): resolve the tracks under the unified max rule
+          // from the cells' pre-layout size claims — each track sizes to the max
+          // claim of its cells, fill tracks split the leftover equally. This
+          // sizes only the FILL cells (a claim cell keeps its own size); the
+          // authoritative PLACEMENT tracks are recomputed from the actual
+          // laid-out cell sizes after the child loop (`gridTracksFromSizes`), so
+          // cell centers pin to the real geometry.
           const gridC = selectGridConstraint(node.constraints);
-          const gridCell = gridC ? gridCellSize(gridC, size) : undefined;
+          const gridCellByName = gridC
+            ? gridCellSizeByName(
+                gridC,
+                resolveGridTracks(
+                  gridC,
+                  node.children,
+                  size,
+                  getScopeRegistry(node.tryGetRenderSession()),
+                  node.key ?? node.type
+                )
+              )
+            : undefined;
 
           // Build the LOCAL scale for each self-scaled (stashed) dim against our
           // own pixel box — see selfScaledSpaces above. The recipe (cf. the
@@ -336,7 +375,12 @@ export const layer = createNodeOperatorSequential(
             // proposal, so nest composes with — and wins on its derived axes
             // over — any budget slice.
             const layoutSize = applyNestLayoutProposal(
-              childLayoutSizeProposal(childName, size, gridCell, sliceByName),
+              childLayoutSizeProposal(
+                childName,
+                size,
+                gridCellByName,
+                sliceByName
+              ),
               layoutPlan.nestPlan?.byDerived.get(i),
               childPlaceables
             );
@@ -379,11 +423,29 @@ export const layer = createNodeOperatorSequential(
             // Compose and solve placement constraints as one per-axis relational
             // problem. Declaration order does not choose an anchor; unanchored
             // components receive a deterministic weak origin.
+            // Placement tracks from the ACTUAL laid-out cell sizes (Stage 6e):
+            // each track's extent is the max of its cells' real geometry, so the
+            // cell-center pins match what rendered (and the solver shadow agrees).
+            const gridTracks = gridC
+              ? gridTracksFromSizes(
+                  gridC,
+                  childPlaceables.map((cp) =>
+                    cp
+                      ? ([
+                          Math.abs(cp.dims[0].size ?? 0),
+                          Math.abs(cp.dims[1].size ?? 0),
+                        ] as [number, number])
+                      : undefined
+                  )
+                )
+              : undefined;
+
             applyConstraints(
               node.constraints,
               nameToPlaceable,
               size,
-              effectivePosScales
+              effectivePosScales,
+              gridTracks
             );
 
             // Place any child the constraints left unplaced at the layer's

--- a/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/positionNode.tsx
@@ -1,7 +1,7 @@
 import { computeAesthetic } from "../../util";
 import { posFn } from "../domain";
 import { GoFishNode } from "../_node";
-import { Size, translateString } from "../dims";
+import { Size } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import {
   anchorAt,

--- a/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/treemap.tsx
@@ -12,13 +12,7 @@ import type { HierarchyNode, HierarchyRectangularNode } from "d3-hierarchy";
 import { GoFishNode, Placeable } from "../_node";
 import { GoFishAST } from "../_ast";
 import { createNodeOperator } from "../withGoFish";
-import {
-  FancyDims,
-  Size,
-  Direction,
-  elaborateDims,
-  translateString,
-} from "../dims";
+import { FancyDims, Size, Direction, elaborateDims } from "../dims";
 import { getMeasure, getValue, isValue, MaybeValue } from "../data";
 import { computeAesthetic, computeSize } from "../../util";
 import { posFn, pxOf } from "../domain";

--- a/packages/gofish-graphics/src/ast/solver/scopes.ts
+++ b/packages/gofish-graphics/src/ast/solver/scopes.ts
@@ -33,7 +33,22 @@ export type ScopeKind =
   | "self-scaled"
   | "constraint-budget"
   | "shared"
-  | "coord";
+  | "coord"
+  | "recenter";
+
+/** One axis's contribution to the #582 equal-measure recentering: either an
+ *  anchored POSITION axis (its data interval and canvas) or a bare SIZE axis
+ *  (just its σ). `unitPx` is the axis's pixels-per-data-unit before recentering
+ *  — the quantity the two axes must agree on when they share a measure. */
+export type EqualMeasureAxis =
+  | {
+      kind: "position";
+      unitPx: number;
+      min: number;
+      range: number;
+      canvas: number;
+    }
+  | { kind: "size"; unitPx: number };
 
 /** Identity of the scope being solved — its root node label and the axis. */
 export interface ScopeMeta {
@@ -121,6 +136,61 @@ export class ScopeRegistry {
       });
     }
     return map;
+  }
+
+  /**
+   * The #582 equal-measure recentering, modeled as a named post-solve scope
+   * operation (Stage 6c). When x and y carry the SAME unit of measure, "1 unit
+   * on x" and "1 unit on y" are the same quantity, so their data→pixel scales
+   * must be EQUAL — a circle stays circular. The two axes' independently-solved
+   * scopes are therefore collapsed into ONE shared σ (the binding, smaller
+   * `unitPx`); the other axis takes slack, centered by convention. A POSITION
+   * axis writes back a recentered anchored map; a SIZE axis writes back its σ
+   * (content stays origin-anchored — SIZE-slack centering is deferred).
+   *
+   * This is the ONE place a post-solve σ adjustment happens, so it lives on the
+   * registry (not inlined in `gofish.tsx`): every slope a render produces is now
+   * registry-sourced, and `GOFISH_DUMP_SCOPES` records the FINAL σ (a `recenter`
+   * entry per axis) rather than the pre-recentering root σ. Mutates `posScales`
+   * / `rootScaleFactors` in place; a no-op unless both axes have a continuous
+   * scale to equate.
+   */
+  recenterEqualMeasure(
+    rootKey: string,
+    axisInfo: [EqualMeasureAxis | undefined, EqualMeasureAxis | undefined],
+    posScales: (AxisMap | undefined)[],
+    rootScaleFactors: (number | undefined)[]
+  ): void {
+    const [ax, ay] = axisInfo;
+    if (ax === undefined || ay === undefined) return;
+    const shared = Math.min(ax.unitPx, ay.unitPx); // binding axis wins
+    for (const axis of [0, 1] as const) {
+      const info = axisInfo[axis]!;
+      if (info.kind === "position") {
+        const offset = (info.canvas - shared * info.range) / 2; // center slack
+        // Same affine map as `(pos − min)·shared + offset`, intercept explicit.
+        posScales[axis] = {
+          sigma: shared,
+          domainMin: info.min,
+          pxMin: offset,
+        };
+      } else {
+        rootScaleFactors[axis] = shared;
+      }
+      if (dumpEnabled())
+        this.entries.push({
+          kind: "recenter",
+          rootKey,
+          axis,
+          allocated: info.kind === "position" ? info.canvas : NaN,
+          frame:
+            info.kind === "position"
+              ? `[${info.min},${info.min + info.range}]→center(σ=${shared})`
+              : `σ:=min(x,y)`,
+          sigma: shared,
+          hasMap: info.kind === "position",
+        });
+    }
   }
 
   /** Print one line per scope: root kind/key, axis, allocated px, the frame

--- a/packages/gofish-graphics/src/ast/solver/scopes.ts
+++ b/packages/gofish-graphics/src/ast/solver/scopes.ts
@@ -1,0 +1,151 @@
+/**
+ * The σ-scope registry (#39 endgame, Stage 6b) — the ONE place σ / posScale is
+ * derived.
+ *
+ * Every continuous axis is one affine map per σ-scope, `px(d) = pxMin + σ·(d −
+ * domainMin)`, and σ is solved once per scope at the frame equation
+ * `content(σ) = allocated` (`Monotonic.inverse`). Before Stage 6b that inversion
+ * lived, hand-ordered, at four+ sites (the render root, a self-scaled axis, a
+ * composed-constraint budget, a `shared` scope, and a coord boundary), with the
+ * #618 propagate-vs-re-root guard hand-written to stop an intermediate from
+ * re-rooting. This module makes those a SINGLE mechanism:
+ *
+ *   - **scope roots solve** — the render root, an axis with an explicit pixel
+ *     size (self-scaling region), a composed-constraint budget that roots its
+ *     own scope, a `shared` operator, a coord boundary — each calls
+ *     {@link ScopeRegistry.solveSize} / {@link ScopeRegistry.solvePosition};
+ *   - **everyone else INHERITS** — the #618 guard is now the structural rule
+ *     "not a root → inherit": a non-root site simply does not call the solve, so
+ *     the inherited σ propagates unchanged.
+ *
+ * The arithmetic is exactly what the sites ran inline (`Monotonic.inverse` for
+ * the slope, `posScaleFromSpace` for the anchored map), so the numbers are
+ * bit-identical; the registry adds the single choke-point plus, behind
+ * `GOFISH_DUMP_SCOPES`, a printable dump of every scope's frame equation.
+ */
+import * as Monotonic from "../../util/monotonic";
+import { posScaleFromSpace, type AxisMap } from "../domain";
+import { envFlag } from "../../util";
+import type { RenderSession } from "../_node";
+
+export type ScopeKind =
+  | "root"
+  | "self-scaled"
+  | "constraint-budget"
+  | "shared"
+  | "coord";
+
+/** Identity of the scope being solved — its root node label and the axis. */
+export interface ScopeMeta {
+  kind: ScopeKind;
+  /** A stable label for the scope root (node key/type) for the dump. */
+  rootKey: string;
+  axis: 0 | 1;
+}
+
+interface ScopeEntry extends ScopeMeta {
+  allocated: number;
+  /** The frame equation LHS, printed (`Monotonic.print`), or a POSITION map's
+   *  `[min,max]→[0,alloc]` shape. */
+  frame: string;
+  sigma: number | undefined;
+  hasMap: boolean;
+}
+
+/** Whether the scope dump is on. Off (and near-zero-cost) in prod. */
+const dumpEnabled = (): boolean => envFlag("GOFISH_DUMP_SCOPES");
+
+/**
+ * Per-render record of every σ-scope solved. Lives on the {@link RenderSession}
+ * (one per render, so no cross-render leakage), and is reset at the start of a
+ * layout pass so it reflects the last pass if layout re-runs.
+ */
+export class ScopeRegistry {
+  private entries: ScopeEntry[] = [];
+
+  /** Clear recorded scopes — called at the root solve so a second layout pass
+   *  does not accumulate stale entries. */
+  reset(): void {
+    this.entries = [];
+  }
+
+  /**
+   * Solve σ for a SIZE frame at a scope root: invert `content(σ) = allocated`.
+   * `frame` is the σ-affine width `Monotonic` (a space's `width`, or a composed
+   * distribute size domain). Returns the slope, or `undefined` when the frame
+   * cannot determine σ (slope 0) — the caller keeps applying its own fallback,
+   * exactly as before.
+   */
+  solveSize(
+    meta: ScopeMeta,
+    frame: Monotonic.Monotonic,
+    allocated: number,
+    opts?: { tolerance?: number; lowerBound?: number; upperBoundGuess?: number }
+  ): number | undefined {
+    const sigma = frame.inverse(allocated, opts);
+    if (dumpEnabled())
+      this.entries.push({
+        ...meta,
+        allocated,
+        frame: Monotonic.print(frame),
+        sigma,
+        hasMap: false,
+      });
+    return sigma;
+  }
+
+  /**
+   * Build the anchored data→pixel map for a POSITION scope root — the space's
+   * `[min,max]` domain onto `[0, allocated]`. Records a scope only when a map
+   * actually results (a non-anchored axis is not a POSITION scope here).
+   */
+  solvePosition(
+    meta: ScopeMeta,
+    space:
+      | { kind: string; dataDomain?: { min: number; max: number } | "delta" }
+      | undefined,
+    allocated: number
+  ): AxisMap | undefined {
+    const map = posScaleFromSpace(space, allocated);
+    if (map !== undefined && dumpEnabled()) {
+      const dom =
+        space && space.dataDomain && space.dataDomain !== "delta"
+          ? `[${space.dataDomain.min},${space.dataDomain.max}]`
+          : "[·]";
+      this.entries.push({
+        ...meta,
+        allocated,
+        frame: `${dom}→[0,${allocated}]`,
+        sigma: map.sigma,
+        hasMap: true,
+      });
+    }
+    return map;
+  }
+
+  /** Print one line per scope: root kind/key, axis, allocated px, the frame
+   *  equation, the solved σ, and whether an anchored map is present. */
+  dump(): void {
+    if (!dumpEnabled() || this.entries.length === 0) return;
+    for (const e of this.entries) {
+      console.log(
+        `[scope] ${e.kind} key=${e.rootKey} axis=${e.axis === 0 ? "x" : "y"} ` +
+          `alloc=${e.allocated}px  ${e.frame} = ${e.allocated}  ` +
+          `σ=${e.sigma ?? "—"} map=${e.hasMap ? "yes" : "no"}`
+      );
+    }
+  }
+}
+
+/**
+ * The render's scope registry: the one on the session (created on first use so
+ * the whole render shares it), or a throwaway when there is no session (a
+ * standalone `layout()` call). Every σ-scope derivation goes through the
+ * returned registry.
+ */
+export function getScopeRegistry(
+  session: RenderSession | undefined
+): ScopeRegistry {
+  if (!session) return new ScopeRegistry();
+  return (session.scopes ??= new ScopeRegistry());
+}

--- a/packages/gofish-graphics/src/ast/solver/scopes.ts
+++ b/packages/gofish-graphics/src/ast/solver/scopes.ts
@@ -34,6 +34,7 @@ export type ScopeKind =
   | "constraint-budget"
   | "shared"
   | "coord"
+  | "grid"
   | "recenter";
 
 /** One axis's contribution to the #582 equal-measure recentering: either an

--- a/packages/gofish-graphics/src/ast/solver/shadow.ts
+++ b/packages/gofish-graphics/src/ast/solver/shadow.ts
@@ -26,7 +26,6 @@ import { pxOf } from "../domain";
 import { localAnchorPoint } from "../dims";
 import type { ConstraintSpec, ConstraintPosScales } from "../constraints";
 import { distributePlacementAnchors } from "../constraints/distribute";
-import { gridCellSize } from "../constraints/grid";
 import { isCONTINUOUS, type UnderlyingSpace } from "../underlyingSpace";
 
 /** Whether the solver shadow assertions run. Off (and zero-cost) in prod, so the
@@ -172,16 +171,16 @@ interface GridLike {
 }
 
 /**
- * Check the `grid` composition — cells centered in equal flex tracks
- * (`grid.ts`). The grid pins each cell's center at
- * `column·(cellW+sx)+cellW/2`, `row·(cellH+sy)+cellH/2` in layer-local space
- * (`gridCellPlacements`); the equal-track structure is therefore an
- * ORIGIN-INDEPENDENT invariant on the placed centers: two cells in adjacent
- * columns of one row have x-centers `cellW+sx` apart, two in adjacent rows of
- * one column have y-centers `cellH+sy` apart — validated against `gridCellSize`
- * (the same `sliceExtent` the layer proposes). Differences cancel the unknown
- * layer origin, so no absolute frame is needed. Cell EXTENT is deliberately not
- * asserted: a cell may keep its own size and only consume the center pin.
+ * Check the `grid` composition — cells centered in their (column, row) tracks
+ * (`grid.ts`). Stage 6e: tracks are content-sized under the unified max rule, so
+ * the gap between two adjacent cells is no longer a uniform `cellExtent+spacing`
+ * — it is `extent(col)/2 + spacing + extent(col+1)/2`, where a track's extent is
+ * the max laid-out size of its cells (a cell that fills equals the extent; a
+ * smaller claim cell is centered, and the column's widest cell pins the extent).
+ * Recovering the track extents from the placed cell sizes and asserting the
+ * center-to-center gaps is the ORIGIN-INDEPENDENT invariant (differences cancel
+ * the unknown layer origin). Cell EXTENT is deliberately not asserted; a cell
+ * whose center is overridden by a `position` pin is skipped on that axis.
  */
 export function shadowCheckGrid(
   constraint: GridLike,
@@ -189,34 +188,53 @@ export function shadowCheckGrid(
   layerSize: [number, number]
 ): void {
   if (!enabled() || constraint.type !== "grid") return;
-  const [cellW, cellH] = gridCellSize(
-    constraint as Parameters<typeof gridCellSize>[0],
-    layerSize
-  );
+  void layerSize;
   const numCols = constraint.numCols;
+  const numRows = Math.ceil(constraint.children.length / numCols);
+  const targetOf = (i: number): Placeable | undefined =>
+    targetByName.get(constraint.children[i]?.name);
   const centerOf = (i: number, idx: 0 | 1): number | undefined => {
-    const t = targetByName.get(constraint.children[i]?.name);
+    const t = targetOf(i);
     return t ? anchorCoord(t, idx, "middle") : undefined;
+  };
+  const sizeOf = (i: number, idx: 0 | 1): number | undefined => {
+    const t = targetOf(i);
+    const s = t?.dims[idx].size;
+    return s === undefined ? undefined : Math.abs(s);
+  };
+  // A track's extent is the max laid-out cell size across the track.
+  const colExtent = (col: number): number => {
+    let m = 0;
+    for (let row = 0; row < numRows; row++)
+      m = Math.max(m, sizeOf(row * numCols + col, 0) ?? 0);
+    return m;
+  };
+  const rowExtent = (row: number): number => {
+    let m = 0;
+    for (let col = 0; col < numCols; col++)
+      m = Math.max(m, sizeOf(row * numCols + col, 1) ?? 0);
+    return m;
   };
   for (let i = 0; i < constraint.children.length; i++) {
     const col = i % numCols;
-    const row = Math.floor(i / numCols);
-    // Adjacent column in the same row → x-centers `cellW + xSpacing` apart.
+    // Adjacent column in the same row → centers half-extents + spacing apart.
     if (col + 1 < numCols && i + 1 < constraint.children.length) {
       const a = centerOf(i, 0);
       const b = centerOf(i + 1, 0);
       if (a !== undefined && b !== undefined) {
-        const gap = cellW + constraint.xSpacing;
+        const gap =
+          colExtent(col) / 2 + constraint.xSpacing + colExtent(col + 1) / 2;
         if (Math.abs(b - a - gap) > 1e-6) report(`grid.col`, b - a, gap);
       }
     }
-    // Adjacent row in the same column → y-centers `cellH + ySpacing` apart.
-    void row;
+    // Adjacent row in the same column → centers half-extents + spacing apart.
+    const row = Math.floor(i / numCols);
     if (i + numCols < constraint.children.length) {
       const a = centerOf(i, 1);
       const b = centerOf(i + numCols, 1);
       if (a !== undefined && b !== undefined) {
-        const gap = cellH + constraint.ySpacing;
+        const gap =
+          rowExtent(row) / 2 + constraint.ySpacing + rowExtent(row + 1) / 2;
         if (Math.abs(b - a - gap) > 1e-6) report(`grid.row`, b - a, gap);
       }
     }

--- a/packages/gofish-graphics/src/ast/solver/shadow.ts
+++ b/packages/gofish-graphics/src/ast/solver/shadow.ts
@@ -6,12 +6,15 @@
  * ledger (stages 0–2). Guarded by `GOFISH_SOLVER_CHECK` (env or `globalThis`);
  * zero-cost and silent when off, so production behavior is unchanged.
  *
- * Phase-1 coverage = PLACEMENT COMPOSITION before data→size: given each child's
- * engine-computed size, does the solver's box-key machinery reproduce the engine's
- * absolute positions? Start with the `distribute` constraint (the composition
- * `spread`/`stack`/`scatter` all elaborate to), edge mode, no pre-placed anchor —
- * the stacked/edge-spread core. Other modes/anchors are skipped (not yet
- * modeled), so a clean run means "every covered case agrees", not "everything".
+ * Coverage = PLACEMENT COMPOSITION (does the box-key model reproduce the engine's
+ * absolute positions given each child's size?) plus the σ-SCOPE frame equation
+ * (does content(σ)=allocated close where σ is solved?). The placement checks span
+ * `distribute` (edge AND center, including pre-placed/data-positioned chains via
+ * the pack/consistency-check boundary), `align`, `position`, `nest`
+ * (inner centered in outer), and `grid` (equal-track cell centers). The frame check
+ * runs at every σ-scope root: the render root (`gofish.tsx`), a shared/self-scaled
+ * layer axis (`layer.tsx`), and a coord boundary (`coord.tsx` fitAxis). A clean
+ * run means "every covered case agrees", not "everything".
  */
 import * as M from "../../util/monotonic";
 import { SolverBox } from "./index";
@@ -22,6 +25,8 @@ import { computeAesthetic, envFlag } from "../../util";
 import { pxOf } from "../domain";
 import { localAnchorPoint } from "../dims";
 import type { ConstraintSpec, ConstraintPosScales } from "../constraints";
+import { distributePlacementAnchors } from "../constraints/distribute";
+import { gridCellSize } from "../constraints/grid";
 import { isCONTINUOUS, type UnderlyingSpace } from "../underlyingSpace";
 
 /** Whether the solver shadow assertions run. Off (and zero-cost) in prod, so the
@@ -50,18 +55,24 @@ interface DistributeLike {
 }
 
 /**
- * Check the edge-distribute CONTIGUITY invariant the engine enforces on its
- * output: consecutive targets satisfy `child[i+1].min == child[i].max + spacing`.
- * This is anchor-agnostic — which child anchored the walk only sets the absolute
- * offset, not the spacing relation — which matters because the shadow runs after
- * the placement solver, by which point every target is placed (so the
- * pre-placement anchor distinction is gone).
+ * Check the distribute SPACING relation the engine enforces on its output. Every
+ * distribute lowers to a chain of anchored relations (`distribute.ts`): between
+ * consecutive targets in placement order, the `to`-anchor of the later child
+ * equals the `from`-anchor of the earlier one plus `spacing`. The two anchors
+ * are mode-dependent — `edge` uses `prev.max → cur.min` (contiguity), `center`
+ * uses `prev.center → cur.center` (center-to-center) — read here through the
+ * same box-key model (`anchorCoord`) `align`/`position` use, so this covers BOTH
+ * modes with one relation.
  *
- * The solver expresses it as an origin chain: seed the first target at its real
- * position (boundary condition), then predict each subsequent child's `min` via
- * `SolverBox` — `baseline = previous.max + spacing`, size pinned — and compare to
- * the engine. Agreement validates the solver representation reproduces the engine
- * composition on real story data (and that target/order/axis extraction is right).
+ * The consistency-check-not-pack boundary (the violin case). Distribute only
+ * PACKS children it places; a chain edge whose BOTH endpoints arrived
+ * pre-positioned on the stack axis (e.g. the violin's `stackY` over rects pinned
+ * at `y: data`) was a no-op in the lowering (`distribute.ts` skips it) — the
+ * spacing relation does NOT hold there, those two keep their data positions.
+ * Every other edge (≥1 unplaced endpoint) is packed, so the relation must hold.
+ * Validating exactly that boundary is the point of this check: it asserts the
+ * relation on packed edges and deliberately does not on the pre-placed ones,
+ * matching the engine's own pack/check split.
  */
 export function shadowCheckDistribute(
   constraint: DistributeLike,
@@ -70,42 +81,145 @@ export function shadowCheckDistribute(
   prePlaced: boolean[]
 ): void {
   if (!enabled() || constraint.type !== "distribute") return;
-  // Center mode (center-to-center spacing) is not yet modeled; only edge.
-  if (constraint.mode !== "edge") return;
   const idx = axisIndex(constraint.dir);
 
-  // Distribute only PACKS children it places. A child already placed on the
-  // stack axis (e.g. the violin's `stackY` over rects pinned at `y: data`) is
-  // data-positioned — distribute consistency-checks it, doesn't pack it — so the
-  // contiguity invariant doesn't apply. Validate only pure packing (nothing
-  // pre-placed); mixed/data-positioned distributes are deferred (honest
-  // coverage, not silently passed). Across all 189 stories this covers 2560
-  // edge-distributes; 934 are skipped here as data-positioned, 3 as center mode.
-  if (prePlaced.some(Boolean)) return;
+  // Placement order (`reverse` reverses the chain — mirror it index-wise so the
+  // pre-placed flags travel with their targets).
+  const order = targets.map((_, i) => i);
+  if (constraint.order === "reverse") order.reverse();
+  if (order.length < 2) return;
 
-  const ordered =
-    constraint.order === "reverse" ? [...targets].reverse() : targets;
-  if (ordered.length < 2) return;
+  // Mode picks the anchor pair the lowering relates: edge = prev.max→cur.min,
+  // center = prev.center→cur.center.
+  const anchors = distributePlacementAnchors(constraint.mode);
 
-  let prevMax: M.Monotonic | undefined;
-  for (let i = 0; i < ordered.length; i++) {
-    const size = ordered[i].dims[idx].size;
-    const engineMin = ordered[i].dims[idx].min;
-    // Bail the whole chain if any link is unplaced/unsized — can't model it.
-    if (size === undefined || engineMin === undefined) return;
-
-    const box = new SolverBox(0); // edge targets are min-anchored (baseline ≡ min)
-    box.add(
-      "baseline",
-      i === 0 ? engineMin : M.adds(prevMax!, constraint.spacing)
-    );
-    box.add("size", size);
-
-    const solverMin = box.read("min", 0)!;
-    if (i > 0 && Math.abs(solverMin - engineMin) > 1e-6) {
-      report(`distribute.edge dir=${constraint.dir}`, solverMin, engineMin);
+  for (let k = 1; k < order.length; k++) {
+    const pi = order[k - 1];
+    const ci = order[k];
+    // Both pre-placed → the lowering emits no relation (consistency check, not a
+    // pack); the spacing relation is not asserted here. See docstring.
+    if (prePlaced[pi] && prePlaced[ci]) continue;
+    const from = anchorCoord(targets[pi], idx, anchors.from);
+    const to = anchorCoord(targets[ci], idx, anchors.to);
+    if (from === undefined || to === undefined) continue; // unplaced/unsized link
+    // `to.anchor == from.anchor + spacing` (the relation direction proved in
+    // placementSolver.reduceToAxisProblem: `to.min = from.min + fromOff + gap −
+    // toOff`, i.e. anchor-point + gap).
+    if (Math.abs(to - (from + constraint.spacing)) > 1e-6) {
+      report(
+        `distribute.${constraint.mode} dir=${constraint.dir}`,
+        to,
+        from + constraint.spacing
+      );
     }
-    prevMax = box.keyMono("max");
+  }
+}
+
+/** The subset of a nest constraint the shadow reads. `x`/`y` are the paddings on
+ *  the constrained axes; `children` is `[outer, inner]`. */
+interface NestLike {
+  type?: string;
+  x?: number;
+  y?: number;
+  children: { name: string }[];
+}
+
+/**
+ * Check the `nest` composition. On each constrained axis `nest` emits ONE
+ * placement relation to the solver (`nest.ts` `lowerNestPlacement`): the inner is
+ * CENTERED in the outer (`outer.center == inner.center`, the middle-to-middle
+ * relate with gap 0). That center coincidence is the hard, placed-geometry
+ * invariant, read here through the box-key model.
+ *
+ * The padded-extent relation (`|outer| == |inner| + 2·padding`) is deliberately
+ * NOT asserted here: it is a size PROPOSAL — the space fold `nestedSpace` plus the
+ * layer's nest layout proposal — that COMPOSES WITH and YIELDS TO other size
+ * claims. In the OUTSIDE_IN direction (`inner = outer − 2·padding`) a
+ * larger-natural-content inner overflows the derived size, so the placed sizes do
+ * not satisfy the wrap relation even though the layout is correct (observed on
+ * GoTree `combine({x:"nest"})` stories). The pad relation is thus validated at the
+ * space-fold layer, not at placed geometry; Stage 6 folds it in as a size
+ * equation, where authority tiers make the override explicit.
+ */
+export function shadowCheckNest(
+  constraint: NestLike,
+  outer: Placeable | undefined,
+  inner: Placeable | undefined
+): void {
+  if (!enabled() || constraint.type !== "nest" || !outer || !inner) return;
+  const axes: [Axis, number | undefined][] = [
+    ["x", constraint.x],
+    ["y", constraint.y],
+  ];
+  for (const [axis, padding] of axes) {
+    if (padding === undefined) continue; // axis left unconstrained
+    const idx = axisIndex(axis);
+    // Centered placement: outer and inner share a center line (the emitted relate).
+    const oc = anchorCoord(outer, idx, "middle");
+    const ic = anchorCoord(inner, idx, "middle");
+    if (oc !== undefined && ic !== undefined && Math.abs(oc - ic) > 1e-6)
+      report(`nest.center ${axis}`, oc, ic);
+  }
+}
+
+/** The subset of a grid constraint the shadow reads. */
+interface GridLike {
+  type?: string;
+  numCols: number;
+  xSpacing: number;
+  ySpacing: number;
+  children: { name: string }[];
+}
+
+/**
+ * Check the `grid` composition — cells centered in equal flex tracks
+ * (`grid.ts`). The grid pins each cell's center at
+ * `column·(cellW+sx)+cellW/2`, `row·(cellH+sy)+cellH/2` in layer-local space
+ * (`gridCellPlacements`); the equal-track structure is therefore an
+ * ORIGIN-INDEPENDENT invariant on the placed centers: two cells in adjacent
+ * columns of one row have x-centers `cellW+sx` apart, two in adjacent rows of
+ * one column have y-centers `cellH+sy` apart — validated against `gridCellSize`
+ * (the same `sliceExtent` the layer proposes). Differences cancel the unknown
+ * layer origin, so no absolute frame is needed. Cell EXTENT is deliberately not
+ * asserted: a cell may keep its own size and only consume the center pin.
+ */
+export function shadowCheckGrid(
+  constraint: GridLike,
+  targetByName: Map<string, Placeable>,
+  layerSize: [number, number]
+): void {
+  if (!enabled() || constraint.type !== "grid") return;
+  const [cellW, cellH] = gridCellSize(
+    constraint as Parameters<typeof gridCellSize>[0],
+    layerSize
+  );
+  const numCols = constraint.numCols;
+  const centerOf = (i: number, idx: 0 | 1): number | undefined => {
+    const t = targetByName.get(constraint.children[i]?.name);
+    return t ? anchorCoord(t, idx, "middle") : undefined;
+  };
+  for (let i = 0; i < constraint.children.length; i++) {
+    const col = i % numCols;
+    const row = Math.floor(i / numCols);
+    // Adjacent column in the same row → x-centers `cellW + xSpacing` apart.
+    if (col + 1 < numCols && i + 1 < constraint.children.length) {
+      const a = centerOf(i, 0);
+      const b = centerOf(i + 1, 0);
+      if (a !== undefined && b !== undefined) {
+        const gap = cellW + constraint.xSpacing;
+        if (Math.abs(b - a - gap) > 1e-6) report(`grid.col`, b - a, gap);
+      }
+    }
+    // Adjacent row in the same column → y-centers `cellH + ySpacing` apart.
+    void row;
+    if (i + numCols < constraint.children.length) {
+      const a = centerOf(i, 1);
+      const b = centerOf(i + numCols, 1);
+      if (a !== undefined && b !== undefined) {
+        const gap = cellH + constraint.ySpacing;
+        if (Math.abs(b - a - gap) > 1e-6) report(`grid.row`, b - a, gap);
+      }
+    }
   }
 }
 
@@ -277,18 +391,22 @@ export function shadowCheckScaleRoot(
 }
 
 /**
- * Single per-constraint shadow hook for the constraint dispatcher — one line in
- * `applyConstraints` instead of three interleaved calls with bespoke pre-state
- * capture, so this disposable observe→assert scaffolding lifts out cleanly when
- * the solver lands. `prePlaced` is the per-target `[x, y]` placement snapshot the
- * caller takes BEFORE applying the constraint (only when the check is enabled);
- * it's `undefined` (and this no-ops) in production.
+ * Single per-constraint shadow hook for `applyConstraints` — one call that
+ * dispatches by constraint type, so this disposable observe→assert scaffolding
+ * lifts out cleanly when the solver lands. `prePlaced` is the per-target `[x, y]`
+ * placement snapshot the caller takes BEFORE the placement solve (only when the
+ * check is enabled); it's `undefined` (and this no-ops) in production.
+ * `nameToPlaceable`/`layerSize` are the layer's resolved children and pixel box,
+ * used by the `nest` and `grid` checks (which read placeables by name and the
+ * grid's track sizes).
  */
 export function shadowCheckConstraint(
   constraint: ConstraintSpec,
   targets: Placeable[],
   posScales: ConstraintPosScales | undefined,
-  prePlaced: [boolean, boolean][] | undefined
+  prePlaced: [boolean, boolean][] | undefined,
+  nameToPlaceable: Map<string, Placeable>,
+  layerSize: [number, number]
 ): void {
   if (!enabled() || !prePlaced) return;
   const c = constraint as { type?: string; dir?: Axis };
@@ -303,5 +421,14 @@ export function shadowCheckConstraint(
     );
   } else if (c.type === "position") {
     shadowCheckPosition(constraint as PositionLike, targets, posScales);
+  } else if (c.type === "nest") {
+    const nest = constraint as NestLike;
+    shadowCheckNest(
+      nest,
+      nameToPlaceable.get(nest.children[0]?.name),
+      nameToPlaceable.get(nest.children[1]?.name)
+    );
+  } else if (c.type === "grid") {
+    shadowCheckGrid(constraint as GridLike, nameToPlaceable, layerSize);
   }
 }

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -46,6 +46,7 @@ import {
 import { discretePosition, value } from "../ast/data";
 import { pxOf, type AxisMap } from "../ast/domain";
 import { POSITION, SIZE, UNDEFINED } from "../ast/underlyingSpace";
+import { ScopeRegistry } from "../ast/solver/scopes";
 import { interval } from "../util/interval";
 
 type Constraint =
@@ -1131,7 +1132,9 @@ console.log("# constraint confluence: child scale factor planning");
     [2, 3],
     [inheritedX, inheritedY],
     undefined,
-    [false, false]
+    [false, false],
+    new ScopeRegistry(),
+    "test"
   );
   ok(
     "self-scaled POSITION axis builds local posScale",
@@ -1159,7 +1162,9 @@ console.log("# constraint confluence: child scale factor planning");
     [2, 3],
     [inheritedX, inheritedY],
     { sizeDomain: [Monotonic.linear(10, 0), Monotonic.linear(0, 10)] },
-    [false, false]
+    [false, false],
+    new ScopeRegistry(),
+    "test"
   );
   ok(
     "intermediate distribute defers to inherited child scale factor (scale-root scoping)",
@@ -1180,7 +1185,9 @@ console.log("# constraint confluence: child scale factor planning");
     [undefined, undefined],
     [inheritedX, inheritedY],
     { sizeDomain: [Monotonic.linear(10, 0), Monotonic.linear(0, 10)] },
-    [false, false]
+    [false, false],
+    new ScopeRegistry(),
+    "test"
   );
   ok(
     "σ-root distribute re-derives child scale factor from its budget when invertible",
@@ -1200,7 +1207,9 @@ console.log("# constraint confluence: child scale factor planning");
     [2, 3],
     [inheritedX, inheritedY],
     { sizeDomain: [Monotonic.linear(10, 0), undefined] },
-    [true, false]
+    [true, false],
+    new ScopeRegistry(),
+    "test"
   );
   ok(
     "shared scale scope overrides budget scale factor and emits shadow check",

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -1430,12 +1430,16 @@ console.log("# constraint confluence: self-placement and override");
     ["A", makePlaceable()],
     ["B", makePlaceable()],
   ]);
-  targets.get("A")!.placementOn = () => "determined";
+  // A is anchored to the x data scale (Stage 6f: the data-positioned fact now
+  // arrives as an explicit ownership input, not a `placementOn` method on the
+  // target). align must leave A where its own scale puts it.
   solvePlacementConstraints(
     [{ type: "align", x: "baseline", children: [A, B] }],
     targets,
     [300, 200],
-    [(value) => value * 10 - 200, undefined]
+    [(value) => value * 10 - 200, undefined],
+    undefined,
+    [new Set(["A"]), new Set()]
   );
   ok(
     "posScale align leaves determined continuous placement alone and normalizes free sibling",

--- a/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
+++ b/packages/gofish-graphics/src/tests/constraintConfluence.test.ts
@@ -8,7 +8,8 @@ import type { Placeable } from "../ast/_node";
 import * as Monotonic from "../util/monotonic";
 import type { AlignConstraint } from "../ast/constraints/align";
 import type { DistributeConstraint } from "../ast/constraints/distribute";
-import type { GridConstraint } from "../ast/constraints/grid";
+import type { GridConstraint, TrackLayout } from "../ast/constraints/grid";
+import { gridCellSizeByName, gridTracksFromSizes } from "../ast/constraints/grid";
 import type { NestConstraint } from "../ast/constraints/nest";
 import {
   compilePlacementCoordinate,
@@ -409,6 +410,107 @@ console.log("# constraint confluence: nest and grid placement");
   );
 }
 
+console.log("# constraint confluence: grid content-sized tracks (Stage 6e)");
+{
+  // Two columns of DIFFERENT extent (content-sized): col0=40, col1=100,
+  // xSpacing=10 → starts [0, 50]; centers col0=20, col1=50+50=100.
+  const grid: GridConstraint = {
+    type: "grid",
+    numCols: 2,
+    xSpacing: 10,
+    ySpacing: 0,
+    children: [A, B],
+  };
+  const tracks: [TrackLayout, TrackLayout] = [
+    { starts: [0, 50], extents: [40, 100] },
+    { starts: [0], extents: [30] },
+  ];
+
+  // The per-cell budget map hands each cell its own track's extent.
+  const cellSizes = gridCellSizeByName(grid, tracks);
+  ok(
+    "grid cell budget = per-cell track extents",
+    JSON.stringify(cellSizes.get("A")) === "[40,30]" &&
+      JSON.stringify(cellSizes.get("B")) === "[100,30]"
+  );
+
+  const contentTargets = () =>
+    new Map<string, Placeable>([
+      ["A", makePlaceable(40, 30)],
+      ["B", makePlaceable(100, 30)],
+    ]);
+  {
+    const t = contentTargets();
+    solvePlacementConstraints([grid], t, [300, 200], undefined, tracks);
+    ok(
+      "content-sized grid centers each cell in its own track",
+      t.get("A")!.dims[0].center === 20 && t.get("B")!.dims[0].center === 100
+    );
+  }
+
+  // grid + align on a NON-cell child C: C's center is aligned (middle x) to the
+  // grid cell A. The two constraints compose and are order-independent.
+  const alignAC: AlignConstraint = { type: "align", x: "middle", children: [A, C] };
+  const withAlign = (order: Constraint[]) => {
+    const t = contentTargets();
+    t.set("C", makePlaceable(10, 10));
+    solvePlacementConstraints(order, t, [300, 200], undefined, tracks);
+    return {
+      A: t.get("A")!.dims[0].center,
+      C: t.get("C")!.dims[0].center,
+    };
+  };
+  const af = withAlign([grid, alignAC]);
+  const as = withAlign([alignAC, grid]);
+  ok(
+    "grid + align on a non-cell composes, order-independent",
+    JSON.stringify(af) === JSON.stringify(as) && af.A === 20 && af.C === 20
+  );
+
+  // grid + position pin of a CELL: the pin overrides that cell's track
+  // centering on the pinned axis; the other cell keeps its track center.
+  const pinB = position("B", 250);
+  const withPin = (order: Constraint[]) => {
+    const t = contentTargets();
+    solvePlacementConstraints(order, t, [300, 200], undefined, tracks);
+    return { A: t.get("A")!.dims[0].center, B: t.get("B")!.dims[0].center };
+  };
+  const pf = withPin([grid, pinB]);
+  const ps = withPin([pinB, grid]);
+  ok(
+    "position pin on a cell overrides its track centering, order-independent",
+    JSON.stringify(pf) === JSON.stringify(ps) && pf.A === 20 && pf.B === 250
+  );
+
+  // Authoritative placement tracks are recomputed from ACTUAL laid-out cell
+  // sizes: a track sizes to the MAX of its cells (a claim cell wider than a
+  // sibling pins the track; a mixed fill/claim track = the claim). 2 cols × 2
+  // rows, xSpacing=10: col0 max(40,20)=40, col1 max(100,60)=100.
+  const grid2x2: GridConstraint = {
+    type: "grid",
+    numCols: 2,
+    xSpacing: 10,
+    ySpacing: 5,
+    children: [A, B, C, child("D")],
+  };
+  const fromSizes = gridTracksFromSizes(grid2x2, [
+    [40, 30],
+    [100, 30],
+    [20, 12],
+    [60, 8],
+  ]);
+  ok(
+    "placement tracks take the max laid-out size per track",
+    JSON.stringify(fromSizes[0].extents) === "[40,100]" &&
+      JSON.stringify(fromSizes[0].starts) === "[0,50]"
+  );
+  ok(
+    "placement track rows take the max height and cumulate with spacing",
+    JSON.stringify(fromSizes[1].extents) === "[30,12]" &&
+      JSON.stringify(fromSizes[1].starts) === "[0,35]"
+  );
+}
+
 console.log("# constraint confluence: nest size dependency planning");
 {
   const nestAB: NestConstraint = {
@@ -584,15 +686,17 @@ console.log("# constraint confluence: distribute size proposals");
 
   const layerSize: [number, number] = [300, 200];
   const gridCell: [number, number] = [90, 40];
+  const gridCellByName = new Map<string, [number, number]>([["A", gridCell]]);
   const sliceByName = new Map<string, [number, number]>([
     ["A", [100, 200]],
   ]);
   ok(
-    "grid proposal overrides distribute slice",
-    childLayoutSizeProposal("A", layerSize, gridCell, sliceByName) === gridCell
+    "grid cell proposal (its track extent) overrides distribute slice",
+    childLayoutSizeProposal("A", layerSize, gridCellByName, sliceByName) ===
+      gridCell
   );
   ok(
-    "named distribute child receives sliced proposal",
+    "a non-cell named child still receives its distribute slice",
     childLayoutSizeProposal("A", layerSize, undefined, sliceByName) ===
       sliceByName.get("A")
   );
@@ -644,23 +748,18 @@ console.log("# constraint confluence: grid proposal ownership");
       throwsWith([grid1, grid2], "Constraint.grid proposal conflict")
   );
 
-  // grid mixed with any non-z-order constraint half-applies (placement sees it,
-  // the space/size fold does not), so selectGridConstraint rejects it.
+  // Stage 6e: grid now GENUINELY composes with sibling constraints, so
+  // selectGridConstraint no longer throws on a non-z-order sibling — it just
+  // selects the one grid (the mixing is exercised for real at placement below).
   const alignMix: AlignConstraint = {
     type: "align",
     y: "middle",
     children: [A, B],
   };
   ok(
-    "grid mixed with align throws in either order",
-    throwsWith(
-      [grid2, alignMix],
-      "Constraint.grid cannot be combined with a 'align' constraint"
-    ) &&
-      throwsWith(
-        [alignMix, grid2],
-        "Constraint.grid cannot be combined with a 'align' constraint"
-      )
+    "grid alongside an align is allowed (composes) in either order",
+    selectGridConstraint([grid2, alignMix]) === grid2 &&
+      selectGridConstraint([alignMix, grid2]) === grid2
   );
 
   // z-order (zAbove/zBelow) is render-time paint order and composes with grid.

--- a/packages/gofish-graphics/src/util/monotonic.ts
+++ b/packages/gofish-graphics/src/util/monotonic.ts
@@ -224,6 +224,48 @@ export const max = (...args: Monotonic[]): Monotonic => {
   return unknown((x: number) => Math.max(...args.map((arg) => arg.run(x))));
 };
 
+/**
+ * Structural equality of two σ-affine claims within an absolute `tolerance`.
+ *
+ * Two points pin a line, so the all-linear common case is exact from probes at
+ * σ = 0 and 1 (the former `monoEqual` in bbox.ts, kept cheap). Once a claim is
+ * piecewise (the `max`-composed track claims of Stage 6e), two probes no longer
+ * suffice: two envelopes can agree at 0 and 1 yet differ on a middle segment. So
+ * when both operands are linear/piecewise (no `unknown`), compare at 0, 1, and
+ * every pairwise breakpoint of the two envelopes' pieces — the only σ where a
+ * convex PWL can change slope. An `unknown` operand has no closed envelope, so
+ * fall back to a spread of multi-point probes.
+ */
+export const approxEqual = (
+  a: Monotonic,
+  b: Monotonic,
+  tolerance = 1e-6
+): boolean => {
+  const close = (x: number, y: number): boolean => Math.abs(x - y) <= tolerance;
+  // All-linear fast path: identical to the two-point probe it replaces.
+  if (isLinear(a) && isLinear(b))
+    return close(a.run(0), b.run(0)) && close(a.run(1), b.run(1));
+
+  const pa = piecesOf(a);
+  const pb = piecesOf(b);
+  if (pa !== undefined && pb !== undefined) {
+    const xs = new Set<number>([0, 1]);
+    const all = [...pa, ...pb];
+    for (let i = 0; i < all.length; i++) {
+      for (let j = i + 1; j < all.length; j++) {
+        const ds = all[i].slope - all[j].slope;
+        if (Math.abs(ds) < 1e-12) continue;
+        const x = (all[j].intercept - all[i].intercept) / ds;
+        if (Number.isFinite(x) && x > 0) xs.add(x);
+      }
+    }
+    return [...xs].every((x) => close(a.run(x), b.run(x)));
+  }
+
+  // An `unknown` (opaque closure) operand: probe a spread of points.
+  return [0, 0.5, 1, 2, 10].every((x) => close(a.run(x), b.run(x)));
+};
+
 /** Pretty-print a Monotonic as the equation it represents — `40σ + 16`,
  *  `max(40σ + 16, 90)`, or `f(σ)` for an opaque closure. Matches the forms in
  *  the layout-synthesis essay; for debugging composed size claims. */

--- a/packages/gofish-graphics/stories/atom/TitanicFacet.stories.tsx
+++ b/packages/gofish-graphics/stories/atom/TitanicFacet.stories.tsx
@@ -43,6 +43,11 @@ export const Default: StoryObj<Args> = {
      chart(titanicPassengers, { color: palette(["#2b8cbe", "#ff8408"]), axes: true })
         .flow(table({
                 by: {x: "pclass", y: "sex"},
+                // Content-sized tracks (σ-affine 6e) pack facets to their dot
+                // blocks; declared gutters replace the equal-split slack the
+                // old box-division provided by accident. The Atom-faithful
+                // semantics (equal cells, fit-derived unit size) is #663.
+                spacing: 32,
               }))
       .mark((d) => chart(d)
             .flow(

--- a/tests/package.json
+++ b/tests/package.json
@@ -11,6 +11,7 @@
     "capture-one": "tsx scripts/capture-one.ts",
     "capture-gallery": "tsx scripts/capture-gallery-thumbnails.ts",
     "capture-diff": "tsx scripts/capture-diff.ts",
+    "capture-pixels": "tsx scripts/capture-pixels.ts",
     "capture-sweep": "tsx scripts/capture-sweep.ts",
     "update-baselines": "tsx scripts/update-baselines.ts",
     "check-sync": "tsx scripts/check-python-sync.ts",

--- a/tests/python-stories/atom/test_titanic_facet.py
+++ b/tests/python-stories/atom/test_titanic_facet.py
@@ -35,7 +35,16 @@ def story_default():
 
     return (
         chart(titanic_passengers, color=palette(["#2b8cbe", "#ff8408"]), axes=True)
-        .flow(table(by={"x": "pclass", "y": "sex"}))
+        .flow(
+            table(
+                by={"x": "pclass", "y": "sex"},
+                # Content-sized tracks (σ-affine 6e) pack facets to their dot
+                # blocks; declared gutters replace the equal-split slack the
+                # old box-division provided by accident. The Atom-faithful
+                # semantics (equal cells, fit-derived unit size) is #663.
+                spacing=32,
+            )
+        )
         .mark(passenger_dots),
         {"w": 720, "h": 480},
     )

--- a/tests/scripts/capture-pixels.ts
+++ b/tests/scripts/capture-pixels.ts
@@ -1,0 +1,221 @@
+/**
+ * capture-pixels.ts
+ *
+ * PIXEL-exact regression gate for #39 stage 6d (translate retirement).
+ *
+ * Unlike `capture-diff.ts` (normalized-DOM geometry diff, platform-stable), this
+ * renders each story to a PNG at HEAD and at <base-ref> — BOTH in the SAME local
+ * Playwright/Chromium — and compares them pixel-for-pixel with pixelmatch at
+ * threshold 0. Because both refs rasterize on the identical browser/platform,
+ * text antialiasing is bit-identical, so a correct behavior-preserving refactor
+ * must yield ZERO differing pixels for every story. Any story with diffs is a
+ * real regression to investigate (do not paper over with tolerance).
+ *
+ * This is the 6d gate specifically: collapsing the per-container translate
+ * closures reshuffles the DOM (see capture-diff) but must not move a single
+ * pixel — a DOM diff there is benign, a pixel diff here is not.
+ *
+ * Usage:
+ *   tsx scripts/capture-pixels.ts <base-ref> [filter]
+ *
+ *   tsx scripts/capture-pixels.ts HEAD           # whole suite vs HEAD (pre-edit self-check)
+ *   tsx scripts/capture-pixels.ts 70d281b4       # vs the 6c tip
+ *   tsx scripts/capture-pixels.ts 70d281b4 bar   # only stories matching "bar"
+ *
+ * Output:
+ *   tests/tmp/capture-pixels/head/<path>.png   PNG at HEAD (edited worktree)
+ *   tests/tmp/capture-pixels/base/<path>.png   PNG at <base-ref>
+ *   tests/tmp/capture-pixels/diff/<path>.png   pixelmatch diff (only for stories that moved)
+ *
+ * Exit code 0 = every story pixel-identical, 1 = at least one story moved (or a
+ * render failed / a story exists in only one ref).
+ */
+
+import { execSync } from "child_process";
+import { readFileSync, writeFileSync, rmSync, mkdirSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { PNG } from "pngjs";
+import pixelmatch from "pixelmatch";
+import { captureStories } from "./capture-core.js";
+import { git, removeWorktree } from "./snapshot-branch.js";
+
+const TESTS_DIR = join(import.meta.dirname, "..");
+const HARNESS_DIR = join(TESTS_DIR, "harness");
+const OUT_DIR = join(TESTS_DIR, "tmp/capture-pixels");
+const HEAD_DIR = join(OUT_DIR, "head");
+const BASE_DIR = join(OUT_DIR, "base");
+const DIFF_DIR = join(OUT_DIR, "diff");
+
+const HEAD_PORT = 3005;
+const BASE_PORT = 3006;
+
+/** Compare two PNGs at threshold 0. Returns differing-pixel count and (when > 0)
+ *  the diff image. Mismatched dimensions are themselves a hard difference. */
+function comparePng(
+  basePath: string,
+  headPath: string
+): { numDiff: number; total: number; diff?: Buffer; note?: string } {
+  const base = PNG.sync.read(readFileSync(basePath));
+  const head = PNG.sync.read(readFileSync(headPath));
+  if (base.width !== head.width || base.height !== head.height) {
+    return {
+      numDiff: base.width * base.height,
+      total: base.width * base.height,
+      note: `dimensions differ: base ${base.width}x${base.height} vs head ${head.width}x${head.height}`,
+    };
+  }
+  const { width, height } = base;
+  const diff = new PNG({ width, height });
+  const numDiff = pixelmatch(base.data, head.data, diff.data, width, height, {
+    threshold: 0,
+  });
+  return {
+    numDiff,
+    total: width * height,
+    diff: numDiff > 0 ? PNG.sync.write(diff) : undefined,
+  };
+}
+
+async function main() {
+  const baseRef = process.argv[2];
+  const filter = process.argv[3];
+
+  if (!baseRef) {
+    console.error(
+      "Usage: tsx scripts/capture-pixels.ts <base-ref> [filter]\n" +
+        "  e.g. tsx scripts/capture-pixels.ts 70d281b4\n" +
+        "       tsx scripts/capture-pixels.ts HEAD bar"
+    );
+    process.exit(2);
+  }
+
+  const baseSha = git(`git rev-parse "${baseRef}"`, { ignoreError: true });
+  if (!baseSha) {
+    console.error(`Cannot resolve base ref "${baseRef}".`);
+    process.exit(2);
+  }
+  const baseShort = baseSha.slice(0, 9);
+
+  if (existsSync(OUT_DIR)) rmSync(OUT_DIR, { recursive: true });
+  mkdirSync(OUT_DIR, { recursive: true });
+
+  // 1. HEAD (current, possibly-edited worktree) → PNGs.
+  console.log(`=== Capturing HEAD (current worktree) → PNG ===\n`);
+  const headResult = await captureStories({
+    harnessDir: HARNESS_DIR,
+    port: HEAD_PORT,
+    outDir: HEAD_DIR,
+    filter,
+    screenshot: true,
+  });
+
+  // 2. <base-ref> from a throwaway worktree → PNGs (same process/browser).
+  const wtPath = join("/tmp", `gofish-capture-pixels-${process.pid}`);
+  removeWorktree(wtPath);
+  let baseResult;
+  try {
+    console.log(
+      `\n=== Checking out ${baseRef} (${baseShort}) into a temp worktree ===`
+    );
+    git(`git worktree add --detach "${wtPath}" ${baseSha}`);
+    console.log(`Installing dependencies in the temp worktree...`);
+    execSync("pnpm install --ignore-scripts", {
+      cwd: wtPath,
+      stdio: "inherit",
+    });
+
+    console.log(`\n=== Capturing ${baseRef} (${baseShort}) → PNG ===\n`);
+    baseResult = await captureStories({
+      harnessDir: join(wtPath, "tests/harness"),
+      port: BASE_PORT,
+      outDir: BASE_DIR,
+      filter,
+      screenshot: true,
+    });
+  } finally {
+    removeWorktree(wtPath);
+  }
+
+  // 3. Pixel-compare per story.
+  const headSet = new Set(
+    headResult.captured.map((p) => p.replace(/\.html$/, ""))
+  );
+  const baseSet = new Set(
+    baseResult.captured.map((p) => p.replace(/\.html$/, ""))
+  );
+  const all = Array.from(new Set([...headSet, ...baseSet])).sort();
+
+  let compared = 0;
+  const moved: {
+    path: string;
+    numDiff: number;
+    total: number;
+    note?: string;
+  }[] = [];
+  const onlyOne: { path: string; where: string }[] = [];
+
+  for (const path of all) {
+    if (!headSet.has(path)) {
+      onlyOne.push({ path, where: baseRef });
+      continue;
+    }
+    if (!baseSet.has(path)) {
+      onlyOne.push({ path, where: "HEAD" });
+      continue;
+    }
+    const headPng = join(HEAD_DIR, `${path}.png`);
+    const basePng = join(BASE_DIR, `${path}.png`);
+    if (!existsSync(headPng) || !existsSync(basePng)) {
+      onlyOne.push({ path, where: existsSync(headPng) ? "HEAD" : baseRef });
+      continue;
+    }
+    compared++;
+    const { numDiff, total, diff, note } = comparePng(basePng, headPng);
+    if (numDiff > 0) {
+      moved.push({ path, numDiff, total, note });
+      if (diff) {
+        const diffPath = join(DIFF_DIR, `${path}.png`);
+        mkdirSync(dirname(diffPath), { recursive: true });
+        writeFileSync(diffPath, diff);
+      }
+    }
+  }
+
+  // 4. Report.
+  console.log(`\n=== Pixel result: HEAD vs ${baseRef} (${baseShort}) ===\n`);
+  console.log(`  Stories compared: ${compared}`);
+  console.log(`  Stories with differing pixels: ${moved.length}`);
+  if (moved.length) {
+    for (const m of moved)
+      console.log(
+        `    ~ ${m.path}: ${m.numDiff}/${m.total} px differ${m.note ? ` (${m.note})` : ""}`
+      );
+    console.log(`\n  Diff PNGs: ${DIFF_DIR}`);
+  }
+  if (onlyOne.length) {
+    console.log(`\n  ${onlyOne.length} story(ies) present in only one ref:`);
+    for (const o of onlyOne)
+      console.log(`    ! ${o.path} (only in ${o.where})`);
+  }
+  const renderFailures = [
+    ...headResult.failed.map((f) => ({ ...f, ref: "HEAD" })),
+    ...baseResult.failed.map((f) => ({ ...f, ref: baseRef })),
+  ];
+  if (renderFailures.length) {
+    console.log(`\n  ${renderFailures.length} render failure(s):`);
+    for (const f of renderFailures)
+      console.log(`    ! [${f.ref}] ${f.path}: ${f.error}`);
+  }
+
+  const clean =
+    moved.length === 0 && onlyOne.length === 0 && renderFailures.length === 0;
+  console.log(
+    `\n  ${clean ? "CLEAN — zero pixels moved." : "PIXELS MOVED / failures — investigate."}`
+  );
+  process.exit(clean ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(2);
+});

--- a/tests/scripts/dump-scopes.ts
+++ b/tests/scripts/dump-scopes.ts
@@ -1,0 +1,62 @@
+// Render the stories matching a filter with GOFISH_DUMP_SCOPES on and print each
+// one's [scope] frame-equation lines — the single-story companion to the
+// whole-corpus capture-sweep, for inspecting a chart's σ-scope structure.
+// Usage: tsx scripts/dump-scopes.ts "<filter>"
+import { chromium } from "playwright";
+import { join } from "path";
+import {
+  startViteServer,
+  waitForVite,
+  type StoryInfo,
+} from "./capture-core.js";
+
+const HARNESS_DIR = join(import.meta.dirname, "..", "harness");
+const PORT = 3007;
+
+async function main() {
+  const filter = (process.argv[2] ?? "").toLowerCase().trim();
+  const viteProc = startViteServer(HARNESS_DIR, PORT);
+  viteProc.stderr?.on("data", (d) => process.stderr.write(d.toString()));
+  const browser = await chromium.launch({ headless: true });
+  try {
+    await waitForVite(PORT);
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.addInitScript(() => {
+      (window as unknown as Record<string, unknown>).GOFISH_DUMP_SCOPES = 1;
+    });
+    let buffer: string[] = [];
+    page.on("console", (msg) => {
+      const t = msg.text();
+      if (t.startsWith("[scope]")) buffer.push(t);
+    });
+    await page.goto(`http://localhost:${PORT}/stories-runner.html`, {
+      waitUntil: "domcontentloaded",
+    });
+    await page.waitForFunction(
+      () => (window as any).__STORIES_RUNNER_READY__ === true,
+      { timeout: 30_000 }
+    );
+    const all = (await page.evaluate(() =>
+      window.__listStories__()
+    )) as StoryInfo[];
+    const stories = all.filter((s) =>
+      `${s.title}/${s.name}`.toLowerCase().includes(filter)
+    );
+    for (const story of stories) {
+      buffer = [];
+      await page.evaluate(async (id) => window.__renderStory__(id), story.id);
+      await page.waitForFunction(() => window.__STORY_RENDER_DONE__ === true, {
+        timeout: 15_000,
+      });
+      await page.waitForTimeout(50);
+      console.log(`\n### ${story.title}/${story.name}`);
+      for (const l of buffer) console.log(l);
+    }
+    await context.close();
+  } finally {
+    await browser.close();
+    viteProc.kill();
+  }
+}
+main();


### PR DESCRIPTION
Advances #39. Stacked on #655 (stage 5); #666 (the #659 nicing fix) stacks on this. **Consolidates the former #656, #658, #660, #664 into one PR — one commit per sub-stage, so review-by-commit preserves the original granularity.** Every sub-stage was gated independently before its commit (full suite + 260-story solver sweep + capture-diff, plus threshold-0 pixelmatch from 6d on).

The five commits, in order:

**6a+6b — full shadow coverage + the σ-scope registry** (`84f8405a`). Shadow checks extended to every skipped mode (center-mode distribute, pre-placed chains, nest, grid, coord frames) — and the constraint-level dispatch turned out to have been silently unwired since the #614 refactor; rewired, 260/260 clean. `ScopeRegistry` (`solver/scopes.ts`): the render root, self-scaling regions, constraint budgets, `sharedScale`, and coord boundaries all delegate σ/posScale derivation to the one scope-root solve; the #618 propagate-vs-re-root guard becomes the structural rule (only roots solve). `GOFISH_DUMP_SCOPES` prints each scope's frame equation.

**6c — one slope per σ-scope, by construction** (`70d281b4`). The registry becomes the sole producer of every slope; `AxisScale.map.sigma` can no longer be set independently. Corpus-wide dual-slope inventory: 10 stories — 6 were a fabricated dead `σ=1` in coord's POSITION branch (deleted, DOM-byte-identical), 4 were two genuinely distinct scopes on one axis. The #582 equal-measure recentering moves on-registry as the one named post-solve operation. (The marginal-histogram characterization was corrected post-review → #659.)

**6d — baked-absolute child lowering** (`eeae565f`). Boundary lower bodies consume baked absolutes via a shared `bakeChildren` instead of composing per-container translate closures (~95→40 lines in layer's lower); dead `translateString` deleted. Findings: zero retirable translate writes (render already reads the ledger projection) and zero DOM churn. New `capture-pixels` tool: threshold-0 pixelmatch across all stories — 260/260 zero pixels moved.

**6e — grid as track equations** (`cfc4a4a7` + `0e40bb39`). One sizing rule, no modes: `track claim = Monotonic.max(cell claims)`, fill cells contribute nothing — all-fill grids reduce to the equal split bit-identically; content-sized tracks emerge automatically. The layer's grid bypasses and Stage 3's mixing throw are deleted; grid genuinely composes (a position pin overrides track centering). `Monotonic.approxEqual` replaces the linear-only equality probe. **One adjudicated mover** — `atom/TitanicFacet` packs to content; Josh accepted it with declared `spacing: 32` (follow-up commit); the Atom fit-derived-unit semantics is #663. The only other diff is a 0.0001px container-width float artifact on the heatmap.

| before (equal box-division) | after (content tracks) | shipped (+ spacing) |
|---|---|---|
| ![before](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-664/before.png) | ![packed](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-664/after-packed.png) | ![spacing](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-664/after-spacing32.png) |

**6f — the guards ask the solver** (`9d8299b9`). The align guard stops reconstructing positioned-ness from the space pass: the data-positioned fact is collected once at the layer boundary and read from the `PlacementOwnershipPlan` like any other authority fact; `placementOn` deleted; `spacePlacement` has zero constraint-path consumers. Honest deviation, forced by evidence: all 376 load-bearing guarded cells derive determinacy from *scope membership*, not placement rank — the new path fires on exactly the same 376. Dual-slope forensics close 6c's inventory: the three remaining stories are dead solves (panel SIZE scopes unconsumed); not #659 variants.

## Verification (per sub-stage, before each commit)

- `capture-diff` vs the pre-stage-0 baseline: identical everywhere except the adjudicated TitanicFacet mover (+ the 0.0001px float artifact).
- `capture-sweep` 260/260 clean at every step; `capture-pixels` 260/260 zero-pixel from 6d on.
- Full suite green throughout (confluence 92 → 98); typecheck, `check-backlinks`, `docs:build` clean at each step.
- CI `visual-test`: expect exactly the TitanicFacet baseline to need Linux regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)