### PR TITLE
Docs sync for line/ribbon PR (#637): address code review #696

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -230,6 +230,17 @@ discrete analogue of `CONTINUOUS`'s measure. It's set from the grouping operator
 own resolved space — a continuous axis by its unit, an ordinal axis by its
 grouping field (see [the layout passes](/internals/layout/passes)).
 
+A companion predicate, **`isPositioningSpace`**, folds the two axis-bearing
+kinds together: it holds for `POSITION` (a data axis) and `ORDINAL` (a category
+axis) but not for `SIZE` (a mark's own extent) or `UNDEFINED`. In other words it
+answers "does this space lay marks _out along an axis_?" — the question you ask
+when you want the axis a set of siblings is arranged on rather than each
+sibling's own size. Its first consumer is the connector's `curve: "auto"`: a
+`line` / `ribbon` reads the underlying space its endpoints resolved to and, when
+that space is a _positioning_ one whose measure is continuous, smooths the path
+(centripetal Catmull–Rom) instead of drawing straight segments — so a line over
+a continuous x auto-curves while one over discrete categories stays polylinear.
+
 The guide a space supports keys on **`dataDomain`** (data-space), never on
 placement:
 

--- a/apps/docs/docs/internals/design-evolution/three-surfaces.md
+++ b/apps/docs/docs/internals/design-evolution/three-surfaces.md
@@ -47,6 +47,18 @@ drawn node refs, driving the ribbon / node-link / labeling patterns via
 `.layer()` + `resolve`; `join` is a one-to-many equi-join relating two data
 tables on a shared key).
 
+Connectors are no longer a surface of their own. The standalone `connect` /
+`connectX` / `connectY` operators (and the capitalized `Connect`) were removed;
+a connector is now the _combinator form_ of an ordinary mark — `line` (center)
+or `ribbon` (edge band, formerly the `area` mark) — invoked with an explicit
+array of `ref(...)` children. The shape of the drawn path is a single `curve`
+key, backed by the pluggable router registry that `lib.ts` re-exports from
+`ast/graphicalOperators/routers` (`registerRoute` / `getRoute` / `resolveCurve`
+and the built-in `straight` / `bezier` / `orthogonal` / `arc` / `perfectArrows`
+routers). `curve: "auto"` smooths automatically on continuous axes — see
+[Underlying Space](/internals/core/underlying-space) for the positioning-space
+test that decides this.
+
 ## Planned contents
 
 - The three surfaces side by side — the same chart in each.

--- a/apps/docs/docs/js/api/constraints/constrain.md
+++ b/apps/docs/docs/js/api/constraints/constrain.md
@@ -300,7 +300,7 @@ Layer([
     PulleyCircle({ r: 25 }).name(A),
     PulleyCircle({ r: 25 }).name(B),
   ]).constrain(/* … */),
-  Connect({ ... }, [ref(A), ref(B)]).name("rope"),
+  line({ ... }, [ref(A), ref(B)]).name("rope"),
 ]).constrain((c) => [
   Constraint.zAbove(c.rope, c.A),  // rope paints over A …
   Constraint.zBelow(c.rope, c.B),  // … but is covered by B

--- a/apps/docs/docs/js/api/core/connect.md
+++ b/apps/docs/docs/js/api/core/connect.md
@@ -90,11 +90,13 @@ keeps the IR small and never leaks an extra layer into your code.
   [`selectAll`](/js/api/selection/ref) form. `.connect()` only threads a chart
   through its own marks.
 
-## Builder `.connect()` vs. the low-level `Connect` operator
+## Builder `.connect()` vs. the combinator form
 
 This page documents the **v3 builder method** `ChartBuilder.connect()`. It is
-distinct from the lower-level [`connect` / `Connect` operator](/js/api/operators/connect),
-which draws a connector between explicitly-listed `ref(...)` children inside a
-layout (anchor/edge modes, source/target anchors). The builder sugar wraps a
-ref-consuming _mark_ (`line` / `ribbon`); the operator is a _layout primitive_ you
-place children into directly.
+distinct from the [combinator form](/js/api/operators/connect) of the
+[`line`](/js/api/marks/line) / [`ribbon`](/js/api/marks/ribbon) marks, which draws
+a connector between explicitly-listed `ref(...)` children inside a layout
+(anchor/edge modes, source/target anchors). The builder sugar wraps a
+ref-consuming _mark_ for you; the combinator form is one you place children into
+directly. The standalone `connect` / `Connect` operators have been removed — see
+that page for the migration table.

--- a/apps/docs/docs/js/api/howto/selection.md
+++ b/apps/docs/docs/js/api/howto/selection.md
@@ -133,7 +133,7 @@ layer([
   chart(data).flow(/* ... */).mark(blank().name("origin")),
   text({ text: "start" }).name("label"),
   // ref("origin") returns one ref; errors if "origin" matched 0 or >1 nodes
-  Connect({ source: "middle" }, [ref("label"), ref("origin")]),
+  line({ source: "middle" }, [ref("label"), ref("origin")]),
 ]);
 ```
 

--- a/apps/docs/docs/js/api/operators/connect.md
+++ b/apps/docs/docs/js/api/operators/connect.md
@@ -137,14 +137,14 @@ diagrams should prefer anchor mode.
 
 ## Visual props
 
-| Option         | Type                          | Default                                                    | Description                                                                                                             |
-| -------------- | ----------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `stroke`       | `string`                      | `fill`                                                     | Stroke color                                                                                                            |
-| `strokeWidth`  | `number`                      | `0`                                                        | Stroke width                                                                                                            |
-| `fill`         | `MaybeValue<string>`          | `"black"`                                                  | Fill (for closed paths; channel-bindable)                                                                               |
-| `opacity`      | `number`                      | `1`                                                        | Element opacity                                                                                                         |
-| `mixBlendMode` | `"multiply" \| "normal"`      | `"multiply"` in edge mode / `"normal"` in `mode: "center"` | Blend mode of the rendered path. Override to `"normal"` for opaque strokes that don't darken under colored backgrounds. |
-| `curve`        | see [Path curve](#path-curve) | `"auto"`                                                   | Shape of the path between consecutive children (replaces the removed `interpolation`)                                   |
+| Option         | Type                          | Default    | Description                                                                                                                      |
+| -------------- | ----------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `stroke`       | `string`                      | `fill`     | Stroke color                                                                                                                     |
+| `strokeWidth`  | `number`                      | `0`        | Stroke width                                                                                                                     |
+| `fill`         | `MaybeValue<string>`          | `"black"`  | Fill (for closed paths; channel-bindable)                                                                                        |
+| `opacity`      | `number`                      | `1`        | Element opacity                                                                                                                  |
+| `mixBlendMode` | `"multiply" \| "normal"`      | `"normal"` | Blend mode of the rendered path. Override to `"multiply"` for overlapping translucent bands that should darken where they cross. |
+| `curve`        | see [Path curve](#path-curve) | `"auto"`   | Shape of the path between consecutive children (replaces the removed `interpolation`)                                            |
 
 ## Path curve
 

--- a/apps/docs/docs/js/api/selection/ref.md
+++ b/apps/docs/docs/js/api/selection/ref.md
@@ -77,7 +77,7 @@ gf.layer([
     .mark(gf.rect({ h: "total" }).name("kpi")),
   gf.text({ text: "peak" }).name("label"),
   // ref("kpi") as the connector's target: one ref; throws on 0 or >1 nodes
-  gf.Connect({ source: "middle" }, [gf.ref("label"), gf.ref("kpi")]),
+  gf.line({ source: "middle" }, [gf.ref("label"), gf.ref("kpi")]),
 ]);
 ```
 

--- a/apps/docs/docs/js/gotree.md
+++ b/apps/docs/docs/js/gotree.md
@@ -359,12 +359,11 @@ conventions and switch from JSON descriptors to callable helpers.
 
 ## Milestone status
 
+All milestones below have shipped:
+
 - **M1** — node-link with `spread` combiner; linear links.
-- **M2** (this milestone) — `Constraint.nest` primitive in `gofish-graphics`;
-  `nest` combiner in `gofish-gotree`; nested-box trees.
+- **M2** — `Constraint.nest` primitive in `gofish-graphics`; `nest` combiner in
+  `gofish-gotree`; nested-box trees.
 - **M3** — polar coord wrap; sunburst and radial node-link.
 - **M4** — `orthogonal`/`bezier`/`arc` links; sort.
 - **M5** — `bottomUp` mode for dendrograms via intrinsic-dim wiring.
-
-Trying to use values from M3+ (`coord: polar(...)`, `orthogonal`/`bezier`/`arc`
-link curves) raises an explicit error.

--- a/apps/docs/docs/python/api/operators/connect.md
+++ b/apps/docs/docs/python/api/operators/connect.md
@@ -125,14 +125,14 @@ diagrams should prefer anchor mode.
 
 ## Visual props
 
-| Option         | Type                          | Default                                                   | Description                                                                                                             |
-| -------------- | ----------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `stroke`       | `str`                         | `fill`                                                    | Stroke color                                                                                                            |
-| `strokeWidth`  | `float`                       | `0`                                                       | Stroke width                                                                                                            |
-| `fill`         | `str` \| `Value`              | `"black"`                                                 | Fill (for closed paths; channel-bindable)                                                                               |
-| `opacity`      | `float`                       | `1`                                                       | Element opacity                                                                                                         |
-| `mixBlendMode` | `"multiply"` \| `"normal"`    | `"multiply"` in edge mode / `"normal"` in `mode="center"` | Blend mode of the rendered path. Override to `"normal"` for opaque strokes that don't darken under colored backgrounds. |
-| `curve`        | see [Path curve](#path-curve) | `"auto"`                                                  | Shape of the path between consecutive children (replaces the removed `interpolation`)                                   |
+| Option         | Type                          | Default    | Description                                                                                                                      |
+| -------------- | ----------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `stroke`       | `str`                         | `fill`     | Stroke color                                                                                                                     |
+| `strokeWidth`  | `float`                       | `0`        | Stroke width                                                                                                                     |
+| `fill`         | `str` \| `Value`              | `"black"`  | Fill (for closed paths; channel-bindable)                                                                                        |
+| `opacity`      | `float`                       | `1`        | Element opacity                                                                                                                  |
+| `mixBlendMode` | `"multiply"` \| `"normal"`    | `"normal"` | Blend mode of the rendered path. Override to `"multiply"` for overlapping translucent bands that should darken where they cross. |
+| `curve`        | see [Path curve](#path-curve) | `"auto"`   | Shape of the path between consecutive children (replaces the removed `interpolation`)                                            |
 
 ## Path curve
 


### PR DESCRIPTION
The [code review on #637](https://github.com/gofish-graphics/gofish-graphics/pull/637#issuecomment-4909675215) came back after that PR merged, flagging six documentation-sync gaps (no runtime bugs — the core refactor was found internally consistent). This PR resolves all six, plus one extra stale reference found while sweeping.

## Findings addressed

| # | Finding | Fix |
|---|---------|-----|
| 1 | `three-surfaces.md` wiki essay stale vs. `lib.ts` (`@wiki`-covered) | Added a paragraph: standalone `connect`/`connectX`/`connectY`/`Connect` removed → `line`/`ribbon` combinator form + the re-exported `routers` curve registry, with a `curve: "auto"` cross-link |
| 2 | `underlying-space.md` wiki essay missing new `isPositioningSpace` export | Documented the predicate next to `spaceMeasure`, and its first consumer — `curve: "auto"` continuous-axis smoothing (verified against `connect.tsx`) |
| 3 | Stale `Connect(...)`/`gf.Connect(...)` in `howto/selection.md` & `selection/ref.md` | Replaced with `line(...)` |
| 4 | Stale `mixBlendMode` default in JS + Python `operators/connect.md` | Corrected to unconditional `"normal"` (matches `connect.tsx`); reworded override hint |
| 5 | `core/connect.md` still called `connect`/`Connect` a live low-level operator | Rewrote the section to describe the `line`/`ribbon` combinator form and note the operators were removed |
| 6 | `gotree.md` self-contradiction: curves documented as working vs. "raise an explicit error" | Dropped the stale error paragraph and `(this milestone)` marker; marked milestones shipped (verified `links.ts`/`tree.tsx` implement the curves + `coord: polar`) |
| + | Extra: stale `Connect(...)` in `constraints/constrain.md` | Replaced with `line(...)` |

Docs-only; `pnpm --filter docs check-backlinks` passes (no `covers:` lists changed).

Closes #696

🤖 Generated with [Claude Code](https://claude.com/claude-code)