### PR TITLE
Port Bluefish gallery wave 1: Quantum Circuit, Topology, Insertion Sort (#438, #440, #435)

### DIFF
--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -1504,7 +1504,7 @@ for the API.
       }
     },
     "EllipseMark": {
-      "description": "An ellipse. Box geometry via the shared dims channels; paint is a strict subset of `paint` (no filter/opacity).",
+      "description": "An ellipse. Box geometry via the shared dims channels; paint is a strict subset of `paint` (no filter).",
       "type": "object",
       "required": ["type"],
       "additionalProperties": true,
@@ -1577,6 +1577,10 @@ for the API.
         },
         "strokeWidth": {
           "type": "number"
+        },
+        "opacity": {
+          "type": "number",
+          "default": 1
         },
         "aspectRatio": {
           "type": "number",
@@ -1797,6 +1801,21 @@ for the API.
           "type": "string",
           "default": "system-ui, sans-serif"
         },
+        "fontStyle": {
+          "type": "string",
+          "description": "Raw CSS font-style (e.g. \"italic\")."
+        },
+        "fontWeight": {
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "CSS font-weight (e.g. 300, 700, \"bold\")."
+        },
         "debugBoundingBox": {
           "type": "boolean",
           "default": false
@@ -1972,6 +1991,10 @@ for the API.
         },
         "strokeWidth": {
           "type": "number"
+        },
+        "opacity": {
+          "type": "number",
+          "default": 1
         },
         "debug": {
           "type": "boolean"

--- a/apps/docs/docs/js/api/marks/ellipse.md
+++ b/apps/docs/docs/js/api/marks/ellipse.md
@@ -16,7 +16,7 @@ gf.ellipse({ w: 100, h: 60, fill: "mediumseagreen" }).render(root, {
 ## Signature
 
 ```ts
-ellipse({ w?, h?, fill?, stroke?, strokeWidth? })
+ellipse({ w?, h?, fill?, stroke?, strokeWidth?, opacity = 1 })
 ```
 
 ## Parameters
@@ -28,6 +28,7 @@ ellipse({ w?, h?, fill?, stroke?, strokeWidth? })
 | `fill`        | `string`           | Fill color or field name for color encoding          |
 | `stroke`      | `string`           | Stroke color (defaults to `fill`)                    |
 | `strokeWidth` | `number`           | Stroke width (default `0`)                           |
+| `opacity`     | `number`           | Opacity, `0`–`1` (default `1`)                       |
 
 ## Examples
 
@@ -40,6 +41,9 @@ ellipse({ w: 60, h: 30, fill: "white", stroke: "black", strokeWidth: 2 });
 
 // Data-driven dimensions
 ellipse({ w: "width", h: "height", fill: "category" });
+
+// Translucent ellipse
+ellipse({ w: 80, h: 40, fill: "coral", opacity: 0.5 });
 ```
 
 ## See Also

--- a/apps/docs/docs/js/api/marks/polygon.md
+++ b/apps/docs/docs/js/api/marks/polygon.md
@@ -27,7 +27,7 @@ gf.chart([{}])
 ## Signature
 
 ```ts
-polygon({ points, fill?, stroke?, strokeWidth? })
+polygon({ points, fill?, stroke?, strokeWidth?, opacity = 1 })
 ```
 
 ## Parameters
@@ -38,6 +38,7 @@ polygon({ points, fill?, stroke?, strokeWidth? })
 | `fill`        | `string`             | `"black"` | Fill color                                                                 |
 | `stroke`      | `string`             | `fill`    | Stroke color (defaults to `fill`)                                          |
 | `strokeWidth` | `number`             | `0`       | Stroke width                                                               |
+| `opacity`     | `number`             | `1`       | Opacity, `0`–`1` (applies to fill and stroke)                              |
 
 ## Coordinates
 

--- a/apps/docs/docs/js/api/marks/text.md
+++ b/apps/docs/docs/js/api/marks/text.md
@@ -17,7 +17,7 @@ gf.chart([{ label: "GoFish" }])
 
 ```ts
 text({ text, fill = "black", stroke?, strokeWidth = 0, fontSize = 12,
-       fontFamily = "system-ui, sans-serif", rotate = 0,
+       fontFamily = "system-ui, sans-serif", fontStyle?, fontWeight?, rotate = 0,
        debugBoundingBox = false, x?, y?, w?, h? })
 ```
 
@@ -31,6 +31,8 @@ text({ text, fill = "black", stroke?, strokeWidth = 0, fontSize = 12,
 | `strokeWidth`      | `number`           | Stroke width (default `0`)                                                   |
 | `fontSize`         | `number`           | Font size in pixels (default `12`)                                           |
 | `fontFamily`       | `string`           | Font family (default `"system-ui, sans-serif"`)                              |
+| `fontStyle`        | `string`           | CSS font style, e.g. `"italic"`                                              |
+| `fontWeight`       | `number \| string` | CSS font weight, e.g. `300`, `700`, `"bold"`                                 |
 | `rotate`           | `number`           | Rotation in degrees about the anchor; `90` reads bottom-to-top for a y-title |
 | `debugBoundingBox` | `boolean`          | Draw the text's bounding box (for layout debugging)                          |
 | `x`, `y`, `w`, `h` | `number \| string` | Explicit position / size accessors                                           |
@@ -61,4 +63,10 @@ layer([
 
 // Rotated y-axis title (reads bottom-to-top)
 .mark(text({ text: "count", rotate: 90, fontSize: 13 }))
+
+// Italic label
+.mark(text({ text: "note", fontStyle: "italic" }))
+
+// Light-weight label
+.mark(text({ text: "caption", fontWeight: 300 }))
 ```

--- a/apps/docs/docs/python/api/marks/ellipse.md
+++ b/apps/docs/docs/python/api/marks/ellipse.md
@@ -16,7 +16,7 @@ ellipse(w=24, h=30, fill="#e15759")
 
 ```python
 ellipse(w=None, h=None, fill=None, stroke=None, strokeWidth=None,
-        debug=None) -> Mark
+        opacity=None, debug=None) -> Mark
 ```
 
 ## Parameters
@@ -27,6 +27,7 @@ ellipse(w=None, h=None, fill=None, stroke=None, strokeWidth=None,
 | `fill`        | `str`          | Fill color — a constant or a field name     |
 | `stroke`      | `str`          | Stroke color                                |
 | `strokeWidth` | `int`          | Stroke width in pixels                      |
+| `opacity`     | `float`        | Opacity, `0`–`1` (default `1`)              |
 
 Returns a `Mark` for use in [`.mark()`](/python/api/core/mark).
 
@@ -38,6 +39,9 @@ chart(data).flow(scatter(x="x", y="y")).mark(ellipse(w="width", h="height"))
 
 # A circle is an ellipse with equal axes
 ellipse(w=20, h=20, fill="#4e79a7")
+
+# Translucent ellipse
+ellipse(w=80, h=40, fill="coral", opacity=0.5)
 ```
 
 ## Notes

--- a/apps/docs/docs/python/api/marks/polygon.md
+++ b/apps/docs/docs/python/api/marks/polygon.md
@@ -23,7 +23,8 @@ chart([{}]).mark(
 ## Signature
 
 ```python
-polygon(*, points=None, fill=None, stroke=None, strokeWidth=None, debug=None) -> Mark
+polygon(*, points=None, fill=None, stroke=None, strokeWidth=None, opacity=None,
+        debug=None) -> Mark
 ```
 
 Keyword-only (matches every existing call site, which already passes
@@ -37,6 +38,7 @@ Keyword-only (matches every existing call site, which already passes
 | `fill`        | `str`               | `"black"` | Fill color                                                                 |
 | `stroke`      | `str`               | `fill`    | Stroke color (defaults to `fill`)                                          |
 | `strokeWidth` | `int`               | `0`       | Stroke width                                                               |
+| `opacity`     | `float`             | `1`       | Opacity, `0`–`1` (applies to fill and stroke)                              |
 
 Returns a `Mark` for use in [`.mark()`](/python/api/core/mark). Call
 [`.name()`](/python/api/core/mark) on the result to make it referenceable via

--- a/apps/docs/docs/python/api/marks/text.md
+++ b/apps/docs/docs/python/api/marks/text.md
@@ -15,16 +15,15 @@ chart([{"label": "GoFish"}]).mark(
 
 ```python
 text(*, text=None, fill=None, stroke=None, strokeWidth=None, filter=None,
-     fontSize=None, fontFamily=None, debugBoundingBox=None, rotate=None,
+     fontSize=None, fontFamily=None, fontStyle=None, fontWeight=None,
+     debugBoundingBox=None, rotate=None,
      x=None, cx=None, x2=None, w=None, emX=None,
      y=None, cy=None, y2=None, h=None, emY=None,
      theta=None, thetaSize=None, r=None, rSize=None, key=None) -> Mark
 ```
 
 Keyword-only (matches every existing call site, which already passes
-`text=...` by keyword). Note: the previously-documented `fontWeight` kwarg
-never existed on the JS side and has been removed — it silently serialized
-and was dropped on the floor at render.
+`text=...` by keyword).
 
 ## Parameters
 
@@ -36,6 +35,8 @@ and was dropped on the floor at render.
 | `filter`                                                 | `str`          | Raw SVG filter attribute                                                      |
 | `fontSize`                                               | `int` \| `str` | Font size in pixels (default 12)                                              |
 | `fontFamily`                                             | `str`          | Font family (default `"system-ui, sans-serif"`)                               |
+| `fontStyle`                                              | `str`          | CSS font style, e.g. `"italic"`                                               |
+| `fontWeight`                                             | `int` \| `str` | CSS font weight, e.g. `300`, `700`, `"bold"`                                  |
 | `debugBoundingBox`                                       | `bool`         | Draw the text's bounding box (for layout debugging)                           |
 | `rotate`                                                 | `int`          | Rotation in degrees about the text anchor                                     |
 | `x`, `cx`, `x2`, `w`, `emX`, `y`, `cy`, `y2`, `h`, `emY` | `int` \| `str` | Box-geometry position channels (position the text anchor)                     |
@@ -76,4 +77,10 @@ layer([
 
 # Computed per-row label
 chart(bottles).mark(text(text=lambda d: f"{d['amount']}%", fontSize=35, fill="#666"))
+
+# Italic label
+text(text="note", fontStyle="italic")
+
+# Light-weight label
+text(text="caption", fontWeight=300)
 ```

--- a/packages/gofish-graphics/src/ast/displayList/paintSVG.tsx
+++ b/packages/gofish-graphics/src/ast/displayList/paintSVG.tsx
@@ -119,6 +119,10 @@ export function paintSVG(
             item.fontSize !== undefined ? `${item.fontSize}px` : undefined
           }
           font-family={item.fontFamily}
+          font-style={
+            item.fontStyle as JSX.TextSVGAttributes<SVGTextElement>["font-style"]
+          }
+          font-weight={item.fontWeight}
           text-anchor={
             item.textAnchor as JSX.TextSVGAttributes<SVGTextElement>["text-anchor"]
           }

--- a/packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/enclose.tsx
@@ -7,7 +7,7 @@ import {
   rectItemFromBox,
 } from "../displayList/lowerHelpers";
 import { GoFishAST } from "../_ast";
-import { black, gray, tailwindColors } from "../../color";
+import { gray } from "../../color";
 import { Domain } from "../domain";
 import { UNDEFINED, UnderlyingSpace } from "../underlyingSpace";
 import { createNodeOperator } from "../withGoFish";
@@ -18,7 +18,21 @@ export const enclose = createNodeOperator(
       padding = 2,
       rx = 2,
       ry = 2,
-    }: { padding?: number; rx?: number; ry?: number },
+      fill = "none",
+      stroke = gray,
+      strokeWidth = 1,
+      strokeDasharray,
+      opacity = 1,
+    }: {
+      padding?: number;
+      rx?: number;
+      ry?: number;
+      fill?: string;
+      stroke?: string;
+      strokeWidth?: number;
+      strokeDasharray?: string;
+      opacity?: number;
+    },
     children: GoFishAST[]
   ) => {
     return new GoFishNode(
@@ -61,8 +75,9 @@ export const enclose = createNodeOperator(
             transform: { translate: [undefined, undefined] },
           };
         },
-        // IR lowering — mirror of render: lower the children under the node's
-        // translate (the legacy `<g transform>`), then the enclosure rect on top.
+        // IR lowering — the enclosure rect paints FIRST (a true background
+        // behind the content), then the children under the node's translate
+        // (the legacy `<g transform>`) on top.
         lower: (
           { intrinsicDims, transform, coordinateTransform },
           _children,
@@ -90,10 +105,16 @@ export const enclose = createNodeOperator(
               rx,
               ry,
               role: "overlay",
-              style: lowerStyle({ fill: "none", stroke: gray, strokeWidth: 1 }),
+              style: lowerStyle({
+                fill,
+                stroke,
+                strokeWidth,
+                strokeDasharray,
+                opacity,
+              }),
             }
           );
-          return [...childItems, box];
+          return [box, ...childItems];
         },
       },
       children

--- a/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/ellipse.tsx
@@ -38,6 +38,7 @@ export const Ellipse = ({
   fill = color6_old[0],
   stroke = fill,
   strokeWidth = 0,
+  opacity = 1,
   aspectRatio,
   label,
   ...fancyDims
@@ -45,6 +46,7 @@ export const Ellipse = ({
   fill?: MaybeValue<string>;
   stroke?: MaybeValue<string>;
   strokeWidth?: number;
+  opacity?: number;
   /** w/h ratio to enforce. When both dims are data-driven, the constraining axis is used. */
   aspectRatio?: number;
   label?: boolean;
@@ -193,6 +195,7 @@ export const Ellipse = ({
           fill: resolvedFill,
           stroke: resolvedStroke,
           strokeWidth: strokeWidth ?? 0,
+          opacity,
         });
 
         // Build an EllipseItem from a display-space center; radii are unchanged
@@ -287,6 +290,7 @@ export const Ellipse = ({
                 fill: "none",
                 stroke: resolvedStroke,
                 strokeWidth: thickness + 0.5,
+                opacity,
               }),
             },
             ...valueLabel(labelX, labelY),
@@ -333,6 +337,7 @@ export const Ellipse = ({
               fill: resolvedFill,
               stroke: resolvedStroke,
               strokeWidth: strokeWidth ?? 0,
+              opacity,
             }),
           },
           ...valueLabel(labelX, labelY),

--- a/packages/gofish-graphics/src/ast/shapes/polygon.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/polygon.tsx
@@ -20,11 +20,13 @@ export const Polygon = ({
   fill = "black",
   stroke = fill,
   strokeWidth = 0,
+  opacity = 1,
   points,
 }: {
   fill?: string;
   stroke?: string;
   strokeWidth?: number;
+  opacity?: number;
   points: [number, number][];
 }) => {
   // Without an explicit guard, Math.min(...[]) → Infinity and
@@ -88,6 +90,7 @@ export const Polygon = ({
               fill,
               stroke: stroke ?? fill ?? "black",
               strokeWidth: strokeWidth ?? 0,
+              opacity,
             }),
           },
         ];

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -57,13 +57,17 @@ const getMeasureContext = (): CanvasRenderingContext2D | null => {
 const estimateTextDimensions = (
   text: string,
   fontSize: number,
-  fontFamily: string
+  fontFamily: string,
+  fontStyle?: string,
+  fontWeight?: number | string
 ): TextDimensions => {
   const ctx = getMeasureContext();
   if (ctx) {
-    // Measure using the same font-family that the <text> element will use.
-    // (We omit weight/style for now since this mark API doesn't expose them.)
-    ctx.font = `${fontSize}px ${fontFamily}`;
+    // Measure using the same font-family/style/weight that the <text> element
+    // will use (CSS shorthand order: style weight size family).
+    ctx.font = `${fontStyle ? `${fontStyle} ` : ""}${
+      fontWeight !== undefined ? `${fontWeight} ` : ""
+    }${fontSize}px ${fontFamily}`;
     const metrics = ctx.measureText(text);
     const width = metrics.width;
     // Prefer font-level metrics for stable line height across strings.
@@ -134,9 +138,17 @@ const resolveTextLayout = (
   fontSize: number,
   fontFamily: string,
   textAnchor: "start" | "middle" | "end",
-  dominantBaseline: "auto" | "central" | "hanging" | "mathematical"
+  dominantBaseline: "auto" | "central" | "hanging" | "mathematical",
+  fontStyle?: string,
+  fontWeight?: number | string
 ): TextLayout => {
-  const dims = estimateTextDimensions(text ?? "", fontSize, fontFamily);
+  const dims = estimateTextDimensions(
+    text ?? "",
+    fontSize,
+    fontFamily,
+    fontStyle,
+    fontWeight
+  );
   const bbox = {
     minX: 0,
     minY: dims.descent,
@@ -172,6 +184,8 @@ export const Text = ({
   filter,
   fontSize = 12,
   fontFamily = "system-ui, sans-serif",
+  fontStyle,
+  fontWeight,
   debugBoundingBox = false,
   rotate = 0,
   ...fancyDims
@@ -184,6 +198,8 @@ export const Text = ({
   filter?: string;
   fontSize?: number;
   fontFamily?: string;
+  fontStyle?: string;
+  fontWeight?: number | string;
   debugBoundingBox?: boolean;
   /** Rotation in degrees, applied in the chart's y-up world frame about the
    *  text anchor. `rotate: 90` yields a conventional y-axis title — it reads
@@ -209,6 +225,8 @@ export const Text = ({
         filter,
         fontSize,
         fontFamily,
+        fontStyle,
+        fontWeight,
         textAnchor,
         debugBoundingBox,
         rotate,
@@ -258,7 +276,9 @@ export const Text = ({
           fontSize,
           fontFamily,
           textAnchor,
-          dominantBaseline
+          dominantBaseline,
+          fontStyle,
+          fontWeight
         );
 
         // Anchor-relative bbox. When the text is rotated, its layout footprint
@@ -358,7 +378,9 @@ export const Text = ({
               fontSize,
               fontFamily,
               textAnchor,
-              dominantBaseline
+              dominantBaseline,
+              fontStyle,
+              fontWeight
             );
           const relRaw = {
             minX: layout.bbox.minX - layout.anchor.x,
@@ -396,6 +418,8 @@ export const Text = ({
           text,
           fontSize,
           fontFamily,
+          fontStyle,
+          fontWeight,
           textAnchor: textAnchor as DisplayList.TextItem["textAnchor"],
           dominantBaseline:
             dominantBaseline as DisplayList.TextItem["dominantBaseline"],

--- a/packages/gofish-graphics/stories/bluefish/InsertionSort.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/InsertionSort.stories.tsx
@@ -1,0 +1,233 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import {
+  arrow,
+  Constraint,
+  createMark,
+  createName,
+  ellipse,
+  enclose,
+  Layer,
+  rect,
+  ref,
+  spreadX,
+  spreadY,
+  text,
+} from "../../src/lib";
+
+// Ported from Bluefish's example-gallery insertion-sort.tsx (#435). Bluefish's
+// `<Group>` (a plain overlay, like GoFish's `Layer`) contains a `StackV` of
+// stages; each stage is a `Group` with an `ArrayOutline` (solid-border row of
+// cells), a `DashedBorder` around the sorted prefix, and a conditional
+// `Arrow` from the moving cell's old slot to its insertion point. Stage
+// labels sit to the left of each row, referencing the row by its `createName`
+// token — mirrored here with GoFish's cross-tier `Layer` + `ref` pattern (see
+// Pulley.stories.tsx).
+
+const meta: Meta = {
+  title: "Bluefish/Insertion Sort",
+};
+export default meta;
+
+// so that colors in this diagram match the colors of the original Bluefish
+// gallery example
+const stageColor = (t: number) => {
+  const T = 0.1 + 0.8 * (1 - t);
+  const s = Math.max(0, Math.min(1, T));
+  const r = Math.max(0.05, Math.min(1, 3 * T - 2));
+  const g = 3 * s * s - 2 * s * s * s;
+  const b = 1 - Math.sqrt(1 - Math.max(0, Math.min(1, 3 * T)));
+  return `rgba(${r * 255}, ${g * 255}, ${b * 255}, 0.75)`;
+};
+
+function findPosToInsert(sorted: number[], item: number): number {
+  const i = sorted.findIndex((v) => v >= item);
+  return i === -1 ? sorted.length : i;
+}
+function insertAtPos<T>(array: T[], pos: number, item: T): T[] {
+  const result = [...array];
+  result.splice(pos, 0, item);
+  return result;
+}
+
+type Move = { ar: number[]; move: [number, number] };
+
+// Insertion sort implemented as a generator: at each stage it yields the
+// array as currently laid out and the [from, to] move the algorithm is about
+// to perform (from === to signals the terminal, fully-sorted stage).
+function* insertionSort(
+  unsorted: number[],
+  sorted: number[] = []
+): Generator<Move> {
+  if (unsorted.length === 0) {
+    yield { ar: sorted, move: [sorted.length, sorted.length] };
+    return;
+  }
+  const entryToSort = unsorted[0];
+  const posToInsert = findPosToInsert(sorted, entryToSort);
+  if (sorted.length > 0) {
+    yield { ar: [...sorted, ...unsorted], move: [sorted.length, posToInsert] };
+  }
+  const newSorted = insertAtPos(sorted, posToInsert, entryToSort);
+  yield* insertionSort(unsorted.slice(1), newSorted);
+}
+
+const stageLabel = (stage: number, length: number) => {
+  if (stage === 0) return "Unsorted";
+  if (stage === length - 1) return "Sorted";
+  return `Stage ${stage}`;
+};
+
+// A single array-entry cell: a rounded, colored square background, a
+// translucent white circle, and the value centered on top.
+const CELL_SIZE = 34;
+const CELL_SPACING = 3;
+// Sorted-prefix (teal) border padding — matches Bluefish's DashedBorder
+// padding={4}. Kept smaller than the row outline's `enclose` padding (8) so
+// the teal stroke (outer edge at padding + strokeWidth/2 = 5.5px) stays
+// clear of the outer light-gray outline instead of crossing it.
+const BORDER_PADDING = 4;
+const OUTLINE_PADDING = 8;
+
+const ArrayEntry = createMark(
+  ({
+    value,
+    color,
+    highlight,
+  }: {
+    value: number;
+    color: string;
+    highlight: boolean;
+  }) =>
+    Layer([
+      rect({ w: CELL_SIZE, h: CELL_SIZE, fill: color, rx: 8, ry: 8 }).name(
+        "body"
+      ),
+      ellipse({ w: 26, h: 26, fill: "rgba(255,255,255,0.6)" }).name("circle"),
+      text({
+        text: String(value),
+        fontFamily: "serif",
+        fontSize: 14,
+        fill: highlight ? "orangered" : "black",
+      }).name("label"),
+    ]).constrain(({ body, circle, label }) => [
+      Constraint.align({ x: "middle", y: "middle" }, [body, circle, label]),
+    ])
+);
+
+export const InsertionSort: StoryObj = {
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Insertion Sort",
+      description:
+        "An insertion sort trace rendered as a stack of array stages, each with a dashed border around its sorted prefix and an arrow showing the element being moved into place.",
+    },
+  },
+  render: () => {
+    const container = initializeContainer();
+
+    const unsortedArray = [4, 2, 7, 1, 3];
+    const stages = [...insertionSort(unsortedArray)];
+
+    // Per-cell name tokens, keyed by [stage][index] — a fresh token per cell
+    // per stage, since the same value can appear in many stages/positions.
+    const entryNames = stages.map((stage, s) =>
+      stage.ar.map((_, i) => createName(`entry-${s}-${i}`))
+    );
+    const rowNames = stages.map((_, s) => createName(`row-${s}`));
+
+    const rows = stages.map(({ ar, move: [from, to] }, stage) => {
+      const cells = ar.map((value, i) =>
+        ArrayEntry({
+          value,
+          color: stageColor(stage / (stages.length - 1 || 1)),
+          highlight: i === stage + 1,
+        }).name(entryNames[stage][i])
+      );
+
+      // Tier 1: the solid-bordered row of cells — a finished, fully-placed
+      // unit (enclose wraps a real stack of fresh children here, not refs).
+      // Tier 2: the dashed sorted-prefix border and the move arrow, both
+      // declared after the row so their ref()s resolve against placed cells.
+      // NB: `spreadX`, not `stackX` — `stack` is spacing-less by design
+      // (StackOptions omits `spacing`; the option is silently dropped and
+      // children touch), so the inter-cell gap needs spread.
+      return Layer([
+        enclose(
+          { padding: OUTLINE_PADDING, rx: 8, ry: 8 },
+          [spreadX({ spacing: CELL_SPACING, alignment: "middle" }, cells)]
+        ).name(rowNames[stage]),
+        // Sorted-prefix border: tried `enclose({padding}, [ref(first),
+        // ref(last)])` first (the direct port of Bluefish's `<DashedBorder>
+        // <Ref .../><Ref .../></DashedBorder>`, which unions just the first
+        // and last cell's boxes). It renders, but always at a fixed
+        // ~cell-sized box regardless of `from` — enclose's layout body calls
+        // `child.layout(...)` and then unconditionally
+        // `place("x"/"y", 0, "baseline")` on every child (see enclose.tsx),
+        // collapsing every ref to the same local origin before measuring, so
+        // the two refs' *relative* offset (which is exactly what should
+        // determine the box's width) is discarded — enclose was written to
+        // lay out fresh children at a shared origin, not to wrap a already-
+        // placed range. See the friction log for the capability that would
+        // fix this (a size-only/no-reposition enclose mode).
+        //
+        // Workaround: the row's own geometry (ArrayOutline padding, cell
+        // size, inter-cell spacing) is fully known at authoring time, so the
+        // sorted-prefix box is placed directly via `rect`'s own `x`/`y`
+        // (local-origin coordinates, relative to the row's first cell,
+        // which — like ArrayOutline's padding above — sits at the row's
+        // local (0, 0)) instead of going through enclose/refs at all.
+        ...(from > 0
+          ? [
+              rect({
+                x: -BORDER_PADDING,
+                y: -BORDER_PADDING,
+                w:
+                  from * CELL_SIZE +
+                  (from - 1) * CELL_SPACING +
+                  2 * BORDER_PADDING,
+                h: CELL_SIZE + 2 * BORDER_PADDING,
+                fill: "none",
+                stroke: "teal",
+                strokeWidth: 3,
+                rx: 12,
+                ry: 12,
+              }),
+            ]
+          : []),
+        ...(from !== to
+          ? [
+              arrow({ padStart: 0, padEnd: 4, straights: false, flip: true }, [
+                ref(entryNames[stage][from]),
+                ref(entryNames[stage][to]),
+              ]),
+            ]
+          : []),
+      ]);
+    });
+
+    // Outer diagram: stages spread vertically (left edges aligned so cells
+    // line up in columns), with a label to the left of each row (cross-tier
+    // ref into the spread, à la Planets' label pattern). The x/y offset
+    // shifts the whole diagram right/down so the leftward-placed labels
+    // don't land at negative coordinates (the root render does not auto-fit
+    // — same trick as Pulley).
+    Layer({ x: 90, y: 20 }, [
+      spreadY({ spacing: 15, alignment: "start" }, rows),
+      ...stages.map((_, stage) =>
+        spreadX({ spacing: 20, alignment: "middle" }, [
+          text({
+            text: stageLabel(stage, stages.length),
+            fontFamily: "serif",
+            fontStyle: "italic",
+            fill: "gray",
+          }),
+          ref(rowNames[stage]),
+        ])
+      ),
+    ]).render(container, {});
+
+    return container;
+  },
+};

--- a/packages/gofish-graphics/stories/bluefish/InsertionSort.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/InsertionSort.stories.tsx
@@ -82,13 +82,20 @@ const stageLabel = (stage: number, length: number) => {
 // translucent white circle, and the value centered on top.
 const CELL_SIZE = 34;
 const CELL_SPACING = 3;
-// Sorted-prefix (teal) border padding — matches Bluefish's DashedBorder
-// padding={4} (upstream example-gallery/insertion-sort.tsx). The teal
-// stroke's outer edge (padding + strokeWidth/2 = 6px) stays clear of the
-// outer black outline, which sits at OUTLINE_PADDING = 10 — upstream
-// ArrayOutline uses Background's default padding of 10 (background.tsx).
+// Sorted-prefix (teal) border padding at a mid-row prefix boundary —
+// matches Bluefish's DashedBorder padding={4} (upstream
+// example-gallery/insertion-sort.tsx), which puts the vertical dash column
+// in the gap just past the last sorted cell.
 const BORDER_PADDING = 4;
+// Row outline padding — upstream ArrayOutline uses Background's default
+// padding of 10 (background.tsx).
 const OUTLINE_PADDING = 10;
+// In the original (Penrose-derived) rendering the teal dashes sit OUTSIDE
+// the black row outline on the top, bottom, and closed ends — the dash
+// band's inner edge is tangent to the outline's outer edge. Outline outer
+// edge = OUTLINE_PADDING + strokeWidth/2 = 11; dash band half-width = 2
+// (strokeWidth 4), so the dash box's edge sits at 13.
+const DASH_OVERHANG = OUTLINE_PADDING + 1 + 2;
 
 const ArrayEntry = createMark(
   ({
@@ -196,10 +203,17 @@ export const InsertionSort: StoryObj = {
         ...(from > 0
           ? [
               // Upstream DashedBorder: <Rect fill="none" stroke="teal"
-              // stroke-width={4} rx={12} stroke-dasharray="12" />.
+              // stroke-width={4} rx={12} stroke-dasharray="12" />. The box
+              // overhangs the black outline (DASH_OVERHANG) on the top,
+              // bottom, and left, and — when the prefix spans the whole row
+              // (the terminal Sorted stage) — on the right too. At a mid-row
+              // prefix boundary the right edge instead dips inside to hug the
+              // last sorted cell at BORDER_PADDING, like the original; since
+              // enclose has a single scalar padding, that asymmetry is folded
+              // into the invisible sizer's width.
               enclose(
                 {
-                  padding: BORDER_PADDING,
+                  padding: DASH_OVERHANG,
                   rx: 12,
                   ry: 12,
                   fill: "none",
@@ -209,7 +223,10 @@ export const InsertionSort: StoryObj = {
                 },
                 [
                   rect({
-                    w: from * CELL_SIZE + (from - 1) * CELL_SPACING,
+                    w:
+                      from * CELL_SIZE +
+                      (from - 1) * CELL_SPACING +
+                      (from === ar.length ? 0 : BORDER_PADDING - DASH_OVERHANG),
                     h: CELL_SIZE,
                     fill: "none",
                     stroke: "none",

--- a/packages/gofish-graphics/stories/bluefish/InsertionSort.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/InsertionSort.stories.tsx
@@ -83,11 +83,12 @@ const stageLabel = (stage: number, length: number) => {
 const CELL_SIZE = 34;
 const CELL_SPACING = 3;
 // Sorted-prefix (teal) border padding — matches Bluefish's DashedBorder
-// padding={4}. Kept smaller than the row outline's `enclose` padding (8) so
-// the teal stroke (outer edge at padding + strokeWidth/2 = 5.5px) stays
-// clear of the outer light-gray outline instead of crossing it.
+// padding={4} (upstream example-gallery/insertion-sort.tsx). The teal
+// stroke's outer edge (padding + strokeWidth/2 = 6px) stays clear of the
+// outer black outline, which sits at OUTLINE_PADDING = 10 — upstream
+// ArrayOutline uses Background's default padding of 10 (background.tsx).
 const BORDER_PADDING = 4;
-const OUTLINE_PADDING = 8;
+const OUTLINE_PADDING = 10;
 
 const ArrayEntry = createMark(
   ({
@@ -154,8 +155,17 @@ export const InsertionSort: StoryObj = {
       // (StackOptions omits `spacing`; the option is silently dropped and
       // children touch), so the inter-cell gap needs spread.
       return Layer([
+        // Row outline — upstream ArrayOutline: <Rect fill="none"
+        // stroke="black" stroke-width={2} rx={8} />.
         enclose(
-          { padding: OUTLINE_PADDING, rx: 8, ry: 8 },
+          {
+            padding: OUTLINE_PADDING,
+            rx: 8,
+            ry: 8,
+            fill: "none",
+            stroke: "black",
+            strokeWidth: 2,
+          },
           [spreadX({ spacing: CELL_SPACING, alignment: "middle" }, cells)]
         ).name(rowNames[stage]),
         // Sorted-prefix border: tried `enclose({padding}, [ref(first),
@@ -174,26 +184,38 @@ export const InsertionSort: StoryObj = {
         //
         // Workaround: the row's own geometry (ArrayOutline padding, cell
         // size, inter-cell spacing) is fully known at authoring time, so the
-        // sorted-prefix box is placed directly via `rect`'s own `x`/`y`
-        // (local-origin coordinates, relative to the row's first cell,
-        // which — like ArrayOutline's padding above — sits at the row's
-        // local (0, 0)) instead of going through enclose/refs at all.
+        // sorted-prefix box's *content* size is computed directly and handed
+        // to `enclose` as an invisible sizer child (enclose collapses every
+        // child to local (0, 0) anyway — see above — so the sizer only needs
+        // the right w/h, not x/y). `enclose`'s own `padding` then reproduces
+        // the same box the old manual `rect` computed, but now picks up
+        // `enclose`'s styling props — in particular `strokeDasharray`, which
+        // `rect` doesn't have — to match Bluefish's dashed sorted-prefix
+        // border (`rect` is still library-only for solid strokes; adding
+        // dash support there is out of scope for this story-only port).
         ...(from > 0
           ? [
-              rect({
-                x: -BORDER_PADDING,
-                y: -BORDER_PADDING,
-                w:
-                  from * CELL_SIZE +
-                  (from - 1) * CELL_SPACING +
-                  2 * BORDER_PADDING,
-                h: CELL_SIZE + 2 * BORDER_PADDING,
-                fill: "none",
-                stroke: "teal",
-                strokeWidth: 3,
-                rx: 12,
-                ry: 12,
-              }),
+              // Upstream DashedBorder: <Rect fill="none" stroke="teal"
+              // stroke-width={4} rx={12} stroke-dasharray="12" />.
+              enclose(
+                {
+                  padding: BORDER_PADDING,
+                  rx: 12,
+                  ry: 12,
+                  fill: "none",
+                  stroke: "teal",
+                  strokeWidth: 4,
+                  strokeDasharray: "12",
+                },
+                [
+                  rect({
+                    w: from * CELL_SIZE + (from - 1) * CELL_SPACING,
+                    h: CELL_SIZE,
+                    fill: "none",
+                    stroke: "none",
+                  }),
+                ]
+              ),
             ]
           : []),
         ...(from !== to
@@ -217,10 +239,15 @@ export const InsertionSort: StoryObj = {
       spreadY({ spacing: 15, alignment: "start" }, rows),
       ...stages.map((_, stage) =>
         spreadX({ spacing: 20, alignment: "middle" }, [
+          // Upstream LabelText: <Text font-family="serif"
+          // font-style="italic" font-weight={300} fill="gray"> at Bluefish
+          // Text's default font-size of 14.
           text({
             text: stageLabel(stage, stages.length),
             fontFamily: "serif",
             fontStyle: "italic",
+            fontWeight: 300,
+            fontSize: 14,
             fill: "gray",
           }),
           ref(rowNames[stage]),

--- a/packages/gofish-graphics/stories/bluefish/QuantumCircuit.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/QuantumCircuit.stories.tsx
@@ -158,11 +158,20 @@ export const QuantumCircuit: StoryObj<Args> = {
     // it lays out itself, but a ref's already-resolved absolute position
     // does not carry over when re-wrapped by enclose from outside its
     // subtree (confirmed by trying it: the enclosure rendered at the tree's
-    // local origin, nowhere near the ref'd content). `enclose`'s fill/stroke
-    // also aren't parameterized, so this renders as a neutral outline rather
-    // than Bluefish's yellow fill.
-    const highlightedOPlus = enclose({ padding: 8 }, [OPlus({})]);
-    const highlightedDescription = enclose({ padding: 4 }, [
+    // local origin, nowhere near the ref'd content). `enclose` takes
+    // fill/stroke/etc. and paints its rect BEHIND its children, so this
+    // matches Bluefish's `<Background background={() => <Rect
+    // fill="rgba(255,200,0,0.333)" rx="10" />}>` exactly — same translucent
+    // yellow, same corner rounding, and Background's default padding of 10.
+    const highlight = {
+      padding: 10,
+      rx: 10,
+      ry: 10,
+      fill: "rgba(255,200,0,0.333)",
+      stroke: "none",
+    } as const;
+    const highlightedOPlus = enclose({ ...highlight }, [OPlus({})]);
+    const highlightedDescription = enclose({ ...highlight }, [
       text({ text: "This is a controlled-NOT." }),
     ]);
 
@@ -199,8 +208,13 @@ export const QuantumCircuit: StoryObj<Args> = {
       ]),
 
       // ── tier 2: control-to-gate connector lines — read the placed refs ──
-      line({ stroke: "black", strokeWidth: 1 }, [ref(c1), ref(z)]),
-      line({ stroke: "black", strokeWidth: 1 }, [ref(c2), ref(oplus)]),
+      // Same stroke as the horizontal wire rails (black, 3px). zOrder(-1)
+      // paints them behind tier 1, so the gate boxes (e.g. the Z box) occlude
+      // the portion of the line that would otherwise run across their face.
+      line({ stroke: "black", strokeWidth: 3 }, [ref(c1), ref(z)]).zOrder(-1),
+      line({ stroke: "black", strokeWidth: 3 }, [ref(c2), ref(oplus)]).zOrder(
+        -1
+      ),
     ]).render(container, { w: args.w, h: args.h });
 
     return container;

--- a/packages/gofish-graphics/stories/bluefish/QuantumCircuit.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/QuantumCircuit.stories.tsx
@@ -1,0 +1,208 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import {
+  Layer,
+  Constraint,
+  line,
+  createMark,
+  createName,
+  rect,
+  circle,
+  text,
+  ref,
+  spread,
+  enclose,
+} from "../../src/lib";
+
+// Ported from Bluefish's example-gallery qc-text.tsx. A quantum-circuit
+// equivalence diagram: a controlled-Z gate (left) is shown equivalent (≡) to
+// an H-CNOT-H sequence (right), with control dots connected by vertical
+// lines to the gates they control, and two yellow-highlighted callouts (the
+// CNOT's ⊕ symbol and a description label).
+//
+// Structured like Pulley.stories.tsx: an inner Layer that fully places the
+// two wire-groups + "≡" + description (tier 1, including the two highlight
+// enclosures, built inline around their own content — see the friction log
+// on why "wrap a ref elsewhere" didn't work), then the vertical
+// control-to-gate connector lines read those placed refs (tier 2).
+
+const meta: Meta = {
+  title: "Bluefish/Quantum Circuit Equivalence",
+};
+export default meta;
+
+type Args = { w: number; h: number };
+
+const SLOT = 60; // pitch between gate slots on a wire — matches Bluefish's
+// `depth * 60` sizing (a hardcoded literal there too; see friction log).
+const GATE = 50; // gate box / wire-symbol side length
+
+// A single gate/dot centered in a fixed 50x50 slot, so that dots and boxes
+// of different intrinsic sizes still land on the same column across two
+// independently-built wires (mirrors Bluefish's <WireSymbol>).
+const WireSlot = createMark(({ content }: { content: any }) =>
+  Layer([
+    rect({ w: GATE, h: GATE, fill: "transparent" }).name("slot"),
+    content.name("content"),
+  ]).constrain(({ slot, content }) => [
+    Constraint.align({ x: "middle", y: "middle" }, [slot, content]),
+  ])
+);
+
+// An empty 50x50 slot — a placeholder gap on a wire (Bluefish's <EmptySpot>).
+// Plain function, not createMark: createMark's shapeFn must return an
+// already-resolved GoFishNode, but a bare rect()/circle() call is itself a
+// still-deferred Mark (see ControlDot below and the friction log) — wrapping
+// one directly in createMark crashes at render time ("node.scope is not a
+// function"). A plain function that just returns the mark call sidesteps it.
+const EmptySlot = () => rect({ w: GATE, h: GATE, fill: "transparent" });
+
+// A labeled square gate (Bluefish's <BoxedSymbol>).
+const BoxedSymbol = createMark(({ label }: { label: string }) =>
+  Layer([
+    rect({
+      w: GATE,
+      h: GATE,
+      fill: "white",
+      stroke: "black",
+      strokeWidth: 3,
+    }).name("box"),
+    text({
+      text: label,
+      fontSize: 30,
+      fontFamily: "italic serif",
+      fill: "black",
+    }).name("label"),
+  ]).constrain(({ box, label }) => [
+    Constraint.align({ x: "middle", y: "middle" }, [box, label]),
+  ])
+);
+
+// The ⊕ (circled-plus) CNOT target symbol (Bluefish's <OPlus>).
+const OPlus = createMark(() =>
+  Layer([
+    circle({ r: 15, fill: "transparent", stroke: "black", strokeWidth: 3 }).name(
+      "ring"
+    ),
+    rect({ w: 30, h: 3, fill: "black" }).name("hbar"),
+    rect({ w: 3, h: 30, fill: "black" }).name("vbar"),
+  ]).constrain(({ ring, hbar, vbar }) => [
+    Constraint.align({ x: "middle", y: "middle" }, [ring, hbar, vbar]),
+  ])
+);
+
+// A filled control dot (Bluefish's <ControlDot>). Plain function — see
+// EmptySlot's comment above.
+const ControlDot = () => circle({ r: 5, fill: "black" });
+
+// A horizontal wire: a full-span black rail with the gates spread evenly
+// along it and vertically centered on it (the rail paints first, so the
+// gates sit on top of it). `span` is the number of slot COLUMNS the rail
+// covers, independent of how many slots this wire actually carries — the
+// analogue of Bluefish's `depth` prop: both wires of a circuit get the
+// circuit's max slot count so they read as two parallel rails of identical
+// extent (Bluefish's right circuit passes depth={3} to the 2-symbol control
+// wire too). Rail width = span*SLOT + 30, matching Bluefish's
+// `depth * 60 + 30`: a 10px stub before the first gate, ~30px after the
+// last full column.
+//
+// The 10px leader is a zero-width transparent rect PREPENDED to the gates
+// spread — the spread's 10px spacing after it becomes the leader (Bluefish
+// does the same with a 10px transparent Rect in its StackH). Tried first: a
+// `Constraint.distribute({dir:"x", spacing:10, mode:"edge"})` between `line`
+// and `gates`. `distribute` SEQUENCES its participants — edge mode places
+// the next one after the previous one's far edge, like a flow layout — it
+// does not overlap them with an offset, so `gates` landed after the rail's
+// right edge instead of 10px past its left edge (and wires with different
+// slot counts shifted by different amounts, bending the vertical connector
+// lines). A plain `align x:"start"` + in-flow leader rect expresses it.
+const Wire = createMark(({ slots, span }: { slots: any[]; span?: number }) =>
+  Layer([
+    rect({
+      w: (span ?? slots.length) * SLOT + 30,
+      h: 3,
+      fill: "black",
+    }).name("line"),
+    spread({ dir: "x", spacing: SLOT - GATE, alignment: "middle" }, [
+      rect({ w: 0, h: GATE, fill: "transparent" }),
+      ...slots,
+    ]).name("gates"),
+  ]).constrain(({ line, gates }) => [
+    Constraint.align({ x: "start", y: "middle" }, [line, gates]),
+  ])
+);
+
+export const QuantumCircuit: StoryObj<Args> = {
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Quantum Circuit Equivalence",
+      description:
+        "A quantum-circuit diagram showing a controlled-Z gate is equivalent to an H-CNOT-H sequence, with control dots wired to their gates and the CNOT called out in a highlighted box.",
+    },
+  },
+  render: (args: Args) => {
+    const container = initializeContainer();
+
+    // Cross-tier names: the connector lines (tier 2) reference marks placed
+    // deep inside the wire-group layers (tier 1).
+    const c1 = createName("c1");
+    const z = createName("z");
+    const c2 = createName("c2");
+    const oplus = createName("oplus");
+
+    // The two highlight callouts (Bluefish's yellow <Background> boxes) are
+    // built with `enclose` wrapping its OWNED content at the point that
+    // content is constructed, not wrapping a `ref()` to something placed
+    // elsewhere — see the friction log: `enclose` bbox-fits around children
+    // it lays out itself, but a ref's already-resolved absolute position
+    // does not carry over when re-wrapped by enclose from outside its
+    // subtree (confirmed by trying it: the enclosure rendered at the tree's
+    // local origin, nowhere near the ref'd content). `enclose`'s fill/stroke
+    // also aren't parameterized, so this renders as a neutral outline rather
+    // than Bluefish's yellow fill.
+    const highlightedOPlus = enclose({ padding: 8 }, [OPlus({})]);
+    const highlightedDescription = enclose({ padding: 4 }, [
+      text({ text: "This is a controlled-NOT." }),
+    ]);
+
+    Layer({ x: 20, y: 20 }, [
+      // ── tier 1: the two wire-groups + "≡" + description — fully placed ──
+      spread({ dir: "x", spacing: 25, alignment: "middle" }, [
+        // Left circuit: controlled-Z.
+        spread({ dir: "y", spacing: 30, alignment: "start" }, [
+          Wire({ slots: [WireSlot({ content: ControlDot() }).name(c1)] }),
+          Wire({ slots: [BoxedSymbol({ label: "Z" }).name(z)] }),
+        ]),
+        text({ text: "≡", fontSize: 40, fontWeight: 300 }),
+        // Right circuit: H-CNOT-H. Both wires span 3 columns (Bluefish
+        // passes depth={3} to both), so the two rails have equal extent
+        // even though the control wire only carries 2 slots.
+        spread({ dir: "y", spacing: 30, alignment: "start" }, [
+          Wire({
+            span: 3,
+            slots: [
+              EmptySlot(),
+              WireSlot({ content: ControlDot() }).name(c2),
+            ],
+          }),
+          Wire({
+            span: 3,
+            slots: [
+              BoxedSymbol({ label: "H" }),
+              WireSlot({ content: highlightedOPlus }).name(oplus),
+              BoxedSymbol({ label: "H" }),
+            ],
+          }),
+        ]),
+        highlightedDescription,
+      ]),
+
+      // ── tier 2: control-to-gate connector lines — read the placed refs ──
+      line({ stroke: "black", strokeWidth: 1 }, [ref(c1), ref(z)]),
+      line({ stroke: "black", strokeWidth: 1 }, [ref(c2), ref(oplus)]),
+    ]).render(container, { w: args.w, h: args.h });
+
+    return container;
+  },
+};

--- a/packages/gofish-graphics/stories/bluefish/QuantumCircuit.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/QuantumCircuit.stories.tsx
@@ -67,10 +67,14 @@ const BoxedSymbol = createMark(({ label }: { label: string }) =>
       stroke: "black",
       strokeWidth: 3,
     }).name("box"),
+    // Upstream is `font-family="serif" font-style="italic"`. ("italic serif"
+    // as a single font-family string is invalid CSS — the browser silently
+    // falls back to the default font, upright.)
     text({
       text: label,
       fontSize: 30,
-      fontFamily: "italic serif",
+      fontFamily: "serif",
+      fontStyle: "italic",
       fill: "black",
     }).name("label"),
   ]).constrain(({ box, label }) => [
@@ -103,12 +107,16 @@ const ControlDot = () => circle({ r: 5, fill: "black" });
 // circuit's max slot count so they read as two parallel rails of identical
 // extent (Bluefish's right circuit passes depth={3} to the 2-symbol control
 // wire too). Rail width = span*SLOT + 30, matching Bluefish's
-// `depth * 60 + 30`: a 10px stub before the first gate, ~30px after the
-// last full column.
+// `depth * 60 + 30`.
 //
-// The 10px leader is a zero-width transparent rect PREPENDED to the gates
-// spread — the spread's 10px spacing after it becomes the leader (Bluefish
-// does the same with a 10px transparent Rect in its StackH). Tried first: a
+// The leader is a 10px transparent rect PREPENDED to the gates spread,
+// exactly as in Bluefish's StackH — and Bluefish's Stack ALSO defaults
+// spacing to 10, so the first gate starts 10 (rect) + 10 (gap) = 20px in.
+// With rail = 60n + 30 and gates ending at 60n + 10, that leaves 20px of
+// rail on BOTH sides: every gate row is horizontally centered on its rail.
+// (An earlier version of this port used a zero-width leader on the theory
+// that the spread's spacing replaced Bluefish's rect; that lost 10px on the
+// left and produced lopsided 10/30 stubs.) Tried first: a
 // `Constraint.distribute({dir:"x", spacing:10, mode:"edge"})` between `line`
 // and `gates`. `distribute` SEQUENCES its participants — edge mode places
 // the next one after the previous one's far edge, like a flow layout — it
@@ -124,7 +132,7 @@ const Wire = createMark(({ slots, span }: { slots: any[]; span?: number }) =>
       fill: "black",
     }).name("line"),
     spread({ dir: "x", spacing: SLOT - GATE, alignment: "middle" }, [
-      rect({ w: 0, h: GATE, fill: "transparent" }),
+      rect({ w: 10, h: GATE, fill: "transparent" }),
       ...slots,
     ]).name("gates"),
   ]).constrain(({ line, gates }) => [
@@ -171,6 +179,11 @@ export const QuantumCircuit: StoryObj<Args> = {
       stroke: "none",
     } as const;
     const highlightedOPlus = enclose({ ...highlight }, [OPlus({})]);
+    // Known 2-3px optical offset: the text ink sits slightly high in this
+    // pill. enclose centers geometry children exactly (see the ⊕ pill), but
+    // a text child's baseline-anchored bbox lands ~2.5px above the pill
+    // center — an enclose+text interaction in the library, not fixable from
+    // the story.
     const highlightedDescription = enclose({ ...highlight }, [
       text({ text: "This is a controlled-NOT." }),
     ]);

--- a/packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/html";
 import { initializeContainer } from "../helper";
 import {
   layer,
-  spread,
   ellipse,
   text,
   position,
@@ -68,11 +67,12 @@ const isAandCNeighbourhood = (n: Neighbourhood) =>
 // between them but is NOT a member of the neighbourhood. GoFish has no
 // concave-enclosure primitive, but it does have `polygon` (explicit
 // local-coordinate point list) — so this samples the original path's cubic
-// Bézier segments into a dense point list and affinely remaps it into this
-// story's own point-spacing/point-size coordinate system, anchored on the
-// two points ("a" and "c") the shape must actually enclose. That keeps the
-// shape faithful to the original hand-drawn artwork instead of
-// re-approximating it with a bbox-based primitive.
+// Bézier segments into a dense point list and remaps it (piecewise-
+// linearly; see AC_X_WARP/AC_Y_WARP) into this story's own
+// point-spacing/point-size coordinate system, anchored on the two points
+// ("a" and "c") the shape must actually enclose. That keeps the shape
+// faithful to the original hand-drawn artwork instead of re-approximating
+// it with a bbox-based primitive.
 const AC_PATH_SEGMENTS: [number, number][][] = [
   // Each entry: [P0, C1, C2, P1] control points of one cubic Bézier segment,
   // transcribed directly from the original path's "d" attribute
@@ -175,16 +175,41 @@ const AC_PATH_SEGMENTS: [number, number][][] = [
   ],
 ];
 
-// Anchor points in the original path's own coordinate space: the centers of
-// the "a" and "c" lobes, derived from the symmetry of the path data (the
-// path is mirror-symmetric about x = 53) and cross-checked against the
-// upstream Path component's hand-tuned x:-7, y:-10 placement offset, which
-// lands the lobes on the actual "a"/"c" point centers.
-const AC_PATH_ANCHOR_A: [number, number] = [14, 17];
-const AC_PATH_ANCHOR_C: [number, number] = [94, 17];
-// Original point spacing (StackH spacing=30 + point diameter 10 = 40
-// center-to-center), so a-to-c center distance is 80 in path-space.
-const AC_ORIGINAL_A_TO_C = 80;
+// Remap from the path's own coordinate space into this story's point
+// layout, as two independent piecewise-linear warps (x and y). A single
+// affine map can't work here: the "a"/"c" lobe anchors must land exactly on
+// this story's dot centers (fixing the x scale between them), while the
+// concave dip's opening must clear this story's label-containing b-pill
+// (which is wider, relative to the dot spacing, than the original's tiny
+// r=5 dot circle) and the dip band must clear both the two-point pills
+// above it and the outer ellipse below it. The knots are hand-tuned against
+// rendered captures. Path-space landmarks (from the segment data above):
+// lobe anchors x=14/94 at y=17 (mirror-symmetric about x=53, cross-checked
+// against upstream's hand-tuned x:-7, y:-10 placement); dip walls at
+// x=41.5/64.5; band from y=42.07 (top) to y=48 (bottom); lobe tops at y=2.
+const AC_X_WARP: [number, number][] = [
+  [2, -66], // outer edge of the "a" lobe
+  [14, -50], // "a" lobe anchor -> dot a
+  [41.5, -30], // left dip wall (widened to clear the b-pill)
+  [64.5, 30], // right dip wall
+  [94, 50], // "c" lobe anchor -> dot c
+  [104, 66], // outer edge of the "c" lobe
+];
+const AC_Y_WARP: [number, number][] = [
+  [17, 0], // lobe anchor height -> dot centerline
+  [42.07, 43.5], // band top: below the two-point pills' deepest edge
+  [48, 49.5], // band bottom: inside the outer ellipse
+];
+
+// Piecewise-linear interpolation through sorted (input, output) knots,
+// extrapolating with the end segments' slopes.
+const warp1d = (knots: [number, number][], v: number): number => {
+  let i = 0;
+  while (i < knots.length - 2 && v > knots[i + 1][0]) i++;
+  const [x0, y0] = knots[i];
+  const [x1, y1] = knots[i + 1];
+  return y0 + ((v - x0) * (y1 - y0)) / (x1 - x0);
+};
 
 const cubicBezierPoint = (
   p0: [number, number],
@@ -206,17 +231,13 @@ const cubicBezierPoint = (
 
 const SAMPLES_PER_SEGMENT = 12;
 
-// Sample the hand-drawn a/c path into a dense point list, then remap from
-// the path's own coordinate space into this story's point layout: uniformly
-// scaled so the "a"-"c" anchor distance matches this story's actual
-// SPACING, and translated so the anchors land on the real "a"/"c" point
-// centers.
+// Sample the hand-drawn a/c path into a dense point list, warped through
+// the piecewise-linear x/y maps above so its lobes land on this story's
+// "a"/"c" dots and its dip clears this story's (larger) pills.
 const acNeighbourhoodPoints = (): [number, number][] => {
-  const scale = (2 * SPACING) / AC_ORIGINAL_A_TO_C;
-  const aCenter: [number, number] = [-SPACING, 0];
   const remap = ([px, py]: [number, number]): [number, number] => [
-    aCenter[0] + (px - AC_PATH_ANCHOR_A[0]) * scale,
-    aCenter[1] + (py - AC_PATH_ANCHOR_A[1]) * scale,
+    warp1d(AC_X_WARP, px),
+    warp1d(AC_Y_WARP, py),
   ];
 
   const pts: [number, number][] = [];
@@ -229,21 +250,35 @@ const acNeighbourhoodPoints = (): [number, number][] => {
   return pts;
 };
 
+// Per-axis ellipse padding, keyed by neighbourhood size. Hand-tuned so
+// every ellipse contains its dots AND their labels (which hang ~22px below
+// the dot centers) with breathing room, while nested pills keep readable
+// gaps: a single-point pill fits inside a two-point pill fits inside the
+// outer ellipse, and disjoint pills (e.g. the a-b pill and a c pill) never
+// touch. Sizing enclosures to contain labels automatically (a Penrose-style
+// optimization pass) is future design direction; these are hand-tuned
+// constants pending that.
+const NEIGHBOURHOOD_PAD: Record<number, { x: number; y: number }> = {
+  1: { x: 14, y: 24 }, // pill: 36 x 56 (rx 18, ry 28)
+  2: { x: 21, y: 34 }, // pill: 100 x 76 (rx 50, ry 38)
+};
+const OUTER_PAD = { x: 34, y: 54 }; // outer: 176 x 116 (rx 88, ry 58)
+
 // Analytic bbox for a neighbourhood: since the three points sit at known,
 // fixed x-offsets (index * SPACING) with a shared y, the ellipse outline
 // spanning a subset of them can be computed directly instead of asking
 // `enclose` to discover it from refs (see finding above).
-const neighbourhoodBox = (n: Neighbourhood, padding: number) => {
+const neighbourhoodBox = (n: Neighbourhood, pad: { x: number; y: number }) => {
   const indices = n.map((p) => POINT_NAMES.indexOf(p));
   const minIdx = Math.min(...indices);
   const maxIdx = Math.max(...indices);
   const spanW = (maxIdx - minIdx) * SPACING + POINT_SIZE;
   return {
     // centerX of the span, relative to the middle point (b, index 1) which
-    // spread({alignment:"middle"}) centers at x = 0.
+    // the panel's local coordinates place at x = 0.
     centerX: (minIdx + maxIdx - 2) * (SPACING / 2),
-    w: spanW + padding * 2,
-    h: POINT_SIZE + padding * 2,
+    w: spanW + pad.x * 2,
+    h: POINT_SIZE + pad.y * 2,
   };
 };
 
@@ -273,7 +308,9 @@ const ThreePointTopology = (
         return position(
           // -4: a single-character italic label is ~8px wide at fontSize 12;
           // approximate centering since text has no measured-width query here.
-          { x: x - 4, y: 14 },
+          // y: 10 keeps the label snug under the dot so the label-containing
+          // pill sizes (NEIGHBOURHOOD_PAD) stay compact.
+          { x: x - 4, y: 10 },
           [text({ text: p, fontStyle: "italic" })]
         );
       })
@@ -284,7 +321,7 @@ const ThreePointTopology = (
   // wrapping the full <StackH>. `overdraw` is accepted-but-unused there too
   // (the component only reads `fill`/`opacity`, both left at their plain
   // defaults), so it renders identically in both modes.
-  const outerBox = neighbourhoodBox(["a", "b", "c"], 36);
+  const outerBox = neighbourhoodBox(["a", "b", "c"], OUTER_PAD);
   const outer = position(
     { x: outerBox.centerX - outerBox.w / 2, y: -outerBox.h / 2 },
     [
@@ -312,14 +349,13 @@ const ThreePointTopology = (
       return polygon({
         points: acNeighbourhoodPoints(),
         fill: overdraw ? "none" : rawColor,
-        stroke: "#999",
+        stroke: "black",
         strokeWidth: 3,
         opacity: overdraw ? 1 : TOPOLOGY_OPACITY,
       });
     }
 
-    const padding = n.length * 17 - 12;
-    const box = neighbourhoodBox(n, padding);
+    const box = neighbourhoodBox(n, NEIGHBOURHOOD_PAD[n.length]);
     return position(
       { x: box.centerX - box.w / 2, y: -box.h / 2 },
       [
@@ -343,8 +379,26 @@ const ThreePointTopology = (
   return layer([outer, ...neighbourhoods, ...points, ...labels]);
 };
 
-const col = (panels: ReturnType<typeof ThreePointTopology>[]) =>
-  spread({ dir: "y", spacing: 40, mode: "edge", alignment: "middle" }, panels);
+// Grid pitches: panel = outer ellipse (176 x 116) + a 40px gutter. The grid
+// is placed EXPLICITLY (position() at fixed pitches) rather than with
+// nested `spread`s: spread spaces panels by their layout extents, and the
+// panels' extents vary spuriously (a label or the a/c polygon inflates a
+// panel's proposed size asymmetrically — see friction log item 7), which
+// produced visibly uneven gutters. The panels' ellipses are all the same
+// size, so a fixed-pitch grid is both correct and deterministic.
+const COL_PITCH = 176 + 40;
+const ROW_PITCH = 116 + 40;
+
+// `cols` is column-major: cols[c][r] is the panel at column c, row r —
+// matching the original Bluefish source's StackH-of-StackV structure.
+const panelGrid = (cols: ReturnType<typeof ThreePointTopology>[][]) =>
+  layer(
+    cols.flatMap((colPanels, c) =>
+      colPanels.map((panel, r) =>
+        position({ x: c * COL_PITCH, y: r * ROW_PITCH }, [panel])
+      )
+    )
+  );
 
 export const Topology: StoryObj<Args> = {
   tags: ["gallery"],
@@ -369,18 +423,18 @@ export const Topology: StoryObj<Args> = {
     Layer(
       {},
       [
-        spread({ dir: "x", spacing: 40, mode: "edge", alignment: "middle" }, [
-          col([
+        panelGrid([
+          [
             ThreePointTopology([], { showLabels: true }),
             ThreePointTopology([["b"]]),
             ThreePointTopology([["a", "b"]]),
-          ]),
-          col([
+          ],
+          [
             ThreePointTopology([["a", "b"], ["a"]], { showLabels: true }),
             ThreePointTopology([["a", "b"], ["c"]]),
             ThreePointTopology([["a", "b"], ["a"], ["b"]]),
-          ]),
-          col([
+          ],
+          [
             ThreePointTopology([["a", "b"], ["b", "c"], ["b"]], {
               showLabels: true,
             }),
@@ -391,7 +445,7 @@ export const Topology: StoryObj<Args> = {
               ["b"],
               ["a", "c"],
             ]),
-          ]),
+          ],
         ]),
       ]
     ).render(container, { w: 700, h: 460 });
@@ -415,13 +469,13 @@ export const TopologyOverdraw: StoryObj<Args> = {
     Layer(
       {},
       [
-        spread({ dir: "x", spacing: 40, mode: "edge", alignment: "middle" }, [
-          col([
+        panelGrid([
+          [
             ThreePointTopology([], { showLabels: true, overdraw: true }),
             ThreePointTopology([["b"]], { overdraw: true }),
             ThreePointTopology([["a", "b"]], { overdraw: true }),
-          ]),
-          col([
+          ],
+          [
             ThreePointTopology([["a", "b"], ["a"]], {
               showLabels: true,
               overdraw: true,
@@ -430,8 +484,8 @@ export const TopologyOverdraw: StoryObj<Args> = {
             ThreePointTopology([["a", "b"], ["a"], ["b"]], {
               overdraw: true,
             }),
-          ]),
-          col([
+          ],
+          [
             ThreePointTopology([["a", "b"], ["b", "c"], ["b"]], {
               showLabels: true,
               overdraw: true,
@@ -443,7 +497,7 @@ export const TopologyOverdraw: StoryObj<Args> = {
               [["a", "b"], ["a", "c"], ["b", "c"], ["b"]],
               { overdraw: true }
             ),
-          ]),
+          ],
         ]),
       ]
     ).render(container, { w: 700, h: 460 });
@@ -494,8 +548,9 @@ export const TopologyOverdraw: StoryObj<Args> = {
 //    (explicit local-coordinate point list), which is enough to *replicate*
 //    Bluefish's hand-authored concave SVG path for the a/c neighbourhood by
 //    sampling its cubic Bézier segments into a dense point list and
-//    affinely remapping them onto this story's own point layout (anchored
-//    on the "a"/"c" point centers) — see `acNeighbourhoodPoints`. That's a
+//    remapping them piecewise-linearly onto this story's own point layout
+//    (anchored on the "a"/"c" point centers, with the dip widened to clear
+//    the label-containing b-pill) — see `acNeighbourhoodPoints`. That's a
 //    faithful reproduction of the *specific* hand-drawn artwork, not a
 //    general concave-hull primitive; a real general fix still needs either
 //    a path-based enclose variant or a documented non-goal. It also
@@ -522,6 +577,24 @@ export const TopologyOverdraw: StoryObj<Args> = {
 // 6. `stack()` silently ignores `spacing` (its type comment says so — "the
 //    same as `spread` but never a gap") which is easy to reach for by
 //    analogy with `spread` and get flush-touching panels with no error.
-//    Switching to `spread({ mode: "edge" })` fixed it, but a runtime warning
-//    (or accepting the option as a no-op-with-warning) would have caught
-//    this immediately instead of via a visual diff.
+//    Switching to `spread({ mode: "edge" })` fixed it (the grid has since
+//    moved off spread entirely — see item 7), but a runtime warning (or
+//    accepting the option as a no-op-with-warning) would have caught this
+//    immediately instead of via a visual diff.
+//
+// 7. Spread spaces panels by phantom-inflated extents, so the grid is
+//    placed explicitly. With identical outer ellipses in every panel,
+//    `spread` should produce a uniform 3x3 grid — but panels containing a
+//    label or the a/c polygon report a layout extent asymmetrically larger
+//    than their visible content (measured: a labeled panel's box bottom sat
+//    at outer-max + label-max, a polygon panel's at outer-max +
+//    polygon-max — a SUM, not a union), producing visibly uneven gutters in
+//    both `mode: "edge"` (uneven gaps) and `mode: "center"` (shifted
+//    middles, since the phantom shifts the bbox middle). Adding invisible
+//    y-mirrored counterweight children did NOT re-center the boxes, which
+//    rules out a simple bbox-union story and points at the size-proposal
+//    pass double-counting positive `position` offsets / free minima (the
+//    #39 bbox-sync family). The story-local fix: place the nine panels at
+//    fixed pitches with `position()` (`panelGrid`), which no layout pass
+//    can perturb. The same inflation is why the rendered canvas is larger
+//    than the ink (item 5's margins).

--- a/packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
@@ -1,0 +1,341 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { initializeContainer } from "../helper";
+import {
+  layer,
+  spread,
+  ellipse,
+  rect,
+  text,
+  position,
+  Layer,
+} from "../../src/lib";
+
+// Ported from Bluefish's example-gallery topology.tsx (issue #440): three
+// labeled points (a, b, c) with nested rounded-rect "neighbourhood" outlines
+// showing different point-set topologies on the same three points.
+//
+// NOTE on enclose+refs: this port originally probed
+// `enclose({}, [ref("a"), ref("b")])` and found it broken — enclose
+// unconditionally re-placed every child at local (0, 0), collapsing refs
+// onto the origin. That bug is fixed in #713 (enclose shares layer's
+// place-only-if-unplaced child semantics via `placeUnplacedChild`); the
+// canonical regression probe lives at
+// stories/lowlevel/EncloseRefs.stories.tsx. The neighbourhood outlines
+// below still use analytic geometry (rect via `position`) rather than
+// enclose-over-refs, for two remaining reasons recorded in the friction
+// log: enclose's hull is a hardcoded gray outline (no fill/stroke opts, so
+// no colored translucent pills), and the a/c neighbourhood needs a concave
+// shape a bbox hull can't express.
+
+const meta: Meta = {
+  title: "Bluefish/Topology",
+};
+export default meta;
+
+type Args = { w: number; h: number };
+
+// ── The actual port ─────────────────────────────────────────────────────────
+
+const POINT_NAMES = ["a", "b", "c"] as const;
+type PointName = (typeof POINT_NAMES)[number];
+type Neighbourhood = PointName[];
+
+const SPACING = 50; // center-to-center distance between adjacent points
+const POINT_SIZE = 8; // point marker diameter
+
+const TOPOLOGY_COLORS = [
+  "#ff2400", // red
+  "#009dff", // blue
+  "#d4c400", // yellow (darkened for contrast on white)
+  "orange",
+  "green",
+  "purple",
+];
+const TOPOLOGY_OPACITY = 0.5;
+
+const isAandCNeighbourhood = (n: Neighbourhood) =>
+  n.length === 2 && n.includes("a") && n.includes("c");
+
+// Analytic bbox for a neighbourhood: since the three points sit at known,
+// fixed x-offsets (index * SPACING) with a shared y, the rounded-rect
+// outline spanning a subset of them can be computed directly instead of
+// asking `enclose` to discover it from refs (see finding above).
+const neighbourhoodBox = (n: Neighbourhood, padding: number) => {
+  const indices = n.map((p) => POINT_NAMES.indexOf(p));
+  const minIdx = Math.min(...indices);
+  const maxIdx = Math.max(...indices);
+  const spanW = (maxIdx - minIdx) * SPACING + POINT_SIZE;
+  return {
+    // centerX of the span, relative to the middle point (b, index 1) which
+    // spread({alignment:"middle"}) centers at x = 0.
+    centerX: (minIdx + maxIdx - 2) * (SPACING / 2),
+    w: spanW + padding * 2,
+    h: POINT_SIZE + padding * 2,
+  };
+};
+
+const ThreePointTopology = (
+  topology: Neighbourhood[],
+  opts: { showLabels?: boolean; overdraw?: boolean } = {}
+) => {
+  const { showLabels = false, overdraw = false } = opts;
+
+  // `position({x, y}, [child])` sets the CHILD's own (min-x, min-y) corner —
+  // rect/ellipse are min-anchored at their own local (0, 0), not centered —
+  // so every placement below subtracts half the shape's extent to land its
+  // *center* at the intended coordinate. (Friction: this offset-by-half-size
+  // bookkeeping is exactly what `enclose`/an align-to-center primitive would
+  // normally absorb; see friction log.)
+  const points = POINT_NAMES.map((p, i) => {
+    const x = (i - 1) * SPACING;
+    return position(
+      { x: x - POINT_SIZE / 2, y: -POINT_SIZE / 2 },
+      [ellipse({ w: POINT_SIZE, h: POINT_SIZE, fill: "black" }).name(p)]
+    );
+  });
+
+  const labels = showLabels
+    ? POINT_NAMES.map((p, i) => {
+        const x = (i - 1) * SPACING;
+        return position(
+          // -4: a single-character italic label is ~8px wide at fontSize 12;
+          // approximate centering since text has no measured-width query here.
+          { x: x - 4, y: -34 },
+          [text({ text: p, fontStyle: "italic" })]
+        );
+      })
+    : [];
+
+  // Whole-stack outline (always present, plain black, never filled) — the
+  // Bluefish `<EllipseBackground padding={36} overdraw={props.overdraw}>`
+  // wrapping the full <StackH>. `overdraw` is accepted-but-unused there too
+  // (the component only reads `fill`/`opacity`, both left at their plain
+  // defaults), so it renders identically in both modes.
+  const outerBox = neighbourhoodBox(["a", "b", "c"], 36);
+  const outer = position(
+    { x: outerBox.centerX - outerBox.w / 2, y: -outerBox.h / 2 },
+    [
+      rect({
+        w: outerBox.w,
+        h: outerBox.h,
+        rx: outerBox.h / 2,
+        ry: outerBox.h / 2,
+        fill: "none",
+        stroke: "black",
+        strokeWidth: 3,
+      }),
+    ]
+  );
+
+  const neighbourhoods = topology.map((n, i) => {
+    const acSpecial = isAandCNeighbourhood(n);
+    // Bluefish draws the a-c neighbourhood as a hand-authored concave SVG
+    // path that dips around "b" (which sits between a and c but is NOT a
+    // member). GoFish has no concave-enclosure primitive today, so this is
+    // approximated with the same convex rounded-rect as every other
+    // neighbourhood — it necessarily (and topologically incorrectly)
+    // covers "b" too. See friction log.
+    const padding = n.length * 17 - 12;
+    const box = neighbourhoodBox(n, padding);
+    return position(
+      { x: box.centerX - box.w / 2, y: -box.h / 2 },
+      [
+        rect({
+          w: box.w,
+          h: box.h,
+          rx: box.h / 2,
+          ry: box.h / 2,
+          fill: overdraw
+            ? "none"
+            : TOPOLOGY_COLORS[i % TOPOLOGY_COLORS.length],
+          stroke: acSpecial ? "#999" : "black",
+          strokeWidth: 3,
+          opacity: overdraw ? 1 : TOPOLOGY_OPACITY,
+        }),
+      ]
+    );
+  });
+
+  // Paint order (last = on top in GoFish's layer z-order): outer outline at
+  // the back, then each neighbourhood outline (in declared order, so later
+  // topology entries sit visually on top of earlier ones — matching
+  // Bluefish's `<For>` source order), then the points and labels on top of
+  // everything so they're never occluded by a filled neighbourhood.
+  return layer([outer, ...neighbourhoods, ...points, ...labels]);
+};
+
+const col = (panels: ReturnType<typeof ThreePointTopology>[]) =>
+  spread({ dir: "y", spacing: 40, mode: "edge", alignment: "middle" }, panels);
+
+export const Topology: StoryObj<Args> = {
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Three-Point Set Topologies",
+      description:
+        "Nine point-set topologies on the same three labeled points, each drawn as nested rounded-rect neighbourhood outlines around the points they contain.",
+    },
+  },
+  render: () => {
+    const container = initializeContainer();
+
+    // The root `Layer`'s own x/y/w/h options (the technique Pulley uses to
+    // shift a bounding box) turned out to have NO effect at the root: the
+    // final canvas normalizes the root's content bbox back to (0, 0)
+    // regardless of the root node's own translate, so root-level margin has
+    // to come from the render() call's own {w, h} (below) — a wider/taller
+    // canvas than the tightly-fit content, which leaves the extra room as a
+    // margin on the bottom/right since content stays anchored at its
+    // auto-fit top-left. See friction log.
+    Layer(
+      {},
+      [
+        spread({ dir: "x", spacing: 40, mode: "edge", alignment: "middle" }, [
+          col([
+            ThreePointTopology([], { showLabels: true }),
+            ThreePointTopology([["b"]]),
+            ThreePointTopology([["a", "b"]]),
+          ]),
+          col([
+            ThreePointTopology([["a", "b"], ["a"]], { showLabels: true }),
+            ThreePointTopology([["a", "b"], ["c"]]),
+            ThreePointTopology([["a", "b"], ["a"], ["b"]]),
+          ]),
+          col([
+            ThreePointTopology([["a", "b"], ["b", "c"], ["b"]], {
+              showLabels: true,
+            }),
+            ThreePointTopology([["a", "b"], ["b", "c"], ["b"], ["c"]]),
+            ThreePointTopology([
+              ["a", "b"],
+              ["b", "c"],
+              ["b"],
+              ["a", "c"],
+            ]),
+          ]),
+        ]),
+      ]
+    ).render(container, { w: 700, h: 460 });
+
+    return container;
+  },
+};
+
+export const TopologyOverdraw: StoryObj<Args> = {
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Three-Point Set Topologies (Outline Only)",
+      description:
+        "The same nine point-set topologies redrawn with unfilled, overlapping outlines instead of translucent fills, so every nested neighbourhood boundary stays legible.",
+    },
+  },
+  render: () => {
+    const container = initializeContainer();
+
+    Layer(
+      {},
+      [
+        spread({ dir: "x", spacing: 40, mode: "edge", alignment: "middle" }, [
+          col([
+            ThreePointTopology([], { showLabels: true, overdraw: true }),
+            ThreePointTopology([["b"]], { overdraw: true }),
+            ThreePointTopology([["a", "b"]], { overdraw: true }),
+          ]),
+          col([
+            ThreePointTopology([["a", "b"], ["a"]], {
+              showLabels: true,
+              overdraw: true,
+            }),
+            ThreePointTopology([["a", "b"], ["c"]], { overdraw: true }),
+            ThreePointTopology([["a", "b"], ["a"], ["b"]], {
+              overdraw: true,
+            }),
+          ]),
+          col([
+            ThreePointTopology([["a", "b"], ["b", "c"], ["b"]], {
+              showLabels: true,
+              overdraw: true,
+            }),
+            ThreePointTopology([["a", "b"], ["b", "c"], ["b"], ["c"]], {
+              overdraw: true,
+            }),
+            ThreePointTopology(
+              [["a", "b"], ["a", "c"], ["b", "c"], ["b"]],
+              { overdraw: true }
+            ),
+          ]),
+        ]),
+      ]
+    ).render(container, { w: 700, h: 460 });
+
+    return container;
+  },
+};
+
+// ── Friction log ─────────────────────────────────────────────────────────
+//
+// 1. `enclose({}, [ref(a), ref(b), ...])` over multiple named refs — the
+//    thing this port was meant to stress-test — was broken when this port
+//    was written: enclose unconditionally re-placed every child at local
+//    (0, 0), collapsing refs onto the origin. FIXED in #713: enclose now
+//    shares layer's place-only-if-unplaced
+//    child semantics (`placeUnplacedChild` in _node.ts) and unions
+//    children's actual placed boxes; the regression probe lives at
+//    stories/lowlevel/EncloseRefs.stories.tsx. This port keeps its analytic
+//    fallback anyway because of items 2 and 4: enclose's hull is a
+//    hardcoded gray outline (no fill/stroke opts — no colored translucent
+//    pills) and a bbox hull can't express the concave a/c neighbourhood.
+//
+// 2. Variable-length groups of refs: even setting the enclose bug aside,
+//    there's no primitive for "outline exactly this list of named
+//    children," full stop — everything is a fixed two-child API (`connect`
+//    between exactly two refs) or an operator meant for *arranging* children
+//    it's laying out for the first time (`spread`/`stack`), not for wrapping
+//    ones already placed elsewhere. A group-of-N-refs "bounding decoration"
+//    (rect/ellipse/pill sized and positioned to the union of N named
+//    children's resolved bboxes) is exactly the missing piece, and would
+//    also directly solve the Bluefish concave a/c-neighbourhood case (item 4
+//    below) if it exposed a shape callback instead of a fixed rect/ellipse.
+//
+// 3. `position({x, y}, [child])`'s coordinate convention (min-corner offset,
+//    not center) meant every call site here had to manually subtract half
+//    the shape's width/height to center something at a computed coordinate
+//    (see the comment at the top of `ThreePointTopology`). A center-anchored
+//    variant (or an `anchor` option, mirroring `connect`'s `AnchorSpec`)
+//    would remove a whole class of off-by-half-size arithmetic bugs — this
+//    port hit exactly that bug on the first pass (every neighbourhood
+//    outline was offset by half its own width) and it was only caught by
+//    rendering and comparing pixel coordinates by hand.
+//
+// 4. No concave-enclosure primitive. Bluefish's a/c-neighbourhood panel
+//    (a and c share a neighbourhood, b does not, and b sits between them)
+//    is drawn there as a hand-authored concave SVG path that dips around b.
+//    GoFish's `enclose`/`position` + rect/ellipse vocabulary is entirely
+//    convex-bbox-based, so there is no way to express "wrap these points but
+//    carve out this other one." This port approximates it with the same
+//    convex pill as every other neighbourhood (necessarily also covering b,
+//    which is topologically wrong) and marks it with a grey instead of black
+//    stroke so the discrepancy is at least visible. A real fix needs either
+//    a path-based enclose variant or a documented non-goal.
+//
+// 5. Auto-fit canvas margin. The root node's own `x`/`y`/`w`/`h` options
+//    (the technique the Pulley story uses to shift a sub-tree's bounding
+//    box) have no effect at the very root: the render entry point
+//    renormalizes the final content bbox to (0, 0) regardless of the root
+//    node's own translate, so a root-level margin can only come from
+//    padding the render() canvas size beyond the tightly-fit content (as
+//    done here: `.render(container, { w: 700, h: 460 })`, leaving the extra
+//    room as bottom/right margin since content stays pinned to its
+//    auto-fit top-left corner). This cost a full render/inspect cycle to
+//    diagnose (multiplying `x`/`y` by 20x produced a byte-identical DOM,
+//    which is what revealed it was inert rather than merely too small a
+//    value) and there's no direct way to add symmetric margin around a
+//    free-floating (non-data-scaled) composition today.
+//
+// 6. `stack()` silently ignores `spacing` (its type comment says so — "the
+//    same as `spread` but never a gap") which is easy to reach for by
+//    analogy with `spread` and get flush-touching panels with no error.
+//    Switching to `spread({ mode: "edge" })` fixed it, but a runtime warning
+//    (or accepting the option as a no-op-with-warning) would have caught
+//    this immediately instead of via a visual diff.

--- a/packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
@@ -190,8 +190,8 @@ const AC_PATH_SEGMENTS: [number, number][][] = [
 const AC_X_WARP: [number, number][] = [
   [2, -66], // outer edge of the "a" lobe
   [14, -50], // "a" lobe anchor -> dot a
-  [41.5, -30], // left dip wall (widened to clear the b-pill)
-  [64.5, 30], // right dip wall
+  [41.5, -16], // left dip wall (hugs the r=9 b-circle, like upstream)
+  [64.5, 16], // right dip wall
   [94, 50], // "c" lobe anchor -> dot c
   [104, 66], // outer edge of the "c" lobe
 ];
@@ -250,16 +250,18 @@ const acNeighbourhoodPoints = (): [number, number][] => {
   return pts;
 };
 
-// Per-axis ellipse padding, keyed by neighbourhood size. Hand-tuned so
-// every ellipse contains its dots AND their labels (which hang ~22px below
-// the dot centers) with breathing room, while nested pills keep readable
-// gaps: a single-point pill fits inside a two-point pill fits inside the
-// outer ellipse, and disjoint pills (e.g. the a-b pill and a c pill) never
-// touch. Sizing enclosures to contain labels automatically (a Penrose-style
-// optimization pass) is future design direction; these are hand-tuned
-// constants pending that.
+// Per-axis ellipse padding, keyed by neighbourhood size, matching the
+// Bluefish original's proportions: a single-point neighbourhood is a SMALL
+// CIRCLE snug around its dot (upstream draws an r=10 circle around an r=5
+// dot — it deliberately does NOT contain the point's label, which sits
+// below/outside it), while the multi-point pills and the outer set ellipse
+// are sized to contain their dots AND the labels (which hang ~22px below
+// the dot centers) with breathing room — label containment applies to
+// those outer levels only. Sizing enclosures to contain labels
+// automatically (a Penrose-style optimization pass) is future design
+// direction; these are hand-tuned constants pending that.
 const NEIGHBOURHOOD_PAD: Record<number, { x: number; y: number }> = {
-  1: { x: 14, y: 24 }, // pill: 36 x 56 (rx 18, ry 28)
+  1: { x: 5, y: 5 }, // circle: 18 x 18 (r 9) — snug, label outside
   2: { x: 21, y: 34 }, // pill: 100 x 76 (rx 50, ry 38)
 };
 const OUTER_PAD = { x: 34, y: 54 }; // outer: 176 x 116 (rx 88, ry 58)

--- a/packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
+++ b/packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
@@ -4,15 +4,19 @@ import {
   layer,
   spread,
   ellipse,
-  rect,
   text,
   position,
+  polygon,
   Layer,
 } from "../../src/lib";
 
 // Ported from Bluefish's example-gallery topology.tsx (issue #440): three
-// labeled points (a, b, c) with nested rounded-rect "neighbourhood" outlines
-// showing different point-set topologies on the same three points.
+// labeled points (a, b, c) with nested ellipse "neighbourhood" outlines
+// showing different point-set topologies on the same three points. The a/c
+// neighbourhood (the one where two non-adjacent points share a
+// neighbourhood but the point between them does not) is drawn as a
+// `polygon` sampled from Bluefish's original hand-authored concave SVG
+// path — see `acNeighbourhoodPoints` below.
 //
 // NOTE on enclose+refs: this port originally probed
 // `enclose({}, [ref("a"), ref("b")])` and found it broken — enclose
@@ -21,11 +25,11 @@ import {
 // place-only-if-unplaced child semantics via `placeUnplacedChild`); the
 // canonical regression probe lives at
 // stories/lowlevel/EncloseRefs.stories.tsx. The neighbourhood outlines
-// below still use analytic geometry (rect via `position`) rather than
-// enclose-over-refs, for two remaining reasons recorded in the friction
-// log: enclose's hull is a hardcoded gray outline (no fill/stroke opts, so
-// no colored translucent pills), and the a/c neighbourhood needs a concave
-// shape a bbox hull can't express.
+// below still use analytic geometry (`ellipse`/`polygon` via `position`)
+// rather than enclose-over-refs, for two remaining reasons recorded in the
+// friction log: enclose's hull is a hardcoded gray outline (no fill/stroke
+// opts, so no colored translucent pills), and enclose only produces convex
+// bbox-based hulls — it can't express the concave a/c neighbourhood.
 
 const meta: Meta = {
   title: "Bluefish/Topology",
@@ -56,10 +60,179 @@ const TOPOLOGY_OPACITY = 0.5;
 const isAandCNeighbourhood = (n: Neighbourhood) =>
   n.length === 2 && n.includes("a") && n.includes("c");
 
+// The a/c neighbourhood in Bluefish's original is a hand-drawn concave SVG
+// path (drawn in Figma, exported, then hand-offset into place — see the
+// upstream comment in bluefish-monorepo's
+// packages/bluefish-solid/src/stories/ThreePointTopologies.stories.tsx) that
+// bulges out to enclose "a" and "c" while dipping away from "b", which sits
+// between them but is NOT a member of the neighbourhood. GoFish has no
+// concave-enclosure primitive, but it does have `polygon` (explicit
+// local-coordinate point list) — so this samples the original path's cubic
+// Bézier segments into a dense point list and affinely remaps it into this
+// story's own point-spacing/point-size coordinate system, anchored on the
+// two points ("a" and "c") the shape must actually enclose. That keeps the
+// shape faithful to the original hand-drawn artwork instead of
+// re-approximating it with a bbox-based primitive.
+const AC_PATH_SEGMENTS: [number, number][][] = [
+  // Each entry: [P0, C1, C2, P1] control points of one cubic Bézier segment,
+  // transcribed directly from the original path's "d" attribute
+  // (M68.5011 48 H53.0011 H37.501 C32.001 48 ... Z).
+  [
+    [68.5011, 48],
+    [68.5011, 48],
+    [53.0011, 48],
+    [53.0011, 48],
+  ],
+  [
+    [53.0011, 48],
+    [53.0011, 48],
+    [37.501, 48],
+    [37.501, 48],
+  ],
+  [
+    [37.501, 48],
+    [32.001, 48],
+    [29.039, 47.7419],
+    [24.001, 46.02],
+  ],
+  [
+    [24.001, 46.02],
+    [14.431, 42.76],
+    [8.50201, 33.96],
+    [7.00201, 31],
+  ],
+  [
+    [7.00201, 31],
+    [5.50201, 28.039],
+    [2.00201, 19.42],
+    [2.00201, 13.5],
+  ],
+  [
+    [2.00201, 13.5],
+    [2.00201, 7.58],
+    [5.15102, 2],
+    [11.502, 2],
+  ],
+  [
+    [11.502, 2],
+    [17.862, 2],
+    [22.002, 4.11],
+    [23.002, 13.5],
+  ],
+  [
+    [23.002, 13.5],
+    [24.002, 22.887],
+    [34.001, 42.07],
+    [41.501, 42.07],
+  ],
+  [
+    [41.501, 42.07],
+    [41.501, 42.07],
+    [53.0011, 42.07],
+    [53.0011, 42.07],
+  ],
+  [
+    [53.0011, 42.07],
+    [53.0011, 42.07],
+    [64.5011, 42.07],
+    [64.5011, 42.07],
+  ],
+  [
+    [64.5011, 42.07],
+    [72.0011, 42.07],
+    [82.0001, 22.887],
+    [83.0001, 13.5],
+  ],
+  [
+    [83.0001, 13.5],
+    [84.0001, 4.11],
+    [88.1401, 2],
+    [94.5001, 2],
+  ],
+  [
+    [94.5001, 2],
+    [100.851, 2],
+    [104, 7.58],
+    [104, 13.5],
+  ],
+  [
+    [104, 13.5],
+    [104, 19.42],
+    [100.5, 28.039],
+    [99.0001, 31],
+  ],
+  [
+    [99.0001, 31],
+    [97.5001, 33.96],
+    [91.5711, 42.76],
+    [82.0011, 46.02],
+  ],
+  [
+    [82.0011, 46.02],
+    [76.9631, 47.7419],
+    [74.0011, 48],
+    [68.5011, 48],
+  ],
+];
+
+// Anchor points in the original path's own coordinate space: the centers of
+// the "a" and "c" lobes, derived from the symmetry of the path data (the
+// path is mirror-symmetric about x = 53) and cross-checked against the
+// upstream Path component's hand-tuned x:-7, y:-10 placement offset, which
+// lands the lobes on the actual "a"/"c" point centers.
+const AC_PATH_ANCHOR_A: [number, number] = [14, 17];
+const AC_PATH_ANCHOR_C: [number, number] = [94, 17];
+// Original point spacing (StackH spacing=30 + point diameter 10 = 40
+// center-to-center), so a-to-c center distance is 80 in path-space.
+const AC_ORIGINAL_A_TO_C = 80;
+
+const cubicBezierPoint = (
+  p0: [number, number],
+  p1: [number, number],
+  p2: [number, number],
+  p3: [number, number],
+  t: number
+): [number, number] => {
+  const mt = 1 - t;
+  const a = mt * mt * mt;
+  const b = 3 * mt * mt * t;
+  const c = 3 * mt * t * t;
+  const d = t * t * t;
+  return [
+    a * p0[0] + b * p1[0] + c * p2[0] + d * p3[0],
+    a * p0[1] + b * p1[1] + c * p2[1] + d * p3[1],
+  ];
+};
+
+const SAMPLES_PER_SEGMENT = 12;
+
+// Sample the hand-drawn a/c path into a dense point list, then remap from
+// the path's own coordinate space into this story's point layout: uniformly
+// scaled so the "a"-"c" anchor distance matches this story's actual
+// SPACING, and translated so the anchors land on the real "a"/"c" point
+// centers.
+const acNeighbourhoodPoints = (): [number, number][] => {
+  const scale = (2 * SPACING) / AC_ORIGINAL_A_TO_C;
+  const aCenter: [number, number] = [-SPACING, 0];
+  const remap = ([px, py]: [number, number]): [number, number] => [
+    aCenter[0] + (px - AC_PATH_ANCHOR_A[0]) * scale,
+    aCenter[1] + (py - AC_PATH_ANCHOR_A[1]) * scale,
+  ];
+
+  const pts: [number, number][] = [];
+  for (const [p0, c1, c2, p1] of AC_PATH_SEGMENTS) {
+    for (let i = 0; i < SAMPLES_PER_SEGMENT; i++) {
+      const t = i / SAMPLES_PER_SEGMENT;
+      pts.push(remap(cubicBezierPoint(p0, c1, c2, p1, t)));
+    }
+  }
+  return pts;
+};
+
 // Analytic bbox for a neighbourhood: since the three points sit at known,
-// fixed x-offsets (index * SPACING) with a shared y, the rounded-rect
-// outline spanning a subset of them can be computed directly instead of
-// asking `enclose` to discover it from refs (see finding above).
+// fixed x-offsets (index * SPACING) with a shared y, the ellipse outline
+// spanning a subset of them can be computed directly instead of asking
+// `enclose` to discover it from refs (see finding above).
 const neighbourhoodBox = (n: Neighbourhood, padding: number) => {
   const indices = n.map((p) => POINT_NAMES.indexOf(p));
   const minIdx = Math.min(...indices);
@@ -100,7 +273,7 @@ const ThreePointTopology = (
         return position(
           // -4: a single-character italic label is ~8px wide at fontSize 12;
           // approximate centering since text has no measured-width query here.
-          { x: x - 4, y: -34 },
+          { x: x - 4, y: 14 },
           [text({ text: p, fontStyle: "italic" })]
         );
       })
@@ -115,11 +288,9 @@ const ThreePointTopology = (
   const outer = position(
     { x: outerBox.centerX - outerBox.w / 2, y: -outerBox.h / 2 },
     [
-      rect({
+      ellipse({
         w: outerBox.w,
         h: outerBox.h,
-        rx: outerBox.h / 2,
-        ry: outerBox.h / 2,
         fill: "none",
         stroke: "black",
         strokeWidth: 3,
@@ -129,26 +300,34 @@ const ThreePointTopology = (
 
   const neighbourhoods = topology.map((n, i) => {
     const acSpecial = isAandCNeighbourhood(n);
+
     // Bluefish draws the a-c neighbourhood as a hand-authored concave SVG
-    // path that dips around "b" (which sits between a and c but is NOT a
-    // member). GoFish has no concave-enclosure primitive today, so this is
-    // approximated with the same convex rounded-rect as every other
-    // neighbourhood — it necessarily (and topologically incorrectly)
-    // covers "b" too. See friction log.
+    // path that bulges around "a" and "c" while dipping away from "b"
+    // (which sits between them but is NOT a member) — replicated here as a
+    // `polygon` sampled from that same path (see `acNeighbourhoodPoints`
+    // above) rather than the convex ellipse every other neighbourhood uses.
+    const rawColor = TOPOLOGY_COLORS[i % TOPOLOGY_COLORS.length];
+
+    if (acSpecial) {
+      return polygon({
+        points: acNeighbourhoodPoints(),
+        fill: overdraw ? "none" : rawColor,
+        stroke: "#999",
+        strokeWidth: 3,
+        opacity: overdraw ? 1 : TOPOLOGY_OPACITY,
+      });
+    }
+
     const padding = n.length * 17 - 12;
     const box = neighbourhoodBox(n, padding);
     return position(
       { x: box.centerX - box.w / 2, y: -box.h / 2 },
       [
-        rect({
+        ellipse({
           w: box.w,
           h: box.h,
-          rx: box.h / 2,
-          ry: box.h / 2,
-          fill: overdraw
-            ? "none"
-            : TOPOLOGY_COLORS[i % TOPOLOGY_COLORS.length],
-          stroke: acSpecial ? "#999" : "black",
+          fill: overdraw ? "none" : rawColor,
+          stroke: "black",
           strokeWidth: 3,
           opacity: overdraw ? 1 : TOPOLOGY_OPACITY,
         }),
@@ -173,7 +352,7 @@ export const Topology: StoryObj<Args> = {
     gallery: {
       title: "Three-Point Set Topologies",
       description:
-        "Nine point-set topologies on the same three labeled points, each drawn as nested rounded-rect neighbourhood outlines around the points they contain.",
+        "Nine point-set topologies on the same three labeled points, each drawn as nested ellipse neighbourhood outlines around the points they contain.",
     },
   },
   render: () => {
@@ -308,16 +487,23 @@ export const TopologyOverdraw: StoryObj<Args> = {
 //    outline was offset by half its own width) and it was only caught by
 //    rendering and comparing pixel coordinates by hand.
 //
-// 4. No concave-enclosure primitive. Bluefish's a/c-neighbourhood panel
-//    (a and c share a neighbourhood, b does not, and b sits between them)
-//    is drawn there as a hand-authored concave SVG path that dips around b.
-//    GoFish's `enclose`/`position` + rect/ellipse vocabulary is entirely
-//    convex-bbox-based, so there is no way to express "wrap these points but
-//    carve out this other one." This port approximates it with the same
-//    convex pill as every other neighbourhood (necessarily also covering b,
-//    which is topologically wrong) and marks it with a grey instead of black
-//    stroke so the discrepancy is at least visible. A real fix needs either
-//    a path-based enclose variant or a documented non-goal.
+// 4. No concave-enclosure OPERATOR. `enclose`/`position` + rect/ellipse is
+//    entirely convex-bbox-based, so there is still no way to ask GoFish to
+//    *discover* a "wrap these points but carve out this other one" shape
+//    from refs. GoFish does, however, have a lower-level `polygon` shape
+//    (explicit local-coordinate point list), which is enough to *replicate*
+//    Bluefish's hand-authored concave SVG path for the a/c neighbourhood by
+//    sampling its cubic Bézier segments into a dense point list and
+//    affinely remapping them onto this story's own point layout (anchored
+//    on the "a"/"c" point centers) — see `acNeighbourhoodPoints`. That's a
+//    faithful reproduction of the *specific* hand-drawn artwork, not a
+//    general concave-hull primitive; a real general fix still needs either
+//    a path-based enclose variant or a documented non-goal. It also
+//    surfaced a smaller gap: `ellipse`/`polygon` had no `opacity` style
+//    prop (unlike `rect`) — since fixed in the library for both, and both
+//    are used here (element opacity dimming fill and stroke together, which
+//    matches how upstream Bluefish applied `opacity` to its whole
+//    Rect/Path elements).
 //
 // 5. Auto-fit canvas margin. The root node's own `x`/`y`/`w`/`h` options
 //    (the technique the Pulley story uses to shift a sub-tree's bounding

--- a/packages/gofish-ir/src/display-list/jsonSchema.ts
+++ b/packages/gofish-ir/src/display-list/jsonSchema.ts
@@ -144,6 +144,8 @@ export const DISPLAY_LIST_JSON_SCHEMA = {
         text: { type: "string" },
         fontSize: { type: "number" },
         fontFamily: { type: "string" },
+        fontStyle: { type: "string" },
+        fontWeight: { type: ["number", "string"] },
         textAnchor: { enum: ["start", "middle", "end"] },
         dominantBaseline: {
           enum: ["auto", "central", "middle", "hanging", "mathematical"],

--- a/packages/gofish-ir/src/display-list/render.ts
+++ b/packages/gofish-ir/src/display-list/render.ts
@@ -67,6 +67,14 @@ const itemToSVG = (item: DisplayItem): string => {
         item.fontFamily !== undefined
           ? ` font-family="${esc(item.fontFamily)}"`
           : "";
+      const fst =
+        item.fontStyle !== undefined
+          ? ` font-style="${esc(item.fontStyle)}"`
+          : "";
+      const fw =
+        item.fontWeight !== undefined
+          ? ` font-weight="${esc(String(item.fontWeight))}"`
+          : "";
       const ta =
         item.textAnchor !== undefined
           ? ` text-anchor="${esc(item.textAnchor)}"`
@@ -79,7 +87,7 @@ const itemToSVG = (item: DisplayItem): string => {
         item.rotate !== undefined
           ? ` transform="rotate(${item.rotate} ${item.x} ${item.y})"`
           : "";
-      return `<text x="${item.x}" y="${item.y}"${fs}${ff}${ta}${db}${rot}${s}>${esc(item.text)}</text>`;
+      return `<text x="${item.x}" y="${item.y}"${fs}${ff}${fst}${fw}${ta}${db}${rot}${s}>${esc(item.text)}</text>`;
     }
     case "image": {
       const par =

--- a/packages/gofish-ir/src/display-list/schema.ts
+++ b/packages/gofish-ir/src/display-list/schema.ts
@@ -99,6 +99,8 @@ export interface TextItem extends BaseDisplayItem {
   text: string;
   fontSize?: number;
   fontFamily?: string;
+  fontStyle?: string;
+  fontWeight?: number | string;
   textAnchor?: "start" | "middle" | "end";
   dominantBaseline?: "auto" | "central" | "middle" | "hanging" | "mathematical";
   /** Rotation in degrees about `(x, y)`, in final screen space (SVG

--- a/packages/gofish-ir/src/display-list/validate.ts
+++ b/packages/gofish-ir/src/display-list/validate.ts
@@ -149,6 +149,20 @@ function checkItem(
         path: `${path}.fontFamily`,
         message: "fontFamily must be a string",
       });
+    if (item.fontStyle !== undefined && !isStr(item.fontStyle))
+      errors.push({
+        path: `${path}.fontStyle`,
+        message: "fontStyle must be a string",
+      });
+    if (
+      item.fontWeight !== undefined &&
+      !isNum(item.fontWeight) &&
+      !isStr(item.fontWeight)
+    )
+      errors.push({
+        path: `${path}.fontWeight`,
+        message: "fontWeight must be a number or a string",
+      });
     if (
       item.textAnchor !== undefined &&
       !["start", "middle", "end"].includes(item.textAnchor as string)

--- a/packages/gofish-ir/src/frontend/descriptors.ts
+++ b/packages/gofish-ir/src/frontend/descriptors.ts
@@ -549,12 +549,13 @@ export const LEAF_MARKS: Record<string, ConstructDescriptor> = {
   }),
 
   ellipse: leafMark("ellipse", {
-    doc: "An ellipse. Box geometry via the shared dims channels; paint is a strict subset of `paint` (no filter/opacity).",
+    doc: "An ellipse. Box geometry via the shared dims channels; paint is a strict subset of `paint` (no filter).",
     include: [boxDims],
     fields: {
       fill: ch.color(),
       stroke: ch.color("Defaults to `fill`."),
       strokeWidth: { type: t.number },
+      opacity: { type: t.number, default: 1 },
       aspectRatio: {
         type: t.number,
         doc: "w/h ratio to enforce. When both dims are data-driven, the constraining axis is used.",
@@ -600,6 +601,14 @@ export const LEAF_MARKS: Record<string, ConstructDescriptor> = {
       filter: { type: t.string, doc: "Raw SVG filter attribute." },
       fontSize: { type: t.number, default: 12 },
       fontFamily: { type: t.string, default: "system-ui, sans-serif" },
+      fontStyle: {
+        type: t.string,
+        doc: 'Raw CSS font-style (e.g. "italic").',
+      },
+      fontWeight: {
+        type: t.union(t.number, t.string),
+        doc: 'CSS font-weight (e.g. 300, 700, "bold").',
+      },
       debugBoundingBox: { type: t.boolean, default: false },
       rotate: {
         type: t.number,
@@ -636,6 +645,7 @@ export const LEAF_MARKS: Record<string, ConstructDescriptor> = {
       fill: { type: t.string, default: "black" },
       stroke: { type: t.string, doc: "Defaults to `fill`." },
       strokeWidth: { type: t.number },
+      opacity: { type: t.number, default: 1 },
       debug: {
         type: t.boolean,
         doc: "Dev-only console.log flag; stripped before layout (FACTORY_ONLY_KEYS).",
@@ -768,6 +778,11 @@ export const COMBINATOR_MARKS: Record<string, ConstructDescriptor> = {
       padding: { type: t.number, default: 2 },
       rx: { type: t.number, default: 2 },
       ry: { type: t.number, default: 2 },
+      fill: { type: t.string, default: "none" },
+      stroke: { type: t.string, default: "#D1D9E2" },
+      strokeWidth: { type: t.number, default: 1 },
+      strokeDasharray: { type: t.string },
+      opacity: { type: t.number, default: 1 },
     },
   }),
 

--- a/packages/gofish-python/gofish/_generated.py
+++ b/packages/gofish-python/gofish/_generated.py
@@ -104,8 +104,8 @@ def circle(*, label: Optional[bool] = None, debug: Optional[bool] = None, r: Opt
             _kw[_k] = _channel(_v)
     return Mark("circle", **_kw)
 
-def ellipse(*, label: Optional[bool] = None, debug: Optional[bool] = None, x: Optional[Union[int, float, str]] = None, cx: Optional[Union[int, float, str]] = None, x2: Optional[Union[int, float, str]] = None, w: Optional[Union[int, float, str]] = None, emX: Optional[bool] = None, y: Optional[Union[int, float, str]] = None, cy: Optional[Union[int, float, str]] = None, y2: Optional[Union[int, float, str]] = None, h: Optional[Union[int, float, str]] = None, emY: Optional[bool] = None, theta: Optional[Union[int, float, str]] = None, thetaSize: Optional[Union[int, float, str]] = None, r: Optional[Union[int, float, str]] = None, rSize: Optional[Union[int, float, str]] = None, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, aspectRatio: Optional[float] = None, **kwargs: Any) -> Mark:
-    """An ellipse. Box geometry via the shared dims channels; paint is a strict subset of `paint` (no filter/opacity).
+def ellipse(*, label: Optional[bool] = None, debug: Optional[bool] = None, x: Optional[Union[int, float, str]] = None, cx: Optional[Union[int, float, str]] = None, x2: Optional[Union[int, float, str]] = None, w: Optional[Union[int, float, str]] = None, emX: Optional[bool] = None, y: Optional[Union[int, float, str]] = None, cy: Optional[Union[int, float, str]] = None, y2: Optional[Union[int, float, str]] = None, h: Optional[Union[int, float, str]] = None, emY: Optional[bool] = None, theta: Optional[Union[int, float, str]] = None, thetaSize: Optional[Union[int, float, str]] = None, r: Optional[Union[int, float, str]] = None, rSize: Optional[Union[int, float, str]] = None, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, opacity: Optional[float] = None, aspectRatio: Optional[float] = None, **kwargs: Any) -> Mark:
+    """An ellipse. Box geometry via the shared dims channels; paint is a strict subset of `paint` (no filter).
 
     Args:
         label: Draw an inline value-label at the mark's center.
@@ -125,6 +125,7 @@ def ellipse(*, label: Optional[bool] = None, debug: Optional[bool] = None, x: Op
         r: Radial position alias (polar coord's y).
         rSize: Radial extent alias (polar coord's h).
         stroke: Defaults to `fill`.
+        opacity: Default 1.
         aspectRatio: w/h ratio to enforce. When both dims are data-driven, the constraining axis is used.
     """
     _kw: Dict[str, Any] = {}
@@ -148,6 +149,7 @@ def ellipse(*, label: Optional[bool] = None, debug: Optional[bool] = None, x: Op
         ("fill", fill),
         ("stroke", stroke),
         ("strokeWidth", strokeWidth),
+        ("opacity", opacity),
         ("aspectRatio", aspectRatio),
     ]:
         if _v is not None:
@@ -208,7 +210,7 @@ def petal(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = N
             _kw[_k] = _channel(_v)
     return Mark("petal", **_kw)
 
-def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = None, x: Optional[Union[int, float, str]] = None, cx: Optional[Union[int, float, str]] = None, x2: Optional[Union[int, float, str]] = None, w: Optional[Union[int, float, str]] = None, emX: Optional[bool] = None, y: Optional[Union[int, float, str]] = None, cy: Optional[Union[int, float, str]] = None, y2: Optional[Union[int, float, str]] = None, h: Optional[Union[int, float, str]] = None, emY: Optional[bool] = None, theta: Optional[Union[int, float, str]] = None, thetaSize: Optional[Union[int, float, str]] = None, r: Optional[Union[int, float, str]] = None, rSize: Optional[Union[int, float, str]] = None, key: Optional[str] = None, text: str, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, filter: Optional[str] = None, fontSize: Optional[float] = None, fontFamily: Optional[str] = None, debugBoundingBox: Optional[bool] = None, rotate: Optional[float] = None) -> Mark:
+def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = None, x: Optional[Union[int, float, str]] = None, cx: Optional[Union[int, float, str]] = None, x2: Optional[Union[int, float, str]] = None, w: Optional[Union[int, float, str]] = None, emX: Optional[bool] = None, y: Optional[Union[int, float, str]] = None, cy: Optional[Union[int, float, str]] = None, y2: Optional[Union[int, float, str]] = None, h: Optional[Union[int, float, str]] = None, emY: Optional[bool] = None, theta: Optional[Union[int, float, str]] = None, thetaSize: Optional[Union[int, float, str]] = None, r: Optional[Union[int, float, str]] = None, rSize: Optional[Union[int, float, str]] = None, key: Optional[str] = None, text: str, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, filter: Optional[str] = None, fontSize: Optional[float] = None, fontFamily: Optional[str] = None, fontStyle: Optional[str] = None, fontWeight: Optional[Union[float, str]] = None, debugBoundingBox: Optional[bool] = None, rotate: Optional[float] = None) -> Mark:
     """A text label. Box geometry via the shared dims channels positions the text anchor.
 
     Args:
@@ -233,6 +235,8 @@ def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = No
         filter: Raw SVG filter attribute.
         fontSize: Default 12.
         fontFamily: Default "system-ui, sans-serif".
+        fontStyle: Raw CSS font-style (e.g. "italic").
+        fontWeight: CSS font-weight (e.g. 300, 700, "bold").
         debugBoundingBox: Default false.
         rotate: Rotation in degrees, applied in the chart's y-up world frame about the text anchor. Default 0.
     """
@@ -262,6 +266,8 @@ def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = No
         ("filter", filter),
         ("fontSize", fontSize),
         ("fontFamily", fontFamily),
+        ("fontStyle", fontStyle),
+        ("fontWeight", fontWeight),
         ("debugBoundingBox", debugBoundingBox),
         ("rotate", rotate),
     ]:
@@ -322,7 +328,7 @@ def image(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = N
             _kw[_k] = _channel(_v)
     return Mark("image", **_kw)
 
-def polygon(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = None, points: List[Any], fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None) -> Mark:
+def polygon(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = None, points: List[Any], fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, opacity: Optional[float] = None) -> Mark:
     """A closed polygon defined by explicit local-coordinate points (y-up). No dims channels — the bbox is computed from `points`.
 
     Args:
@@ -331,6 +337,7 @@ def polygon(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] =
         points: Vertex list, at least 3 points.
         fill: Default "black".
         stroke: Defaults to `fill`.
+        opacity: Default 1.
     """
     _kw: Dict[str, Any] = {}
     for _k, _v in [
@@ -340,6 +347,7 @@ def polygon(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] =
         ("fill", fill),
         ("stroke", stroke),
         ("strokeWidth", strokeWidth),
+        ("opacity", opacity),
     ]:
         if _v is not None:
             _kw[_k] = _channel(_v)
@@ -453,19 +461,28 @@ def mask(children: List["Mark"]) -> Mark:
     """
     return Mark("mask", _children=list(children))
 
-def enclose(children: List["Mark"], *, padding: Optional[float] = None, rx: Optional[float] = None, ry: Optional[float] = None) -> Mark:
+def enclose(children: List["Mark"], *, padding: Optional[float] = None, rx: Optional[float] = None, ry: Optional[float] = None, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, strokeDasharray: Optional[str] = None, opacity: Optional[float] = None) -> Mark:
     """Draw a rounded-rect enclosure around the union of the children's bboxes, padded by `padding`.
 
     Args:
         padding: Default 2.
         rx: Default 2.
         ry: Default 2.
+        fill: Default "none".
+        stroke: Default "#D1D9E2".
+        strokeWidth: Default 1.
+        opacity: Default 1.
     """
     kwargs: Dict[str, Any] = {}
     for _k, _v in [
         ("padding", padding),
         ("rx", rx),
         ("ry", ry),
+        ("fill", fill),
+        ("stroke", stroke),
+        ("strokeWidth", strokeWidth),
+        ("strokeDasharray", strokeDasharray),
+        ("opacity", opacity),
     ]:
         if _v is not None:
             kwargs[_k] = _v

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -19,6 +19,28 @@
 # and byte-parity-validated.
 packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
 #
+# QuantumCircuit (Bluefish port, #438) is a low-level Layer/createName/
+# createMark/enclose diagram (cross-tier refs into nested wire-group layers,
+# an `enclose()` bake boundary used as a highlight box) — the same low-level
+# vocabulary as Pulley/PythonTutor above, not yet expressible via the
+# fluent chart() pipeline.
+packages/gofish-graphics/stories/bluefish/QuantumCircuit.stories.tsx
+#
+# InsertionSort (Bluefish port, #435) is a low-level Layer/createName/
+# createMark diagram (per-cell dynamic name tokens, cross-tier ref arrows
+# from the moving cell to its insertion point, an `enclose()` row outline) —
+# the same low-level vocabulary as QuantumCircuit/Pulley/PythonTutor above,
+# not yet expressible via the fluent chart() pipeline.
+packages/gofish-graphics/stories/bluefish/InsertionSort.stories.tsx
+#
+# Topology (Bluefish port, #440) uses the `position({x, y}, [child])`
+# graphical operator (an absolute-pixel-offset placement primitive) to place
+# analytically-computed neighbourhood outlines (enclose can't style its hull
+# or draw the concave a/c case — see the file's friction-log comment).
+# `position` has no entry in the gofish-ir descriptor table yet, so it isn't
+# in the generated Python wrapper — not portable until it's added.
+packages/gofish-graphics/stories/bluefish/Topology.stories.tsx
+#
 # ViolinPlot is ported too (tests/python-stories/low-level-syntax/
 # test_violin_plot.py) but stays exempt: the JS story uses `fast-kde`'s
 # density1d, while the idiomatic Python port uses `scipy.stats.gaussian_kde`.


### PR DESCRIPTION
Three diagram ports from the Bluefish example gallery, done as design probes for the operators-over-placed-nodes thread (#707).

## Round 2: fidelity pass

The first round got the three stories close to the Bluefish originals. This round checks each one directly against the upstream Bluefish source (joshpoll/bluefish-monorepo) and fixes the remaining gaps instead of guessing at them.

Story fixes:

- **Quantum circuit.** The highlight box now uses the exact upstream color and shape, `rgba(255,200,0,0.333)` with a corner radius of 10 and 10 pixels of padding. The connectors are now 3 pixels wide to match the wire rails, and they sit behind the gate boxes using `zOrder(-1)`.
- **Topology.** Labels sit below the dots instead of beside them. The neighborhood shapes are ellipses instead of rounded rectangles. The concave region for the "a, c" neighborhood is now a faithful port of the upstream path, built from 16 cubic Bezier segments and drawn as a polygon. Element opacity now matches the upstream values.
- **Insertion sort.** The sorted prefix now has a dashed teal border, drawn with `enclose` using a stroke dash pattern of 12 and a stroke width of 4. Each row has a 2 pixel black outline. The labels are italic serif, gray, at font weight 300 and size 14.

These story fixes exposed gaps in the library itself. Each one is fixed end to end, from the JS API through the IR schema, the descriptor table, the generated Python wrapper, and the docs:

- `enclose` now supports `fill`, `stroke`, `strokeWidth`, `strokeDasharray`, and `opacity`. Its background now paints behind its children instead of on top of them.
- `text` now supports `fontStyle` and `fontWeight`. Both are threaded through the canvas measurement code, so styled text measures at its true width instead of the width of the unstyled text.
- `ellipse` and `polygon` now support `opacity`.

We ran `capture-diff` against main to check for unintended side effects on other stories. The only changes are inert `opacity="1"` attributes, the expected reorder of enclose's paint order (pixel-identical to before), and one real fix: the wine bottle story's `fontWeight: "bold"` now actually takes effect. It was silently dropped before this change.

## Round 3: fixes from user review

- **Quantum circuit.** The wire connector had a port bug. Upstream Bluefish's `Stack` defaults its spacing to 10 pixels, so the leader rect needs to be 10 pixels wide, not 0. It was 0. The gate stubs were 10 and 30 pixels and are now an even 20 and 20. We also fixed an invalid `fontFamily` value of "italic serif", which browsers silently render upright, and replaced it with a proper `serif` font family plus a separate italic style.
- **Topology.** The border on the concave "a, c" polygon is now black to match the ellipses. The ellipses are larger, with padding set separately on each axis, so both the dots and their labels stay inside the ellipse at every nesting level. The labels sit closer to their dots. The 3x3 grid of panels is now placed at fixed pitches instead of relying on the layout to space it, which removed phantom extra spacing (see friction log item 7).
- **Insertion sort.** The dashed teal border around the sorted prefix now overhangs the black outline, so it is tangent to the outline's outer edge, matching the Penrose-based original. This includes the slight asymmetry the original has in the middle row at prefix boundaries.

Topology got one follow-up after further review: the innermost single-point neighborhoods are back to small snug circles around just the dot, with the label outside, like the original.

### Round 3 screenshots

**Quantum Circuit Equivalence**

![Quantum circuit equivalence, round 3](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-714/quantum-circuit-round3.png)

**Three-Point Set Topologies**

![Topology, round 4](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-714/topology-round4.png)

![Topology outline-only, round 4](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-714/topology-overdraw-round4.png)

**Insertion Sort**

![Insertion sort, round 3](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-714/insertion-sort-round3.png)

## Round 1 screenshots (for comparison)

**Quantum Circuit Equivalence** (#438)

![Quantum circuit equivalence](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-714/quantum-circuit-equivalence--quantum-circuit.png)

**Three-Point Set Topologies** (#440)

![Topology](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-714/topology--topology.png)

![Topology outline-only](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-714/topology--topology-overdraw.png)

**Insertion Sort** (#435)

![Insertion sort](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-714/insertion-sort--insertion-sort.png)

## Stories

- `stories/bluefish/QuantumCircuit.stories.tsx`, controlled-Z equivalent to H-CNOT-H: two wire-group circuits with full-width parallel rails, gates centered on the bottom rail, cross-tier named refs for the vertical control connectors, and enclose highlight boxes.
- `stories/bluefish/Topology.stories.tsx`, three-point set topologies: a 3x3 panel grid, nested translucent neighborhood shapes computed analytically (see the friction log for why not enclose-over-refs), plus an outline-only variant.
- `stories/bluefish/InsertionSort.stories.tsx`, five algorithm stages, per-cell dynamic name tokens, cross-tier ref arrows from the moving cell to its insertion point, and a growing sorted-prefix border.

All three are gallery-tagged, so the docs example pages and gallery entries auto-generate. They are exempted from Python parity because they use low-level Layer, createName, and createMark vocabulary, the same as Pulley and PythonTutor.

## Why these three

We chose these three to stress reference-heavy patterns: variable-length groups of refs (Topology), a range-of-refs region with dynamic arrow endpoints (Insertion Sort), and backgrounds and alignment across independently built subtrees (Quantum Circuit). Each story ends with a friction-log comment. The recurring findings from round 1 were:

- No span or size matching (4 concrete instances across the three ports). Every extent relationship had to be computed in JS and hardcoded. This is the "span" and "size" alignment-value proposal in the operators-over-placed-nodes essay.
- Enclose over refs collapsed to the origin. All three ports hit this independently. Fixed separately in #713.
- Enclose had no fill or stroke options. Highlight and region styling had to be hand-rolled. Fixed in round 2, see above.
- Assorted DX traps recorded in the logs: `stack` silently dropping `spacing`, silent `.name()` overwrite, `createName()` with no tag, `position()`'s min-corner anchor, and root `Layer` x/y having no effect.

## Verification

We reviewed every story render against the Bluefish original using the capture-one loop. `capture-diff main` shows only the added stories plus the inert diffs described above. `check-python-sync-all` passes.

New stories will need visual baselines recorded on CI (Linux), not generated on Mac, per repo policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #716.


Closes #435. Closes #438. Closes #440.

