### PR TITLE
docs: mark GoFish as alpha on the landing hero

### DIFF
--- a/apps/docs/docs/.vitepress/data/version.data.js
+++ b/apps/docs/docs/.vitepress/data/version.data.js
@@ -1,0 +1,21 @@
+// VitePress data loader exposing the current GoFish package version at build
+// time, so the landing-page version tag tracks
+// packages/gofish-graphics/package.json automatically — no manual bump.
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const pkgPath = fileURLToPath(
+  new URL(
+    "../../../../../packages/gofish-graphics/package.json",
+    import.meta.url
+  )
+);
+
+export default {
+  // Re-read when the package version changes during dev.
+  watch: ["../../../../../packages/gofish-graphics/package.json"],
+  load() {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf-8"));
+    return { version: pkg.version };
+  },
+};

--- a/apps/docs/docs/.vitepress/theme/components/landing/CtaBlock.vue
+++ b/apps/docs/docs/.vitepress/theme/components/landing/CtaBlock.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref } from "vue";
 import { docsLang } from "../../docsLang";
+import { data as pkgData } from "../../../data/version.data.js";
 
 // Shared call-to-action: the three nav buttons + the copy-to-clipboard install
 // chip. Rendered twice on the landing page (hero and closing band). Each
 // instance owns its own `copied` flash so clicking one chip never lights up the
 // other.
+//
+// `version` renders the taped release-line tag centered under the install chip
+// (hero instance only). The version is read from
+// packages/gofish-graphics/package.json at build time (see version.data.js), so
+// it tracks the real version with no manual bump.
+const props = defineProps<{ version?: boolean }>();
+const VERSION = pkgData.version;
 //
 // All links follow the reader's language preference (the toggle lives in the
 // real navbar). VitePress intercepts internal <a href> for SPA navigation.
@@ -87,4 +95,12 @@ onBeforeUnmount(() => clearTimeout(copiedTimer));
       </svg>
     </span>
   </button>
+  <span v-if="props.version" class="hero-version">
+    <span
+      class="tape"
+      style="left: calc(50% - 30px); top: -12px; --tape-angle: -4deg"
+      aria-hidden="true"
+    ></span>
+    v{{ VERSION }}
+  </span>
 </template>

--- a/apps/docs/docs/.vitepress/theme/components/landing/LandingPage.vue
+++ b/apps/docs/docs/.vitepress/theme/components/landing/LandingPage.vue
@@ -2,6 +2,11 @@
 import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { docsLang } from "../../docsLang";
 import CtaBlock from "./CtaBlock.vue";
+import { data as pkgData } from "../../../data/version.data.js";
+
+// Current release line, read from packages/gofish-graphics/package.json at
+// build time (see version.data.js) — shown on the hero version tag.
+const VERSION = pkgData.version;
 
 // Large static SVG / HTML chunks live in sibling fragment files imported as raw
 // strings and rendered with v-html, so the 400KB of inline chart art never goes
