### PR TITLE
enclose: stop re-placing already-placed children (refs collapsed to origin)

### DIFF
--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -158,6 +158,28 @@ export type Placeable = {
   pinAnchor?: (axis: FancyDirection, value: number, anchor: Anchor) => void;
 };
 
+/** Place a child at `(0, 0)` on whichever axes it hasn't already resolved a
+ *  position for — the "fresh vs. already-placed" child rule shared by every
+ *  operator that lays out already-placed operands (e.g. a `ref` whose
+ *  translate was reconciled against its LCA during its own `layout()`)
+ *  alongside fresh ones. `dims[axis].min === undefined` IS that placed/unplaced
+ *  signal (see `combineDims`): a fresh node reports an undefined translate
+ *  until placed, while an already-placed node (a ref, or any other
+ *  initially-placed target — see `isInitiallyPlaced` in
+ *  `constraints/placementLowering.ts`, the same rule) already has a
+ *  determined `min`, so re-placing it here would be a no-op-that-should-be —
+ *  except `GoFishRef.place()` has no ledger to make that a true no-op, so it
+ *  must not be called at all in that case. This is `layer`'s own
+ *  unplaced-child finalization (its constrained-children branch); `enclose`
+ *  reuses it verbatim rather than re-deriving the rule. */
+export function placeUnplacedChild(
+  child: Placeable,
+  anchor: Anchor = "baseline"
+): void {
+  if (child.dims[0].min === undefined) child.place("x", 0, anchor);
+  if (child.dims[1].min === undefined) child.place("y", 0, anchor);
+}
+
 // `scales` is the per-axis data→pixel affine scale handed down (the single
 // {@link AxisScale} carrier: `sigma` = pixels-per-data-unit for size, `map` =
 // the anchored data→pixel map). A node MUST NOT mutate this array: to establish

