### PR TITLE
Python parity: un-exempt 13 stories (26 exports), all byte-identical

### DIFF
--- a/apps/docs/docs/.vitepress/config.mts
+++ b/apps/docs/docs/.vitepress/config.mts
@@ -494,6 +494,10 @@ export default defineConfig({
               items: [
                 { text: "palette", link: "/js/api/color/palette" },
                 { text: "gradient", link: "/js/api/color/gradient" },
+                {
+                  text: "assignGradientColor",
+                  link: "/js/api/color/assign-gradient-color",
+                },
               ],
             },
             {
@@ -616,6 +620,10 @@ export default defineConfig({
               items: [
                 { text: "palette", link: "/python/api/color/palette" },
                 { text: "gradient", link: "/python/api/color/gradient" },
+                {
+                  text: "assign_gradient_color",
+                  link: "/python/api/color/assign-gradient-color",
+                },
               ],
             },
             {

--- a/apps/docs/docs/js/api/color/assign-gradient-color.md
+++ b/apps/docs/docs/js/api/color/assign-gradient-color.md
@@ -1,0 +1,47 @@
+# assignGradientColor
+
+```ts
+assignGradientColor(scale, t);
+```
+
+Interpolates a [`gradient`](/js/api/color/gradient) config at `t` (`0` to `1`)
+and returns the resulting hex color, in LAB space. Use it to precompute a
+per-row fill color inside [`derive`](/js/api/operators/derive) — for example
+when one chart draws colors from more than one gradient, so a single `fill`
+field can't reference a single scale.
+
+```ts
+import {
+  chart,
+  derive,
+  spread,
+  stack,
+  rect,
+  gradient,
+  assignGradientColor,
+} from "gofish";
+
+const warmGradient = gradient(["#ffe0b2", "#e65100"]);
+const coldGradient = gradient(["#bbdefb", "#0d47a1"]);
+
+chart(pairedBars)
+  .flow(
+    derive((d) => {
+      const values = d.map((item) => item.value);
+      const min = Math.min(...values);
+      const max = Math.max(...values);
+      return d.map((item) => {
+        const t = max === min ? 0 : (item.value - min) / (max - min);
+        const scale = item.type === "warm" ? warmGradient : coldGradient;
+        return { ...item, color: assignGradientColor(scale, t) };
+      });
+    }),
+    spread({ by: "pair", dir: "x" }),
+    stack({ by: "type", dir: "x" })
+  )
+  .mark(rect({ h: "value", fill: "color" }))
+  .render(container, { w: 400, h: 400 });
+```
+
+See also [`gradient`](/js/api/color/gradient) and
+[`palette`](/js/api/color/palette).

--- a/apps/docs/docs/js/api/color/gradient.md
+++ b/apps/docs/docs/js/api/color/gradient.md
@@ -27,4 +27,6 @@ chart(data, { color: gradient(["#f7fbff", "#08306b"]) });
 
 **Built-in schemes:** `"viridis"`, `"blues"`, `"reds"`
 
-See also [`palette`](/js/api/color/palette) for categorical data.
+See also [`palette`](/js/api/color/palette) for categorical data, and
+[`assignGradientColor`](/js/api/color/assign-gradient-color) to precompute a
+color from a gradient outside of a chart's `fill` channel.

--- a/apps/docs/docs/python/api/color/assign-gradient-color.md
+++ b/apps/docs/docs/python/api/color/assign-gradient-color.md
@@ -1,0 +1,40 @@
+# assign_gradient_color
+
+```python
+assign_gradient_color(gradient_config, t)
+```
+
+Interpolates a [`gradient`](/python/api/color/gradient) config at `t` (`0` to
+`1`) and returns the resulting hex color, in LAB space. Use it to precompute a
+per-row fill color inside [`derive`](/python/api/operators/derive) — for
+example when one chart draws colors from more than one gradient, so a single
+`fill` field can't reference a single scale.
+
+```python
+from gofish import chart, derive, spread, stack, rect, gradient
+from gofish.ast import assign_gradient_color
+
+warm_gradient = gradient(["#ffe0b2", "#e65100"])
+cold_gradient = gradient(["#bbdefb", "#0d47a1"])
+
+
+def assign_colors(rows):
+    values = [row["value"] for row in rows]
+    lo, hi = min(values), max(values)
+    out = []
+    for row in rows:
+        t = 0 if hi == lo else (row["value"] - lo) / (hi - lo)
+        scale = warm_gradient if row["type"] == "warm" else cold_gradient
+        out.append({**row, "color": assign_gradient_color(scale, t)})
+    return out
+
+
+chart(paired_bars).flow(
+    derive(assign_colors),
+    spread(by="pair", dir="x"),
+    stack(by="type", dir="x"),
+).mark(rect(h="value", fill="color"))
+```
+
+See also [`gradient`](/python/api/color/gradient) and
+[`palette`](/python/api/color/palette).

--- a/apps/docs/docs/python/api/color/gradient.md
+++ b/apps/docs/docs/python/api/color/gradient.md
@@ -26,4 +26,6 @@ chart(data, color=gradient(["#f7fbff", "#08306b"]))
 
 **Built-in schemes:** `"viridis"`, `"blues"`, `"reds"`
 
-See also [`palette`](/python/api/color/palette) for categorical data.
+See also [`palette`](/python/api/color/palette) for categorical data, and
+[`assign_gradient_color`](/python/api/color/assign-gradient-color) to
+precompute a color from a gradient outside of a chart's `fill` channel.

--- a/notes/design/modular-layout-algorithms.md
+++ b/notes/design/modular-layout-algorithms.md
@@ -1,0 +1,518 @@
+# Modular Layout Algorithms
+
+**Status:** speculative research survey (2026-07-01). Rewritten from scratch against primary
+sources (d3-hierarchy, d3-sankey, dagre source; the original papers) — supersedes the earlier
+draft. Companion to the internals essays [layout-synthesis](../../apps/docs/docs/internals/design/layout-synthesis.md)
+and [constraint-semantics](../../apps/docs/docs/internals/design/constraint-semantics.md).
+
+**Question.** Treemap, tidy tree, circle packing, Sankey, and layered graph layout (dagre) are
+shipped everywhere as monolithic imperative procedures. Halide, TACO, and the pretty-printing
+line of work each took a domain that looked like "inherently clever algorithms" and split it
+into a small declarative spec plus a swappable strategy. GoFish already has a central constraint
+engine — align/distribute/nest/position over monotone size claims, solved by one σ-inversion per
+scope plus a difference-constraint placement pass. Could that engine (possibly extended) be the
+substrate these five algorithms compile onto?
+
+**Answer, compressed.** More of each algorithm is already inside GoFish's two semirings than the
+"custom layout node" framing suggests — in three of the five cases the published algorithm is
+_provably_ an evaluation strategy for a constraint system the engine can almost state. But the
+analogy to Halide only becomes precise after splitting "schedule" into two different things the
+layout literature conflates (§1). The residue that is genuinely outside any constraint engine is
+small and always the same species: a discrete plan decision (grouping, ordering, alignment
+commitment). That residue has a clean interface — it consumes solved geometry and emits operator
+trees or ordering constraints — which is exactly where a Halide-style seam belongs.
+
+---
+
+## 1. The lens: three layers, not two
+
+Halide's split is algorithm/schedule. Applied to layout naively, it wobbles: Halide schedules
+never change the output image, whereas swapping squarify for slice-and-dice very much changes
+the picture. The literature sorts cleanly once you use **three** layers:
+
+1. **Spec** — the constraint system and (optionally) an objective. _"Leaf areas proportional to
+   weights, nested axis-aligned rectangles, exhaust the parent."_ _"Minimize width subject to
+   per-level non-overlap of rigid subtree silhouettes and parents centered over children."_
+2. **Policy** — which point of the feasible set to return when the spec underdetermines the
+   answer. Squarify vs. binary vs. strip are _policies_: all satisfy the treemap spec, they pick
+   different tessellations. Tidy-tree symmetry (Kennedy's mean of the left-biased and
+   right-biased solutions) is a policy. So are d3-sankey's sort orders, Brandes–Köpf's choice of
+   which alignments to commit, and — inside GoFish today — the fill split and the weak-origin
+   rule, which the internals essays already call "policy verdicts." Policies change the output,
+   but only within the spec's feasible set.
+3. **Schedule** — how the chosen point is computed. Output-invariant by definition. Contours +
+   threads + mods vs. materialized per-level constraints (tidy tree); network simplex vs. LP
+   (dagre ranking); Welzl move-to-front vs. an SOCP solver (enclosing circle); resquarify's
+   frozen row plan re-evaluated with new numbers; greedy fits-check vs. Pareto dynamic
+   programming (pretty printing, when the objective makes the optimum unique).
+
+The prior art maps onto this frame as follows.
+
+**Halide** (PLDI 2013) lives purely in layers 1+3: the algorithm language is restricted (pure
+functions over infinite grids, feed-forward DAG) precisely so that _every_ schedule — tile,
+fuse, vectorize, compute_at — is semantics-preserving, with interval-based bounds inference as
+the fixed "checker" that makes any schedule executable. The lesson is not "add scheduling knobs";
+it is **restrict the spec language until strategies can't change meaning, and invest in the one
+inference pass that connects them** (bounds inference ≈ a layout engine's claim/proposal
+protocol).
+
+**TACO** (OOPSLA 2017) adds a second orthogonal strategy axis: not just loop order but **data
+representation** (each tensor mode independently dense or compressed). Same index expression,
+different formats, different generated loops. For layout the analogous second axis is the
+_representation of geometric extent_ — scalar bbox vs. per-depth silhouette vs. circle — see §5.
+
+**Exo / Elevate** reify schedules as user-authored sequences of verified rewrites: the fixed part
+is the _checker_, not the strategy vocabulary. **FTL / Superconductor** (Meyerovich & Bodik, WWW
+2010, PPoPP 2013) is the closest thing to "Halide for layout" that exists, and it is squarely in
+our domain: layout spec = an **attribute grammar** over the document/scene tree (inherited
+attributes flow down, synthesized flow up); schedule = a first-class term in a tiny grammar —
+`parPre | parPost | recursive` traversals composed with `;` and `||`, each annotated with which
+attributes it computes, checked against the grammar's dependences, with **holes that a
+synthesizer completes and an autotuner profiles**. Their case studies include CSS (a 1132-line
+grammar synthesized to a 9-pass parallel engine) and — directly on point — **a treemap specified
+as an attribute grammar and synthesized to a 5-pass parallel schedule**, GPU-compiled to animate
+100K+ nodes. What FTL could not express is equally instructive: anything iterative or
+optimizing (force layouts, crossing minimization) is outside the attribute-grammar spec language
+— the same restriction that bought the safety.
+
+**Pretty printing** contributes the _policy_ layer's technology. Wadler's algebra is six
+combinators, of which one — `group` = "flattened, if it fits, else broken" — is a **choice
+operator**: a document denotes a _set_ of layouts and the evaluator picks one. The greedy
+evaluator (Oppen, Wadler) is sound only because the fitness measure is monotone: if the
+flattened first line overflows, no continuation rescues it. Bernardy (ICFP 2017) upgrades to the
+optimal choice by summarizing each sub-layout with a small vector of monotone measures
+`(height, maxWidth, lastWidth)` and doing dynamic programming over **Pareto frontiers** —
+domination pruning is exact because all combinators are monotone in the measures. Porncharoenwase
+et al. (OOPSLA 2023) then decouple the objective entirely (any monotone, composable "cost
+factory" slots into the same DP). **Knuth–Plass** is the same shape a level down: box (rigid) /
+glue (ideal ± stretch/shrink — affine slack, i.e. a soft interval constraint) / penalty (soft
+constraint) as the spec IR; first-fit vs. total-demerits shortest path as two strategies for it.
+
+The recurring pattern, in every system: **a restricted declarative spec; an order/monotonicity
+property that the restriction guarantees; and strategies that are swappable _because_ the
+property holds, certified by one fixed checker.** GoFish's engine already is such a system for
+its fragment: the (max, +) claim algebra is the restricted spec language, monotonicity is the
+guaranteed property, `Monotonic.inverse`'s three tiers (closed-form linear / exact convex
+piecewise / bisection) are literally three schedules for one spec, selected by a normal-form
+check. The question of this note is which parts of the five classics can be brought inside that
+discipline.
+
+---
+
+## 2. Anatomy of the five algorithms
+
+Each subsection: how the algorithm actually works (verified against source), then the
+spec/policy/schedule split, then the verdict relative to GoFish's generators. Throughout,
+"the engine" means: size claims folded in (max, +) and inverted once per scope; placement as a
+forest of difference constraints in (min, +); no iteration, no objectives, no discrete search
+(all three exclusions are by design, per the internals essays).
+
+### 2.1 Treemaps
+
+**Pipeline** (d3-hierarchy):
+
+| step | what                                                                                             | data-flow shape                               |
+| ---- | ------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| 1    | `sum(value)`: node value = own + Σ children                                                      | bottom-up fold                                |
+| 2    | `sort` (optional; squarify wants descending)                                                     | per-node local sort — _policy_                |
+| 3    | `eachBefore(positionNode)`: parent rect known, call `tile(node, x0,y0,x1,y1)`                    | pure top-down; zero geometric feedback upward |
+| 4    | padding: outer insets the tile region; inner via half-insets per depth, applied _after_ division | per-node affine inset                         |
+| 5    | rounding                                                                                         | per-node quantization                         |
+
+The entire variability surface is one strategy slot, the **tiling function**
+`tile(parent, x0, y0, x1, y1)` — a local, stateless function that partitions a concrete
+rectangle among children whose values are already summed. Variants:
+
+- **Slice / dice** — 1-D proportional division: `k = extent/parent.value`, prefix-sum scan.
+  This _is_ a value-proportional stack; the σ solve does it today.
+- **Slice-and-dice** (Shneiderman 1992) — `(depth & 1 ? slice : dice)`: orientation is a static
+  function of depth. This is a mosaic plot without axes (Wickham & Hofmann's "alternating
+  hspines and vspines"), and GoFish's mosaic work already covers it.
+- **Squarify** (Bruls et al. 2000) — greedy row building along the shorter side: keep adding the
+  next child to the current row while the row's worst aspect ratio does not worsen
+  (`worst(R,w) = max(w²r⁺/s², s²/(w²r⁻))`, `s = ΣR`); on worsening, close the row and recurse
+  in the remaining rectangle. Global optimum is NP-hard; the greedy is a heuristic. **The
+  structural fact that matters:** d3's `squarifyRatio` materializes each row as a synthetic node
+  `{value, dice, children}` and then calls plain `treemapDice`/`treemapSlice` on it. Squarify's
+  geometry is _nothing but_ slice/dice applied to a dynamically invented two-level tree.
+- **Binary** — recursive weight-median bisection along the longer side; the split coordinate
+  `xk = (x0·v_R + x1·v_L)/v` is affine; the median search is a binary search over prefix sums
+  (a monotone inversion, not open-ended search).
+- **Strip / pivot** (Bederson et al. 2002) — order-preserving variants; strip uses an
+  average-aspect stopping rule plus an optional one-strip lookahead repair; pivot layouts end
+  with an explicit _enumerate-and-choose_ ("try pivot/quad/snake, keep the best average ratio").
+- **Resquarify** — freeze the row decomposition from a previous run; on data update, re-run only
+  the proportional arithmetic within the frozen plan. **This is a genuine plan/execution
+  separation already shipping in d3**: same spec, the plan cached as a schedule artifact,
+  trading aspect quality for update stability.
+
+**Split.** Spec: area ∝ weight, nested rectangles, exhaustion. Policy: the tiling function —
+more precisely, tiling functions are **plan synthesizers**: pure functions
+`(weights, container aspect) → a tree of oriented proportional stacks`, after which _all_ actual
+geometry is solver-friendly 1-D proportional division. Schedule: resquarify's caching; d3's
+padding-after-division (which breaks exact proportionality — a constraint engine solving
+"fixed gaps + proportional flex" simultaneously, as `stack` with spacing already does, is
+_strictly more principled_ than d3 here).
+
+**Verdict.** Given the plan, a treemap is nested `stack`s with value-proportional claims and
+constant gaps — fully inside the engine, and the engine fixes d3's padding approximation for
+free. The plan decision is the residue: a greedy scan that must run _inside the top-down pass_
+because it consumes the concrete remaining rectangle (its aspect ratio) mid-layout. Note the
+engine-facing consequence: this residue does not need iteration, objectives in the solver, or
+non-affine constraints — it needs a sanctioned place for a pure function to observe a proposal
+and emit an operator subtree (§5, Option B). GoFish's current `treemap` node (wrapping
+d3-hierarchy, imposing rects as scribbles) is the maximally opaque version of this; #541's
+"emit constraints instead" is the halfway point; plan-synthesis is the full decomposition.
+
+### 2.2 Tidy trees
+
+**Pipeline** (d3 `tree.js` = Buchheim–Jünger–Leipert; Reingold–Tilford's aesthetic):
+
+| step | what                                                                                                                                                                                                                           | data-flow shape                                                              |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- |
+| 1    | `firstWalk`: prelim x per node; for each new sibling subtree, `apportion` scans the two facing **contours** level by level, computes the max overlap deficit, shifts the subtree right by it                                   | bottom-up fold whose accumulator is the merged silhouette of siblings so far |
+| 2    | `moveSubtree`: O(1) rigid shift via `mod` (deferred translation); intermediate siblings get an arithmetic-progression share recorded in O(1) (`shift`/`change`), realized later by `executeShifts` (a second-order prefix sum) | lazy translation bookkeeping                                                 |
+| 3    | `secondWalk`: absolute x = prelim + Σ mods on root path; y = depth · k                                                                                                                                                         | top-down prefix sum                                                          |
+
+**The load-bearing observation.** Because subtrees are **rigid** (identical subtrees render
+identically — Kennedy's rule 4), the whole system collapses to one variable per subtree root:
+every interior node's x is an affine function of its root's offset. The constraints are, for
+each adjacent sibling pair and each shared depth d:
+
+```
+x_R − x_L ≥ rightContour_L(d) − leftContour_R(d) + separation
+```
+
+— a difference-constraint system over a sibling-ordered DAG, whose least solution is computed by
+a greedy left-to-right scan taking a max over depths. That is a **max-plus system, monotone in
+every input** — exactly the species GoFish's size fold solves, except the claim bubbling up is
+not a scalar extent but a **per-depth vector** (the contour), merged pointwise and fit by a max
+of differences. Contours, threads, and mods are then _pure schedule_: Kennedy's functional pearl
+(JFP 1996) is the executable compositional spec in the middle (extents as explicit lists — an
+associative merge monoid, fit as `max` over pairwise deficits, "absolute positions are a later
+pass"); Walker/BJL/van der Ploeg are the same algorithm with progressively more aggressive
+representations (threads = O(1) contour continuation; mod = the relative-coordinates change
+Kennedy himself notes would make his O(n²) merge linear). BJL's paper title is literally the
+schedule claim: _same layouts as Walker, linear time_. Van der Ploeg extends the spec (variable
+node heights → contours compared over y-intervals) without changing its species.
+
+**Split.** Spec: y stratified by depth (or by `stack` in y for the non-layered variant); minimum
+width subject to per-level non-overlap of rigid silhouettes; parents centered over children.
+Policy: which feasible point — the greedy left scan gives the _least_ solution; symmetric
+tidiness is `mean(least, greatest)` (Kennedy computes both folds and averages; Walker/BJL
+approximate by even redistribution). Note this "average the extremal solutions" policy is the
+same trick Brandes–Köpf uses for graph x-coordinates — it recurs. Schedule: contours/threads/
+mods/`executeShifts`; also the witness bookkeeping (`ancestor`/`nextAncestor`) exists only so
+the greedy schedule can attribute shifts in O(1) — a solver never needs it.
+
+**Two honest caveats.** (1) Rigidity is not an aesthetic freebie; it is the _compositionality
+axiom_ that makes the problem a fold (dropping it gives narrower non-tidy layouts and, with
+integer coordinates, NP-hardness — Supowit & Reingold 1983). In GoFish terms, rigidity =
+"each subtree presents one claim and is placed as a unit," which the engine already assumes.
+(2) The constraint set is per-_depth_, i.e. between nodes in _different_ layers of _different_
+subtrees — GoFish's `distribute` gives non-overlap only between sibling bounding boxes on one
+axis. Bounding-box tidy trees (gotree-style) are reachable today; contour-tight ones need the
+richer claim carrier (§5, Option C).
+
+**Verdict.** The strongest case of the five. The spec is already in the engine's semiring; what
+is missing is only the _carrier_ of the claim (a per-depth vector instead of a scalar) and the
+policy hook (choice of feasible point). No iteration, no discrete search anywhere.
+
+### 2.3 Circle packing
+
+**Pipeline** (d3 `pack`):
+
+| step | what                                                                                                                                                              | data-flow shape                                                         |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| 1    | leaf radii `r = √value`                                                                                                                                           | pointwise map                                                           |
+| 2    | `eachAfter`: pack each node's children in a local frame (front-chain greedy), compute smallest enclosing circle → that circle _is_ the node at the parent's level | bottom-up fold; per-node body = sequential greedy + geometric reduction |
+| 3    | (padding) re-pack once with radii inflated by pad·(root.r/extent)                                                                                                 | one iteration of a fixed point                                          |
+| 4    | `eachBefore`: `r *= k; x = parent.x + k·x_local` with `k = extent/(2·root.r)`                                                                                     | top-down affine cascade                                                 |
+
+The front chain: circles inserted tangent to a chosen pair on the current outer boundary
+(closed-form tangency: two quadratic distance equations), conflicts resolved by splicing the
+chain and retrying, next pair chosen greedily closest to the centroid (Wang et al., CHI 2006).
+The enclosing circle is Welzl/MSW — an LP-type problem whose spec is a tiny second-order cone
+program (`min R s.t. |X − cᵢ| + rᵢ ≤ R`) and whose combinatorial algorithm is, again, a fast
+exact schedule for it. Determinism comes from a fixed-seed LCG — **the schedule is pinned to
+stabilize an underdetermined spec.**
+
+**Split.** Spec: pairwise non-overlap, tangency/compactness, minimal enclosing circle, area ∝
+value at leaves. Policy: insertion order and the greedy pair choice — and here, unlike tidy
+trees, **the policy is most of the visible output**: any non-overlapping tangent packing
+satisfies the spec, and shuffling input order changes the picture. Schedule: front-chain
+representation, MSW move-to-front, the fixed seed.
+
+**Verdict.** Two genuinely different halves. The _composition_ structure is engine-shaped: the
+inter-level contract is exactly a claim ("children in a local frame → one radius"), and because
+packing is homogeneous of degree 1 in the radii, the final scale-to-fit is a σ-style
+one-unknown solve (`k · 2·root.r = extent`). **Homogeneity is the membership criterion** for a
+foreign layout joining the affine cascade — and d3's own padding is the documented violation
+(pixel padding breaks homogeneity, hence d3's pack-measure-repack, i.e. one fixed-point step:
+monotone-with-affine-fast-path territory). The _interior_ of `packSiblings` — quadratic
+tangencies, mutable chain, order-dependent greedy — is irreducibly foreign: no constraint
+formulation recovers it, and unlike the other four there is no published "same spec, exact
+solver" twin short of full optimization (the optimizing cousin is the Voronoi treemap: same
+spec family, power-diagram iteration as strategy, gap-free). Keep it a leaf algorithm node
+forever; the research content is the _contract_ it must satisfy (monotone, ideally homogeneous
+face to the solve), not its decomposition.
+
+### 2.4 Sankey
+
+**Pipeline** (d3-sankey — a fixed six-stage function composition):
+
+| step | what                                                                                                                                                                              | engine reading                                                         |
+| ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| 1    | resolve links, group by endpoint                                                                                                                                                  | relational join                                                        |
+| 2    | `value = max(Σin, Σout)`                                                                                                                                                          | size claim per node                                                    |
+| 3–4  | longest-path layering, both directions                                                                                                                                            | max-plus graph fold (twice)                                            |
+| 5a   | column x from a **pluggable align policy** (`left/right/center/justify` — one-liners over the two ranks)                                                                          | `spread` on x; policy = data transform                                 |
+| 5b   | `ky = min over columns of (extent − (n−1)·pad)/Σ value`                                                                                                                           | **shared scale = min of per-column affine fits — literally a σ solve** |
+| 5c   | initial stack + even slack distribution per column                                                                                                                                | `stack` + `distribute`                                                 |
+| 5d   | `iterations` rounds of alternating barycenter relaxation (span-weighted pulls toward link-straightness) + `resolveCollisions` (1-D push-apart from the middle, clamped to extent) | fixed-point iteration = projected coordinate descent                   |
+| 6    | stack link stubs inside each node, ordered by far-endpoint y                                                                                                                      | `stack` inside each node                                               |
+
+**Split.** Spec: heights = value·k with one shared k; no overlap within columns; containment;
+links straight as possible; few crossings. Zarate et al. (PacificVis 2018) state the exact spec
+as a MILP (ordering booleans + continuous positions) — d3's relaxation loop is a heuristic
+strategy for it, with `alpha = 0.99^i` annealing and a final `beta = 1` pass that guarantees
+feasibility. Policy: `nodeAlign`, `nodeSort`, `linkSort` — and note the design move: supplying
+a sort **converts an optimized degree of freedom into a fixed one**. Schedule: sweep order,
+iteration count, annealing constants.
+
+**Verdict.** The decisive fact: **with `nodeSort` and `linkSort` given, the entire layout is
+closed-form constraint evaluation** — spreads, stacks, and a min-of-affine-fits scale solve the
+engine performs today. The iterative core is separable and optional, not load-bearing. So
+Sankey factors as: _discrete ordering decision_ (optimize it, accept it from data, or accept it
+from the user) _→ pure GoFish constraints_. Of the five, this is the cheapest high-fidelity
+port: an algorithm node (or eventually a choice/objective pass) that outputs only _orders_,
+feeding operators that already exist. It is also the cleanest illustration that the residue is
+an ordering problem, not a geometry problem.
+
+### 2.5 Layered graph layout (dagre / Sugiyama / ELK)
+
+**Pipeline.** dagre's `runLayout` is a flat list of ~25 passes over one mutable graph, each with
+pre/post-conditions stated as attribute-schema invariants (`rank` exists; every edge spans one
+rank; `order` exists) — informally, IR levels. The spine: **acyclic** (reverse a feedback edge
+set; tag for later restore) → **nesting graph** (compile _clusters_ into border dummy nodes +
+minlen inflation — `nest` desugared into difference constraints) → **rank** → **normalize**
+(split long edges into chains of dummy nodes so all later phases reason only about adjacent
+layers; record `dummyChains`) → **order** → **position** → a stack of `undo`s that read
+dummy coordinates back as bend points and restore reversed edges. Two structural facts: every
+lowering pass is bracketed with an undo (lower/readback pairs — the same elaboration-with-
+provenance move as GoFish chrome), and `rankdir` is implemented by transposing the graph before
+and after (direction is a coordinate transform, not an algorithm parameter).
+
+**The three hard phases:**
+
+- **Rank.** Spec: minimize `Σ weight·(rank(w) − rank(v))` s.t. `rank(w) − rank(v) ≥ minlen` —
+  an integer program whose constraint matrix is totally unimodular, so the LP relaxation is
+  integral. dagre ships three interchangeable rankers for the one spec: `longest-path` (a
+  max-plus fold — _feasibility is something GoFish's fold already computes_), `tight-tree`,
+  `network-simplex` (Gansner et al. 1993). Same spec, three schedules of increasing optimality;
+  the objective, not feasibility, is what the engine lacks.
+- **Order.** Crossing minimization: NP-hard for even two layers; everyone sweeps
+  barycenters/medians up and down against a cross-count until stale. Genuinely outside any
+  affine fragment — permutation search. Notably dagre accepts ordering _constraints_
+  (`{left, right}` pairs, subgraph atomicity) — the same vocabulary an ordering-aware
+  `distribute` would take — and a `customOrder` escape hatch.
+- **Position (x).** **The smoking gun for spec/strategy separation.** One spec — within-layer
+  separations `x_{i+1} − x_i ≥ (w_i+w_{i+1})/2 + sep` (= `distribute`), plus a weighted-L1
+  straightness objective `Σ Ω·ω·|x(u) − x(v)|` prioritizing dummy chains — and two published
+  strategies: Gansner et al. solve it by _feeding an auxiliary graph to the same network
+  simplex used for ranking_ (one engine, two phases — strong evidence both are the same
+  constraint species), while Brandes–Köpf (2001) is a combinatorial O(V+E) pass: greedily
+  commit conflict-free median _alignments_ (choosing which `align` constraints to activate),
+  collapse aligned chains into blocks, compact the block graph with a max-plus fold (then a
+  min-plus pull), do all four up/down×left/right symmetries, and **average the extremal
+  candidates** — the tidy-tree symmetry policy again. Once the alignment choices are fixed,
+  everything remaining in BK is monotone-affine. And y-positioning is literally
+  `stack(layers, ranksep)` with per-layer max claims.
+
+**ELK Layered** is the existence proof that this pipeline modularizes in production: five phase
+_interfaces_ (cycle breaking, layering, crossing minimization, node placement, edge routing),
+each with 2–7 registered implementations, plus ~57 intermediate processors slotted
+before/between/after phases — and each phase implementation _declares which processors it
+needs_, with an assembler unioning them into the final pipeline. That is dependency-driven
+pipeline assembly, the closest thing in layout practice to Halide's "schedule pulls in its
+lowering."
+
+**Verdict.** Sugiyama was _born_ modular — the framework is literally named as four phases.
+The engine-relevant reading: ranking and x-assignment are difference-constraint systems with L1
+objectives (feasible today, optimal not); ordering is the irreducible discrete core; lowering
+(dummy nodes, cluster borders) is an elaboration discipline GoFish already practices. A GoFish
+Sugiyama would be: algorithm nodes for order (and optionally rank objectives), constraints for
+everything else, `connect`/ribbons for edges through dummy positions.
+
+---
+
+## 3. The common factorization
+
+Reading the five side by side, every one factors into the same five step species — and no
+algorithm needs more than one instance of the "hard" species:
+
+|                 | bottom-up fold                               | discrete plan (policy)                                                 | continuous solve                                         | top-down evaluation       | iteration                         |
+| --------------- | -------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------- | ------------------------- | --------------------------------- |
+| **treemap**     | Σ values                                     | tile = plan synthesis (greedy rows / bisection / enumerate-and-choose) | proportional division + gaps _(σ solve)_                 | recursive rect assignment | —                                 |
+| **tidy tree**   | contour merge _(max-plus, vector carrier)_   | symmetry = choice of feasible point                                    | least solution of max-plus fit                           | mod prefix-sum            | —                                 |
+| **circle pack** | radius per node _(homogeneous face)_         | insertion order + tangent pair _(greedy, output-visible)_              | enclosing circle (SOCP); scale-to-fit _(1 unknown)_      | affine cascade            | 1 step (padding)                  |
+| **sankey**      | node values; longest-path ranks _(max-plus)_ | node/link ordering                                                     | `ky` = min of affine fits _(σ solve)_; stacks            | link stub offsets         | optional (collapses when ordered) |
+| **sugiyama**    | longest-path ranks _(max-plus)_              | edge reversal; crossing order; alignment commitment                    | separations + L1 straightness _(difference constraints)_ | dummy→bend readback       | order sweeps                      |
+
+Three observations fall out.
+
+**1. The continuous solve column is always GoFish's two semirings.** Proportional division,
+min-of-affine-fits shared scales, difference constraints with max-plus least solutions,
+one-unknown scale-to-fit — nothing in that column is outside (max, +)/(min, +) except the L1
+_objectives_ (which choose among feasible points, i.e. are policy machinery, not new constraint
+species).
+
+**2. The "schedules" of the layout literature split exactly along the §1 line.** Output-
+invariant schedules (threads/mods, BK-given-alignments, network simplex vs. LP, Welzl,
+resquarify's cache) could be adopted or ignored freely — they are performance engineering.
+Output-_selecting_ mechanisms (greedy rows, front-chain order, barycenter sweeps, even-
+redistribution) are policies for underdetermined specs; the honest way to host them is the
+pretty-printer way — a choice construct plus either a pinned deterministic policy or an
+objective — not the Halide way.
+
+**3. Iteration is never load-bearing.** Everywhere it appears it is a heuristic strategy for an
+optimization spec (sankey relaxation ← MILP; order sweeps ← NP-hard crossing count; pack's
+repack ← non-homogeneous padding), and in two of three cases there is a mode where it vanishes
+entirely (sorted sankey; padding-free pack). GoFish's no-fixpoint rule survives this survey
+intact: iteration belongs _inside_ algorithm nodes or _outside_ the engine (an optimizer that
+emits orders/pins), never in the propagation core. This matches FTL, which got a browser's
+worth of layout out of statically-ordered passes and handled the one global feature (floats) by
+speculate-check-rerun at the schedule level.
+
+Where each algorithm needs to touch the engine also classifies cleanly by _which pass hosts the
+seam_: treemap's plan runs top-down (consumes proposals, emits subtrees); tidy tree and pack are
+bottom-up (emit claims — vector-valued and circular respectively); sankey and sugiyama need a
+pre-pass (emit orderings) before any geometry at all.
+
+---
+
+## 4. What GoFish already has
+
+Worth stating plainly, because the survey kept landing on machinery that already exists:
+
+- **The continuous solve**, both semirings, with the three-tier schedule in `monotonic.ts`
+  (linear / convex-piecewise exact / bisection) selected by normal form — already an
+  algorithm/schedule separation in miniature.
+- **The policy concept**, named: fill splits and weak origins are documented as policy verdicts
+  for under-determination. The engine has layer 2 of §1; it just has no _user-facing_ choice
+  construct yet.
+- **Elaboration with provenance** (chrome → ordinary nodes, re-resolved) — the same
+  lower/readback bracket as dagre's normalize/undo and d3's synthetic row nodes.
+- **The algorithm-node escape hatch**, semi-formalized: "custom layouts sit outside the
+  generators but inside the language: arbitrary computation that emits claims, proposals, and
+  placements under the same ownership rules" — with `treemap.tsx` on main as the (currently
+  scribble-emitting) example and #541 as the plan to make it emit constraints.
+- **Value-proportional division and shared scales** — the σ solve _is_ d3-sankey's `ky`
+  computation and slice/dice's `k`, generalized.
+
+And the known gaps, confirmed rather than discovered by this survey: no choice/`min` in the
+claim algebra (would cost the convex fast path, not invertibility); no objectives; no ordering
+decisions; scalar-per-axis claim carrier only; area/px² outside the per-axis algebra; no
+inter-subtree (contour-level) separation constraints.
+
+---
+
+## 5. Design options
+
+Ordered roughly by cost. These compose; they are not alternatives. No commitment implied — this
+is the option space.
+
+**A. Formalize the foreign-layout contract (small).** Write down what today's escape hatch must
+promise: an algorithm node presents a _monotone_ face to the σ solve (constant box at minimum),
+and joins the scale-to-fit cascade iff its output is _(positively) homogeneous_ in its inputs —
+the criterion circle packing satisfies and pixel-padding violates. Bottom-up nodes (pack) need
+frozen children; top-down nodes (treemap) need only the proposal; iterative nodes (force) need
+a pinned box. Cheap, and it turns "escape hatch" into a checkable interface — the analogue of
+Halide accepting an `extern` stage with declared bounds behavior.
+
+**B. Plan synthesizers: algorithms that emit operator trees (medium; highest leverage-per-cost).**
+Generalize d3's tiling interface: a pure function `(children's claims, proposed extent) → an
+operator subtree over those children`, invoked during the top-down pass, its output then laid
+out by the ordinary engine. Squarify becomes ~15 lines emitting nested oriented stacks; binary,
+strip, pivot, slice-dice are trivial; resquarify falls out as _caching the emitted tree_. The
+engine repays immediately: exact gap+proportion solving (better than d3's padding), and plans
+whose leaves are ordinary marks compose with everything else (coords, embedding, selection).
+This is #541 taken to its logical end, and the natural first probe: treemap-as-plan-synthesizer
+with a pluggable `tile`.
+
+**C. Enrich the claim carrier (medium-large; the tidy-tree unlock).** Two independent
+extensions, both staying inside "monotone measures, max-plus composition":
+
+- **`min`/choice in the algebra** — already analyzed (min ≡ the pretty-printer's `group`;
+  monotone piecewise-linear is closed under min and still uniquely invertible; concrete
+  implementation shadow = a difference-of-convex normal form in `monotonic.ts`, or route
+  through `unknown` and lose printability). Ship predicate-guarded choice first; automatic
+  selection needs the objective story.
+- **Vector-valued claims** — the TACO move (representation as a strategy axis). A contour is
+  a claim valued in per-depth max-plus vectors: merge = pointwise max/passthrough
+  (associative, identity []), fit = max of pairwise differences, and Kennedy's paper is
+  the reference semantics. The same generalization covers baselines-as-part-of-the-measure
+  (already bubbled) and is where Bernardy's Pareto frontier appears _if_ choice and
+  vector measures combine (incomparable branches). Without choice, vector claims alone keep
+  the single-solution world and buy contour-tight tidy trees.
+
+**D. Ordering as a first-class decision (large).** Sankey and Sugiyama both reduce to "decide
+orders, then pure constraints." Options within the option: accept orders from data/user
+(zero engine work — worth doing regardless, as the sorted-sankey fact shows); a `distribute`
+that takes partial-order constraints (dagre's `{left, right}` vocabulary); an optimizer node
+that owns a permutation variable and emits it (the MILP/heuristic choice hidden behind it, per
+the cost-factory pattern). The solver core never sees a permutation in any variant.
+
+**E. A schedule language proper (thesis-scale, speculative).** FTL's grammar
+(`parPre | parPost | recursive`, `;`, `||`, holes + checker + autotuner) is a ready-made
+starting point, and GoFish's pass list is already close to a term in it. The honest assessment:
+this pays off for _parallel/incremental/GPU execution_ and for proving pass-order correctness —
+not for expressiveness. None of the five algorithms needs it to be _expressed_; it is how you'd
+make the whole engine fast and verifiable afterward. Park it until A–D create demand.
+
+**Non-goals, deliberately.** Crossing-minimization search and front-chain interior geometry stay
+foreign forever — one is NP-hard permutation search, the other order-dependent nonlinear
+greedy; both are exactly what the restricted-spec lesson says to fence out, and both have clean
+seams (an order; a radius) behind which to live. Simultaneous nonlinear constraint solving
+(Penrose's territory) remains out of the language by design; Penrose marks the far end of the
+spectrum — all spec, all optimizer, no schedule — and its cost profile is the argument for
+staying tropical where possible.
+
+---
+
+## 6. If one probe had to be picked
+
+Treemap-as-plan-synthesizer (Option B applied to the existing `treemap` node): smallest surface
+(one new interface + a rewrite of an existing node), immediately user-visible (exact padding,
+composability of leaves), exercises the top-down seam that pivot/strip/mosaic variants also
+need, and produces the first hard evidence for or against the "plans + constraints" contract.
+The tidy-tree carrier (Option C) is the theoretically richest follow-up — it is the one place a
+classic algorithm sits _entirely_ inside the semiring, waiting only on the carrier.
+
+---
+
+## 7. Sources
+
+**Read source code:** d3-hierarchy (`treemap/*` incl. `squarify.js`/`resquarify.js`/`binary.js`;
+`tree.js`; `pack/{index,siblings,enclose}.js`, `lcg.js`), d3-sankey (`sankey.js`, `align.js`),
+dagre (TypeScript `lib/`: `layout.ts`, `acyclic.ts`, `nesting-graph.ts`, `rank/*` incl.
+`network-simplex.ts`, `normalize.ts`, `order/*`, `position/{index,bk}.ts`,
+`coordinate-system.ts`), van der Ploeg's `non-layered-tidy-trees` reference `Paper.java`.
+
+**Papers.** Treemap: Shneiderman TOG 1992; Bruls, Huizing & van Wijk 2000
+(vanwijk.win.tue.nl/stm.pdf); Bederson, Shneiderman & Wattenberg TOG 2002 (ordered/strip/pivot,
+quantum); Wickham & Hofmann, Product Plots, TVCG 2011. Tidy tree: Reingold & Tilford 1981;
+Walker 1990; Buchheim, Jünger & Leipert GD 2002; Kennedy, "Functional Pearl: Drawing Trees,"
+JFP 1996 (+ Gibbons, "Deriving Tidy Drawings," JFP 1996); van der Ploeg SP&E 2014; Supowit &
+Reingold 1983 (NP-hardness); Zxch3n's tidy (Rust, O(depth) incremental). Pack: Wang, Wang, Dai
+& Wang CHI 2006; Welzl 1991 / Matoušek–Sharir–Welzl 1996; Balzer & Deussen, Voronoi Treemaps,
+InfoVis 2005. Sankey: Zarate et al., Optimal Sankey Diagrams via Integer Programming,
+PacificVis 2018. Graphs: Sugiyama, Tagawa & Toda 1981; Gansner, Koutsofios, North & Vo, TSE
+1993 (graphviz.org/documentation/TSE93.pdf); Brandes & Köpf GD 2001; ELK (eclipse.dev/elk;
+arXiv 2311.00533 — 5 phases, ~57 processors). DSLs: Ragan-Kelley et al., Halide, PLDI 2013
+(CACM 2018); Kjolstad et al., TACO, OOPSLA 2017; Ikarashi et al., Exo, PLDI 2022; Meyerovich &
+Bodik WWW 2010 + Meyerovich, Torok, Atkinson & Bodik PPoPP 2013 (FTL schedule synthesis;
+treemap-as-attribute-grammar case study) + Superconductor LASH-C 2013. Printing: Oppen TOPLAS
+1980; Hughes 1995; Wadler 1998; Bernardy ICFP 2017; Porncharoenwase, Pombrio & Torlak OOPSLA
+2023; Knuth & Plass SP&E 1981. Adjacent: Panchekha et al. (Cassius/Troika, formal CSS); Ye et
+al., Penrose, SIGGRAPH 2020.

--- a/packages/gofish-graphics/src/lib.ts
+++ b/packages/gofish-graphics/src/lib.ts
@@ -194,6 +194,7 @@ import "./ast/marks/builderMixins";
 // stays scoped (`Serialize.mapMark`, etc.).
 export * as Serialize from "./serialize";
 export { palette, gradient, assignGradientColor } from "./ast/colorSchemes";
+export { barChart } from "./charts/bar";
 export type {
   ColorConfig,
   PaletteScale,

--- a/packages/gofish-python/gofish/__init__.py
+++ b/packages/gofish-python/gofish/__init__.py
@@ -39,6 +39,7 @@ from .ast import (
     selectAll,
     palette,
     gradient,
+    assign_gradient_color,
     normalize,
     repeat,
     rect,
@@ -55,6 +56,7 @@ from .ast import (
     field,
 )
 from .transforms import bin
+from .charts import bar_chart
 
 __all__ = [
     "chart",
@@ -93,6 +95,7 @@ __all__ = [
     "selectAll",
     "palette",
     "gradient",
+    "assign_gradient_color",
     "normalize",
     "repeat",
     "rect",
@@ -108,6 +111,7 @@ __all__ = [
     "datum",
     "field",
     "bin",
+    "bar_chart",
 ]
 
 __version__ = "0.1.0"

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -1812,6 +1812,276 @@ def gradient(stops: Union[str, List[str]]) -> dict:
     return {"_tag": "gradient", "stops": stops}
 
 
+# Named gradient schemes, mirrored from packages/gofish-graphics/src/ast/colorSchemes.ts.
+# Only the gradient-type schemes are needed here; assign_gradient_color() is the
+# Python-side counterpart of assignGradientColor() for use inside a derive()
+# callback, where the interpolated hex must be byte-identical to chroma-js's
+# `chroma.scale(stops).mode("lab")(t).hex()`.
+_GRADIENT_SCHEMES: Dict[str, List[str]] = {
+    "viridis": ["#440154", "#31688e", "#35b779", "#fde725"],
+    "blues": ["#f7fbff", "#deebf7", "#9ecae1", "#3182bd", "#08306b"],
+    "reds": ["#fff5f0", "#fc9272", "#de2d26", "#67000d"],
+}
+
+# chroma-js Lab constants (D65 white point), transcribed verbatim from
+# chroma-js/src/io/lab/lab-constants.js so the Lab<->sRGB round trip below
+# matches chroma-js bit-for-bit (both are IEEE-754 doubles).
+_LAB_XN = 0.95047
+_LAB_YN = 1.0
+_LAB_ZN = 1.08883
+_LAB_KE = 216.0 / 24389.0
+_LAB_KK = 24389.0 / 27.0
+
+_MTX_RGB2XYZ = {
+    "m00": 0.4124564390896922,
+    "m01": 0.21267285140562253,
+    "m02": 0.0193338955823293,
+    "m10": 0.357576077643909,
+    "m11": 0.715152155287818,
+    "m12": 0.11919202588130297,
+    "m20": 0.18043748326639894,
+    "m21": 0.07217499330655958,
+    "m22": 0.9503040785363679,
+}
+_MTX_XYZ2RGB = {
+    "m00": 3.2404541621141045,
+    "m01": -0.9692660305051868,
+    "m02": 0.055643430959114726,
+    "m10": -1.5371385127977166,
+    "m11": 1.8760108454466942,
+    "m12": -0.2040259135167538,
+    "m20": -0.498531409556016,
+    "m21": 0.041556017530349834,
+    "m22": 1.0572251882231791,
+}
+# used in rgb2xyz's chromatic adaptation
+_LAB_AS = 0.9414285350000001
+_LAB_BS = 1.040417467
+_LAB_CS = 1.089532651
+_MTX_ADAPT_MA = {
+    "m00": 0.8951,
+    "m01": -0.7502,
+    "m02": 0.0389,
+    "m10": 0.2664,
+    "m11": 1.7135,
+    "m12": -0.0685,
+    "m20": -0.1614,
+    "m21": 0.0367,
+    "m22": 1.0296,
+}
+_MTX_ADAPT_MA_I = {
+    "m00": 0.9869929054667123,
+    "m01": 0.43230526972339456,
+    "m02": -0.008528664575177328,
+    "m10": -0.14705425642099013,
+    "m11": 0.5183602715367776,
+    "m12": 0.04004282165408487,
+    "m20": 0.15996265166373125,
+    "m21": 0.0492912282128556,
+    "m22": 0.9684866957875502,
+}
+# RefWhiteRGB in chroma-js is D65 too, same as the default Lab white point
+_REF_WHITE_RGB = {"X": 0.95047, "Y": 1.0, "Z": 1.08883}
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[float, float, float]:
+    """Parse a `#rgb` / `#rrggbb` hex string into 0-255 rgb components."""
+    s = hex_color.lstrip("#")
+    if len(s) == 3:
+        s = "".join(ch * 2 for ch in s)
+    r = int(s[0:2], 16)
+    g = int(s[2:4], 16)
+    b = int(s[4:6], 16)
+    return (float(r), float(g), float(b))
+
+
+def _gamma_adjust_srgb(companded: float) -> float:
+    sign = -1.0 if companded < 0 else (1.0 if companded > 0 else 0.0)
+    companded = abs(companded)
+    linear = (
+        companded / 12.92
+        if companded <= 0.04045
+        else ((companded + 0.055) / 1.055) ** 2.4
+    )
+    return linear * sign
+
+
+def _rgb_to_xyz(r: float, g: float, b: float) -> tuple[float, float, float]:
+    r = _gamma_adjust_srgb(r / 255)
+    g = _gamma_adjust_srgb(g / 255)
+    b = _gamma_adjust_srgb(b / 255)
+
+    m = _MTX_RGB2XYZ
+    x = r * m["m00"] + g * m["m10"] + b * m["m20"]
+    y = r * m["m01"] + g * m["m11"] + b * m["m21"]
+    z = r * m["m02"] + g * m["m12"] + b * m["m22"]
+
+    ma = _MTX_ADAPT_MA
+    ad = _LAB_XN * ma["m00"] + _LAB_YN * ma["m10"] + _LAB_ZN * ma["m20"]
+    bd = _LAB_XN * ma["m01"] + _LAB_YN * ma["m11"] + _LAB_ZN * ma["m21"]
+    cd = _LAB_XN * ma["m02"] + _LAB_YN * ma["m12"] + _LAB_ZN * ma["m22"]
+
+    xx = x * ma["m00"] + y * ma["m10"] + z * ma["m20"]
+    yy = x * ma["m01"] + y * ma["m11"] + z * ma["m21"]
+    zz = x * ma["m02"] + y * ma["m12"] + z * ma["m22"]
+
+    xx *= ad / _LAB_AS
+    yy *= bd / _LAB_BS
+    zz *= cd / _LAB_CS
+
+    mai = _MTX_ADAPT_MA_I
+    x2 = xx * mai["m00"] + yy * mai["m10"] + zz * mai["m20"]
+    y2 = xx * mai["m01"] + yy * mai["m11"] + zz * mai["m21"]
+    z2 = xx * mai["m02"] + yy * mai["m12"] + zz * mai["m22"]
+
+    return (x2, y2, z2)
+
+
+def _xyz_to_lab(x: float, y: float, z: float) -> tuple[float, float, float]:
+    xr = x / _LAB_XN
+    yr = y / _LAB_YN
+    zr = z / _LAB_ZN
+
+    fx = xr ** (1.0 / 3.0) if xr > _LAB_KE else (_LAB_KK * xr + 16.0) / 116.0
+    fy = yr ** (1.0 / 3.0) if yr > _LAB_KE else (_LAB_KK * yr + 16.0) / 116.0
+    fz = zr ** (1.0 / 3.0) if zr > _LAB_KE else (_LAB_KK * zr + 16.0) / 116.0
+
+    return (116.0 * fy - 16.0, 500.0 * (fx - fy), 200.0 * (fy - fz))
+
+
+def _rgb_to_lab(r: float, g: float, b: float) -> tuple[float, float, float]:
+    x, y, z = _rgb_to_xyz(r, g, b)
+    return _xyz_to_lab(x, y, z)
+
+
+def _lab_to_xyz(lab_l: float, lab_a: float, lab_b: float) -> tuple[float, float, float]:
+    fy = (lab_l + 16.0) / 116.0
+    fx = 0.002 * lab_a + fy
+    fz = fy - 0.005 * lab_b
+
+    fx3 = fx * fx * fx
+    fz3 = fz * fz * fz
+
+    xr = fx3 if fx3 > _LAB_KE else (116.0 * fx - 16.0) / _LAB_KK
+    yr = ((lab_l + 16.0) / 116.0) ** 3.0 if lab_l > 8.0 else lab_l / _LAB_KK
+    zr = fz3 if fz3 > _LAB_KE else (116.0 * fz - 16.0) / _LAB_KK
+
+    return (xr * _LAB_XN, yr * _LAB_YN, zr * _LAB_ZN)
+
+
+def _compand(linear: float) -> float:
+    sign = -1.0 if linear < 0 else (1.0 if linear > 0 else 0.0)
+    linear = abs(linear)
+    companded = (
+        linear * 12.92 if linear <= 0.0031308 else 1.055 * (linear ** (1.0 / 2.4)) - 0.055
+    )
+    return companded * sign
+
+
+def _xyz_to_rgb(x: float, y: float, z: float) -> tuple[float, float, float]:
+    ma = _MTX_ADAPT_MA
+    mai = _MTX_ADAPT_MA_I
+    m = _MTX_XYZ2RGB
+    rw = _REF_WHITE_RGB
+
+    as_ = _LAB_XN * ma["m00"] + _LAB_YN * ma["m10"] + _LAB_ZN * ma["m20"]
+    bs_ = _LAB_XN * ma["m01"] + _LAB_YN * ma["m11"] + _LAB_ZN * ma["m21"]
+    cs_ = _LAB_XN * ma["m02"] + _LAB_YN * ma["m12"] + _LAB_ZN * ma["m22"]
+
+    ad = rw["X"] * ma["m00"] + rw["Y"] * ma["m10"] + rw["Z"] * ma["m20"]
+    bd = rw["X"] * ma["m01"] + rw["Y"] * ma["m11"] + rw["Z"] * ma["m21"]
+    cd = rw["X"] * ma["m02"] + rw["Y"] * ma["m12"] + rw["Z"] * ma["m22"]
+
+    x1 = (x * ma["m00"] + y * ma["m10"] + z * ma["m20"]) * (ad / as_)
+    y1 = (x * ma["m01"] + y * ma["m11"] + z * ma["m21"]) * (bd / bs_)
+    z1 = (x * ma["m02"] + y * ma["m12"] + z * ma["m22"]) * (cd / cs_)
+
+    x2 = x1 * mai["m00"] + y1 * mai["m10"] + z1 * mai["m20"]
+    y2 = x1 * mai["m01"] + y1 * mai["m11"] + z1 * mai["m21"]
+    z2 = x1 * mai["m02"] + y1 * mai["m12"] + z1 * mai["m22"]
+
+    r = _compand(x2 * m["m00"] + y2 * m["m10"] + z2 * m["m20"])
+    g = _compand(x2 * m["m01"] + y2 * m["m11"] + z2 * m["m21"])
+    b = _compand(x2 * m["m02"] + y2 * m["m12"] + z2 * m["m22"])
+
+    return (r * 255, g * 255, b * 255)
+
+
+def _lab_to_rgb(lab_l: float, lab_a: float, lab_b: float) -> tuple[float, float, float]:
+    x, y, z = _lab_to_xyz(lab_l, lab_a, lab_b)
+    return _xyz_to_rgb(x, y, z)
+
+
+def _clip_channel(v: float) -> float:
+    return max(0.0, min(255.0, v))
+
+
+def _rgb_to_hex(r: float, g: float, b: float) -> str:
+    ri = round(_clip_channel(r))
+    gi = round(_clip_channel(g))
+    bi = round(_clip_channel(b))
+    return f"#{ri:02x}{gi:02x}{bi:02x}"
+
+
+def _lab_mix_hex(hex1: str, hex2: str, t: float) -> str:
+    """chroma.js `mix(col1, col2, t, 'lab')` — Lab-space linear interpolation."""
+    l0, a0, b0 = _rgb_to_lab(*_hex_to_rgb(hex1))
+    l1, a1, b1 = _rgb_to_lab(*_hex_to_rgb(hex2))
+    lab_l = l0 + t * (l1 - l0)
+    lab_a = a0 + t * (a1 - a0)
+    lab_b = b0 + t * (b1 - b0)
+    return _rgb_to_hex(*_lab_to_rgb(lab_l, lab_a, lab_b))
+
+
+def assign_gradient_color(gradient_config: dict, t: float) -> str:
+    """
+    Assign a gradient color by interpolating at position t in [0, 1].
+
+    Python-side counterpart of `assignGradientColor` (colorSchemes.ts). Meant for
+    use inside a `derive()` callback that needs to precompute a literal hex fill
+    (a raw `fill` channel) rather than going through the JS-side `color:
+    gradient(...)` chart option. Reproduces chroma-js's
+    `chroma.scale(stops).mode("lab")(t).hex()` byte-for-bit: Lab-space
+    (D65, `mode("lab")`) piecewise-linear interpolation across the stops, with
+    chroma-js's exact clip-then-`Math.round` behavior converting back to sRGB.
+
+    Args:
+        gradient_config: A `gradient(...)` config dict (`{"_tag": "gradient",
+            "stops": ...}`).
+        t: Interpolation position in [0, 1] (values outside are clamped).
+
+    Returns:
+        A lowercase `#rrggbb` hex color string.
+    """
+    stops = gradient_config["stops"]
+    if isinstance(stops, str):
+        scheme = _GRADIENT_SCHEMES.get(stops)
+        if scheme is None:
+            return stops
+        colors = scheme
+    else:
+        colors = list(stops)
+
+    if len(colors) == 1:
+        colors = [colors[0], colors[0]]
+
+    n = len(colors)
+    positions = [i / (n - 1) for i in range(n)]
+    tt = max(0.0, min(1.0, t))
+
+    for i, p in enumerate(positions):
+        if tt <= p:
+            return colors[i]
+        if tt >= p and i == len(positions) - 1:
+            return colors[i]
+        if tt > p and tt < positions[i + 1]:
+            local_t = (tt - p) / (positions[i + 1] - p)
+            return _lab_mix_hex(colors[i], colors[i + 1], local_t)
+
+    # unreachable: positions[0] == 0 and tt is clamped to [0, 1]
+    return colors[-1]
+
+
 # Coordinate transforms
 
 

--- a/packages/gofish-python/gofish/charts.py
+++ b/packages/gofish-python/gofish/charts.py
@@ -1,0 +1,88 @@
+"""Chart templates — Python mirror of the JS ``src/charts/`` helpers.
+
+Each template is a thin composition over the public ``chart``/``spread``/mark
+wrapper functions, so it lowers to exactly the same IR as hand-writing the
+builder chain (and byte-identically to the JS helper's output).
+
+Currently ports ``barChart`` (packages/gofish-graphics/src/charts/bar.ts).
+"""
+
+from typing import Any, Callable, List, Optional
+
+from ._generated import rect
+from .ast import ChartBuilder, Mark, chart, spread
+
+__all__ = ["bar_chart"]
+
+
+def bar_chart(
+    data: List[dict],
+    *,
+    x: Optional[str] = None,
+    y: Optional[str] = None,
+    orientation: str = "y",
+    fill: Optional[str] = None,
+    axes: Any = None,
+    mark: Optional[Callable[..., Mark]] = None,
+) -> ChartBuilder:
+    """Bar-chart template mirroring the JS ``barChart(data, options)`` helper.
+
+    Desugars to a plain builder chain:
+
+    - ``orientation="y"`` (vertical, the default): spread along x by the ``x``
+      field, bar height from the ``y`` field::
+
+          chart(data, axes=...).flow(spread(by=x, dir="x")).mark(rect(h=y, fill=fill))
+
+    - ``orientation="x"`` (horizontal): spread along y by the ``y`` field, bar
+      width from the ``x`` field::
+
+          chart(data, axes=...).flow(spread(by=y, dir="y")).mark(rect(w=x, fill=fill))
+
+    Args:
+        data: Rows to chart (positional, per wrapper conventions).
+        x: Field for the x encoding channel. Required.
+        y: Field for the y encoding channel. Required.
+        orientation: ``"y"`` for vertical bars (default) or ``"x"`` for
+            horizontal bars.
+        fill: Fill color (CSS string) or a field name for a color scale.
+        axes: Chart-level axes option (``True``/``False``/per-dimension dict),
+            passed through to ``chart(data, axes=...)``.
+        mark: Mark factory to use instead of ``rect`` — called with the same
+            kwargs (``h=``/``w=`` and ``fill=``), e.g. ``mark=circle``.
+
+    Returns:
+        A ``ChartBuilder``. NOTE: the JS helper wraps its builder in a
+        ``BarChartBuilder`` adding a ``.stack(field, options)`` convenience;
+        that wrapper is not ported (the parity harness serializes plain
+        ``ChartBuilder``s) — call ``.flow(stack(by=field, dir=orientation))``
+        on the returned builder directly instead.
+    """
+    # Both x and y are required (mirrors the JS error).
+    if x is None or y is None:
+        raise ValueError("bar chart requires both 'x' and 'y' encoding channels")
+
+    mark_fn = mark if mark is not None else rect
+    chart_options = {} if axes is None else {"axes": axes}
+
+    # Vertical bar chart (orientation "y"): spread along x-axis using the x
+    # field, height from the y field.
+    if orientation == "y":
+        return (
+            chart(data, chart_options or None)
+            .flow(spread(by=x, dir="x"))
+            .mark(mark_fn(h=y, fill=fill))
+        )
+
+    # Horizontal bar chart (orientation "x"): spread along y-axis using the y
+    # field, width from the x field.
+    if orientation == "x":
+        return (
+            chart(data, chart_options or None)
+            .flow(spread(by=y, dir="y"))
+            .mark(mark_fn(w=x, fill=fill))
+        )
+
+    raise ValueError(
+        f"bar chart orientation must be either 'x' or 'y', got '{orientation}'"
+    )

--- a/packages/gofish-python/uv.lock
+++ b/packages/gofish-python/uv.lock
@@ -103,7 +103,7 @@ wheels = [
 ]
 
 [[package]]
-name = "gofish-python"
+name = "gofish-graphics"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -20,23 +20,12 @@
 # (IR + render) without failing the byte-parity gate.
 packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx
 
-# ImageMixedPrimitives stays exempt: it renders large binary image assets
-# (over Vite's inline threshold) whose hrefs become build-hashed URLs the DOM
-# normalizer doesn't touch, so a Python port can't byte-match the JS hrefs —
-# the same fundamental blocker as the ImageMarks shape story below.
-# TODO(#404): the DOM normalizer now collapses <image> hrefs to their
-# hash-stripped basename, so this href blocker is resolved. This story (and
-# ImageMarks below) may be un-exemptable once the image-bearing DOM baselines
-# are re-accepted via the Visual Diff Review. Keeping the exemption for now;
-# revisit after re-baselining.
-packages/gofish-graphics/stories/lowlevel/ImageMixedPrimitives.stories.tsx
-
-# Shape primitives
-packages/gofish-graphics/stories/shapes/TextMarks.stories.tsx
-# TODO(#404): ImageMarks' only parity blocker was build-hashed <image> hrefs,
-# now normalized to basename by the DOM normalizer. Likely un-exemptable after
-# the image-bearing DOM baselines are re-accepted via the Visual Diff Review.
-packages/gofish-graphics/stories/shapes/ImageMarks.stories.tsx
+# Per-export exemption — PolarText constructs a raw custom coordinate
+# transform inline ({ type, transform: ([r, theta]) => ..., domain }), an
+# arbitrary JS closure rather than one of the IR's named coord transforms
+# (polar/clock/wavy/bipolar/arcLengthPolar/linear), so it cannot cross the
+# bridge. The other TextMarks exports are ported.
+packages/gofish-graphics/stories/shapes/TextMarks.stories.tsx::PolarText
 
 # Docs regression test
 packages/gofish-graphics/stories/DocsContextRegression.stories.tsx
@@ -47,10 +36,6 @@ packages/gofish-graphics/stories/forwardsyntax/Bar/BarWithLabels.stories.tsx
 # with fresh text — the refs can't cross the Python derive RPC, so it can't be
 # expressed with a Python mark-fn. (Ribbon/Layered and NodeLink ARE ported.)
 packages/gofish-graphics/stories/forwardsyntax/LabeledChart.stories.tsx
-packages/gofish-graphics/stories/forwardsyntax/Bar/BarTemplate.stories.tsx
-
-# Forward syntax stories needing mark-as-function or nested chart
-packages/gofish-graphics/stories/forwardsyntax/FacetedChart.stories.tsx
 
 # FlowerChart is a labeled-bar-chart shape: the stems are a real bar chart
 # (one chart, so their heights share a scale) and each flower is the stem's
@@ -62,29 +47,12 @@ packages/gofish-graphics/stories/forwardsyntax/FacetedChart.stories.tsx
 # Tracked by #591 (bridge selectAll-label / ref-datum mark-fns to Python).
 packages/gofish-graphics/stories/lowlevel/FlowerChart.stories.tsx
 
-# Atom unit-visualization replications (stories/atom/) that build a per-group
-# *nested chart* inside a mark-as-function (`.mark((d) => chart(d).flow(...)...)`)
-# to wrap each unit grid. The Python mark-fn runs over the RPC bridge and
-# receives plain JSON rows, not a builder it can re-`chart()`, so these can't be
-# expressed as a Python mark-fn — same blocker as FacetedChart. (The pure-spec
-# atom stories TitanicFacet, TitanicUnitDots, and Mosaic ARE ported.)
-packages/gofish-graphics/stories/atom/UnitColumnChart.stories.tsx
-packages/gofish-graphics/stories/atom/UnitHistogram.stories.tsx
-packages/gofish-graphics/stories/atom/Violin.stories.tsx
-packages/gofish-graphics/stories/atom/UnitMosaic.stories.tsx
-
 # Forward syntax stories needing coord transforms other than clock
 # (clock is now supported)
 
 # (Vega-Lite ports were brought over from exempt to real parity tests;
 # see tests/python-stories/vega-lite/.)
 
-
-# Per-export exemption — uses `assignGradientColor` to precompute per-row
-# fills from two distinct gradients in a single chart. The Python wrapper
-# doesn't expose `assignGradientColor` (one chart, one color config), so
-# this story can't be ported without a workaround or a wrapper extension.
-packages/gofish-graphics/stories/forwardsyntax/ColorScales.stories.tsx::PairedPalettes
 
 # Per-export exemption for Cut.stories.tsx — ImageCutWithLabels builds a
 # per-slice `layer(...)` inside a mark-as-function over `selectAll("part")`,

--- a/tests/python-stories/atom/test_unit_column_chart.py
+++ b/tests/python-stories/atom/test_unit_column_chart.py
@@ -1,0 +1,46 @@
+"""Equivalent of UnitColumnChart.stories.tsx — atom/UnitColumnChart."""
+
+import pandas as pd
+
+from gofish import chart, circle, derive, palette, spread
+
+
+def story_default():
+    titanic_passengers = pd.read_json(
+        "packages/gofish-graphics/src/data/titanicPassengers.json"
+    )
+
+    def order_by_survived(rows):
+        return sorted(rows, key=lambda row: row["survived"], reverse=True)
+
+    def chunk_rows(rows):
+        size = 14
+        return [rows[i : i + size] for i in range(0, len(rows), size)]
+
+    def passenger_dots(group_data):
+        return (
+            chart(group_data)
+            .flow(
+                derive(order_by_survived),
+                derive(chunk_rows),
+                # Reverse the rows so the ragged partial row lands at the top.
+                spread(spacing=2, dir="y", reverse=True),
+                spread(spacing=2, dir="x"),
+            )
+            .mark(circle(r=4, fill="survived"))
+        )
+
+    return (
+        chart(
+            titanic_passengers,
+            color=palette(["#2b8cbe", "#ff8408"]),
+            # x = pclass (the columns) at the bottom (y-end), under the
+            # upward-filling columns; y is the dot-row index, so suppress it.
+            axes={"x": {"side": "end"}, "y": False},
+        )
+        # Bottom-align the columns (y-down free space: "end" = bottom) so the
+        # unit stacks share a baseline and grow upward.
+        .flow(spread(by="pclass", dir="x", spacing=24, alignment="end"))
+        .mark(passenger_dots),
+        {"w": 520, "h": 580},
+    )

--- a/tests/python-stories/atom/test_unit_histogram.py
+++ b/tests/python-stories/atom/test_unit_histogram.py
@@ -1,0 +1,90 @@
+"""Equivalent of UnitHistogram.stories.tsx — atom/UnitHistogram."""
+
+import math
+
+import pandas as pd
+
+from gofish import chart, circle, derive, palette, spread
+
+
+def _age_decade(age):
+    return math.floor(age / 10) * 10
+
+
+def _load_aged_passengers():
+    titanic_passengers = pd.read_json(
+        "packages/gofish-graphics/src/data/titanicPassengers.json"
+    )
+
+    def to_age_num(age):
+        try:
+            return float(age)
+        except (TypeError, ValueError):
+            return float("nan")
+
+    titanic_passengers = titanic_passengers.assign(
+        ageNum=titanic_passengers["age"].apply(to_age_num)
+    )
+    titanic_passengers = titanic_passengers[
+        titanic_passengers["ageNum"].apply(math.isfinite)
+    ]
+    titanic_passengers = titanic_passengers.assign(
+        ageBin=titanic_passengers["ageNum"].apply(_age_decade)
+    )
+    return titanic_passengers
+
+
+def story_default():
+    aged_passengers = _load_aged_passengers()
+
+    def order_by_survived(rows):
+        return sorted(rows, key=lambda row: row["survived"], reverse=True)
+
+    def order_by_age_bin(rows):
+        return sorted(rows, key=lambda row: row["ageBin"])
+
+    def chunk_rows(rows):
+        size = 3
+        return [rows[i : i + size] for i in range(0, len(rows), size)]
+
+    def bin_dots(bin_data):
+        return (
+            chart(bin_data)
+            .flow(
+                derive(order_by_survived),
+                derive(chunk_rows),
+                # Reverse so the ragged partial row lands at the top.
+                spread(spacing=1.5, dir="y", reverse=True),
+                spread(spacing=1.5, dir="x"),
+            )
+            .mark(circle(r=3, fill="survived"))
+        )
+
+    def panel_bars(panel_data):
+        return (
+            chart(panel_data)
+            .flow(
+                # Age bins in ascending order along x — `spread` lays groups
+                # out in data-appearance order, so sort by the bin key first
+                # (as the strip plot sorts before its categorical spread).
+                derive(order_by_age_bin),
+                spread(by="ageBin", dir="x", spacing=6, alignment="end"),
+            )
+            .mark(bin_dots)
+        )
+
+    return (
+        chart(
+            aged_passengers,
+            color=palette(["#2b8cbe", "#ff8408"]),
+            # x = pclass (the panels) at the bottom (y-end); y is the
+            # dot-row index, so suppress it.
+            axes={"x": {"side": "end"}, "y": False},
+        )
+        # Bottom-align panels and their age-bin bars (y-down free space:
+        # "end" = bottom) so every unit stack shares a baseline and grows
+        # upward.
+        .flow(spread(by="pclass", dir="x", spacing=40, alignment="end"))
+        .mark(panel_bars),
+        {"w": 900, "h": 560},
+    )

--- a/tests/python-stories/atom/test_unit_mosaic.py
+++ b/tests/python-stories/atom/test_unit_mosaic.py
@@ -1,0 +1,96 @@
+"""Equivalent of UnitMosaic.stories.tsx — atom/UnitMosaic."""
+
+import math
+
+import pandas as pd
+
+from gofish import chart, circle, derive, palette, spread
+
+DOTS_PER_ROW = 34  # target group-size per dot-row; tunes the mosaic's aspect
+
+
+def _js_round(x):
+    # JS `Math.round` rounds half away from zero (toward +Infinity for
+    # positive numbers); Python's built-in `round` uses banker's rounding —
+    # match JS exactly since group sizes can land on an exact `.5`.
+    return math.floor(x + 0.5)
+
+
+def _chunk(rows, size):
+    size = size if size and size > 0 else 1
+    return [rows[i : i + size] for i in range(0, len(rows), size)]
+
+
+def _chunk_by_grid_rows(rows):
+    size = rows[0].get("gridRows", 1) if rows else 1
+    return _chunk(rows, size)
+
+
+def _mosaic_passengers():
+    titanic_passengers = pd.read_json(
+        "packages/gofish-graphics/src/data/titanicPassengers.json"
+    )
+
+    # Rows per (class, sex) block — shared by its Yes/No cells so they tile flush.
+    group_sizes = titanic_passengers.groupby(["pclass", "sex"]).size()
+    rows_by_group = {
+        key: max(1, _js_round(count / DOTS_PER_ROW))
+        for key, count in group_sizes.items()
+    }
+
+    titanic_passengers["gridRows"] = [
+        rows_by_group.get((row["pclass"], row["sex"]), 1)
+        for _, row in titanic_passengers.iterrows()
+    ]
+
+    # One global sort pins every nested `spread`'s group order: pclass
+    # ascending (1st row ends up at the bottom), sex ascending (female below
+    # male), survived descending (survived/blue column on the left), so the
+    # Yes/No split is consistent across blocks.
+    return titanic_passengers.sort_values(
+        ["pclass", "sex", "survived"],
+        ascending=[True, True, False],
+        kind="mergesort",
+    )
+
+
+def story_default():
+    def cell_dots(cell_data):
+        return (
+            chart(cell_data)
+            .flow(
+                # Fill column-by-column — each column `gridRows` tall — so
+                # every cell has flush top and bottom edges and only the
+                # last column is short. (Row-major chunking instead left a
+                # ragged partial *row* spanning the whole cell width, which
+                # broke the band boundaries.)
+                derive(_chunk_by_grid_rows),
+                spread(spacing=1, dir="x"),
+                spread(spacing=1, dir="y", reverse=True),
+            )
+            .mark(circle(r=3, fill="survived"))
+        )
+
+    def survived_cols(sex_row_data):
+        return (
+            chart(sex_row_data)
+            # survived columns: survived (blue) left, died (orange) right
+            .flow(spread(by="survived", dir="x", spacing=3, alignment="start"))
+            .mark(cell_dots)
+        )
+
+    def sex_rows(cls_data):
+        return (
+            chart(cls_data)
+            # sex sub-rows within a class: female bottom, male top
+            .flow(spread(by="sex", dir="y", spacing=3, alignment="start"))
+            .mark(survived_cols)
+        )
+
+    return (
+        chart(_mosaic_passengers(), color=palette(["#2b8cbe", "#ff8408"]))
+        # pclass rows: 1st at the bottom, 3rd at the top
+        .flow(spread(by="pclass", dir="y", spacing=6, alignment="start"))
+        .mark(sex_rows),
+        {"w": 400, "h": 300},
+    )

--- a/tests/python-stories/atom/test_violin.py
+++ b/tests/python-stories/atom/test_violin.py
@@ -1,0 +1,65 @@
+"""Equivalent of Violin.stories.tsx — atom/Violin."""
+
+import math
+
+import pandas as pd
+
+from gofish import chart, circle, palette, spread
+
+
+def _age_bin(age):
+    return math.floor(age / 2) * 2
+
+
+def story_default():
+    titanic_passengers = pd.read_json(
+        "packages/gofish-graphics/src/data/titanicPassengers.json"
+    )
+    titanic_passengers["ageNum"] = pd.to_numeric(
+        titanic_passengers["age"], errors="coerce"
+    )
+    aged_passengers = titanic_passengers[
+        titanic_passengers["ageNum"].apply(math.isfinite)
+    ].copy()
+    aged_passengers["ageBin"] = aged_passengers["ageNum"].apply(_age_bin)
+    aged_passengers = aged_passengers.sort_values(
+        ["ageBin", "survived"], ascending=[True, False], kind="mergesort"
+    )
+
+    def dot_row(bin_data):
+        return (
+            chart(bin_data)
+            .flow(spread(dir="x", spacing=1, alignment="middle"))
+            .mark(circle(r=2, fill="survived"))
+        )
+
+    def age_panel(panel_data):
+        return (
+            chart(panel_data)
+            .flow(
+                # Reverse so age increases UPWARD (youngest bin at the bottom)
+                # in y-down free space — the density silhouette stacks up the
+                # age axis.
+                spread(
+                    by="ageBin",
+                    dir="y",
+                    spacing=1,
+                    alignment="middle",
+                    reverse=True,
+                )
+            )
+            .mark(dot_row)
+        )
+
+    return (
+        chart(
+            aged_passengers,
+            color=palette(["#2b8cbe", "#ff8408"]),
+            # x = pclass (the violins) at the bottom (y-end); y is the dot-row
+            # index, so suppress it.
+            axes={"x": {"side": "end"}, "y": False},
+        )
+        .flow(spread(by="pclass", dir="x", spacing=48, alignment="middle"))
+        .mark(age_panel),
+        {"w": 680, "h": 260},
+    )

--- a/tests/python-stories/forward-syntax-v3/bar/test_template.py
+++ b/tests/python-stories/forward-syntax-v3/bar/test_template.py
@@ -1,0 +1,125 @@
+"""Equivalent of BarTemplate.stories.tsx — Forward Syntax V3/Bar/Template.
+
+Every story uses the ``bar_chart`` template helper (gofish/charts.py, the
+Python mirror of src/charts/bar.ts) rather than a hand-written builder chain.
+"""
+
+from gofish import circle
+from gofish.charts import bar_chart
+
+# Test data for template-based bar charts (mirrors the JS testData).
+TEST_DATA = [
+    {"category": "A", "value": 30, "color": "#ff6b6b"},
+    {"category": "B", "value": 80, "color": "#4ecdc4"},
+    {"category": "C", "value": 45, "color": "#45b7d1"},
+    {"category": "D", "value": 60, "color": "#f9ca24"},
+    {"category": "E", "value": 20, "color": "#6c5ce7"},
+]
+
+_OPTIONS = {"w": 500, "h": 400}
+
+
+def story_vertical():
+    return (
+        bar_chart(TEST_DATA, x="category", y="value", axes=True),
+        _OPTIONS,
+    )
+
+
+def story_horizontal():
+    return (
+        bar_chart(TEST_DATA, x="value", y="category", orientation="x", axes=True),
+        _OPTIONS,
+    )
+
+
+def story_vertical_with_fill_color():
+    return (
+        bar_chart(TEST_DATA, x="category", y="value", fill="#4ecdc4", axes=True),
+        _OPTIONS,
+    )
+
+
+def story_horizontal_with_fill_color():
+    return (
+        bar_chart(
+            TEST_DATA,
+            x="value",
+            y="category",
+            orientation="x",
+            fill="#ff6b6b",
+            axes=True,
+        ),
+        _OPTIONS,
+    )
+
+
+def story_vertical_with_fill_field():
+    return (
+        bar_chart(TEST_DATA, x="category", y="value", fill="color", axes=True),
+        _OPTIONS,
+    )
+
+
+def story_horizontal_with_fill_field():
+    return (
+        bar_chart(
+            TEST_DATA,
+            x="value",
+            y="category",
+            orientation="x",
+            fill="color",
+            axes=True,
+        ),
+        _OPTIONS,
+    )
+
+
+def story_vertical_with_custom_mark():
+    return (
+        bar_chart(TEST_DATA, x="category", y="value", mark=circle, axes=True),
+        _OPTIONS,
+    )
+
+
+def story_horizontal_with_custom_mark():
+    return (
+        bar_chart(
+            TEST_DATA,
+            x="value",
+            y="category",
+            orientation="x",
+            mark=circle,
+            axes=True,
+        ),
+        _OPTIONS,
+    )
+
+
+def story_vertical_with_custom_mark_and_fill():
+    return (
+        bar_chart(
+            TEST_DATA,
+            x="category",
+            y="value",
+            fill="#45b7d1",
+            mark=circle,
+            axes=True,
+        ),
+        _OPTIONS,
+    )
+
+
+def story_horizontal_with_custom_mark_and_fill():
+    return (
+        bar_chart(
+            TEST_DATA,
+            x="value",
+            y="category",
+            orientation="x",
+            fill="#f9ca24",
+            mark=circle,
+            axes=True,
+        ),
+        _OPTIONS,
+    )

--- a/tests/python-stories/forward-syntax-v3/test_color_scales.py
+++ b/tests/python-stories/forward-syntax-v3/test_color_scales.py
@@ -16,6 +16,7 @@ from gofish import (
     palette,
     gradient,
 )
+from gofish.ast import assign_gradient_color
 from python_stories.data import SEAFOOD, SCORES_DATA
 
 
@@ -51,6 +52,44 @@ def story_gradient_string_array():
         chart(SCORES_DATA, color=gradient(["#f7fbff", "#42c663", "#6b0808"]))
         .flow(spread(by="label", dir="x"))
         .mark(rect(h="value", fill="value")),
+        {"w": 400, "h": 400, "axes": True},
+    )
+
+
+_PAIRED_BARS = [
+    {"pair": "P1", "type": "warm", "value": 20},
+    {"pair": "P1", "type": "cold", "value": 20},
+    {"pair": "P2", "type": "warm", "value": 45},
+    {"pair": "P2", "type": "cold", "value": 45},
+    {"pair": "P3", "type": "warm", "value": 70},
+    {"pair": "P3", "type": "cold", "value": 70},
+    {"pair": "P4", "type": "warm", "value": 90},
+    {"pair": "P4", "type": "cold", "value": 90},
+]
+
+_WARM_GRADIENT = gradient(["#ffe0b2", "#e65100"])
+_COLD_GRADIENT = gradient(["#bbdefb", "#0d47a1"])
+
+
+def story_paired_palettes():
+    def _assign_colors(d):
+        values = [item["value"] for item in d]
+        mn, mx = min(values), max(values)
+        out = []
+        for item in d:
+            t = 0 if mx == mn else (item["value"] - mn) / (mx - mn)
+            scale = _WARM_GRADIENT if item["type"] == "warm" else _COLD_GRADIENT
+            out.append({**item, "color": assign_gradient_color(scale, t)})
+        return out
+
+    return (
+        chart(_PAIRED_BARS)
+        .flow(
+            derive(_assign_colors),
+            spread(by="pair", dir="x"),
+            stack(by="type", dir="x"),
+        )
+        .mark(rect(h="value", fill="color")),
         {"w": 400, "h": 400, "axes": True},
     )
 

--- a/tests/python-stories/forward-syntax-v3/test_faceted_chart.py
+++ b/tests/python-stories/forward-syntax-v3/test_faceted_chart.py
@@ -1,0 +1,52 @@
+"""Equivalent of forwardsyntax/FacetedChart.stories.tsx — Forward Syntax V3/Faceted Chart."""
+
+from gofish import chart, circle, rect, scatter, spread
+from python_stories.data import DRIVING_SHIFTS, SEAFOOD
+
+
+def story_default():
+    def species_bars(data):
+        return (
+            chart(data)
+            .flow(spread(by="species", dir="x", spacing=2, axes={"x": True, "y": False}))
+            .mark(rect(h="count", w=20))
+        )
+
+    return (
+        chart(SEAFOOD, axes=True)
+        .flow(spread(by="lake", dir="x", spacing=15))
+        .mark(species_bars),
+        {"w": 1000, "h": 400},
+    )
+
+
+def story_faceted_scatter_driving():
+    def year_miles_scatter(data):
+        return (
+            chart(data)
+            .flow(scatter(x="year", y="miles", axes={"x": True, "y": False}))
+            .mark(circle(r=3, fill="#4682b4"))
+        )
+
+    return (
+        chart(DRIVING_SHIFTS, axes=True)
+        .flow(spread(by="side", dir="x", spacing=50))
+        .mark(year_miles_scatter),
+        {"w": 800, "h": 400},
+    )
+
+
+def story_faceted_scatter_y():
+    def year_gas_scatter(data):
+        return (
+            chart(data)
+            .flow(scatter(x="year", y="gas", axes={"x": False, "y": True}))
+            .mark(circle(r=3, fill="#e07b39"))
+        )
+
+    return (
+        chart(DRIVING_SHIFTS, axes=True)
+        .flow(spread(by="side", dir="y", spacing=50))
+        .mark(year_gas_scatter),
+        {"w": 400, "h": 800},
+    )

--- a/tests/python-stories/low-level-syntax/test_image_mixed_primitives.py
+++ b/tests/python-stories/low-level-syntax/test_image_mixed_primitives.py
@@ -1,0 +1,179 @@
+"""Equivalent of lowlevel/ImageMixedPrimitives.stories.tsx — Low Level
+Syntax/Image Mixed Primitives.
+
+`image({href, w, h})` mixed into low-level `spread`/`spreadX`/`spreadY`
+combinators alongside `rect` and `text` — cards, labeled rows, and a data-URI
+SVG mixed with raster assets.
+
+Image assets: the JS storybook imports `bottle.jpg`,
+`maja7777-glass-bottle-free-2451180_1280.png`, and
+`schwarzenarzisse-isolated-2437759_1280.png` via Vite, which serves them from
+the dev server via the `/@fs/<absolute-path>` form in dev (see
+tests/python-stories/piccl/test_bottle.py and
+tests/python-stories/forward-syntax-v3/test_cut.py for the same pattern); the
+DOM normalizer collapses these to their basenames for comparison against the
+JS baseline. The inline SVG badge is a `data:image/svg+xml;utf8,` URI built
+inline in the JS story itself (not a Vite-resolved asset) via
+`encodeURIComponent`; the normalizer leaves data URIs untouched, so we
+reconstruct the byte-identical percent-encoding here with Python's
+`urllib.parse.quote`, using the safe-character set that matches
+`encodeURIComponent`'s unreserved set (`A-Za-z0-9-_.!~*'()`).
+"""
+
+import os
+from urllib.parse import quote
+
+from gofish import image, rect, spread, text
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+_ASSETS = f"{_REPO_ROOT}/packages/gofish-graphics/stories/assets"
+BOTTLE_JPG = f"/@fs{_ASSETS}/bottle.jpg"
+BOTTLE_PHOTO_PNG = (
+    f"/@fs{_ASSETS}/maja7777-glass-bottle-free-2451180_1280.png"
+)
+FLOWER_PNG = f"/@fs{_ASSETS}/schwarzenarzisse-isolated-2437759_1280.png"
+
+
+def _encode_uri_component(s: str) -> str:
+    """Python equivalent of JS `encodeURIComponent`."""
+    return quote(s, safe="-_.!~*'()")
+
+
+_INLINE_BADGE_SVG_MARKUP = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="120" height="72" '
+    'viewBox="0 0 120 72"><rect width="120" height="72" rx="12" '
+    'fill="#e2e8f0"/><rect x="10" y="12" width="48" height="48" rx="8" '
+    'fill="#94a3b8"/><rect x="64" y="20" width="44" height="10" rx="5" '
+    'fill="#0f172a"/><rect x="64" y="36" width="32" height="8" rx="4" '
+    'fill="#475569"/></svg>'
+)
+INLINE_BADGE_SVG = (
+    "data:image/svg+xml;utf8," + _encode_uri_component(_INLINE_BADGE_SVG_MARKUP)
+)
+
+
+def _image_card(title, subtitle, image_node):
+    return spread(
+        [
+            text(text=title, fontSize=14, fill="#0f172a"),
+            rect(w=180, h=2, fill="#cbd5e1"),
+            image_node,
+            text(text=subtitle, fontSize=12, fill="#475569"),
+        ],
+        dir="y",
+        spacing=6,
+        alignment="start",
+    )
+
+
+def story_cards_row():
+    return (
+        spread(
+            [
+                _image_card(
+                    "Bottle Icon",
+                    "fixed 120x120",
+                    image(href=BOTTLE_JPG, w=120, h=120),
+                ),
+                _image_card(
+                    "Bottle Photo",
+                    "fixed 170x110",
+                    image(href=BOTTLE_PHOTO_PNG, w=170, h=110),
+                ),
+                _image_card(
+                    "Flower",
+                    "fixed 120x150",
+                    image(href=FLOWER_PNG, w=120, h=150),
+                ),
+            ],
+            dir="x",
+            spacing=28,
+            alignment="start",
+        ),
+        {"w": 980, "h": 300},
+    )
+
+
+def story_labeled_rows():
+    return (
+        spread(
+            [
+                spread(
+                    [
+                        rect(w=12, h=60, fill="#7dd3fc", rx=3, ry=3),
+                        image(href=BOTTLE_JPG, w=60, h=60),
+                        text(
+                            text="Square thumbnail with color marker",
+                            fontSize=14,
+                            fill="#0f172a",
+                        ),
+                    ],
+                    dir="x",
+                    spacing=12,
+                    alignment="middle",
+                ),
+                spread(
+                    [
+                        rect(w=12, h=60, fill="#86efac", rx=3, ry=3),
+                        image(href=BOTTLE_PHOTO_PNG, w=92, h=60),
+                        text(
+                            text="Wide thumbnail mixed with text",
+                            fontSize=14,
+                            fill="#0f172a",
+                        ),
+                    ],
+                    dir="x",
+                    spacing=12,
+                    alignment="middle",
+                ),
+                spread(
+                    [
+                        rect(w=12, h=60, fill="#fda4af", rx=3, ry=3),
+                        image(href=FLOWER_PNG, w=44, h=60),
+                        text(
+                            text="Tall thumbnail with matching row layout",
+                            fontSize=14,
+                            fill="#0f172a",
+                        ),
+                    ],
+                    dir="x",
+                    spacing=12,
+                    alignment="middle",
+                ),
+            ],
+            dir="y",
+            spacing=16,
+            alignment="start",
+        ),
+        {"w": 820, "h": 360},
+    )
+
+
+def story_data_uri_with_assets():
+    return (
+        spread(
+            [
+                _image_card(
+                    "Inline SVG",
+                    "w only (w=120, h inferred)",
+                    image(href=INLINE_BADGE_SVG, w=120),
+                ),
+                _image_card(
+                    "Asset JPG",
+                    "fixed 110x110",
+                    image(href=BOTTLE_JPG, w=110, h=110),
+                ),
+                _image_card(
+                    "Asset PNG",
+                    "fixed 120x90",
+                    image(href=BOTTLE_PHOTO_PNG, w=120, h=90),
+                ),
+            ],
+            dir="x",
+            spacing=24,
+            alignment="start",
+        ),
+        {"w": 760, "h": 260},
+    )

--- a/tests/python-stories/shapes/test_image_marks.py
+++ b/tests/python-stories/shapes/test_image_marks.py
@@ -1,0 +1,94 @@
+"""Equivalent of shapes/ImageMarks.stories.tsx — Shapes/Image Marks.
+
+`image({href, w, h})` sizing resolution: a data-URI SVG that resolves its
+intrinsic 96x64 size when no `w`/`h` are given, three raster assets pinned to
+explicit `w`+`h`, and one asset pinned by `w` only (h inferred from aspect).
+
+Image assets: the JS storybook imports `bottle.jpg`,
+`maja7777-glass-bottle-free-2451180_1280.png`, and
+`schwarzenarzisse-isolated-2437759_1280.png` via Vite, which serves them from
+the dev server via the `/@fs/<absolute-path>` form in dev (see
+tests/python-stories/piccl/test_bottle.py and
+tests/python-stories/forward-syntax-v3/test_cut.py for the same pattern); the
+DOM normalizer collapses these to their basenames for comparison against the
+JS baseline. The inline SVG badge is a `data:image/svg+xml;utf8,` URI built
+inline in the JS story itself (not a Vite-resolved asset) via
+`encodeURIComponent`; the normalizer leaves data URIs untouched, so we
+reconstruct the byte-identical percent-encoding here with Python's
+`urllib.parse.quote`, using the safe-character set that matches
+`encodeURIComponent`'s unreserved set (`A-Za-z0-9-_.!~*'()`).
+"""
+
+import os
+from urllib.parse import quote
+
+from gofish import image, spread, stack, text
+
+_REPO_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+_ASSETS = f"{_REPO_ROOT}/packages/gofish-graphics/stories/assets"
+BOTTLE_JPG = f"/@fs{_ASSETS}/bottle.jpg"
+BOTTLE_PHOTO_PNG = (
+    f"/@fs{_ASSETS}/maja7777-glass-bottle-free-2451180_1280.png"
+)
+FLOWER_PNG = f"/@fs{_ASSETS}/schwarzenarzisse-isolated-2437759_1280.png"
+
+
+def _encode_uri_component(s: str) -> str:
+    """Python equivalent of JS `encodeURIComponent`."""
+    return quote(s, safe="-_.!~*'()")
+
+
+_INLINE_BADGE_SVG_MARKUP = (
+    '<svg xmlns="http://www.w3.org/2000/svg" width="96" height="64" '
+    'viewBox="0 0 96 64"><rect width="96" height="64" rx="10" '
+    'fill="#e0f2fe"/><circle cx="20" cy="32" r="10" fill="#38bdf8"/>'
+    '<rect x="36" y="24" width="44" height="16" rx="5" fill="#0284c7"/></svg>'
+)
+INLINE_BADGE_SVG = (
+    "data:image/svg+xml;utf8," + _encode_uri_component(_INLINE_BADGE_SVG_MARKUP)
+)
+
+
+def _labeled_image(label, image_node):
+    return stack(
+        [
+            text(text=label, fontSize=14, fill="#1f2937"),
+            image_node,
+        ],
+        dir="y",
+        spacing=8,
+        alignment="start",
+    )
+
+
+def story_size_resolution():
+    return (
+        spread(
+            [
+                _labeled_image(
+                    "data URI (intrinsic 96x64)", image(href=INLINE_BADGE_SVG)
+                ),
+                _labeled_image(
+                    "asset 1 (w+h 110x110)",
+                    image(href=BOTTLE_JPG, w=110, h=110),
+                ),
+                _labeled_image(
+                    "asset 2 (w+h 160x100)",
+                    image(href=BOTTLE_PHOTO_PNG, w=160, h=100),
+                ),
+                _labeled_image(
+                    "asset 3 (w+h 110x140)",
+                    image(href=FLOWER_PNG, w=110, h=140),
+                ),
+                _labeled_image(
+                    "asset 1 (w only 90)", image(href=BOTTLE_JPG, w=90)
+                ),
+            ],
+            dir="x",
+            spacing=36,
+            alignment="start",
+        ),
+        {"w": 960, "h": 260},
+    )

--- a/tests/python-stories/shapes/test_text_marks.py
+++ b/tests/python-stories/shapes/test_text_marks.py
@@ -1,0 +1,69 @@
+"""Equivalent of shapes/TextMarks.stories.tsx — Shapes/Text Marks.
+
+Text mark layout: spreads of styled text labels (vertical, middle-aligned,
+horizontal) plus a text mark spread against an ellipse. JS `For(...)` is
+array-map sugar and becomes a list comprehension. The JS stories pass
+`textAnchor: "start"` to text(), but it is a no-op in JS (the renderer
+hardcodes "start") and is not an IR field, so it is omitted here.
+PolarText is exempt (raw JS coordinate-transform closure).
+"""
+
+from gofish import ellipse, spread, text
+
+FONT_FAMILY = "Inter, sans-serif"
+
+LABELS = [
+    {"text": "GoFish", "color": "#22577a"},
+    {"text": "Text", "color": "#38a3a5"},
+    {"text": "Stacky", "color": "#57cc99"},
+    {"text": "Mark", "color": "#80ed99"},
+]
+
+
+def _label_texts():
+    return [
+        text(
+            text=label["text"],
+            fill=label["color"],
+            fontSize=28,
+            fontFamily=FONT_FAMILY,
+            debugBoundingBox=True,
+        )
+        for label in LABELS
+    ]
+
+
+def story_text_stack():
+    return (
+        spread(_label_texts(), dir="y", spacing=18, alignment="start"),
+        {"w": 500, "h": 240},
+    )
+
+
+def story_text_stack_middle_alignment():
+    return (
+        spread(_label_texts(), dir="y", spacing=18, alignment="middle"),
+        {"w": 500, "h": 240},
+    )
+
+
+def story_text_stack_horizontal():
+    return (
+        spread(_label_texts(), dir="x", spacing=18, alignment="start"),
+        {"w": 500, "h": 240},
+    )
+
+
+def story_text_stack_with_ellipse():
+    return (
+        spread(
+            [
+                ellipse(w=10, h=10, fill="red"),
+                text(text="Mercury"),
+            ],
+            dir="y",
+            spacing=60,
+            alignment="middle",
+        ),
+        {"w": 500, "h": 240},
+    )


### PR DESCRIPTION
## What

An audit of `tests/.python-sync-exempt` found that most exemptions no longer hold. This PR un-exempts 13 stories (26 exports) and ports them all to real byte-parity coverage, plus two small Python wrapper additions the ports needed. Every port is verified byte-identical to the JS DOM.

### Stale exemptions removed

- **FacetedChart + atom UnitColumnChart / UnitHistogram / Violin / UnitMosaic** — exempted as "nested chart inside a mark-as-function can't cross the bridge," but that predates the `_MarkFn` nested-chart support; the identical plain-rows pattern already passes parity in TitanicFacet. Ported directly, no wrapper changes.
- **ImageMarks + ImageMixedPrimitives** — the build-hashed `<image>` href blocker was resolved by the #404 DOM normalizer (`normalizeImageHrefs`). Ported using the same `/@fs` asset-path pattern as the existing bottle/cut ports; the inline SVG data-URIs reproduce `encodeURIComponent` byte-for-byte via `urllib.parse.quote`.
- **TextMarks** — 4/5 exports had no blocker at all (the file had no documented reason). Ported; the exemption is narrowed to `::PolarText`, which hand-rolls a raw JS coordinate-transform closure and is genuinely non-serializable.
- **ColorScales::PairedPalettes** — needed only `assign_gradient_color` in the wrapper. Added to `gofish/ast.py` alongside `palette`/`gradient`: a plain-Python transcription of chroma-js's Lab-space `scale(...)(t).hex()`; verified against chroma-js ground truth (18/18 hex values exact, including multi-segment stops).
- **BarTemplate** — misclassified as a bridge blocker; it has no mark-fn. The `barChart` template was simply never mirrored. Added `gofish.charts.bar_chart` (thin composition over `chart`/`spread`/`rect`, lowering to identical IR) and ported all 10 exports.

### Docs

`assign-gradient-color` pages under `api/color/` for both languages, cross-linked from `gradient.md`, registered in both sidebars. `bar_chart`/`barChart` docs are deferred to #704: there is no templates/helpers section under `api/` yet to house the pair.

### Still exempt, now with verified reasons

ViolinPlot (fast-kde vs scipy KDE — curve values can't byte-match), DocsContextRegression (JS-runtime meta-test), Labels ×4 and Constraints ×8 (multi-chart-per-story layouts outside the one-chart harness; semantics covered by their ported single-chart siblings), TextMarks::PolarText (raw coord-transform closure), LayeredBarsAndArea (`.zOrder(fn)` not in IR; revisit with the emphasize API #641), and the four ref-embedding stories tracked by #591 (BarWithLabels, LabeledChart, FlowerChart, Cut::ImageCutWithLabels).

## Verification

- `capture-python` full suite vs `capture-js` at HEAD on the same machine: **186/186 stories byte-identical**, 0 mismatches (1 skip = ViolinPlot, exempt by design).
- `validate-python-ir`: 187/187 pass. Two new WARNs (`h`/`w` on circle in the custom-mark template stories) mirror the JS behavior exactly — `barChart` hands the custom mark factory an ignored size channel — and leaf-mark channels only warn during the current rollout.
- `check-python-sync --all`: everything in scope covered. (The only remaining missing entries are the uncommitted `stories/thesis/AxisSpaceThumbnails` exports from a separate work thread.)
- `uv.lock`: one-line drift fix (`gofish-python` → `gofish-graphics`) matching the already-committed `pyproject.toml` rename.

## Follow-ups (not in this PR)

- **#591 can likely be narrowed instead of implemented**: a design pass found the `d[0]` ref-embedding in all four remaining stories is incidental — a `sum()`-style label accessor plus a mark-valued `.label()`/`.attach()` would give them declarative, serializable spellings with no RPC ref-bridging. Writing that up separately.
- `barChart` is now exported from `lib.ts` (second commit), resolving the JS/Python asymmetry; a docs home for the template pair is tracked in #704.
- #691/#692 (descriptor-table Stage 6/7) are orthogonal to parity — no exempt story was blocked on them — and proceed independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
