### PR TITLE
operators-over-placed-nodes: second round — relate(), plurality, span/size

### DIFF
--- a/apps/docs/docs/internals/design/operators-over-placed-nodes.md
+++ b/apps/docs/docs/internals/design/operators-over-placed-nodes.md
@@ -69,6 +69,15 @@ the semantics only (§2.1), defer the label-accessor spelling to the field-expre
 the label plumbing out as
 [#706](https://github.com/gofish-graphics/gofish-graphics/issues/706).
 
+**Second round (2026-07-09).** A design conversation extended the essay in five ways,
+folded in below: a semantic reading of refs as _variables_ that makes the reporting rule a
+theorem rather than a policy (§2.5); the combinator slot renamed **`relate()`** and opened
+to _mixed_ operand lists, resolving open question 1 (§3.2); an explicit-iteration answer to
+plural refs — no implicit comprehension, `.each()` templates instead (§3.4); a **`"span"` /
+`"size"` alignment-value grammar** that subsumes Bluefish's `LayoutFunction` (all five live
+gallery call sites are one pattern) and piccl's `lengthMatch` (§3.5); and
+ownership-conflict errors promoted from nice-to-have to prerequisite (§4, item 6).
+
 ## 1. Where the language is today
 
 Mechanics established by code reading (2026-07-08), so the design rests on what actually