@@ -287,6 +292,21 @@ onBeforeUnmount(() => {
         <div class="hero-cards" v-html="heroCards"></div>
 
         <div class="inner">
+          <!-- alpha status: an inked rubber stamp; the release line rides a
+               taped paper tag (reusing the same masking tape as the specimen
+               cards). Kept as real text so it is announced to screen readers;
+               only the tape itself is decorative. -->
+          <span class="hero-stamp rise" style="animation-delay: 240ms"
+            >alpha</span
+          >
+          <span class="hero-version rise" style="animation-delay: 300ms">
+            <span
+              class="tape"
+              style="left: calc(50% - 30px); top: -12px; --tape-angle: -4deg"
+              aria-hidden="true"
+            ></span>
+            v{{ VERSION }}
+          </span>
           <h1 id="hero-h" class="rise" style="animation-delay: 0ms">GoFish</h1>
           <p class="subtitle rise" style="animation-delay: 90ms">
             an open-source visualization library for

--- a/apps/docs/docs/.vitepress/theme/components/landing/LandingPage.vue
+++ b/apps/docs/docs/.vitepress/theme/components/landing/LandingPage.vue
@@ -2,11 +2,6 @@
 import { onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { docsLang } from "../../docsLang";
 import CtaBlock from "./CtaBlock.vue";
-import { data as pkgData } from "../../../data/version.data.js";
-
-// Current release line, read from packages/gofish-graphics/package.json at
-// build time (see version.data.js) — shown on the hero version tag.
-const VERSION = pkgData.version;
 
 // Large static SVG / HTML chunks live in sibling fragment files imported as raw
 // strings and rendered with v-html, so the 400KB of inline chart art never goes
@@ -292,28 +287,21 @@ onBeforeUnmount(() => {
         <div class="hero-cards" v-html="heroCards"></div>
 
         <div class="inner">
-          <!-- alpha status: an inked rubber stamp; the release line rides a
-               taped paper tag (reusing the same masking tape as the specimen
-               cards). Kept as real text so it is announced to screen readers;
-               only the tape itself is decorative. -->
-          <span class="hero-stamp rise" style="animation-delay: 240ms"
-            >alpha</span
-          >
-          <span class="hero-version rise" style="animation-delay: 300ms">
-            <span
-              class="tape"
-              style="left: calc(50% - 30px); top: -12px; --tape-angle: -4deg"
-              aria-hidden="true"
-            ></span>
-            v{{ VERSION }}
-          </span>
-          <h1 id="hero-h" class="rise" style="animation-delay: 0ms">GoFish</h1>
+          <!-- The wordmark carries an inked "alpha" rubber stamp slapped over
+               its right end at an angle. Kept as real text so it is announced to
+               screen readers. The release-line tag lives under the install chip
+               (CtaBlock, version prop). -->
+          <h1 id="hero-h" class="wordmark rise" style="animation-delay: 0ms">
+            GoFish<span class="hero-stamp" style="animation-delay: 240ms"
+              >alpha</span
+            >
+          </h1>
           <p class="subtitle rise" style="animation-delay: 90ms">
             an open-source visualization library for
             JavaScript&nbsp;and&nbsp;Python
           </p>
           <div class="rise" style="animation-delay: 180ms">
-            <CtaBlock />
+            <CtaBlock version />
           </div>
         </div>
       </section>

--- a/apps/docs/docs/.vitepress/theme/components/landing/landing.css
+++ b/apps/docs/docs/.vitepress/theme/components/landing/landing.css
@@ -312,7 +312,7 @@ html.landing-page .DocSearch-Button {
   top: 50%;
   z-index: 6;
   /* rest the stamp against the "h" at the wordmark's end, shallow tilt */
-  transform: translate(-18%, -64%) rotate(27deg);
+  transform: translate(-16%, -64%) rotate(27deg);
   font-family: "Spline Sans", sans-serif;
   font-weight: 800;
   font-size: clamp(0.8rem, 1.4vw, 1.05rem);

--- a/apps/docs/docs/.vitepress/theme/components/landing/landing.css
+++ b/apps/docs/docs/.vitepress/theme/components/landing/landing.css
@@ -296,6 +296,69 @@ html.landing-page .DocSearch-Button {
   max-width: 560px;
   margin: 26px auto 0;
 }
+
+/* ---- alpha stamp + version tag (flank the wordmark) ---- */
+/* Inked rubber stamp: oxblood, rotated, edges eroded by a noise mask so it
+   reads as hand-stamped rather than printed. */
+.landing .hero-stamp {
+  position: absolute;
+  top: -0.5em;
+  right: 3%;
+  z-index: 6;
+  font-family: "Spline Sans", sans-serif;
+  font-weight: 800;
+  font-size: clamp(0.82rem, 1.5vw, 1.12rem);
+  letter-spacing: 0.22em;
+  text-indent: 0.22em; /* balance the trailing letter-spacing */
+  text-transform: uppercase;
+  color: #b23a2e;
+  padding: 0.26em 0.5em 0.22em;
+  border: 2.5px solid #b23a2e;
+  border-radius: 4px;
+  /* faint inner rule — the double frame reads as a stamp, not a chip */
+  box-shadow: inset 0 0 0 1px rgba(178, 58, 46, 0.4);
+  transform: rotate(-8deg);
+  opacity: 0.85;
+  mix-blend-mode: multiply;
+  pointer-events: none;
+  -webkit-mask: var(--stamp-erode);
+  mask: var(--stamp-erode);
+  /* chew the edges/fill with two noise scales so the ink looks pressed, not printed */
+  --stamp-erode: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='e'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.45 0.5' numOctaves='3' seed='7' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -1.1 0.98'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='1 1 1 1 1 0 1 0 1'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23e)'/%3E%3C/svg%3E");
+}
+
+/* Release line on a small paper tag, held by a strip of the same masking tape
+   as the specimen cards. */
+.landing .hero-version {
+  position: absolute;
+  top: 2em;
+  left: 2%;
+  z-index: 6;
+  font-family: "Spline Sans Mono", monospace;
+  font-size: clamp(0.68rem, 1.15vw, 0.88rem);
+  color: var(--ink);
+  background: #fffdf7;
+  padding: 7px 12px 6px;
+  border-radius: 4px;
+  transform: rotate(4deg);
+  box-shadow:
+    0 1px 2px var(--shadow-warm),
+    2px 4px 12px var(--shadow-warm);
+  pointer-events: none;
+}
+
+@media (max-width: 560px) {
+  .landing .hero-stamp {
+    top: -0.3em;
+    right: 1%;
+    font-size: 0.72rem;
+  }
+  .landing .hero-version {
+    top: 0.4em;
+    left: 1%;
+    font-size: 0.62rem;
+  }
+}
 .landing .cta-row {
   margin-top: 36px;
   display: flex;

--- a/apps/docs/docs/.vitepress/theme/components/landing/landing.css
+++ b/apps/docs/docs/.vitepress/theme/components/landing/landing.css
@@ -311,8 +311,8 @@ html.landing-page .DocSearch-Button {
   left: 100%;
   top: 50%;
   z-index: 6;
-  /* pull back over the last letters, then tilt 45° the other way */
-  transform: translate(-46%, -52%) rotate(45deg);
+  /* rest the stamp against the "h" at the wordmark's end, shallow tilt */
+  transform: translate(-18%, -64%) rotate(27deg);
   font-family: "Spline Sans", sans-serif;
   font-weight: 800;
   font-size: clamp(0.8rem, 1.4vw, 1.05rem);

--- a/apps/docs/docs/.vitepress/theme/components/landing/landing.css
+++ b/apps/docs/docs/.vitepress/theme/components/landing/landing.css
@@ -311,8 +311,8 @@ html.landing-page .DocSearch-Button {
   left: 100%;
   top: 50%;
   z-index: 6;
-  /* pull back over the last letters, then tilt 45° */
-  transform: translate(-46%, -52%) rotate(-45deg);
+  /* pull back over the last letters, then tilt 45° the other way */
+  transform: translate(-46%, -52%) rotate(45deg);
   font-family: "Spline Sans", sans-serif;
   font-weight: 800;
   font-size: clamp(0.8rem, 1.4vw, 1.05rem);

--- a/apps/docs/docs/.vitepress/theme/components/landing/landing.css
+++ b/apps/docs/docs/.vitepress/theme/components/landing/landing.css
@@ -297,19 +297,27 @@ html.landing-page .DocSearch-Button {
   margin: 26px auto 0;
 }
 
-/* ---- alpha stamp + version tag (flank the wordmark) ---- */
-/* Inked rubber stamp: oxblood, rotated, edges eroded by a noise mask so it
-   reads as hand-stamped rather than printed. */
+/* ---- alpha stamp (on the wordmark) + version tag (under the install chip) ---- */
+/* The wordmark shrinks to its text so the stamp can anchor to its right end. */
+.landing .hero h1.wordmark {
+  display: inline-block;
+  position: relative;
+  overflow: visible;
+}
+/* Inked rubber stamp slapped over the right end of "GoFish" at 45°: oxblood,
+   edges eroded by a noise mask so it reads as pressed ink rather than printed. */
 .landing .hero-stamp {
   position: absolute;
-  top: -0.5em;
-  right: 3%;
+  left: 100%;
+  top: 50%;
   z-index: 6;
+  /* pull back over the last letters, then tilt 45° */
+  transform: translate(-46%, -52%) rotate(-45deg);
   font-family: "Spline Sans", sans-serif;
   font-weight: 800;
-  font-size: clamp(0.82rem, 1.5vw, 1.12rem);
-  letter-spacing: 0.22em;
-  text-indent: 0.22em; /* balance the trailing letter-spacing */
+  font-size: clamp(0.8rem, 1.4vw, 1.05rem);
+  letter-spacing: 0.2em;
+  text-indent: 0.2em; /* balance the trailing letter-spacing */
   text-transform: uppercase;
   color: #b23a2e;
   padding: 0.26em 0.5em 0.22em;
@@ -317,22 +325,23 @@ html.landing-page .DocSearch-Button {
   border-radius: 4px;
   /* faint inner rule — the double frame reads as a stamp, not a chip */
   box-shadow: inset 0 0 0 1px rgba(178, 58, 46, 0.4);
-  transform: rotate(-8deg);
   opacity: 0.85;
   mix-blend-mode: multiply;
   pointer-events: none;
+  white-space: nowrap;
   -webkit-mask: var(--stamp-erode);
   mask: var(--stamp-erode);
   /* chew the edges/fill with two noise scales so the ink looks pressed, not printed */
   --stamp-erode: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='e'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.45 0.5' numOctaves='3' seed='7' stitchTiles='stitch'/%3E%3CfeColorMatrix type='matrix' values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 -1.1 0.98'/%3E%3CfeComponentTransfer%3E%3CfeFuncA type='discrete' tableValues='1 1 1 1 1 0 1 0 1'/%3E%3C/feComponentTransfer%3E%3C/filter%3E%3Crect width='120' height='120' filter='url(%23e)'/%3E%3C/svg%3E");
 }
 
-/* Release line on a small paper tag, held by a strip of the same masking tape
-   as the specimen cards. */
+/* Release line on a small paper tag, centered under the install chip and held
+   by a strip of the same masking tape as the specimen cards. */
 .landing .hero-version {
-  position: absolute;
-  top: 2em;
-  left: 2%;
+  display: block;
+  width: fit-content;
+  margin: 18px auto 0;
+  position: relative;
   z-index: 6;
   font-family: "Spline Sans Mono", monospace;
   font-size: clamp(0.68rem, 1.15vw, 0.88rem);
@@ -340,7 +349,7 @@ html.landing-page .DocSearch-Button {
   background: #fffdf7;
   padding: 7px 12px 6px;
   border-radius: 4px;
-  transform: rotate(4deg);
+  transform: rotate(-2.5deg);
   box-shadow:
     0 1px 2px var(--shadow-warm),
     2px 4px 12px var(--shadow-warm);
@@ -349,14 +358,7 @@ html.landing-page .DocSearch-Button {
 
 @media (max-width: 560px) {
   .landing .hero-stamp {
-    top: -0.3em;
-    right: 1%;
-    font-size: 0.72rem;
-  }
-  .landing .hero-version {
-    top: 0.4em;
-    left: 1%;
-    font-size: 0.62rem;
+    font-size: 0.68rem;
   }
 }
 .landing .cta-row {


### PR DESCRIPTION
Surfaces GoFish's **alpha** status on the landing hero, styled to match the field-notebook / specimen-scrapbook aesthetic instead of a generic 45° corner ribbon.

## What

Two annotations flank the `GoFish` wordmark:

- **Inked `ALPHA` rubber stamp** — oxblood, rotated ~8°, with a double frame and noise-eroded edges so it reads as a pressed-ink impression rather than a printed chip.
- **Taped paper version tag** — shows the current release line, held by a strip of the *same* masking tape used on the hero specimen cards.

The version is **read from `packages/gofish-graphics/package.json` at build time** via a new `version.data.js` VitePress data loader, so the tag tracks the real version automatically — no manual bump. Both markers are real text (announced to screen readers); only the tape is decorative.

Independent of #669 (that PR only touches the install snippets).

## Screenshots

Desktop:

![landing hero with alpha stamp and version tag](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-670/hero.png)

Mobile (specimen cards hide; both markers still flank the wordmark):

![landing hero on mobile](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-670/hero-mobile.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)