### PR TITLE
docs: default install snippets to nightly/dev builds

### DIFF
--- a/apps/docs/docs/.vitepress/theme/components/landing/CtaBlock.vue
+++ b/apps/docs/docs/.vitepress/theme/components/landing/CtaBlock.vue
@@ -15,10 +15,12 @@ const apiHref = computed(() => `/${docsLang.value}/api/core/chart`);
 
 // The computed text is SSR-safe; clipboard/document access is confined to the
 // click handler below.
+// Point at the nightly / dev builds — the stable release lags well behind
+// active development while GoFish is pre-1.0.
 const installCmd = computed(() =>
   docsLang.value === "python"
-    ? "pip install gofish-graphics"
-    : "npm install gofish-graphics"
+    ? "pip install --pre gofish-graphics"
+    : "npm install gofish-graphics@nightly"
 );
 const copied = ref(false);
 let copiedTimer: ReturnType<typeof setTimeout> | undefined;

--- a/apps/docs/docs/js/get-started.md
+++ b/apps/docs/docs/js/get-started.md
@@ -5,20 +5,17 @@ GoFish is a JavaScript library for making bespoke graphics.
 ## 1. Install GoFish
 
 ```bash
-npm install gofish-graphics
-```
-
-::: tip Recommended while GoFish is pre-1.0: use the nightly build
-GoFish is moving fast, and the published stable release lags well behind active
-development. While the library is in early development we recommend early
-adopters install the **nightly** build to get the latest features and fixes:
-
-```bash
 npm install gofish-graphics@nightly
 ```
 
-Nightlies are published whenever `main` changes. Pin a specific one with
-`gofish-graphics@<version>` once you find a build you like.
+::: tip Why the nightly build?
+GoFish is moving fast, and the published stable release lags well behind active
+development. While the library is in early development we recommend early
+adopters install the **nightly** build (shown above) to get the latest features
+and fixes. Nightlies are published whenever `main` changes; pin a specific one
+with `gofish-graphics@<version>` once you find a build you like.
+
+Prefer the stable release? Install it with `npm install gofish-graphics`.
 :::
 
 ## 2. Create a chart!

--- a/apps/docs/docs/python/get-started.md
+++ b/apps/docs/docs/python/get-started.md
@@ -8,20 +8,17 @@ marimo notebooks.
 ## Install
 
 ```bash
-pip install gofish-graphics
-```
-
-::: tip Recommended while GoFish is pre-1.0: use the nightly build
-GoFish is moving fast, and the published stable release lags well behind active
-development. While the library is in early development we recommend early
-adopters install the latest **dev** build with `--pre`:
-
-```bash
 pip install --pre gofish-graphics
 ```
 
-Dev builds are published whenever `main` changes. Pin a specific one with
+::: tip Why the dev build?
+GoFish is moving fast, and the published stable release lags well behind active
+development. While the library is in early development we recommend early
+adopters install the latest **dev** build with `--pre` (shown above). Dev builds
+are published whenever `main` changes; pin a specific one with
 `gofish-graphics==<version>` once you find a build you like.
+
+Prefer the stable release? Install it with `pip install gofish-graphics`.
 :::
 
 Import it as `gofish`:


### PR DESCRIPTION
Points the user-facing install fields at the nightly (JS) and `--pre` dev (Python) builds, since the stable release lags well behind active development while GoFish is pre-1.0.

## Changes

- **Landing-page install chip** (`CtaBlock.vue`) — the copy-to-clipboard command now shows `npm install gofish-graphics@nightly` / `pip install --pre gofish-graphics` depending on the selected language.
- **`js/get-started.md`** — primary snippet is now `npm install gofish-graphics@nightly`; the tip block reframed to explain the nightly build and note the stable command as a fallback.
- **`python/get-started.md`** — primary snippet is now `pip install --pre gofish-graphics`; tip block reframed the same way.

The root `README.md` already leads with the `@nightly` commands, so no change was needed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)