### PR TITLE
align "span"/"size" values + ownership errors for placement writes (#726, #725 core)

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -344,7 +344,9 @@ composes its targets' spaces into the layer's claim on that axis:
   (A former POSITION's pixel extent at σ=1 is `width.run(1) = b−a`, so the
   unified `width`-based sum subsumes the old separate POSITION-sum branch.)
 - `Constraint.align` contributes the alignment fold (`alignSpaceFold` →
-  `resolveAlignmentSpace`) on its axis.
+  `resolveAlignmentSpace`) on its axis — but only for a point-anchor value;
+  `"span"`/`"size"` (#726, below) contribute nothing to the space fold, since
+  their target is UNDEFINED on that axis by construction.
 - `Constraint.nest` contributes the nesting fold (`nestedSpace`,
   `constraints/nest.ts`) and a deterministic dependency plan
   (`constraints/nestPlan.ts`). It is the first _size-setting_ constraint: on
@@ -395,6 +397,31 @@ composes its targets' spaces into the layer's claim on that axis:
   scatter channel such as `x: "lake"` lowers to discrete placement coordinates
   `i / count · axisSize`; those are placement coordinates, not datum values, so
   they become numeric placement facts without affecting the layer's data domain.
+
+- `align`'s `"span"`/`"size"` values (#726, `constraints/align.ts`) are the
+  **third** size-setting mechanism — ships the unbound-target case from the
+  "lingering open item" [[operators-vs-constraints]] flags (a bound target is
+  still an ownership conflict, not a silent write; see
+  [[operators-over-placed-nodes]] §3.5): `"span"` reads the source's
+  already-solved `(min, size)` at lowering time and emits two strong
+  `anchor-pin` facts on the target (`start`/`end`) — the same two-edge
+  cell-closure route `position`'s interval form uses, so it reaches rank 2
+  through the existing bbox machinery with no new solver phase. `"size"` needs
+  a genuinely rank-1 write (a size with **no** position coupling), which the
+  anchor-pin vocabulary can't express (every anchor maps to a `min`/`max`/
+  `center` box key) — it gets its own `SizePinFact`/`emitter.pinSize` that
+  writes the `size` box key directly. `closeSizes` reads a box's `size` key
+  even when the box never reaches rank 2 (a direct pin, not just the solved
+  system), so a size-pin with no companion anchor pin still surfaces a
+  determined size with no solved position; the write-back for that case is a
+  new rank-1 sibling of `setExtent`, `GoFishNode.setSizeOnly` (writes
+  `intrinsicDims[dir].size` only — no ledger, no translate), so the target's
+  position is left to whatever else determines it (a companion align, or the
+  parent-seed `placeUnplacedChild` fallback). Both values are scoped to an
+  **unbound** target — `spaceOn(axis)` is `UNDEFINED` (no `w`/`h`/data
+  binding on that axis) — checked before any fact is emitted; a bound target
+  is an ownership conflict, reported per the paragraph below rather than
+  clobbered.
 
 The layer composes these per axis — children not covered by a constraint
 max-union in as overlay siblings. On an axis a constraint **does** cover, that
@@ -490,7 +517,16 @@ closed box), else the node's local-frame anchor offset. `position`, `align`,
 go through BFS components + pin offsets + distribute/normalized-origin
 fallbacks. Every solved cell writes back through **one path**: a size-strong
 cell sets its extent (`setExtent({min, max})`), a position-only cell pins its
