### PR TITLE
docs: default docs language to JavaScript

### DIFF
--- a/apps/docs/docs/.vitepress/config.mts
+++ b/apps/docs/docs/.vitepress/config.mts
@@ -264,7 +264,7 @@ export default defineConfig({
   appearance: false,
   title: "GoFish Graphics",
   description:
-    "GoFish is an open-source visualization library for Python and JavaScript.",
+    "GoFish is an open-source visualization library for JavaScript and Python.",
   // Per-page social-preview tags (title / description / url / image). Only the
   // truly invariant tags (og:type, og:site_name, twitter:card) live in `head`
   // below; everything page-specific is set here so a shared deep link previews
@@ -281,7 +281,7 @@ export default defineConfig({
     const description =
       pageData.description ||
       pageData.frontmatter.description ||
-      "GoFish is an open-source visualization library for Python and JavaScript.";
+      "GoFish is an open-source visualization library for JavaScript and Python.";
 
     // Social-preview image: each example page previews with its OWN branded chart
     // card (so a shared /js/examples/<id> link unfurls as the chart); every other
@@ -322,12 +322,12 @@ export default defineConfig({
     // through to the saved preference — harmless. The same script also adds the
     // `landing-page` class on the home route so the desk/navbar styling paints
     // immediately on direct loads instead of flashing a stock white docs page.
-    // NOTE: the 'python' fallback literal must match DEFAULT_LANG in
+    // NOTE: the 'js' fallback literal must match DEFAULT_LANG in
     // theme/docsLang.ts (this inline script can't import it).
     [
       "script",
       {},
-      `(function(){try{var p=location.pathname,l;if(p.indexOf('/python/')===0){l='python';}else if(p.indexOf('/js/')===0){l='js';}else{var s=localStorage.getItem('gofish-docs-lang');l=(s==='python'||s==='js')?s:'python';}document.documentElement.setAttribute('data-docs-lang',l);if(p==='/'||p==='/index.html'){document.documentElement.classList.add('landing-page');}}catch(e){}})();`,
+      `(function(){try{var p=location.pathname,l;if(p.indexOf('/python/')===0){l='python';}else if(p.indexOf('/js/')===0){l='js';}else{var s=localStorage.getItem('gofish-docs-lang');l=(s==='python'||s==='js')?s:'js';}document.documentElement.setAttribute('data-docs-lang',l);if(p==='/'||p==='/index.html'){document.documentElement.classList.add('landing-page');}}catch(e){}})();`,
     ],
     ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
     [

--- a/apps/docs/docs/.vitepress/theme/components/LanguageToggle.vue
+++ b/apps/docs/docs/.vitepress/theme/components/LanguageToggle.vue
@@ -29,8 +29,8 @@ const hidden = computed(() => {
 });
 
 const LANGS = [
-  { id: "python", label: "Python" },
   { id: "js", label: "JavaScript" },
+  { id: "python", label: "Python" },
 ] as const;
 type Lang = (typeof LANGS)[number]["id"];
 

--- a/apps/docs/docs/.vitepress/theme/components/landing/LandingPage.vue
+++ b/apps/docs/docs/.vitepress/theme/components/landing/LandingPage.vue
@@ -290,7 +290,7 @@ onBeforeUnmount(() => {
           <h1 id="hero-h" class="rise" style="animation-delay: 0ms">GoFish</h1>
           <p class="subtitle rise" style="animation-delay: 90ms">
             an open-source visualization library for
-            Python&nbsp;and&nbsp;JavaScript
+            JavaScript&nbsp;and&nbsp;Python
           </p>
           <div class="rise" style="animation-delay: 180ms">
             <CtaBlock />

--- a/apps/docs/docs/.vitepress/theme/docsLang.ts
+++ b/apps/docs/docs/.vitepress/theme/docsLang.ts
@@ -11,7 +11,7 @@ export type DocsLang = "js" | "python";
 // and the reader has expressed no saved preference. The pre-paint inline script
 // in config.mts hardcodes this same literal (it can't import this module) — keep
 // the two in sync.
-export const DEFAULT_LANG: DocsLang = "python";
+export const DEFAULT_LANG: DocsLang = "js";
 
 const STORAGE_KEY = "gofish-docs-lang";
 const ATTR = "data-docs-lang";

--- a/apps/docs/docs/.vitepress/theme/style.css
+++ b/apps/docs/docs/.vitepress/theme/style.css
@@ -199,16 +199,16 @@
 /* Language-aware home hero + toggle. Keyed off <html data-docs-lang>, set
    before first paint by the inline script in config.mts. These rules are
    global on purpose — running them through a component's scoped-CSS transform
-   mangles the nested :not() selector. The :not([data-docs-lang="js"]) default
-   direction encodes Python as the default — keep in sync with DEFAULT_LANG in
-   docsLang.ts. */
-html[data-docs-lang="js"] .hero-lang-python,
-html:not([data-docs-lang="js"]) .hero-lang-js {
+   mangles the nested :not() selector. The :not([data-docs-lang="python"])
+   default direction encodes JavaScript as the default — keep in sync with
+   DEFAULT_LANG in docsLang.ts. */
+html[data-docs-lang="python"] .hero-lang-js,
+html:not([data-docs-lang="python"]) .hero-lang-python {
   display: none;
 }
 
-html:not([data-docs-lang="js"]) .lang-toggle__btn[data-lang="python"],
-html[data-docs-lang="js"] .lang-toggle__btn[data-lang="js"] {
+html:not([data-docs-lang="python"]) .lang-toggle__btn[data-lang="js"],
+html[data-docs-lang="python"] .lang-toggle__btn[data-lang="python"] {
   color: #fff;
   background: var(--vp-c-brand-1);
 }


### PR DESCRIPTION
Makes JavaScript the default docs language instead of Python.

## Changes

- **Language toggle order** — the switcher now lists **JavaScript first (left)**, Python second (`LanguageToggle.vue`).
- **Default language** — `DEFAULT_LANG` is now `"js"`. The two places that must mirror it are updated in lockstep:
  - the pre-paint inline script in `config.mts` (fallback literal `'python'` → `'js'`)
  - the `data-docs-lang` CSS defaults in `style.css` (the `:not([data-docs-lang="…"])` default direction now keys off `python`, so with no `/js/`·`/python/` route or saved preference the JS hero code strip shows and the JS toggle button is highlighted).
- **Marketing copy** — now reads **"JavaScript and Python"** wherever it appears as branding: the two site meta / social-preview description strings (`config.mts`) and the landing hero subtitle (`LandingPage.vue`).

Technical prose describing serialization/marshalling order ("Python and JavaScript serialize to the same IR", "data transfer between Python and JavaScript") is intentionally left unchanged — it is not marketing copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)