@@ -208,6 +217,59 @@ where its ink goes — the same altitude question the emphasize thread
 ([#641](https://github.com/gofish-graphics/gofish-graphics/issues/641)) is circling, and
 whatever `emphasize` decides should bind here too.
 
+### 2.5 The binding reading: refs are variables
+
+The reporting rule and the operand-kind table both fall out of one reading, borrowed from
+programming languages: **`.name()` is a binder, and a ref is a variable occurrence.** The
+`.constrain()` callback is literally a binding form today — `collectConstraintRefs` builds
+an environment from the layer's named children and passes it to the callback, a `where`
+clause scoped over siblings (and GoFish's hygienic, bounded name scoping is, in this
+reading, the choice of lexical over dynamic scope). The spec with refs is then a DAG whose
+spanning tree is the ownership tree; refs are the non-tree edges — the standard
+terms-with-sharing picture.
+
+Three consequences do real work:
+
+- **The box equation is a theorem.** "A node's box comes from its fresh children only" is
+  just: attributes are computed over the spanning tree, and _a variable is a reference to a
+  value, not a second occurrence of it_. Each node's geometry is counted once, at its
+  binding site; the double-count bug is what you get from confusing a variable with its
+  value. Likewise a "group of refs" — a term whose subterms are all variables — denotes a
+  _view_ of existing geometry, and views add nothing to the picture. Wrap the view in ink
+  (an enclosure, even an invisible one) and you have built a new closed term whose value is
+  a function of the environment; that term has a box. Survey evidence agrees: every
+  group-of-refs use in the Bluefish gallery is ink-mediated (a background, a border, an
+  underline); none uses a bare ref-group's bbox.
+- **Coordinates are single-assignment variables.** Each (node, axis) placement cell is
+  written exactly once: "initially placed" means already bound; an `align` against a pinned
+  baseline binds unbound cells through a bound one; two writers is a conflict that must be
+  a structured error naming both (today's silent second-write no-op is an unsound checker
+  for a sound discipline — [[constraints-as-core]] records the fix as Bluefish-style
+  `bboxOwners`). The sibling-order requirement (a referencing composite lays out after the
+  referenced chart) is dataflow scheduling of reads-after-writes, and a ref cycle is a
+  deadlock, correctly rejected rather than fixpointed. The configuration has a name in the
+  literature: **reference attribute grammars** (attribute grammars extended so an attribute
+  may reference and read attributes of non-ancestor nodes — Hedin's RAGs, the JastAdd
+  line). GoFish is a RAG that replaces demand-driven evaluation with a required topological
+  order.
+- **Why flow-over-a-selection is impossible, not just weird** (sharpening §3.2's mitigation
+  2, maintainer articulation): **flow position cannot contain unbound coordinates.**
+  Operators bind placements as they traverse, so by the time a selection exists, every
+  coordinate in it is bound — there is nothing left for a "constraint in flow position" to
+  write. Unbound coordinates exist only among siblings inside a composite that has not
+  finished laying out, which is why the writable slot lives on `layer`/composites and
+  nowhere else. The tuple-vs-list asymmetry between `.constrain()` and the
+  `selectAll → resolve → line` pipeline is not two arities of one construct; it is
+  single-assignment showing through the syntax (writable = same scope, pre-placement;
+  read-only = cross scope, post-placement).
+
+One refinement the mixed row forces: **fresh-vs-placed is per-node placement state, not
+ref-vs-literal syntax.** An enclosure over refs is a fresh node (owned by its clause, its
+ink reports upward) whose _coordinates_ are already bound, because they are derived from
+its refs — so inside an outer arrangement it enters pinned, exactly like a ref. This is
+what the implementation already keys on (`isInitiallyPlaced` checks placement, not
+ref-ness, §1); the model just names it.
+
 ## 3. Syntax
 
 ### 3.1 Label accessors → deferred to #700
@@ -247,10 +309,14 @@ layer([bars, labels]).constrain(({ bars, labels }) => [
 ]);
 ```
 
-replaces an `align` + `distribute` pair, and the eight parity-exempt
-`Constraints.stories.tsx` equivalence stories stop being _demonstrations_ that
-`spread ≡ align ∘ distribute` and become _definitionally_ true — the two-panel stories
-could collapse to one chart each (which would also un-exempt them).
+replaces an `align` + `distribute` pair. Precision recorded on review: the equivalence
+`spread ≡ align ∘ distribute` is _already_ definitional in the implementation (`spread`
+elaborates to the shared folds — [[operators-vs-constraints]]); the stories check it
+observationally and remain equivalence stories either way. What this change buys is at the
+surface: today the right-hand side needs a second vocabulary (`Constraint.align` +
+`Constraint.distribute`), while after it, both sides are the _same expression in two
+positions_ — an equivalence between positions rather than between vocabularies, retiring
+the parallel surface.
 
 The recorded worry — "if spread is a constraint maybe the specs start to look weird" — is
 real and worth naming precisely. In `.flow()` position, `spread` reads as _traverse the
@@ -282,6 +348,37 @@ the composed case. The only genuinely deferrable lexical question is which spell
 docs teach for the composed case — decidable late, with real specs side by side, because
 both denote the same fold.
 
+**Second round: the slot is `relate()`, and it admits open terms.** Two decisions,
+resolving open question 1:
+
+1. **Open terms, not refs-only.** `.constrain()` is refs-only by construction (the callback
+   receives only name-keyed handles). Requiring every operand to be a variable is the
+   surface-syntax equivalent of forcing A-normal form — the compiler intermediate form in
+   which every subexpression must be named before use. No language imposes that on users:
+   `x + 1` is normal; nobody writes `let one = 1 in x + one`. Refs-only is why labeling a
+   group today takes the awkward two-step (add the text to the layer, name it, then relate
+   it in a separate clause). Instead, a clause may mix variables and fresh subterms —
+   `spread({ dir: "y" }, [bars, text(...)])` is an expression with one free variable and
+   one literal — and the §2 equations already price it: it claims for its fresh parts,
+   reports fresh-plus-ink upward, and reads-but-never-counts the ref. The whole design
+   compresses to one line:
+
+   > **Children are closed terms; `relate()` clauses are children with free variables. A
+   > mark is a term with no subterms; a constraint is a clause with no fresh subterms and
+   > no ink.** The four table rows are just which parts of a clause happen to be empty.
+
+2. **The rename.** A slot whose clauses include labels, enclosures, and connectors is not
+   well described by "constrain" — connectors and labels constrain nothing. `relate()`
+   (verb, parallel to `flow`) says what the slot does: relate things, some of which already
+   exist. Bluefish's `rels` prop is the honest prior art. `constrain` either retires or
+   survives as informal shorthand for the refs-only special case, the way `align`/
+   `distribute` survive as the named halves.
+
+Fresh operands born inside a `relate()` clause report to the layer that owns the callback —
+they are ordinary children whose spelling happens to sit next to the variables they are
+arranged against. So `relate()` is not a new category of node; it is a _scoping construct_:
+the one place a child expression may mention its siblings by name.
+
 ### 3.3 The mixed row and mark-valued content (later)
 
 `FlowerChart`'s flower is not an annotation of the stem; it is a data glyph co-located with
@@ -301,6 +398,13 @@ taken up:
   [#591](https://github.com/gofish-graphics/gofish-graphics/issues/591)'s `{__inputRef}`
   ref-wrapping RPC is the wrong investment: in every exempt story the ref crosses the
   bridge only to serve as an anchor, and the anchor is the arrangement's business.
+- The structural version of that argument (second round): **names are the serializable
+  alternative to closures.** The exempt mark-functions can't cross the bridge because they
+  _capture_ — a closure over `d[0]` has no wire format. A `relate()` clause _names_: its
+  environment is explicit, its variables are strings, its body is ordinary spec IR. This is
+  defunctionalization — replacing a function value with a first-order description of what
+  it does — and it is the structural reason the open-terms design kills the `d[0]` idiom
+  rather than relocating it.
 
 Simple text labels on marks are _not_ blocked on any of this: multi-label and text-style
 plumbing is split out as
@@ -308,10 +412,120 @@ plumbing is split out as
 `ImageCutWithLabels` — its four constraints are literally the positions `outset-right` and
 `center`).
 
+### 3.4 Plurality: no implicit comprehension
+
+A name bound by a data-driven mark is table-valued — `bars` is one ref per lake. Two
+meanings are genuinely needed for a plural ref in relate position, with one gallery example
+each: relate the _collection_ internally (one enclosure around all the points of a topology
+neighborhood), and instantiate a clause _per element_ (one value label per bar). Any
+surface must distinguish them.
+
+**Rejected: the implicit positional rule.** A first draft distinguished by syntactic
+position — a plural ref as _one operand among others_ auto-maps the clause per element,
+while a plural ref as _the whole operand list_ relates the collection. It failed the
+confusion test immediately: in design review the maintainer could not predict which
+behavior a `spread` over `[enclose(..., cells.slice(0, k)), text(...)]` would trigger, and
+a rule the designer can't predict is a bad rule. Recorded so it isn't reinvented.
+
+**Adopted: plural refs never auto-map.**
+
+- **List position keeps collection semantics** — `enclose({ padding: 8 }, points)` is one
+  hull around the whole selection, matching how `selectAll` already behaves as chart data.
+- **Per-element instantiation is explicit**, via a template method:
+
+  ```ts
+  layer([
+    chart(seafood)
+      .flow(spread({ by: "lake", dir: "x" }))
+      .mark(rect({ h: "count" }).name("bars")),
+  ]).relate(({ bars }) => [
+    bars.each((bar) =>
+      spread({ dir: "y", alignment: "middle", spacing: 10 }, [
+        bar,
+        text({ text: field("count").sum() }),
+      ])
+    ),
+  ]);
+  ```
+
+  `.each` cannot be plain JavaScript `.map`: the selection's cardinality is data-driven and
+  unknown at spec time (`PythonTutor`'s `flatMap` builds N arrows eagerly only because it
+  iterates the _data table_, whose cardinality is known). Instead the callback runs once,
+  _symbolically_, with a placeholder ref — the same move `field("count").sum()` already
+  makes — producing a closed template with one declared binder, instantiated per element at
+  resolution time. A template with a declared binder is defunctionalized, not a capturing
+  closure, so the §3.3 serializability argument survives intact.
+
+Composition notes, recorded but **not needed by any known story** (no commitments implied):
+a clause over two plurals is a join, and the default should be keyed — `caps.at(bar)`
+dereferencing on the shared partition key is exactly `resolve()`'s existing many-to-one
+dereference (default key `__splitBy`); zip is join-on-index if asked for; cross is a nested
+`each`, available but never accidental. Re-partitioning is `.group()`:
+`pts.group("family").each((grp) => line(grp))` is the relate spelling of the existing
+bag-form story (`chart(selectAll("pts")).flow(group({ by: "family" })).mark(line())`). So
+`relate` adds no new scoping mechanism — plural refs carry their partition (each element's
+datum is its group's rows, the usual homogeneity collapse), and the comprehension is
+definable by desugaring to `selectAll` + `group` + `resolve`.
+
+### 3.5 `"span"` and `"size"`: the alignment-value grammar
+
+Two pieces of external evidence, one grammar.
+
+**Bluefish's `LayoutFunction` is empirically one pattern.** The construct is an arbitrary
+layout lambda (`f(fromBBox, toBBox) => partial bbox`, stamped onto the second child), and
+it is the main primitive gap for porting the remaining gallery examples — but across all
+five live gallery call sites (brownie ×2, DFSCQ ×1, ohm ×2) the body is the identical
+extent copy: take the source's `{left, width, right}` (or `{top, height, bottom}`) and
+stamp it onto a bare rect — a cell border, a divider line, a highlight, an underline.
+Nobody reads the second bbox; nobody uses the general form. The "arbitrary lambda" is, in
+the wild, a **span-match constraint**.
+
+**piccl's constraints fit the same slot.** [piccl](https://piccl.github.io/) exposes
+`lineSnap` (align source's reference line to target's on one axis, anchors being fractions
+0–1 or named edges, independently chosen per side, plus an offset), `pointSnap` (2D:
+lineSnap on x ∧ y), `lengthMatch` (source's width/height := target's, cross-channel
+allowed), and `orientMatch` (rotation; out of scope here). Every one is an equation over
+_interval statistics_:
+
+| construct                                    | in interval terms                     | GoFish status                                |
+| -------------------------------------------- | ------------------------------------- | -------------------------------------------- |
+| `lineSnap`, same anchor both sides           | equate `point(t)` on one axis         | today's `align` (t ∈ {0, ½, 1})              |
+| `lineSnap`, fractional/two-sided, offset     | equate `point(t₁)` with `point(t₂)`+c | fits the value slot; deferred                |
+| `pointSnap`                                  | lineSnap on x ∧ lineSnap on y         | ~`position`/anchor territory                 |
+| `lengthMatch`, same channel                  | equate `length`                       | proposed `"size"`                            |
+| `lengthMatch`, cross-channel (w ↔ h)        | equate lengths across axes            | fits the slot; deferred, no gallery evidence |
+| Bluefish `LayoutFunction` (as actually used) | equate the whole interval             | proposed `"span"` = point(0) ∧ point(1)      |
+
+The grammar: an alignment value names which statistic(s) of the axis interval to equate — a
+point (today's `start`/`middle`/`end` are the projections of a span, consistent with the
+placement lattice's span→position vocabulary), **`"size"`** (length only; makes the target
+the same extent without moving it), or **`"span"`** (both endpoints, hence position _and_
+size):
+
+```ts
+align({ x: "span" }, [colGroup, borderRect]); // border adopts colGroup's left AND right
+align({ y: "span" }, [rowGroup, borderRect]); // together: border bounds the cell col × row
+```
+
+That one addition covers all five Bluefish `LayoutFunction` sites and unblocks the brownie,
+DFSCQ, and ohm ports. Fractional and two-sided anchors, offsets, and cross-axis
+`lengthMatch` all fit the same value slot without new constructs, but are deferred until a
+ported example demands one. House rule carried over from the equal-aspect work: when a size
+equality is _data-driven_, it should come from a shared measure
+(`field(name, measure)` on both axes), not a geometric constraint; `"size"` is for the
+geometry-driven residue (a divider matching a stack it has no measure in common with).
+
+Implementation honesty: `"span"`/`"size"` write the _size_ cell, and sizes live in the
+pre-layout claim fold while positions live in placement — that boundary-crossing is
+precisely why size-setting constraints have been the lingering open item in
+[[operators-vs-constraints]]. The Bluefish evidence says the needed case is the easy one:
+the target is always a bare rect with no intrinsic size, so the size cell is genuinely
+unbound. Ship the unbound-target case; let the ownership error (§4, item 6) catch the rest.
+
 ## 4. Implementation
 
 Ordered by independence; each lands separately and is pixel-gated (`capture-diff`, plus the
-parity suite for anything touching IR). Work items 3–5 are tracked by
+parity suite for anything touching IR). Work items 3–7 are tracked by
 [#707](https://github.com/gofish-graphics/gofish-graphics/issues/707).
 
 1. **Label plumbing (#706, S).** Multiple labels per mark, `fontWeight`/`fontFamily`
@@ -341,12 +555,25 @@ parity suite for anything touching IR). Work items 3–5 are tracked by
    fonts are consulted; gate on pixels.
 5. **The mixed-row surface (+ mark-valued content) (L, design-first).** The declarative
    spelling of "arrange fresh content against a selection's nodes" with the anchor
-   implicit, per §3.2/§3.3. Needs the
+   implicit — now concretely `relate()` with open terms and `.each()` templates, per
+   §3.2/§3.3/§3.4. Needs the
    [#641](https://github.com/gofish-graphics/gofish-graphics/issues/641) altitude answer
    for paint order and the
    [#681](https://github.com/gofish-graphics/gofish-graphics/issues/681) claim/scope
    vocabulary settled. Unblocks `FlowerChart` (and gives `LabeledChart` a home if its
    `resolve`-driven variant returns).
+6. **Ownership errors (S–M, prerequisite for opening the vocabulary).** Record an owner per
+   (node, axis, cell) — O(1) per write — and report a structured error naming both writers
+   (Bluefish's `bboxOwners`, as [[constraints-as-core]] already recommends), replacing the
+   silent second-write no-op. An open `relate()` vocabulary with silent conflict swallowing
+   reproduces Bluefish's action-at-a-distance debugging stories; the error must land first
+   or with it. Also turns "arrangement over operands that are all already placed, with
+   nothing movable" from a silent no-op into an honest diagnostic.
+7. **`"span"` and `"size"` alignment values (M).** Per §3.5: the unbound-target case only
+   (target has no intrinsic size on that axis), ownership error otherwise. Evidence-backed
+   by all five Bluefish `LayoutFunction` sites; unblocks the brownie/DFSCQ/ohm gallery
+   ports and the table-as-constraint-folds thread
+   ([#548](https://github.com/gofish-graphics/gofish-graphics/issues/548)).
 
 **What this does to #591:** items (1)–(2) un-exempt two of its four stories with no bridge
 work; item (5) covers `FlowerChart` and plausibly `LabeledChart`. Recommendation: narrow
@@ -356,10 +583,11 @@ are the arrangement's job.
 
 ## 5. Open questions
 
-1. **Where may the constraint instantiation appear?** `.constrain()` only (recommended in
-   §3.2), or also flow-over-selection? The latter is where specs start reading weird — and
-   where placement authority gets contested.
-2. **Vocabulary end-state for the composed case** — teach `spread(opts, refs)` in constrain
+1. ~~**Where may the constraint instantiation appear?**~~ **Resolved (second round):** the
+   slot is `relate()` on composites, and it admits open terms (§3.2). Flow-over-selection
+   is not merely discouraged but impossible under the binding reading — flow position
+   cannot contain unbound coordinates (§2.5).
+2. **Vocabulary end-state for the composed case** — teach `spread(opts, refs)` in relate
    position, or the `align` + `distribute` pair? Purely lexical; decidable late with real
    specs side by side. (The atoms themselves stay public either way — §3.2.)
 3. **Connectors over fresh children** — `connect` mechanically accepts them today. Under
@@ -374,3 +602,14 @@ are the arrangement's job.
 6. **Cross-scope anchoring** — error on non-translate ref paths now (§2.3); the real fix
    composes full transforms along the LCA walk. Same machinery the
    scoped-resolution-boundaries thread needs; do they share an implementation?
+7. **The exact `.each()` surface.** The symbolic-template mechanics (§3.4) need a concrete
+   IR shape (a declared binder + closed clause body), a Python spelling
+   (`bars.each(lambda bar: ...)` running the lambda once against a placeholder), and a
+   decision on whether `.at()`/`.group()` ship at all before a story needs them.
+8. **Deferred piccl semantics** — fractional and two-sided anchors, snap offsets,
+   cross-axis `lengthMatch` (§3.5). All fit the alignment-value slot; adopt individually
+   when a ported example demands one, not before.
+9. **Does `.connect()` fold into `relate()`?** `.connect(line())` is already sugar over the
+   selectAll pipeline; under the one-slot view it could lower to a relate clause. It stays
+   the canonical spelling for simple line/area charts either way — the question is only
+   what it desugars to.


### PR DESCRIPTION
Folds the second design round (2026-07-09) into the operators-over-placed-nodes essay. Advances #707.

## What's new

- **§2.5 The binding reading**: refs are variables (`.name()` = binder, the constrain callback = a `where` clause building an environment); the ownership tree is the spanning tree of the spec DAG, which makes the "box = fresh children only" rule a counted-once theorem rather than a policy. Coordinates are single-assignment cells — today's silent second-write no-op is an unsound checker for a sound discipline. Cites reference attribute grammars (Hedin/JastAdd) as the named configuration. Records the maintainer's argument that flow position *cannot* contain unbound coordinates, making flow-over-selection impossible rather than merely discouraged.
- **§3.2**: the slot is **`relate()`** (renamed from `.constrain()`; Bluefish's `rels` is the prior art) and admits **open terms** — requiring every operand to be a ref is forced A-normal form. Resolves open question 1. Grammar one-liner: children are closed terms; relate clauses are children with free variables.
- **§3.3**: the defunctionalization argument — names are the serializable alternative to closures — as the structural case against #591's `{__inputRef}` RPC.
- **§3.4 Plurality**: no implicit comprehension. List position keeps collection semantics; per-element instantiation is explicit `.each()` templates (symbolic evaluation with a placeholder ref, same move as field expressions). The rejected implicit positional rule is recorded so it isn't reinvented.
- **§3.5 `"span"`/`"size"` alignment values**: Bluefish's `LayoutFunction` is empirically one pattern — all 5 live gallery call sites are an axis-extent copy onto a bare rect — and piccl's `lineSnap`/`lengthMatch` fit the same interval-statistic grammar. The wave-1 ports (#714) produced four more concrete instances of the need.
- **§4**: ownership errors (`bboxOwners`-style) promoted to a prerequisite plan item; span/size added. **§5**: Q1 marked resolved; three questions added (`.each()` surface, deferred piccl semantics, whether `.connect()` desugars to a relate clause).

Empirical grounding from the wave-1 Bluefish ports is in #714's friction logs; the enclose bug those ports surfaced is fixed in #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)