-`min` anchor — replacing the old three-way branch and the size side-channel.
+`min` anchor, a rank-1 size-with-no-position cell (align `"size"`, above)
+sets its size only (`setSizeOnly`) — replacing the old three-way branch and
+the size side-channel. `solvePlacementConstraints` throws on a bbox conflict
+(both intervals' owners named in the message) rather than the silent
+last-writer-wins an ungoverned second write would otherwise produce
+(#725/#726) — align `"span"`/`"size"` reuse this exact path for their
+unbound-target check, and `lowerAlignPlacement` separately warns (not
+throws) when a constraint ends up with nothing movable — every listed
+operand already placed — except the deliberate `isDataPositionedAlignTarget`
+skip (a self-scaled scatter facet), which stays silent.
 
 The placement-coordinate compiler preserves the literal/datum distinction until
 facts are emitted: literals are pixels, while datum coordinates elaborate

--- a/apps/docs/docs/internals/design/constraints-as-core.md
+++ b/apps/docs/docs/internals/design/constraints-as-core.md
@@ -491,6 +491,14 @@ sub-issues for size-setting constraints (#545), scatter/position (#546),
 treemap (#541), the general composition algebra (#547), table (#548), and
 sharedScale claim hoisting (#549).
 
+✅ **Size-setting constraints, unbound-target slice (#726).** `align`'s
+`"span"`/`"size"` values ship a third size-setting mechanism alongside
+`position`'s interval form and `nest` — scoped to a target with no intrinsic
+size on the axis (the case all the Bluefish `LayoutFunction` evidence
+actually needs; see [[operators-over-placed-nodes]] §3.5). A bound target is
+an ownership conflict, not silently resolved — the residual case (#545) is
+still open for a target that already carries a size.
+
 ## Python / IR implications
 
 **Decision: the high-level IR stays the Python bridge target.** Operators

--- a/apps/docs/docs/internals/design/operators-over-placed-nodes.md
+++ b/apps/docs/docs/internals/design/operators-over-placed-nodes.md
@@ -562,17 +562,26 @@ parity suite for anything touching IR). Work items 3–7 are tracked by
    [#681](https://github.com/gofish-graphics/gofish-graphics/issues/681) claim/scope
    vocabulary settled. Unblocks `FlowerChart` (and gives `LabeledChart` a home if its
    `resolve`-driven variant returns).
-6. **Ownership errors (S–M, prerequisite for opening the vocabulary).** Record an owner per
-   (node, axis, cell) — O(1) per write — and report a structured error naming both writers
-   (Bluefish's `bboxOwners`, as [[constraints-as-core]] already recommends), replacing the
-   silent second-write no-op. An open `relate()` vocabulary with silent conflict swallowing
-   reproduces Bluefish's action-at-a-distance debugging stories; the error must land first
-   or with it. Also turns "arrangement over operands that are all already placed, with
-   nothing movable" from a silent no-op into an honest diagnostic.
-7. **`"span"` and `"size"` alignment values (M).** Per §3.5: the unbound-target case only
-   (target has no intrinsic size on that axis), ownership error otherwise. Evidence-backed
-   by all five Bluefish `LayoutFunction` sites; unblocks the brownie/DFSCQ/ohm gallery
-   ports and the table-as-constraint-folds thread
+6. ✅ **Ownership errors (S–M, prerequisite for opening the vocabulary). SHIPPED (#725 core)
+   alongside item 7.** The placement solver's rank-2 bbox (`constraints/bbox.ts`) already
+   recorded an owner per equation and returned a structured `BBoxConflict`; what shipped here
+   is `solvePlacementConstraints` throwing on it (naming both writers, their asserted/implied
+   values, the axis) instead of a silent second-write no-op, plus a `console.warn` in
+   `lowerAlignPlacement` when a constraint's operands are all already placed and nothing is
+   movable — except the deliberate `isDataPositionedAlignTarget` skip (a self-scaled scatter
+   facet stays silent). The general per-(node,axis,cell) owner ledger across every `place()`
+   call site (item 6's original full scope — seed-vs-assert write strength, threading an
+   `owner` string through every operator) is NOT done; only the constraint-solver write-back
+   path (already the one with real ownership data) got the throw. Still open.
+7. ✅ **`"span"` and `"size"` alignment values (M). SHIPPED.** Per §3.5: the unbound-target case
+   only (target has no intrinsic size on that axis — checked via the target's
+   `spaceOn`/`isUNDEFINED`), ownership error otherwise, reusing item 6's throw path. `"span"`
+   reduces to `position`'s existing two-edge-pin route (`constraints/align.ts`); `"size"` needed
+   a genuinely rank-1 size-only write with no position coupling, added as a new
+   `SizePinFact`/`emitter.pinSize` fact kind and a `GoFishNode.setSizeOnly` write-back sibling
+   of `setExtent`. Evidence-backed by all five Bluefish `LayoutFunction` sites; unblocks the
+   brownie/DFSCQ/ohm gallery ports (not yet done — this item is the primitive, not the ports)
+   and the table-as-constraint-folds thread
    ([#548](https://github.com/gofish-graphics/gofish-graphics/issues/548)).
 
 **What this does to #591:** items (1)–(2) un-exempt two of its four stories with no bridge

--- a/apps/docs/docs/js/api/constraints/constrain.md
+++ b/apps/docs/docs/js/api/constraints/constrain.md
@@ -42,14 +42,34 @@ Aligns a set of children to a shared edge or center on one or both axes. At leas
 Constraint.align({ x?, y? }, [ref1, ref2, ...])
 ```
 
-| Option | Type                           | Default | Description                                                           |
-| ------ | ------------------------------ | ------- | --------------------------------------------------------------------- |
-| `x`    | `AlignAnchor \| AlignAnchor[]` | —       | Edge/center/origin to align on the x axis (omit to leave x untouched) |
-| `y`    | `AlignAnchor \| AlignAnchor[]` | —       | Edge/center/origin to align on the y axis (omit to leave y untouched) |
+| Option | Type                          | Default | Description                                                                 |
+| ------ | ----------------------------- | ------- | --------------------------------------------------------------------------- |
+| `x`    | `AlignValue \| AlignAnchor[]` | —       | Value/edge/center/origin to align on the x axis (omit to leave x untouched) |
+| `y`    | `AlignValue \| AlignAnchor[]` | —       | Value/edge/center/origin to align on the y axis (omit to leave y untouched) |
 
-`AlignAnchor` is `"start" \| "middle" \| "end" \| "baseline"`. The first three anchor a child by its bounding-box edge or center. `"baseline"` anchors a child by its **origin** (its local 0 point) instead of its box. With no placed sibling the fallback is the **axis origin**: the scale's zero (`posScale(0)`) on a scaled axis, the layer's origin on a pixel-pure one. On a pixel-pure axis, `align({ y: "baseline" })` thus means "stay where you were laid out" — regardless of how far its box overhangs the origin (a bar dipping below zero, axis labels hanging under a chart). For an unconditional origin pin regardless of axis, use `Constraint.position({ x: 0, y: 0, anchor: "baseline" })`. Pass a single value to share one anchor across every child (the common case); pass an array to assign one anchor _per child_ positionally — the array length must equal the number of children.
+`AlignValue` is `AlignAnchor | "span" | "size"`, where `AlignAnchor` is `"start" \| "middle" \| "end" \| "baseline"`. The first three anchor a child by its bounding-box edge or center. `"baseline"` anchors a child by its **origin** (its local 0 point) instead of its box. With no placed sibling the fallback is the **axis origin**: the scale's zero (`posScale(0)`) on a scaled axis, the layer's origin on a pixel-pure one. On a pixel-pure axis, `align({ y: "baseline" })` thus means "stay where you were laid out" — regardless of how far its box overhangs the origin (a bar dipping below zero, axis labels hanging under a chart). For an unconditional origin pin regardless of axis, use `Constraint.position({ x: 0, y: 0, anchor: "baseline" })`. Pass a single value to share one anchor across every child (the common case); pass an array to assign one anchor _per child_ positionally — the array length must equal the number of children (`"span"`/`"size"` are whole-constraint values and cannot appear inside a per-child array).
 
 The first already-placed child in the list acts as the anchor on each specified axis (read at _that child's_ anchor). Unplaced children are moved to match it (placed at _their own_ anchor). If no child is placed yet, the fallback depends on the axis's underlying space: a scaled axis uses the scale origin `posScale(0)`, a pixel-pure axis uses the layer's own edge (`start` = 0, `middle` = midpoint, `end` = full extent, `baseline` = layer origin). When both `x` and `y` are given, x is resolved before y.
+
+### `"span"` and `"size"`
+
+`"span"` and `"size"` name an **interval statistic** rather than a point anchor — they equate the size cell itself, not just a position on it:
+
+- `"span"` — the target adopts the source's **both** endpoints: position AND size (e.g. a border rect that exactly bounds a placed group).
+- `"size"` — the target adopts only the source's **length**, without moving (e.g. a divider that matches a stack's width but is positioned independently).
+
+Like the point-anchor form, the source is the first already-placed child; every other listed child is a target.
+
+```ts
+Layer([group, rect({ fill: "none", stroke: "#333" }).name("border")]).constrain(
+  ({ group, border }) => [
+    Constraint.align({ x: "span" }, [group, border]), // border adopts group's left AND right
+    Constraint.align({ y: "span" }, [group, border]), // together: border exactly bounds the group
+  ]
+);
+```
+
+**Unbound-target scope**: `"span"`/`"size"` only apply when the target has **no intrinsic size** on that axis (a bare `rect({})` with no `w`/`h`/data binding on that axis). If the target already has an intrinsic size, this is an ownership conflict — GoFish throws a structured error naming the constraint and the target's own size option, rather than silently clobbering or skipping it. Fractional/two-sided anchors, offsets, and cross-axis length matching are not supported.
 
 ### Per-child anchors
 

--- a/apps/docs/docs/python/api/constraints/constrain.md
+++ b/apps/docs/docs/python/api/constraints/constrain.md
@@ -64,6 +64,38 @@ a scaled axis uses the scale origin `posScale(0)`, a pixel-pure axis uses the
 layer's own edge (`start` = 0, `middle` = midpoint, `end` = full extent,
 `baseline` = layer origin).
 
+### `"span"` and `"size"`
+
+`x` / `y` also accept `"span"` and `"size"` — an **interval statistic** rather
+than a point anchor, equating the size cell itself:
+
+- `"span"` — the target adopts the source's **both** endpoints: position AND
+  size (e.g. a border rect that exactly bounds a placed group).
+- `"size"` — the target adopts only the source's **length**, without moving
+  (e.g. a divider that matches a stack's width but is positioned
+  independently).
+
+As with the point-anchor form, the source is the first already-placed ref;
+every other listed ref is a target.
+
+```python
+layer([group, rect(fill="none", stroke="#333").name("border")]).constrain(
+    lambda group, border: [
+        Constraint.align([group, border], x="span"),  # border adopts group's left AND right
+        Constraint.align([group, border], y="span"),  # together: border exactly bounds the group
+    ]
+)
+```
+
+**Unbound-target scope**: `"span"`/`"size"` only apply when the target has
+**no intrinsic size** on that axis (a bare `rect()` with no `w`/`h`/data
+binding on that axis). If the target already has an intrinsic size, this is
+an ownership conflict — GoFish raises a structured error naming the
+constraint and the target's own size option, rather than silently clobbering
+or skipping it. Fractional/two-sided anchors, offsets, and cross-axis length
+matching are not supported. `"span"`/`"size"` are whole-constraint values and
+cannot appear inside a per-ref list.
+
 ### Per-ref anchors
 
 The list form of `x` / `y` expresses "edges share" relations directly — the

--- a/packages/gofish-graphics/src/ast/_node.ts
+++ b/packages/gofish-graphics/src/ast/_node.ts
@@ -156,6 +156,18 @@ export type Placeable = {
    *  Handles `baseline` too, so a scatter override never bypasses the ledger.
    *  Optional for the same reason as `setExtent` (a `ref` stand-in omits it). */
   pinAnchor?: (axis: FancyDirection, value: number, anchor: Anchor) => void;
+  /** Write ONLY this axis's size, leaving position untouched (#726, align
+   *  `"size"`) — the genuinely rank-1 sibling of `setExtent`'s rank-2 write
+   *  (which requires ≥2 keys and refuses a lone `size`, since that alone
+   *  can't determine a position; here that's the point). Optional for the
+   *  same reason as `setExtent`/`pinAnchor`. */
+  setSizeOnly?: (axis: FancyDirection, size: number, owner?: string) => void;
+  /** This target's resolved {@link UnderlyingSpace} on `dir`, when known — the
+   *  unbound-target test for align `"span"`/`"size"` (#726): `isUNDEFINED` on
+   *  this means the target has no intrinsic size/position on that axis (a bare
+   *  `rect({})`), so the size cell is free for the constraint to own. Optional
+   *  for the same reason as the other constraint write hooks. */
+  spaceOn?: (dir: Direction) => UnderlyingSpace | undefined;
 };
 
 /** Place a child at `(0, 0)` on whichever axes it hasn't already resolved a
@@ -1231,6 +1243,29 @@ export class GoFishNode {
       value -
       localAnchorPoint(anchor, intrinsic?.min ?? 0, intrinsic?.size ?? 0);
     this._clearTranslateIfSolved(dir);
+  }
+
+  /**
+   * Write ONLY this axis's size (#726, align `"size"`) — no bbox ledger, no
+   * translate write. Overwrites whatever the node's own layout computed for
+   * `size` (e.g. a bare rect's baked `DEFAULT_RECT_SIZE`) in place, so a
+   * subsequent position write (a companion align, or the parent-seed
+   * `placeUnplacedChild` fallback) still lands normally — this genuinely does
+   * not participate in position resolution at all.
+   */
+  public setSizeOnly(
+    axis: FancyDirection,
+    size: number,
+    _owner?: string
+  ): void {
+    const dir = elaborateDirection(axis);
+    if (!this.intrinsicDims) this.intrinsicDims = [];
+    this.intrinsicDims[dir] = { ...(this.intrinsicDims[dir] ?? {}), size };
+  }
+
+  /** {@link Placeable.spaceOn} */
+  public spaceOn(dir: Direction): UnderlyingSpace | undefined {
+    return this._underlyingSpace?.[dir];
   }
 
   /** Lazily ensure `transform.translate` exists (preserving any `scale`) and

--- a/packages/gofish-graphics/src/ast/constraints/align.ts
+++ b/packages/gofish-graphics/src/ast/constraints/align.ts
@@ -5,12 +5,14 @@
 import type { Placeable } from "../_node";
 import type {
   AlignAnchor,
+  AlignValue,
   Axis,
   ConstraintPosScales,
   ConstraintRef,
 } from "./shared";
 import { axisIndex } from "./shared";
 import type { UnderlyingSpace } from "../underlyingSpace";
+import { isUNDEFINED } from "../underlyingSpace";
 import { resolveAlignmentSpace } from "../graphicalOperators/alignment";
 import type { PlacementFactEmitter } from "./placementFacts";
 
@@ -33,12 +35,15 @@ export function alignSpaceFold(
 }
 
 /**
- * Anchor spec for one axis of an `align` constraint. A single anchor
+ * Value spec for one axis of an `align` constraint. A single anchor
  * is shared by every child (the common case). An array gives each child its
  * own anchor positionally — `align({x: ["middle", "start"]}, [A, B])` aligns
  * A's center with B's start. The array length must equal `children.length`.
+ * `"span"`/`"size"` (#726) are whole-constraint values, not per-child — a
+ * heterogeneous array of point anchors has no span/size equivalent, so they
+ * are rejected inside an array (see `normalizedAnchors`).
  */
-export type AlignAxisSpec = AlignAnchor | AlignAnchor[];
+export type AlignAxisSpec = AlignValue | AlignAnchor[];
 
 export interface AlignConstraint {
   type: "align";
@@ -64,7 +69,10 @@ export const createAlignConstraint = (
   return { type: "align", x, y, children };
 };
 
-function normalizedAnchors(spec: AlignAxisSpec, count: number): AlignAnchor[] {
+function normalizedAnchors(
+  spec: AlignAnchor | AlignAnchor[],
+  count: number
+): AlignAnchor[] {
   if (!Array.isArray(spec)) return new Array<AlignAnchor>(count).fill(spec);
   if (spec.length !== count) {
     throw new Error(
@@ -103,8 +111,79 @@ export function lowerAlignPlacement(
     isPinned: (axis: Axis, name: string) => boolean;
   }
 ): void {
+  /**
+   * `"span"`/`"size"` (#726): equate an interval statistic against the first
+   * PINNED (already-placed) child — the source — rather than a point anchor.
+   * Scope: the unbound-target case only (§3.5 of
+   * operators-over-placed-nodes.md) — a target with no intrinsic size on this
+   * axis (`isUNDEFINED` on its resolved space). A target that already has an
+   * intrinsic size is an ownership conflict (two writers for one cell): report
+   * it, don't clobber or silently skip.
+   */
+  const emitSpanOrSize = (axis: Axis, kind: "span" | "size") => {
+    const idx = axisIndex(axis);
+    const children = constraint.children.filter((child) =>
+      targets.has(child.name)
+    );
+    if (children.length < 2) return;
+    const sourceRef = children.find((child) => isPinned(axis, child.name));
+    if (!sourceRef) {
+      throw new Error(
+        `Constraint.align: "${kind}" on axis "${axis}" (${owner}) needs an ` +
+          `already-placed source — none of [${children
+            .map((c) => c.name)
+            .join(", ")}] is placed yet.`
+      );
+    }
+    const source = targets.get(sourceRef.name)!;
+    const sourceMin = source.dims[idx].min;
+    const sourceSize = source.dims[idx].size;
+    if (sourceMin === undefined || sourceSize === undefined) {
+      throw new Error(
+        `Constraint.align: "${kind}" on axis "${axis}" (${owner}) source ` +
+          `"${sourceRef.name}" has no resolved extent yet.`
+      );
+    }
+    for (const child of children) {
+      if (child.name === sourceRef.name) continue;
+      const target = targets.get(child.name)!;
+      const space = target.spaceOn?.(idx);
+      if (space === undefined || !isUNDEFINED(space)) {
+        throw new Error(
+          `Constraint.align: "${kind}" on axis "${axis}" (${owner}) cannot ` +
+            `set "${child.name}"'s ${
+              kind === "size" ? "size" : "position and size"
+            } — it already has an intrinsic ${
+              axis === "x" ? "width" : "height"
+            } (writer: "${child.name}"'s own size option). "${kind}" only ` +
+            `applies to a target with no intrinsic size on that axis.`
+        );
+      }
+      if (kind === "span") {
+        emitter.pin({
+          axis,
+          target: { name: child.name, anchor: "start" },
+          value: sourceMin,
+          owner,
+        });
+        emitter.pin({
+          axis,
+          target: { name: child.name, anchor: "end" },
+          value: sourceMin + sourceSize,
+          owner,
+        });
+      } else {
+        emitter.pinSize({ axis, name: child.name, value: sourceSize, owner });
+      }
+    }
+  };
+
   const emit = (axis: Axis, spec: AlignAxisSpec | undefined) => {
     if (spec === undefined) return;
+    if (spec === "span" || spec === "size") {
+      emitSpanOrSize(axis, spec);
+      return;
+    }
     const children = constraint.children.filter((child) =>
       targets.has(child.name)
     );
@@ -126,12 +205,34 @@ export function lowerAlignPlacement(
     // writes. Faceted scatter panels, where every panel is already
     // data-positioned, still contribute no write targets.
     const source = entries.find(({ child }) => isPinned(axis, child.name));
-    const movable = entries.filter(({ child, anchor }) => {
-      if (isPinned(axis, child.name)) return false;
+    const nonPinned = entries.filter(
+      ({ child }) => !isPinned(axis, child.name)
+    );
+    const movable = nonPinned.filter(({ child, anchor }) => {
       const target = targets.get(child.name);
       return !isDataPositionedAlignTarget(target, anchor, idx, posScales);
     });
-    if (movable.length === 0) return;
+    if (movable.length === 0) {
+      // Nothing this constraint can write is either the deliberate
+      // data-positioned skip (scatter facets — stay silent, `align` never
+      // fights a self-scaled panel) or a genuine "every operand is already
+      // placed" no-op, which is worth an honest diagnostic (#725 item 6)
+      // rather than a silent nothing.
+      const allDataPositioned =
+        nonPinned.length > 0 &&
+        nonPinned.every(({ child, anchor }) => {
+          const target = targets.get(child.name);
+          return isDataPositionedAlignTarget(target, anchor, idx, posScales);
+        });
+      if (!allDataPositioned) {
+        console.warn(
+          `[align] ${owner} on axis "${axis}": nothing movable — every ` +
+            `operand [${children.map((c) => c.name).join(", ")}] is ` +
+            `already placed.`
+        );
+      }
+      return;
+    }
 
     if (source) {
       for (const target of movable) {

--- a/packages/gofish-graphics/src/ast/constraints/compose.ts
+++ b/packages/gofish-graphics/src/ast/constraints/compose.ts
@@ -282,7 +282,11 @@ export function composeConstraintSpaces(
     if (idx === undefined) continue;
     for (const axis of [0, 1] as const) {
       const spec = axis === 0 ? a.x : a.y;
-      if (typeof spec === "string")
+      // "span"/"size" (#726) are placement-time interval statistics, not a
+      // point-anchor space fold — the target they write is UNDEFINED on this
+      // axis by construction (that's the unbound-target scope), so it
+      // contributes no space claim here.
+      if (typeof spec === "string" && spec !== "span" && spec !== "size")
         alignFolds.push({ axis, anchor: spec, idx });
     }
   }

--- a/packages/gofish-graphics/src/ast/constraints/placementFacts.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementFacts.ts
@@ -40,10 +40,27 @@ export type AnchorParticipantFact = {
   owner: string;
 };
 
+/** A size-cell equation independent of any anchor (#726, align `"size"`): the
+ *  target's `size` box key := `value`, with no coupling to `min`/`max`/`center`.
+ *  Consumed directly by `closeSizes` — it feeds the SAME per-node `BBox` an
+ *  anchor pin would, so it combines with a companion anchor pin (from another
+ *  constraint or an authoritative position pin) to reach rank 2, but alone it
+ *  stays under-determined for POSITION (by design — "size" must not move the
+ *  target) while still being read back by `reduceToAxisProblem`'s strong-size
+ *  substitution. */
+export type SizePinFact = {
+  type: "size-pin";
+  node: NodeId;
+  axis: Axis;
+  value: number;
+  owner: string;
+};
+
 export type AnchorFact =
   | AnchorPinFact
   | AnchorRelationFact
-  | AnchorParticipantFact;
+  | AnchorParticipantFact
+  | SizePinFact;
 
 export type AnchorProgram = { axes: [AnchorFact[], AnchorFact[]] };
 
@@ -84,6 +101,15 @@ export type PlacementPinRequest = {
   owner: string;
 };
 
+/** Request a size-only equation on `name` (#726, align `"size"`) — see
+ *  {@link SizePinFact}. */
+export type PlacementSizePinRequest = {
+  axis: Axis;
+  name: NodeId;
+  value: number;
+  owner: string;
+};
+
 export type PlacementParticipant = {
   type: "participant";
   name: NodeId;
@@ -108,6 +134,7 @@ export interface PlacementFactEmitter {
   pin(request: PlacementPinRequest): void;
   include(request: PlacementParticipantRequest): void;
   relate(request: PlacementRelationRequest): void;
+  pinSize(request: PlacementSizePinRequest): void;
 }
 
 export const anchorExpr = (

--- a/packages/gofish-graphics/src/ast/constraints/placementProgramLowerer.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementProgramLowerer.ts
@@ -12,6 +12,7 @@ import type {
   PlacementParticipantRequest,
   PlacementPinRequest,
   PlacementRelationRequest,
+  PlacementSizePinRequest,
 } from "./placementFacts";
 import { emptyAnchorProgram } from "./placementFacts";
 
@@ -96,6 +97,17 @@ export class PlacementProgramLowerer implements PlacementFactEmitter {
       from: { node: request.from.name, anchor: request.from.anchor },
       to: { node: request.to.name, anchor: request.to.anchor },
       gap: request.gap,
+      owner: request.owner,
+    });
+  }
+
+  pinSize(request: PlacementSizePinRequest): void {
+    if (!this.target(request.name)) return;
+    this.anchorFacts(request.axis).push({
+      type: "size-pin",
+      node: request.name,
+      axis: request.axis,
+      value: request.value,
       owner: request.owner,
     });
   }

--- a/packages/gofish-graphics/src/ast/constraints/placementSolver.ts
+++ b/packages/gofish-graphics/src/ast/constraints/placementSolver.ts
@@ -87,17 +87,21 @@ function closeSizes(
   const boxOwner = new Map<NodeId, string>();
   const conflicts: PlacementConflict[] = [];
   for (const fact of pins) {
-    if (fact.type !== "anchor-pin") continue;
+    if (fact.type !== "anchor-pin" && fact.type !== "size-pin") continue;
     if (fact.owner === "self-placement") continue; // weak seed, not a strong fact
-    if (fact.anchor === "baseline") continue; // baseline is not a size box key
+    if (fact.type === "anchor-pin" && fact.anchor === "baseline") continue; // baseline is not a size box key
     // start→min, middle→center, end→max — the same edge classification
     // `anchorOffset` applies (a non-canonical value falls to the same branch).
+    // A size-pin (#726, align `"size"`) writes the `size` key directly,
+    // independent of any anchor.
     const boxKey =
-      fact.anchor === "start"
-        ? "min"
-        : fact.anchor === "middle"
-          ? "center"
-          : "max";
+      fact.type === "size-pin"
+        ? "size"
+        : fact.anchor === "start"
+          ? "min"
+          : fact.anchor === "middle"
+            ? "center"
+            : "max";
     let box = boxes.get(fact.node);
     if (!box) {
       boxes.set(fact.node, (box = new BBox()));
@@ -117,7 +121,10 @@ function closeSizes(
   const sizes = new Map<NodeId, number>();
   const owners = new Map<NodeId, string>();
   for (const [node, box] of boxes) {
-    if (!box.solved) continue;
+    // Not gated on `box.solved`: a rank-1 box holding only a direct `"size"`
+    // pin (align `"size"`, no companion anchor) still reads its size back
+    // (`BBox.read` falls back to the direct pin when under-determined) — that
+    // is exactly the "size without a determined position" case.
     const size = box.read("size");
     if (size !== undefined) {
       sizes.set(node, size);
@@ -158,6 +165,12 @@ function reduceToAxisProblem(
   };
 
   for (const fact of facts) {
+    // A size-pin only feeds `closeSizes`'s box closure (above) — it has no
+    // anchor/position content of its own, so the difference graph never sees
+    // it. When it stays rank-1 (no companion anchor pin lands on this node),
+    // the target's size is under-determined here and keeps whatever its own
+    // layout gave it — exactly "size" without movement.
+    if (fact.type === "size-pin") continue;
     if (fact.type === "anchor-pin") {
       const offset = resolveOffset(fact.node, fact.anchor);
       if (offset === undefined) continue;
@@ -199,7 +212,11 @@ function solveRank2Axis(
   axis: Axis,
   facts: AnchorFact[],
   targets: Map<string, Placeable>
-): { cells: Map<NodeId, SolvedCell>; conflicts: PlacementConflict[] } {
+): {
+  cells: Map<NodeId, SolvedCell>;
+  sizeOnly: Map<NodeId, { size: number; owner: string }>;
+  conflicts: PlacementConflict[];
+} {
   const { sizes, owners, conflicts: sizeConflicts } = closeSizes(axis, facts);
   const problem = reduceToAxisProblem(axis, facts, sizes, targets);
   const { positions, conflicts: graphConflicts } = solveAxisProblem(
@@ -219,7 +236,16 @@ function solveRank2Axis(
       sizeOwner: owners.get(node),
     });
   }
-  return { cells, conflicts: [...sizeConflicts, ...graphConflicts] };
+  // A determined size with no solved position: align `"size"` with no
+  // companion anchor pin never becomes a difference-graph participant, so it
+  // never surfaces in `positions` above — it still needs a write-back, just
+  // the size, with no position coupling (#726).
+  const sizeOnly = new Map<NodeId, { size: number; owner: string }>();
+  for (const [node, size] of sizes) {
+    if (cells.has(node)) continue;
+    sizeOnly.set(node, { size, owner: owners.get(node)! });
+  }
+  return { cells, sizeOnly, conflicts: [...sizeConflicts, ...graphConflicts] };
 }
 
 export function solvePlacementConstraints(
@@ -266,6 +292,10 @@ export function solvePlacementConstraints(
         );
       } else if (target.pinAnchor) target.pinAnchor(axis, cell.min, "min");
       else target.place(axis, cell.min, "min");
+    }
+    for (const [name, { size, owner }] of result.sizeOnly) {
+      const target = targets.get(name);
+      target?.setSizeOnly?.(axisLabel, size, owner);
     }
   });
   return conflicts;

--- a/packages/gofish-graphics/src/ast/constraints/shared.ts
+++ b/packages/gofish-graphics/src/ast/constraints/shared.ts
@@ -13,6 +13,14 @@ export type Alignment = "start" | "middle" | "end";
  *  solver normalizes that floating component so its minimum coordinate is 0. */
 export type AlignAnchor = Alignment | "baseline";
 
+/** The align constraint's full per-axis value grammar (#726): a point anchor
+ *  ({@link AlignAnchor}), or an interval statistic over the size cell —
+ *  `"size"` (equate lengths only; the target does not move) or `"span"`
+ *  (equate both endpoints: position AND size). `"span"`/`"size"` are align-only
+ *  — they name a relation the target has no intrinsic size for, not a point on
+ *  a box, so `position`/`distribute` do not accept them. */
+export type AlignValue = AlignAnchor | "span" | "size";
+
 /** Lightweight handle for referencing a named child inside .constrain() */
 export type ConstraintRef = { readonly name: string };
 

--- a/packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx
+++ b/packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx
@@ -516,3 +516,74 @@ export const AlignCenterDistributeY: StoryObj<Args> = {
     return container;
   },
 };
+
+// ──────────────────────────────────────────────────────────
+// "span" / "size" alignment values (#726)
+// ──────────────────────────────────────────────────────────
+
+/**
+ * `align({ x: "span" })` / `align({ y: "span" })`: a bare, unbound rect
+ * ("border") adopts an already-placed group's full extent on both axes —
+ * position AND size — without the group moving. `group` is a literal-
+ * positioned sub-layer (so it is already placed when the outer align runs),
+ * matching the Bluefish `LayoutFunction` pattern this value grammar replaces
+ * (cell border / highlight / underline — take the source's `[min, max]` and
+ * stamp it onto a bare rect).
+ */
+export const AlignSpan: StoryObj<Args> = {
+  args: { w: 340, h: 220 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    const group = layer({ x: 40, y: 50 }, [
+      rect({ w: 60, h: 60, fill: "#e63946" }).name("a"),
+      rect({ w: 60, h: 60, fill: "#457b9d" }).name("b"),
+      rect({ w: 60, h: 60, fill: "#2a9d8f" }).name("c"),
+    ])
+      .constrain(({ a, b, c }) => [
+        Constraint.align({ y: "start" }, [a, b, c]),
+        Constraint.distribute({ dir: "x", spacing: 10 }, [a, b, c]),
+      ])
+      .name("group");
+
+    layer([
+      group,
+      rect({ fill: "none", stroke: "#333", strokeWidth: 2 }).name("border"),
+    ])
+      .constrain(({ group, border }) => [
+        Constraint.align({ x: "span" }, [group, border]),
+        Constraint.align({ y: "span" }, [group, border]),
+      ])
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};
+
+/**
+ * `align({ x: "size" })`: a bare, unbound-on-x divider rect adopts a placed
+ * stack's WIDTH without moving — its x position is left to the parent seed
+ * (it is not itself given an x, and no other constraint touches its x), and
+ * its y is set independently (a literal `y`, positioning it below the
+ * stack). Verifies "size" copies length only, with no position coupling.
+ */
+export const AlignSize: StoryObj<Args> = {
+  args: { w: 320, h: 180 },
+  render: (args: Args) => {
+    const container = initializeContainer();
+    const stack = layer({ x: 0, y: 20 }, [
+      rect({ w: 220, h: 30, fill: "#e63946" }).name("s1"),
+      rect({ w: 220, h: 30, fill: "#457b9d" }).name("s2"),
+    ])
+      .constrain(({ s1, s2 }) => [
+        Constraint.align({ x: "start" }, [s1, s2]),
+        Constraint.distribute({ dir: "y", spacing: 4 }, [s1, s2]),
+      ])
+      .name("stack");
+
+    layer([stack, rect({ y: 110, h: 10, fill: "#2a9d8f" }).name("divider")])
+      .constrain(({ stack, divider }) => [
+        Constraint.align({ x: "size" }, [stack, divider]),
+      ])
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  },
+};

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -673,11 +673,16 @@ class Constraint:
         Args:
             refs: List of RefSentinels (typically the kwargs given to the
                 constrain callback).
-            x: Optional `"start" | "middle" | "end"` — alignment on the
-                x-axis. Pass a list of the same length as `refs` to assign
-                one anchor per child positionally (e.g.
-                `["middle", "start"]` aligns the first child's center to
-                the second child's start).
+            x: Optional `"start" | "middle" | "end" | "baseline"` — alignment
+                on the x-axis. Also accepts the interval-statistic values
+                `"span"` (the target adopts the source's position AND size)
+                and `"size"` (the target adopts only the source's length,
+                without moving) — see the docs page for the unbound-target
+                scope these require. Pass a list of the same length as
+                `refs` to assign one point anchor per child positionally
+                (e.g. `["middle", "start"]` aligns the first child's center
+                to the second child's start) — `"span"`/`"size"` cannot
+                appear inside a list.
             y: Optional alignment on the y-axis. Same shape as `x`.
 
         At least one of `x` or `y` must be provided.

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -99,9 +99,10 @@ packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx::PositionShowc
 # a 2-column grid with section headers, demonstrating that
 # `spread({alignment, ...})` equals `align(...) + distribute(...)`. The
 # parity harness captures one chart per story, so this layout shape can't
-# be byte-matched. The six single-chart exports (AlignOnly, AlignOnlyManualY,
-# DistributeOnly, SubsetSelection, BackgroundNotDistributed, AlignCenterDistributeY)
-# are ported.
+# be byte-matched. The eight single-chart exports (AlignOnly, AlignOnlyManualY,
+# DistributeOnly, SubsetSelection, BackgroundNotDistributed, AlignCenterDistributeY,
+# AlignSpan, AlignSize — the last two are the #726 "span"/"size" alignment
+# values) are ported.
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_AlignStart
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_AlignEnd
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_AlignMiddle

--- a/tests/python-stories/low-level-syntax/test_constraints.py
+++ b/tests/python-stories/low-level-syntax/test_constraints.py
@@ -1,8 +1,9 @@
 """Equivalent of lowlevel/Constraints.stories.tsx — Low Level Syntax/Constraints.
 
-Ports the seven single-chart stories: the six that demonstrate
-`layer + constrain` directly, plus `SpreadEnd_UnderCoordTransform` (the
-pixel-pure `end` fallback canary, #552). The eight side-by-side equivalence
+Ports the nine single-chart stories: the six that demonstrate
+`layer + constrain` directly, `SpreadEnd_UnderCoordTransform` (the
+pixel-pure `end` fallback canary, #552), and `AlignSpan`/`AlignSize` (#726 —
+the `"span"`/`"size"` alignment values). The eight side-by-side equivalence
 stories (`SpreadY_*`, `SpreadX_*`) use a multi-panel DOM scaffold that
 doesn't fit the single-chart parity harness — those are per-export exempt.
 `SpreadY_AlignMiddle` specifically now compares two freely translated systems
@@ -120,4 +121,65 @@ def story_align_center_distribute_y():
             Constraint.distribute([a, b, c, d], dir="y", spacing=8),
         ]),
         {"w": 300, "h": 400},
+    )
+
+
+# ─── "span" / "size" alignment values (#726) ────────────────────────────────
+
+
+def story_align_span():
+    group = (
+        layer(
+            [
+                rect(w=60, h=60, fill="#e63946").name("a"),
+                rect(w=60, h=60, fill="#457b9d").name("b"),
+                rect(w=60, h=60, fill="#2a9d8f").name("c"),
+            ],
+            x=40,
+            y=50,
+        )
+        .constrain(lambda a, b, c: [
+            Constraint.align([a, b, c], y="start"),
+            Constraint.distribute([a, b, c], dir="x", spacing=10),
+        ])
+        .name("group")
+    )
+
+    return (
+        layer([
+            group,
+            rect(fill="none", stroke="#333", strokeWidth=2).name("border"),
+        ]).constrain(lambda group, border, **_: [
+            Constraint.align([group, border], x="span"),
+            Constraint.align([group, border], y="span"),
+        ]),
+        {"w": 340, "h": 220},
+    )
+
+
+def story_align_size():
+    stack = (
+        layer(
+            [
+                rect(w=220, h=30, fill="#e63946").name("s1"),
+                rect(w=220, h=30, fill="#457b9d").name("s2"),
+            ],
+            x=0,
+            y=20,
+        )
+        .constrain(lambda s1, s2: [
+            Constraint.align([s1, s2], x="start"),
+            Constraint.distribute([s1, s2], dir="y", spacing=4),
+        ])
+        .name("stack")
+    )
+
+    return (
+        layer([
+            stack,
+            rect(y=110, h=10, fill="#2a9d8f").name("divider"),
+        ]).constrain(lambda stack, divider, **_: [
+            Constraint.align([stack, divider], x="size"),
+        ]),
+        {"w": 320, "h": 180},
     )


### PR DESCRIPTION
Closes #726. Advances #725.

## What this adds

This PR extends the align constraint's per-axis value grammar with two values, per the operators-over-placed-nodes essay §3.5:

- `"size"` makes the target adopt the source's length on that axis without moving it.
- `"span"` makes the target adopt both of the source's endpoints on that axis, so it copies position and size together.

The source is the first already-placed child, the same convention align uses today. The scope is the unbound-target case only. The target must have no intrinsic size on that axis (a bare `rect({})`). If it does, the constraint throws a structured error naming both writers instead of clobbering or silently skipping. All five live uses of Bluefish's `LayoutFunction` across its gallery are this exact pattern, so this one value unblocks the remaining Bluefish ports (#436, #437, #439).

```ts
layer([group, rect({ stroke: "#333" }).name("border")]).constrain(({ group, border }) => [
  Constraint.align({ x: "span" }, [group, border]),
  Constraint.align({ y: "span" }, [group, border]),
]);
```

## How it works

- `"span"` reads the placed source's extent at lowering time and emits two strong anchor pins (start and end) on the target, the same route `position`'s interval form already uses. The rank-2 write-back through `setExtent` then sets both position and size.
- `"size"` is a new rank-1 fact kind (`SizePinFact`), which writes the size cell of the per-node box with no position coupling, plus a matching `setSizeOnly` write-back on the node. The target's position still comes from wherever it would otherwise (another constraint or the parent seed).
- If no child of the constraint is already placed, the constraint throws an honest error rather than mis-solving.

## Ownership errors (#725, the core)

The essay promotes ownership errors to a prerequisite for opening the alignment vocabulary, so the guard rails land here:

- A span or size write onto a bound target throws an error naming the constraint and the intrinsic writer.
- Conflicting strong pins already threw with both owners named through the `BBox` ledger. Span rides that same path, so a genuine double-write conflict names both constraints.
- An align constraint whose operands are all already placed, with nothing movable, now warns with the constraint and operand names instead of silently doing nothing. The deliberate data-positioned skip for scatter facets stays silent.

The general per-`place()` owner ledger (every operator seed write recording its owner) is not in this PR. The essay's item 6 status note says exactly what shipped and what remains, and #725 stays open for the rest.

## Verification

- `pnpm capture-diff origin/main` is byte-identical except the two new probe stories, `AlignSpan` and `AlignSize` (screenshots below).
- Both error paths were exercised directly: the bound-target error and the double-assert conflict both name both writers.
- `validate-python-ir` passes, including two new Python parity ports of the probe stories (`story_align_span`, `story_align_size`). No IR or codegen changes were needed because align's options are untyped at the bridge.
- Docs updated in the same change: the JS and Python `constrain` pages, the Python `Constraint.align` docstring, and the internals essays (underlying-space, constraints-as-core, operators-over-placed-nodes items 6 and 7).

## Screenshots

`AlignSpan`: the black-stroked border rect is a bare rect whose x and y spans both come from the placed group.

![AlignSpan](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-727/constraints--align-span.png)

`AlignSize`: the teal divider adopts the stack's width but is positioned independently below it.

![AlignSize](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-727/constraints--align-size.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