--- a/packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx
@@ -1,4 +1,4 @@
-import { GoFishNode } from "../_node";
+import { GoFishNode, placeUnplacedChild } from "../_node";
 import { Size, displayTranslate } from "../dims";
 import type { DisplayList } from "gofish-ir";
 import {
@@ -9,6 +9,7 @@ import {
 import { GoFishAST } from "../_ast";
 import { black, gray, tailwindColors } from "../../color";
 import { Domain } from "../domain";
+import { foldFinite } from "../../util";
 import { UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
 import { createNodeOperator } from "../withGoFish";
 
@@ -32,31 +33,50 @@ export const enclose = createNodeOperator(
           return [UNDEFINED, UNDEFINED];
         },
         layout: (shared, size, scales, children) => {
+          // Child placement mirrors `layer`'s own rule exactly (see
+          // `placeUnplacedChild` in `_node.ts`, reused here rather than
+          // re-derived): a FRESH child (e.g. a plain shape) reports an
+          // undefined translate until placed, so it gets `layer`'s usual
+          // baseline-origin placement. An ALREADY-PLACED operand — most
+          // notably a `ref(...)` child, which reconciles its own translate
+          // against its LCA during its own `layout()` (see `GoFishRef.layout`
+          // in `_ref.tsx`) — must NOT be re-placed: `GoFishRef.place()` has no
+          // ledger to make that a no-op, so calling it would collapse every
+          // ref onto one point (see `enclose({}, [ref("1"), ref("2"), ...])`
+          // used to do). Enclose's own contribution beyond `layer` is purely
+          // the hull/bbox union + padding below, read from each child's ACTUAL
+          // (placed) box — the same union `layer` folds over `childPlaceables`.
           const childPlaceables = [];
 
           for (const child of children) {
             const childPlaceable = child.layout(size, scales);
-            childPlaceable.place("x", 0, "baseline");
-            childPlaceable.place("y", 0, "baseline");
+            placeUnplacedChild(childPlaceable);
             childPlaceables.push(childPlaceable);
           }
 
-          const maxWidth = Math.max(
-            ...childPlaceables.map(
-              (childPlaceable) => childPlaceable.dims[0].max!
-            )
+          const minX = foldFinite(
+            childPlaceables.map((cp) => cp.dims[0].min),
+            Math.min
           );
-          const maxHeight = Math.max(
-            ...childPlaceables.map(
-              (childPlaceable) => childPlaceable.dims[1].max!
-            )
+          const maxX = foldFinite(
+            childPlaceables.map((cp) => cp.dims[0].max),
+            Math.max
           );
+          const minY = foldFinite(
+            childPlaceables.map((cp) => cp.dims[1].min),
+            Math.min
+          );
+          const maxY = foldFinite(
+            childPlaceables.map((cp) => cp.dims[1].max),
+            Math.max
+          );
+
           return {
             intrinsicDims: {
-              x: -padding,
-              y: -padding,
-              w: maxWidth + padding * 2,
-              h: maxHeight + padding * 2,
+              x: minX - padding,
+              y: minY - padding,
+              w: maxX - minX + padding * 2,
+              h: maxY - minY + padding * 2,
             },
             transform: { translate: [undefined, undefined] },
           };
@@ -76,15 +96,20 @@ export const enclose = createNodeOperator(
           const [tx, ty] = displayTranslate(transform);
           const outer = node.getRenderSession().toPixel!;
 
+          const localMinX = intrinsicDims?.[0]?.min ?? -padding;
+          const localMinY = intrinsicDims?.[1]?.min ?? -padding;
           const w = intrinsicDims?.[0]?.size ?? 0;
           const h = intrinsicDims?.[1]?.size ?? 0;
-          // Enclosure rect at local (-padding, -padding, w, h), inside the
-          // node's translate → absolute y-up box, mapped via the outer toPixel.
+          // Enclosure rect at local (localMinX, localMinY, w, h) — the hull's
+          // own box (children's bbox union ± padding; see `layout` above),
+          // inside the node's translate → absolute y-up box, mapped via the
+          // outer toPixel. `localMinX/Y` collapse to `-padding` in the common
+          // (all-fresh-children) case, matching the old hardcoded assumption.
           const box = rectItemFromBox(
-            tx - padding,
-            tx - padding + w,
-            ty - padding,
-            ty - padding + h,
+            tx + localMinX,
+            tx + localMinX + w,
+            ty + localMinY,
+            ty + localMinY + h,
             outer,
             {
               rx,

--- a/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/layer.tsx
@@ -2,7 +2,7 @@
 // @wiki Underlying Space — /internals/core/underlying-space
 // </gofish-wiki>
 
-import { GoFishNode, type ToPixel } from "../_node";
+import { GoFishNode, placeUnplacedChild, type ToPixel } from "../_node";
 import type { DisplayList } from "gofish-ir";
 import { shadowCheckScaleRoot } from "../solver/shadow";
 import { flattenForZOrder, topoSortByZOrder } from "../paintOrder";
@@ -431,8 +431,7 @@ export const layer = createNodeOperatorSequential(
             // tier laid out after them (see notes/nested-layer-tiers.md), not
             // rely on a re-layout pass here.
             for (const cp of childPlaceables) {
-              if (cp.dims[0].min === undefined) cp.place("x", 0, "baseline");
-              if (cp.dims[1].min === undefined) cp.place("y", 0, "baseline");
+              placeUnplacedChild(cp);
             }
           } else {
             // Default layer behavior: place all children at (0, 0)

--- a/packages/gofish-graphics/stories/lowlevel/EncloseRefs.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/EncloseRefs.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import { spreadX, rect, layer, enclose, ref } from "../../src/lib";
+import { color6 } from "../../src/color";
+
+const meta: Meta = {
+  title: "Low Level Syntax/Enclose Refs",
+};
+export default meta;
+
+// Regression probe for the enclose-around-refs collapse bug: `enclose`'s
+// children were unconditionally re-placed at the local origin, which is right
+// for a FRESH child but wrong for an already-placed operand — a `ref(...)`
+// child reconciles its own translate against its LCA during its own
+// `layout()`, and re-placing it collapsed every ref onto one point (see
+// `packages/gofish-graphics/src/tests/stacking.ts:41`'s long-commented-out
+// probe). NOT gallery-tagged — this is a regression repro, not a showpiece.
+export const EncloseRefs: StoryObj = {
+  render: () => {
+    const container = initializeContainer();
+    layer([
+      spreadX({ spacing: 64, alignment: "middle" }, [
+        rect({ w: 32, h: 32, fill: color6[0] }).name("1"),
+        rect({ w: 32, h: 64, fill: color6[1] }).name("2"),
+        rect({ w: 32, h: 40, fill: color6[2] }).name("3"),
+      ]),
+      // A later sibling referencing the three named rects above: the hull
+      // must wrap all three (spread apart by spreadX) plus padding — not
+      // collapse to one rect's size at the origin.
+      enclose({ padding: 6 }, [ref("1"), ref("2"), ref("3")]),
+    ]).render(container, {});
+    return container;
+  },
+};

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -38,6 +38,14 @@ packages/gofish-graphics/stories/shapes/TextMarks.stories.tsx::PolarText
 # Docs regression test
 packages/gofish-graphics/stories/DocsContextRegression.stories.tsx
 
+# EncloseRefs regression probe: guards the enclose-around-refs collapse bug
+# (enclose used to unconditionally re-place already-placed children, e.g.
+# ref() operands, collapsing them onto one point). Uses only portable
+# constructs (layer/ref), but it's a layout regression repro, not a showpiece
+# spec meant for Python-parity coverage — same rationale as
+# DocsContextRegression above.
+packages/gofish-graphics/stories/lowlevel/EncloseRefs.stories.tsx
+
 # Benchmark plot stories: dev/bench tooling, not portable specs. They render
 # benchmark numbers injected at runtime via `window.__BENCH_RESULTS__` /
 # `__BENCH_HISTORY__` (with an embedded synthetic fallback) and use Math/window


### PR DESCRIPTION
## Bug

`enclose`'s layout unconditionally called `place(axis, 0, "baseline")` on every child. `GoFishNode.place()` self-guards via its `_bbox` ledger, but `GoFishRef.place()` has no ledger — it overwrites the ref's LCA-reconciled translate. So `enclose({}, [ref("a"), ref("b"), ref("c")])` collapsed every ref onto the local origin and drew a hull around a single point. This has never worked: the ref-enclose call at `src/tests/stacking.ts:41` has been commented out since it was written, and all three Bluefish wave-1 port attempts (#435/#438/#440) independently hit it.

## Fix

enclose gets **layer's child semantics** (enclose = layer + hull ink):

- Layer's existing place-only-if-unplaced check (the `translate === undefined` ⇒ "parent may place me" signal, same rule as `isInitiallyPlaced`) is extracted into a shared `placeUnplacedChild` helper in `_node.ts`.
- `layer.tsx`'s constrained-children branch now calls the helper instead of its identical inline check (behavior-preserving refactor).
- `enclose.tsx` places each child through the same helper, and computes its hull `intrinsicDims` and lowered box from the children's **actual** placed min/max union instead of assuming min = 0.

## Verification

- New regression probe `stories/lowlevel/EncloseRefs.stories.tsx`: three named rects spread apart + `enclose` over refs to all three — the hull now visibly wraps all three with padding (was: a collapsed box around the first).
- `pnpm capture-diff main`: **byte-identical for every existing story** — fresh-children enclosures take the same code path with min always 0, so `stacking`, `nestedWaffle`, `ScopeRegressions/EncloseMixed`, and everything else is unchanged. The only diff entries are added stories.
- `check-python-sync-all` passes (probe exempted as a regression repro, same rationale as DocsContextRegression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)