### PR TITLE
ci(visual-tests): report deleted stories and prune their stale baselines

### DIFF
--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -190,6 +190,23 @@ jobs:
         if: github.event_name == 'pull_request'
         run: pnpm --filter @gofish/tests exec tsx scripts/compare.ts --js-only
 
+      # Removed stories are informational (they don't fail compare.ts), so on a
+      # green PR they'd otherwise only appear in the console log. Surface them
+      # in the job summary regardless of the compare outcome.
+      - name: Report removed stories (PR only)
+        if: (success() || failure()) && github.event_name == 'pull_request'
+        run: |
+          SUMMARY=tests/tmp/diff-summary.json
+          if [ -f "$SUMMARY" ] && [ "$(jq '.removed // 0' "$SUMMARY")" -gt 0 ]; then
+            {
+              echo "### Removed stories"
+              echo ""
+              echo "Baseline exists but the story is no longer present (baselines are pruned automatically on the next main push):"
+              echo ""
+              jq -r '.removedStories[] | "- `\(.)`"' "$SUMMARY"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       # On main push: auto-accept all captures as the new baselines and push
       # to snapshots/main. This keeps snapshots/main in sync after every merge.
       - name: Configure git for snapshot commit (main push only)
@@ -264,6 +281,13 @@ jobs:
               }
               if (summary.newStories > 0) {
                 parts.push(plural(summary.newStories, 'new story', 'new stories'));
+              }
+              // Removed stories never fail the job (deletion is often
+              // intentional — see compare.ts), but still worth surfacing
+              // here since this description is the first thing seen on the
+              // PR's checks list.
+              if (summary.removed > 0) {
+                parts.push(plural(summary.removed, 'removed story', 'removed stories'));
               }
               if (parts.length > 0) {
                 description = parts.join(', ') + ' — click Details to review';

--- a/.github/workflows/visual-tests.yml
+++ b/.github/workflows/visual-tests.yml
@@ -190,18 +190,20 @@ jobs:
         if: github.event_name == 'pull_request'
         run: pnpm --filter @gofish/tests exec tsx scripts/compare.ts --js-only
 
-      # Removed stories are informational (they don't fail compare.ts), so on a
-      # green PR they'd otherwise only appear in the console log. Surface them
-      # in the job summary regardless of the compare outcome.
+      # Removed stories now fail compare.ts like any other unreviewed change
+      # (baseline exists, story no longer present), so this only ever runs
+      # alongside the other failure-path steps below (upload/review site).
+      # Kept as a quick-glance summary in the Checks tab, without needing to
+      # open the review site, for the common "just deleted a story" case.
       - name: Report removed stories (PR only)
-        if: (success() || failure()) && github.event_name == 'pull_request'
+        if: failure() && github.event_name == 'pull_request'
         run: |
           SUMMARY=tests/tmp/diff-summary.json
           if [ -f "$SUMMARY" ] && [ "$(jq '.removed // 0' "$SUMMARY")" -gt 0 ]; then
             {
               echo "### Removed stories"
               echo ""
-              echo "Baseline exists but the story is no longer present (baselines are pruned automatically on the next main push):"
+              echo "Baseline exists but the story is no longer present. Accept the removal in the review site to delete its baseline (or restore the story):"
               echo ""
               jq -r '.removedStories[] | "- `\(.)`"' "$SUMMARY"
             } >> "$GITHUB_STEP_SUMMARY"
@@ -282,10 +284,9 @@ jobs:
               if (summary.newStories > 0) {
                 parts.push(plural(summary.newStories, 'new story', 'new stories'));
               }
-              // Removed stories never fail the job (deletion is often
-              // intentional — see compare.ts), but still worth surfacing
-              // here since this description is the first thing seen on the
-              // PR's checks list.
+              // Removed stories fail the job like any other unreviewed
+              // change (see compare.ts) — surfaced here since this
+              // description is the first thing seen on the PR's checks list.
               if (summary.removed > 0) {
                 parts.push(plural(summary.removed, 'removed story', 'removed stories'));
               }

--- a/tests/scripts/build-review-site.ts
+++ b/tests/scripts/build-review-site.ts
@@ -25,6 +25,7 @@ import {
   collectDiffs,
   collectRemovedStories,
   formatDomDiff,
+  escapeHtml,
   type DiffEntry,
 } from "./diff-utils.js";
 import { computePixelDiff } from "./pixel-diff.js";
@@ -64,18 +65,16 @@ function copyDir(src: string, dest: string): void {
 
 console.log("Building review site...");
 
-// Collect diffs
-const diffs: DiffEntry[] = collectDiffs();
+// Collect diffs. Removed stories (baseline exists, story no longer present)
+// are first-class DiffEntry("removed") too — they fail the job like any
+// other unreviewed change (see compare.ts), and accepting one deletes the
+// baseline instead of writing a new one.
+const removedEntries = collectRemovedStories();
+const diffs: DiffEntry[] = [...collectDiffs(), ...removedEntries];
 console.log(`  ${diffs.length} diff(s) found`);
-
-// Removed stories (baseline exists, story no longer present). Informational
-// only — not reviewable/acceptable like the DiffEntry kinds above, since
-// there's no "after" state to accept. See compare.ts for why removals never
-// fail the job.
-const removedStories = collectRemovedStories();
-if (removedStories.length > 0) {
+if (removedEntries.length > 0) {
   console.log(
-    `  ${removedStories.length} removed stor${removedStories.length === 1 ? "y" : "ies"} found`
+    `  ${removedEntries.length} removed stor${removedEntries.length === 1 ? "y" : "ies"} found`
   );
 }
 
@@ -133,9 +132,6 @@ const meta = {
    *  after Commit Accepted, so visual-test re-runs against the new baselines
    *  and python-parity (blocked on visual-test) is allowed to run. */
   runId: process.env.REVIEW_RUN_ID ?? "",
-  /** Baseline exists, story no longer present — informational, not part of
-   *  `diffs` (nothing to accept/reject: there's no "after" state). */
-  removedStories,
 };
 
 write(join(OUT_DIR, "data/meta.json"), JSON.stringify(meta, null, 2));
@@ -157,6 +153,12 @@ for (const entry of diffs) {
     write(
       join(OUT_DIR, "data/dom-diffs", entry.path),
       "<em>New story — no baseline to diff against.</em>"
+    );
+  } else if (entry.beforeDom !== null) {
+    // Removed: no "after" DOM — show the baseline that would be deleted.
+    write(
+      join(OUT_DIR, "data/dom-diffs", entry.path),
+      `<pre style="margin:0;white-space:pre-wrap;padding:12px;">${escapeHtml(entry.beforeDom)}</pre>`
     );
   }
 
@@ -238,6 +240,7 @@ const html = `<!DOCTYPE html>
     .kind-regression { color: #f38ba8; }
     .kind-new { color: #89b4fa; }
     .kind-parity { color: #fab387; }
+    .kind-removed { color: #9399b2; }
     .status-accepted { color: #a6e3a1 !important; }
     .status-rejected { color: #f38ba8 !important; }
 
@@ -304,7 +307,6 @@ const html = `<!DOCTYPE html>
     <h2>Visual Diff Review</h2>
     <div id="sidebar-meta"></div>
     <div id="sidebar-stats"></div>
-    <div id="sidebar-removed" style="display:none;font-size:11px;color:#a6adc8;margin-top:6px;font-family:monospace;line-height:1.5;"></div>
   </div>
   <div id="sidebar-filters">
     <button class="filter-btn active" data-filter="all">All</button>
@@ -356,6 +358,7 @@ const html = `<!DOCTYPE html>
           <h4 style="font-size:12px;color:#666;margin:0 0 6px;">After (current)</h4>
           <div style="background:#fff;border:1px solid #e0e0e0;border-radius:6px;padding:12px;min-height:80px;display:flex;align-items:flex-start;justify-content:center;">
             <img id="sbs-after" style="max-width:100%;display:block;" />
+            <div id="sbs-no-after" style="color:#aaa;font-size:13px;padding:32px;display:none;">Story removed — no current render</div>
           </div>
         </div>
       </div>
@@ -426,14 +429,6 @@ const html = `<!DOCTYPE html>
     const shortSha = meta.sha.slice(0, 8);
     metaEl.textContent = meta.branch + ' @ ' + shortSha;
 
-    if (meta.removedStories && meta.removedStories.length > 0) {
-      const removedEl = document.getElementById('sidebar-removed');
-      removedEl.style.display = 'block';
-      removedEl.innerHTML = meta.removedStories.length +
-        ' removed (baseline exists, story no longer present):<br>' +
-        meta.removedStories.map(p => '&nbsp;&nbsp;' + escHtml(p)).join('<br>');
-    }
-
     renderSidebar();
     const first = filteredDiffs()[0];
     if (first) selectStory(first.path);
@@ -503,7 +498,7 @@ const html = `<!DOCTYPE html>
     if (strobeInterval) { clearInterval(strobeInterval); strobeInterval = null; }
   }
 
-  function startStrobe(hasBefore) {
+  function startStrobe(hasBefore, singleLabel, singleColor) {
     stopStrobe();
     const imgAfter = document.getElementById('img-after');
     const imgBefore = document.getElementById('img-before');
@@ -511,8 +506,8 @@ const html = `<!DOCTYPE html>
 
     if (!hasBefore) {
       imgBefore.style.opacity = '0';
-      label.textContent = 'After (new)';
-      label.style.background = '#3498db';
+      label.textContent = singleLabel || 'After (new)';
+      label.style.background = singleColor || '#3498db';
       return;
     }
 
@@ -550,9 +545,14 @@ const html = `<!DOCTYPE html>
     document.getElementById('main-title').textContent = path;
     const badge = document.getElementById('main-kind-badge');
     badge.textContent = entry.kind.toUpperCase();
-    const kindColors = { regression: '#e74c3c', new: '#3498db', parity: '#e67e22' };
+    const kindColors = { regression: '#e74c3c', new: '#3498db', parity: '#e67e22', removed: '#7f8c8d' };
     const color = kindColors[entry.kind] || '#888';
     badge.style.cssText = 'background:' + color + '22;color:' + color + ';border:1px solid ' + color + ';border-radius:12px;padding:2px 10px;font-size:11px;font-weight:700;';
+
+    const acceptBtn = document.getElementById('btn-accept');
+    acceptBtn.textContent = entry.kind === 'removed'
+      ? '✖ Accept removal — delete baseline'
+      : '✓ Accept';
 
     document.getElementById('empty-state').style.display = 'none';
     renderCurrentView(entry);
@@ -581,7 +581,20 @@ const html = `<!DOCTYPE html>
     const sbsBefore = document.getElementById('sbs-before');
     const sbsAfter = document.getElementById('sbs-after');
     const noBefore = document.getElementById('sbs-no-before');
+    const noAfter = document.getElementById('sbs-no-after');
 
+    if (entry.kind === 'removed') {
+      sbsBefore.src = screenshotUrl('before', entry.path);
+      sbsBefore.style.display = 'block';
+      noBefore.style.display = 'none';
+      sbsAfter.src = '';
+      sbsAfter.style.display = 'none';
+      noAfter.style.display = 'block';
+      return;
+    }
+
+    noAfter.style.display = 'none';
+    sbsAfter.style.display = 'block';
     sbsAfter.src = screenshotUrl('after', entry.path);
     if (entry.kind !== 'new') {
       sbsBefore.src = screenshotUrl('before', entry.path);
@@ -597,6 +610,15 @@ const html = `<!DOCTYPE html>
   function renderStrobe(entry) {
     const imgAfter = document.getElementById('img-after');
     const imgBefore = document.getElementById('img-before');
+
+    if (entry.kind === 'removed') {
+      // No "after" state — show the baseline being deleted, no strobing.
+      imgAfter.src = screenshotUrl('before', entry.path);
+      imgBefore.style.display = 'none';
+      imgBefore.src = '';
+      startStrobe(false, 'Removed (baseline shown)', '#7f8c8d');
+      return;
+    }
 
     imgAfter.src = screenshotUrl('after', entry.path);
     if (entry.kind !== 'new') {
@@ -710,22 +732,29 @@ const html = `<!DOCTYPE html>
     const acceptedEntries = allDiffs.filter(d => d.status === 'accepted');
     if (acceptedEntries.length === 0) return;
 
+    // "removed" entries have no after-state to write — accepting one means
+    // deleting the baseline instead of updating it. Split so we only fetch
+    // after-files for real updates.
+    const updateEntries = acceptedEntries.filter(e => e.kind !== 'removed');
+    const removalEntries = acceptedEntries.filter(e => e.kind === 'removed');
+
     // Cloudflare Workers cap each invocation at 50 outgoing subrequests
     // (free plan). The Worker spends 5–7 on fixed Git data API calls and
     // 1 blob-create per accepted screenshot, so a single /api/commit
-    // beyond ~42 entries trips the limit. Chunk the accepts and let the
-    // Worker make one commit per chunk on top of the previous chunk's
-    // HEAD — final result is a small commit chain instead of one.
+    // beyond ~42 entries trips the limit. Chunk the accepts (updates and
+    // removals together) and let the Worker make one commit per chunk on
+    // top of the previous chunk's HEAD — final result is a small commit
+    // chain instead of one.
     const CHUNK_SIZE = 25;
 
     setAcceptBusy(true);
     try {
       // Phase 1: fetch file contents in the browser (avoids Worker subrequest limit)
       document.getElementById('action-status').innerHTML =
-        '<span class="spinner"></span>Fetching ' + acceptedEntries.length + ' file(s)...';
+        '<span class="spinner"></span>Fetching ' + updateEntries.length + ' file(s)...';
       const domContents = {};
       const screenshotContents = {};
-      await Promise.all(acceptedEntries.map(async (entry) => {
+      await Promise.all(updateEntries.map(async (entry) => {
         const pngPath = entry.path.replace(/\\.html$/, '.png');
         const [domRes, screenshotRes] = await Promise.all([
           fetch('/_after-files/dom/' + entry.path),
@@ -736,12 +765,17 @@ const html = `<!DOCTYPE html>
       }));
 
       // Phase 2: send to Worker for committing, chunked.
+      const combined = [
+        ...updateEntries.map(e => ({ path: e.path, action: 'update' })),
+        ...removalEntries.map(e => ({ path: e.path, action: 'remove' })),
+      ];
       const chunks = [];
-      for (let i = 0; i < acceptedEntries.length; i += CHUNK_SIZE) {
-        chunks.push(acceptedEntries.slice(i, i + CHUNK_SIZE));
+      for (let i = 0; i < combined.length; i += CHUNK_SIZE) {
+        chunks.push(combined.slice(i, i + CHUNK_SIZE));
       }
 
       let totalAccepted = 0;
+      let totalRemoved = 0;
       let lastCommitSha = '';
       const allErrors = [];
       const allWarnings = [];
@@ -749,11 +783,13 @@ const html = `<!DOCTYPE html>
       for (let ci = 0; ci < chunks.length; ci++) {
         const chunk = chunks[ci];
         const isLastChunk = ci === chunks.length - 1;
+        const chunkPaths = chunk.filter(c => c.action === 'update').map(c => c.path);
+        const chunkRemovals = chunk.filter(c => c.action === 'remove').map(c => c.path);
         const chunkDom = {};
         const chunkScreens = {};
-        for (const entry of chunk) {
-          if (domContents[entry.path] != null) chunkDom[entry.path] = domContents[entry.path];
-          const pngPath = entry.path.replace(/\\.html$/, '.png');
+        for (const path of chunkPaths) {
+          if (domContents[path] != null) chunkDom[path] = domContents[path];
+          const pngPath = path.replace(/\\.html$/, '.png');
           if (screenshotContents[pngPath] != null) chunkScreens[pngPath] = screenshotContents[pngPath];
         }
 
@@ -765,7 +801,8 @@ const html = `<!DOCTYPE html>
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            paths: chunk.map(e => e.path),
+            paths: chunkPaths,
+            removals: chunkRemovals,
             domContents: chunkDom,
             screenshotContents: chunkScreens,
             repo: meta.repo,
@@ -793,6 +830,7 @@ const html = `<!DOCTYPE html>
           return;
         }
         totalAccepted += data.accepted || 0;
+        totalRemoved += data.removed || 0;
         lastCommitSha = data.commitSha || lastCommitSha;
         if (data.errors && data.errors.length) allErrors.push(...data.errors);
         if (data.postCommitWarnings && data.postCommitWarnings.length) allWarnings.push(...data.postCommitWarnings);
@@ -801,7 +839,8 @@ const html = `<!DOCTYPE html>
       hasUncommittedAccepts = false;
       const warnings = allWarnings.join('; ');
       const commitsNote = chunks.length > 1 ? ' over ' + chunks.length + ' commits' : '';
-      const msg = 'Committed ' + totalAccepted + ' diff(s)' + commitsNote + ': ' + (lastCommitSha || '').slice(0, 8) +
+      const removedNote = totalRemoved > 0 ? ', removed ' + totalRemoved : '';
+      const msg = 'Committed ' + totalAccepted + ' diff(s)' + removedNote + commitsNote + ': ' + (lastCommitSha || '').slice(0, 8) +
         (allErrors.length ? ' (' + allErrors.length + ' errors)' : '') +
         (warnings ? ' — warnings: ' + warnings : '');
       setActionStatus(msg, allErrors.length > 0 || Boolean(warnings));

--- a/tests/scripts/build-review-site.ts
+++ b/tests/scripts/build-review-site.ts
@@ -21,7 +21,12 @@ import {
   readdirSync,
 } from "fs";
 import { join, dirname } from "path";
-import { collectDiffs, formatDomDiff, type DiffEntry } from "./diff-utils.js";
+import {
+  collectDiffs,
+  collectRemovedStories,
+  formatDomDiff,
+  type DiffEntry,
+} from "./diff-utils.js";
 import { computePixelDiff } from "./pixel-diff.js";
 
 // ---------------------------------------------------------------------------
@@ -62,6 +67,17 @@ console.log("Building review site...");
 // Collect diffs
 const diffs: DiffEntry[] = collectDiffs();
 console.log(`  ${diffs.length} diff(s) found`);
+
+// Removed stories (baseline exists, story no longer present). Informational
+// only — not reviewable/acceptable like the DiffEntry kinds above, since
+// there's no "after" state to accept. See compare.ts for why removals never
+// fail the job.
+const removedStories = collectRemovedStories();
+if (removedStories.length > 0) {
+  console.log(
+    `  ${removedStories.length} removed stor${removedStories.length === 1 ? "y" : "ies"} found`
+  );
+}
 
 // Compute pixel diffs
 for (const entry of diffs) {
@@ -117,6 +133,9 @@ const meta = {
    *  after Commit Accepted, so visual-test re-runs against the new baselines
    *  and python-parity (blocked on visual-test) is allowed to run. */
   runId: process.env.REVIEW_RUN_ID ?? "",
+  /** Baseline exists, story no longer present — informational, not part of
+   *  `diffs` (nothing to accept/reject: there's no "after" state). */
+  removedStories,
 };
 
 write(join(OUT_DIR, "data/meta.json"), JSON.stringify(meta, null, 2));
@@ -285,6 +304,7 @@ const html = `<!DOCTYPE html>
     <h2>Visual Diff Review</h2>
     <div id="sidebar-meta"></div>
     <div id="sidebar-stats"></div>
+    <div id="sidebar-removed" style="display:none;font-size:11px;color:#a6adc8;margin-top:6px;font-family:monospace;line-height:1.5;"></div>
   </div>
   <div id="sidebar-filters">
     <button class="filter-btn active" data-filter="all">All</button>
@@ -405,6 +425,14 @@ const html = `<!DOCTYPE html>
     const metaEl = document.getElementById('sidebar-meta');
     const shortSha = meta.sha.slice(0, 8);
     metaEl.textContent = meta.branch + ' @ ' + shortSha;
+
+    if (meta.removedStories && meta.removedStories.length > 0) {
+      const removedEl = document.getElementById('sidebar-removed');
+      removedEl.style.display = 'block';
+      removedEl.innerHTML = meta.removedStories.length +
+        ' removed (baseline exists, story no longer present):<br>' +
+        meta.removedStories.map(p => '&nbsp;&nbsp;' + escHtml(p)).join('<br>');
+    }
 
     renderSidebar();
     const first = filteredDiffs()[0];

--- a/tests/scripts/cf-functions/api/commit.ts
+++ b/tests/scripts/cf-functions/api/commit.ts
@@ -7,8 +7,13 @@
  * sends them in the request body. The Worker only makes GitHub API calls:
  * - 1 blob creation per screenshot (binary, needs blob API)
  * - DOM files use tree `content` field directly (no blob API needed)
- * - 5–7 fixed GitHub calls: get ref, get commit, create tree, create commit,
- *   update/create ref, and (final chunk only) status update + rerun.
+ * - Deletions (`removals`) use the same tree API with `sha: null` — no blob
+ *   calls, plus 1 extra recursive-tree fetch (only when removals is
+ *   non-empty) to know which paths actually exist on the base tree, since
+ *   the tree API errors if asked to delete a path that isn't there.
+ * - 6–9 fixed GitHub calls: get ref, get commit, (get recursive tree if
+ *   removals present), create tree, create commit, update/create ref, and
+ *   (final chunk only) status update + rerun.
  *
  * Cloudflare caps each invocation at 50 outgoing subrequests (free plan),
  * so the client splits accepts into chunks of ~25 and calls /api/commit
@@ -17,7 +22,7 @@
  * history is already a long "Accept N visual diff(s)" chain.
  *
  * Request body:
- *   { paths, domContents, screenshotContents, repo, branch,
+ *   { paths, removals?, domContents, screenshotContents, repo, branch,
  *     headSha?, runId? }  // headSha/runId set on the final chunk only
  *
  * GITHUB_TOKEN is a Cloudflare Pages secret.
@@ -28,7 +33,14 @@ interface Env {
 }
 
 interface CommitBody {
+  /** Story paths to add/update as baselines. */
   paths: string[];
+  /**
+   * Story paths whose baseline (dom + screenshot) should be deleted from
+   * the snapshot branch — the accept-removal counterpart to `paths`.
+   * Additive: omitting it (older clients) behaves exactly as before.
+   */
+  removals?: string[];
   domContents: Record<string, string>; // storyPath → HTML text
   screenshotContents: Record<string, string>; // pngPath → base64
   repo: string;
@@ -45,7 +57,7 @@ type TreeItem = {
   path: string;
   mode: string;
   type: string;
-  sha?: string;
+  sha?: string | null;
   content?: string;
 };
 
@@ -103,12 +115,9 @@ async function handleCommit(
   let body: CommitBody;
   try {
     const raw = (await request.json()) as Partial<CommitBody>;
-    if (
-      !Array.isArray(raw.paths) ||
-      raw.paths.length === 0 ||
-      !raw.repo ||
-      !raw.branch
-    ) {
+    const hasPaths = Array.isArray(raw.paths) && raw.paths.length > 0;
+    const hasRemovals = Array.isArray(raw.removals) && raw.removals.length > 0;
+    if ((!hasPaths && !hasRemovals) || !raw.repo || !raw.branch) {
       return json({ error: "Invalid request body" }, 400);
     }
     body = raw as CommitBody;
@@ -117,7 +126,8 @@ async function handleCommit(
   }
 
   const {
-    paths,
+    paths = [],
+    removals = [],
     domContents = {},
     screenshotContents = {},
     repo,
@@ -180,10 +190,6 @@ async function handleCommit(
     }
   }
 
-  if (treeItems.length === 0) {
-    return json({ ok: false, accepted: 0, errors });
-  }
-
   // Get current HEAD SHA of the snapshot branch, or null if it doesn't exist yet.
   const refRes = await fetch(`${apiBase}/git/ref/heads/${branch}`, {
     headers: githubHeaders,
@@ -239,6 +245,59 @@ async function handleCommit(
     throw new Error(`GitHub get ref failed (${refRes.status}): ${text}`);
   }
 
+  // Process removals (accept-removal: delete a stale baseline). Uses the
+  // same git data/trees API as the additions above — a tree entry with
+  // `sha: null` deletes that path — so no Contents-API blob-sha lookups are
+  // needed. The tree API errors if asked to delete a path that isn't on the
+  // base tree, so first fetch the base tree's full path list (one recursive
+  // GET, regardless of how many removals there are) and only emit delete
+  // entries for paths that are actually present.
+  let removed = 0;
+  if (removals.length > 0 && baseTreeSha) {
+    let existingPaths = new Set<string>();
+    try {
+      const treeData = await githubJson<{ tree: { path: string }[] }>(
+        await fetch(`${apiBase}/git/trees/${baseTreeSha}?recursive=1`, {
+          headers: githubHeaders,
+        }),
+        `get tree ${baseTreeSha} (recursive)`
+      );
+      existingPaths = new Set(treeData.tree.map((t) => t.path));
+    } catch (e) {
+      errors.push(`list existing baseline tree for removals: ${String(e)}`);
+    }
+
+    for (const storyPath of removals) {
+      const domPath = `dom/${storyPath}`;
+      const screenshotPath = `screenshots/${storyPath.replace(/\.html$/, ".png")}`;
+      if (existingPaths.has(domPath)) {
+        treeItems.push({
+          path: domPath,
+          mode: "100644",
+          type: "blob",
+          sha: null,
+        });
+      }
+      if (existingPaths.has(screenshotPath)) {
+        treeItems.push({
+          path: screenshotPath,
+          mode: "100644",
+          type: "blob",
+          sha: null,
+        });
+      }
+      removed++;
+    }
+  } else if (removals.length > 0) {
+    // No base tree at all (fresh repo, no snapshots/main either) — nothing
+    // to delete, but the desired end state (baseline absent) already holds.
+    removed = removals.length;
+  }
+
+  if (treeItems.length === 0) {
+    return json({ ok: false, accepted, removed, errors });
+  }
+
   // Create tree with all changes (base_tree omitted for orphan branch creation).
   const newTree = await githubJson<{ sha: string }>(
     await fetch(`${apiBase}/git/trees`, {
@@ -253,12 +312,18 @@ async function handleCommit(
   );
 
   // Create single commit (no parents if this is a new orphan branch).
+  const messageParts: string[] = [];
+  if (accepted > 0) messageParts.push(`Accept ${accepted} visual diff(s)`);
+  if (removed > 0) messageParts.push(`remove ${removed} stale baseline(s)`);
+  const commitMessage =
+    messageParts.length > 0 ? messageParts.join(", ") : "Update snapshots";
+
   const newCommit = await githubJson<{ sha: string }>(
     await fetch(`${apiBase}/git/commits`, {
       method: "POST",
       headers: githubHeaders,
       body: JSON.stringify({
-        message: `Accept ${accepted} visual diff(s)`,
+        message: commitMessage,
         tree: newTree.sha,
         parents: headSha ? [headSha] : [],
       }),
@@ -309,7 +374,10 @@ async function handleCommit(
         body: JSON.stringify({
           state: "success",
           target_url: `https://github.com/${repo}/tree/${branch}`,
-          description: `Accepted ${accepted} diff(s); re-running tests`,
+          description:
+            `Accepted ${accepted} diff(s)` +
+            (removed > 0 ? `, removed ${removed}` : "") +
+            `; re-running tests`,
           context: "Visual Diff Review",
         }),
       });
@@ -342,6 +410,7 @@ async function handleCommit(
   return json({
     ok: errors.length === 0,
     accepted,
+    removed,
     errors,
     commitSha: newCommit.sha,
     postCommitWarnings,

--- a/tests/scripts/compare.ts
+++ b/tests/scripts/compare.ts
@@ -15,6 +15,7 @@ import { join, relative } from "path";
 import { execSync } from "child_process";
 import { getSnapshotBranchName, pullSnapshots } from "./snapshot-branch.js";
 import { storyToPath } from "./path-mapping.js";
+import { collectRemovedStories } from "./diff-utils.js";
 
 const ROOT = join(import.meta.dirname, "../..");
 const BASELINE_DIR = join(ROOT, "__snapshots__/dom");
@@ -176,12 +177,14 @@ function main() {
 
   const regressions = checkRegressions();
   const parityFailures = jsOnly ? [] : checkParity();
+  const removedStories = collectRemovedStories();
 
   const rCount = regressions.filter((f) => f.kind === "regression").length;
   const mCount = regressions.filter(
     (f) => f.kind === "missing-baseline"
   ).length;
   const pCount = parityFailures.length;
+  const remCount = removedStories.length;
 
   // Print summary
   if (rCount > 0) {
@@ -205,15 +208,34 @@ function main() {
     }
   }
 
+  // Removed stories are informational, not a failure: deletion is often
+  // intentional (see mCount above for the symmetric "added" case, which
+  // *does* fail the job). Mentioned so a PR that deletes a story doesn't
+  // pass through CI silently.
+  if (remCount > 0) {
+    console.log(
+      `  ${remCount} removed stor${remCount === 1 ? "y" : "ies"} (baseline exists, story no longer present):`
+    );
+    for (const path of removedStories) {
+      console.log(`    - ${path}`);
+    }
+  }
+
   const allFailures = [...regressions, ...parityFailures];
 
   // Always emit a structured summary so downstream tooling (CI status
   // descriptions, the review site) can render counts without re-parsing
-  // logs.
+  // logs. `removed` is additive: it never affects exit status.
   writeFileSync(
     SUMMARY_PATH,
     JSON.stringify(
-      { regressions: rCount, newStories: mCount, parityFailures: pCount },
+      {
+        regressions: rCount,
+        newStories: mCount,
+        parityFailures: pCount,
+        removed: remCount,
+        removedStories,
+      },
       null,
       2
     )

--- a/tests/scripts/compare.ts
+++ b/tests/scripts/compare.ts
@@ -82,7 +82,7 @@ function listHtmlFiles(dir: string, prefix = ""): string[] {
 }
 
 interface Failure {
-  kind: "regression" | "parity" | "missing-baseline";
+  kind: "regression" | "parity" | "missing-baseline" | "removed";
   path: string;
   expected?: string;
   actual?: string;
@@ -177,14 +177,21 @@ function main() {
 
   const regressions = checkRegressions();
   const parityFailures = jsOnly ? [] : checkParity();
-  const removedStories = collectRemovedStories();
+  // Removed stories join the failure set exactly like a new/missing-baseline
+  // story: a story with a baseline but no current capture must be reviewed
+  // and accepted (which deletes the baseline) before the job goes green.
+  const removedFailures: Failure[] = collectRemovedStories().map((entry) => ({
+    kind: "removed",
+    path: entry.path,
+    expected: entry.beforeDom ?? undefined,
+  }));
 
   const rCount = regressions.filter((f) => f.kind === "regression").length;
   const mCount = regressions.filter(
     (f) => f.kind === "missing-baseline"
   ).length;
   const pCount = parityFailures.length;
-  const remCount = removedStories.length;
+  const remCount = removedFailures.length;
 
   // Print summary
   if (rCount > 0) {
@@ -208,24 +215,22 @@ function main() {
     }
   }
 
-  // Removed stories are informational, not a failure: deletion is often
-  // intentional (see mCount above for the symmetric "added" case, which
-  // *does* fail the job). Mentioned so a PR that deletes a story doesn't
-  // pass through CI silently.
+  // Removed stories fail the job like any other unreviewed change: baseline
+  // exists but the story is gone, so someone must accept the removal
+  // (deleting the baseline) or restore the story.
   if (remCount > 0) {
     console.log(
       `  ${remCount} removed stor${remCount === 1 ? "y" : "ies"} (baseline exists, story no longer present):`
     );
-    for (const path of removedStories) {
-      console.log(`    - ${path}`);
+    for (const f of removedFailures) {
+      console.log(`    - ${f.path}`);
     }
   }
 
-  const allFailures = [...regressions, ...parityFailures];
+  const allFailures = [...regressions, ...parityFailures, ...removedFailures];
 
   // Always emit a structured summary so downstream tooling (CI status
-  // descriptions, the review site) can render counts without re-parsing
-  // logs. `removed` is additive: it never affects exit status.
+  // descriptions, the review site) can render counts without re-parsing logs.
   writeFileSync(
     SUMMARY_PATH,
     JSON.stringify(
@@ -234,7 +239,7 @@ function main() {
         newStories: mCount,
         parityFailures: pCount,
         removed: remCount,
-        removedStories,
+        removedStories: removedFailures.map((f) => f.path),
       },
       null,
       2

--- a/tests/scripts/diff-report.ts
+++ b/tests/scripts/diff-report.ts
@@ -1,7 +1,7 @@
 /**
  * Generate a self-contained HTML diff report for visual review.
  *
- * For each failing story (regression or parity), the report shows:
+ * For each failing story (regression, parity, new, or removed), the report shows:
  *   - Strobe animation between before/after screenshots (base64-embedded, CSS keyframes)
  *   - Pixel diff image (base64-embedded) with diff percentage
  *   - Colored line diff of the DOM snapshot
@@ -47,7 +47,7 @@ interface ReportEntry extends DiffEntry {
   computedDiffPercent: number | null;
 }
 
-function buildReportEntries(diffs: DiffEntry[]): ReportEntry[] {
+function buildReportEntries(diffs: readonly DiffEntry[]): ReportEntry[] {
   return diffs.map((d) => {
     const beforeB64 = d.beforeScreenshotPath
       ? readImageBase64(d.beforeScreenshotPath)
@@ -73,43 +73,19 @@ function buildReportEntries(diffs: DiffEntry[]): ReportEntry[] {
   });
 }
 
-/**
- * A "removed stories" banner: baseline exists, story no longer present.
- * Informational only (never fails the job — see compare.ts) so it's a plain
- * list, not a reviewable/acceptable DiffEntry like the regression/new/parity
- * cards below.
- */
-function generateRemovedBanner(removedStories: string[]): string {
-  if (removedStories.length === 0) return "";
-  const items = removedStories
-    .map((path) => `<li><code>${escapeHtml(path)}</code></li>`)
-    .join("\n");
-  return `
-  <div style="border:1px solid #ddd;margin:16px 0;border-radius:6px;overflow:hidden;">
-    <div style="padding:12px 16px;background:#95a5a622;border-bottom:1px solid #ddd;">
-      <span style="font-weight:bold;color:#7f8c8d;">REMOVED</span>
-      <span style="margin-left:12px;color:#666;">baseline exists, story no longer present (${removedStories.length})</span>
-    </div>
-    <ul style="padding:12px 16px 16px 32px;margin:0;font-family:monospace;font-size:13px;">
-      ${items}
-    </ul>
-  </div>`;
-}
-
-function generateReport(
-  entries: ReportEntry[],
-  removedStories: string[]
-): string {
+function generateReport(entries: ReportEntry[]): string {
   const kindLabel: Record<string, string> = {
     regression: "REGRESSION",
     parity: "PARITY MISMATCH",
     new: "NEW (no baseline)",
+    removed: "REMOVED",
   };
 
   const kindColor: Record<string, string> = {
     regression: "#e74c3c",
     parity: "#e67e22",
     new: "#3498db",
+    removed: "#7f8c8d",
   };
 
   const entryHtml = entries
@@ -119,7 +95,9 @@ function generateReport(
           ? formatDomDiff(d.beforeDom, d.afterDom)
           : d.afterDom
             ? `<pre style="margin:0;white-space:pre-wrap;">${escapeHtml(d.afterDom)}</pre>`
-            : "";
+            : d.beforeDom
+              ? `<pre style="margin:0;white-space:pre-wrap;">${escapeHtml(d.beforeDom)}</pre>`
+              : "";
 
       // Strobe animation: two overlapping images, CSS toggles opacity
       const afterImg = d.afterB64
@@ -127,7 +105,13 @@ function generateReport(
         : `<div style="color:#999;padding:40px;text-align:center;">No screenshot</div>`;
 
       let strobeHtml: string;
-      if (d.beforeB64) {
+      if (d.kind === "removed") {
+        // No "after" state to strobe against — just show the baseline that
+        // accepting this entry would delete.
+        strobeHtml = d.beforeB64
+          ? `<img src="data:image/png;base64,${d.beforeB64}" style="display:block;max-width:100%;" />`
+          : `<div style="color:#999;padding:40px;text-align:center;">No screenshot</div>`;
+      } else if (d.beforeB64) {
         const beforeImg = `<img src="data:image/png;base64,${d.beforeB64}" style="position:absolute;top:0;left:0;max-width:100%;display:block;animation:strobeBefore_${i} 1s step-end infinite;" />`;
         const afterImgAnim = d.afterB64
           ? `<img src="data:image/png;base64,${d.afterB64}" style="display:block;max-width:100%;animation:strobeAfter_${i} 1s step-end infinite;" />`
@@ -194,7 +178,6 @@ function generateReport(
 <body>
   <h1>Visual Diff Report</h1>
   <p>${entries.length} difference(s) found. This is a static view-only report. Run <code>pnpm test:visual:review</code> for the interactive review server.</p>
-  ${generateRemovedBanner(removedStories)}
   ${entryHtml}
 </body>
 </html>`;
@@ -207,14 +190,15 @@ function generateReport(
 function main() {
   const diffs = collectDiffs();
   const removedStories = collectRemovedStories();
+  const allDiffs = [...diffs, ...removedStories];
 
-  if (diffs.length === 0 && removedStories.length === 0) {
+  if (allDiffs.length === 0) {
     console.log("No diffs to report.");
     return;
   }
 
-  const entries = buildReportEntries(diffs);
-  const html = generateReport(entries, removedStories);
+  const entries = buildReportEntries(allDiffs);
+  const html = generateReport(entries);
   writeFileSync(OUTPUT, html, "utf-8");
   console.log(
     `Diff report written to ${OUTPUT} (${entries.length} entries, ${removedStories.length} removed)`

--- a/tests/scripts/diff-report.ts
+++ b/tests/scripts/diff-report.ts
@@ -13,6 +13,7 @@ import { readFileSync, writeFileSync, existsSync } from "fs";
 import { join } from "path";
 import {
   collectDiffs,
+  collectRemovedStories,
   formatDomDiff,
   escapeHtml,
   JS_DIR,
@@ -72,7 +73,33 @@ function buildReportEntries(diffs: DiffEntry[]): ReportEntry[] {
   });
 }
 
-function generateReport(entries: ReportEntry[]): string {
+/**
+ * A "removed stories" banner: baseline exists, story no longer present.
+ * Informational only (never fails the job — see compare.ts) so it's a plain
+ * list, not a reviewable/acceptable DiffEntry like the regression/new/parity
+ * cards below.
+ */
+function generateRemovedBanner(removedStories: string[]): string {
+  if (removedStories.length === 0) return "";
+  const items = removedStories
+    .map((path) => `<li><code>${escapeHtml(path)}</code></li>`)
+    .join("\n");
+  return `
+  <div style="border:1px solid #ddd;margin:16px 0;border-radius:6px;overflow:hidden;">
+    <div style="padding:12px 16px;background:#95a5a622;border-bottom:1px solid #ddd;">
+      <span style="font-weight:bold;color:#7f8c8d;">REMOVED</span>
+      <span style="margin-left:12px;color:#666;">baseline exists, story no longer present (${removedStories.length})</span>
+    </div>
+    <ul style="padding:12px 16px 16px 32px;margin:0;font-family:monospace;font-size:13px;">
+      ${items}
+    </ul>
+  </div>`;
+}
+
+function generateReport(
+  entries: ReportEntry[],
+  removedStories: string[]
+): string {
   const kindLabel: Record<string, string> = {
     regression: "REGRESSION",
     parity: "PARITY MISMATCH",
@@ -167,6 +194,7 @@ function generateReport(entries: ReportEntry[]): string {
 <body>
   <h1>Visual Diff Report</h1>
   <p>${entries.length} difference(s) found. This is a static view-only report. Run <code>pnpm test:visual:review</code> for the interactive review server.</p>
+  ${generateRemovedBanner(removedStories)}
   ${entryHtml}
 </body>
 </html>`;
@@ -178,16 +206,19 @@ function generateReport(entries: ReportEntry[]): string {
 
 function main() {
   const diffs = collectDiffs();
+  const removedStories = collectRemovedStories();
 
-  if (diffs.length === 0) {
+  if (diffs.length === 0 && removedStories.length === 0) {
     console.log("No diffs to report.");
     return;
   }
 
   const entries = buildReportEntries(diffs);
-  const html = generateReport(entries);
+  const html = generateReport(entries, removedStories);
   writeFileSync(OUTPUT, html, "utf-8");
-  console.log(`Diff report written to ${OUTPUT} (${entries.length} entries)`);
+  console.log(
+    `Diff report written to ${OUTPUT} (${entries.length} entries, ${removedStories.length} removed)`
+  );
 }
 
 main();

--- a/tests/scripts/diff-utils.ts
+++ b/tests/scripts/diff-utils.ts
@@ -9,6 +9,7 @@ import {
   mkdirSync,
   existsSync,
   cpSync,
+  rmSync,
 } from "fs";
 import { join, dirname } from "path";
 import { diffLines } from "diff";
@@ -56,7 +57,12 @@ export const PYTHON_DIR = join(import.meta.dirname, "../tmp/python");
 export interface DiffEntry {
   /** Relative path like "forward-syntax-v3/bar--basic.html" */
   path: string;
-  kind: "regression" | "parity" | "new";
+  /**
+   * "removed" = baseline exists, story no longer captured (deleted/renamed
+   * since the baseline was recorded). Has no "after" state — accepting it
+   * deletes the baseline instead of writing a new one.
+   */
+  kind: "regression" | "parity" | "new" | "removed";
   /** "pending" | "accepted" | "rejected" — runtime review state */
   status: "pending" | "accepted" | "rejected";
   beforeDom: string | null;
@@ -170,15 +176,35 @@ export function collectDiffs(): DiffEntry[] {
 
 /**
  * Stories with a baseline but no current JS capture — i.e. deleted (or
- * renamed) since the baseline was recorded. Informational only: a removed
- * story is not a regression and must not fail the job by itself, but it
- * should still be reported so deletions aren't silently invisible in CI.
+ * renamed) since the baseline was recorded. These fail the job exactly like
+ * a new/missing-baseline story: a removal must be reviewed and accepted
+ * (which deletes the baseline) before CI goes green.
+ *
+ * Returned as first-class `DiffEntry`s (kind: "removed") so the report and
+ * review site can render them as regular reviewable cards: `beforeDom`/
+ * `beforeScreenshotPath` hold the old baseline, `afterDom`/
+ * `afterScreenshotPath` are always null since there's no new render.
  */
-export function collectRemovedStories(): string[] {
+export function collectRemovedStories(): DiffEntry[] {
   const jsFiles = new Set(listHtmlFiles(JS_DIR));
-  return listHtmlFiles(BASELINE_DOM)
+  const removedPaths = listHtmlFiles(BASELINE_DOM)
     .filter((file) => !jsFiles.has(file))
     .sort();
+
+  return removedPaths.map((path) => {
+    const pngFile = path.replace(/\.html$/, ".png");
+    const beforePng = join(BASELINE_SCREENSHOTS, pngFile);
+    return {
+      path,
+      kind: "removed",
+      status: "pending",
+      beforeDom: readOptional(join(BASELINE_DOM, path)),
+      afterDom: null,
+      beforeScreenshotPath: existsSync(beforePng) ? beforePng : null,
+      afterScreenshotPath: null,
+      diffPercent: null,
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -255,6 +281,24 @@ export function acceptStory(path: string): void {
     mkdirSync(dirname(pngDest), { recursive: true });
     cpSync(pngSrc, pngDest);
   }
+}
+
+// ---------------------------------------------------------------------------
+// Accept a removal (delete baseline dom + screenshot)
+// ---------------------------------------------------------------------------
+
+/**
+ * Accepting a "removed" DiffEntry has no "after" state to copy in — it
+ * deletes the stale baseline instead. This is the manual-review analog of
+ * the auto-prune in update-baselines.ts (which does the same thing in bulk
+ * on every main push).
+ */
+export function removeBaselineStory(path: string): void {
+  const htmlPath = join(BASELINE_DOM, path);
+  if (existsSync(htmlPath)) rmSync(htmlPath, { force: true });
+
+  const pngPath = join(BASELINE_SCREENSHOTS, path.replace(/\.html$/, ".png"));
+  if (existsSync(pngPath)) rmSync(pngPath, { force: true });
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/scripts/diff-utils.ts
+++ b/tests/scripts/diff-utils.ts
@@ -165,6 +165,23 @@ export function collectDiffs(): DiffEntry[] {
 }
 
 // ---------------------------------------------------------------------------
+// Removed stories: baseline exists, story no longer present in JS_DIR
+// ---------------------------------------------------------------------------
+
+/**
+ * Stories with a baseline but no current JS capture — i.e. deleted (or
+ * renamed) since the baseline was recorded. Informational only: a removed
+ * story is not a regression and must not fail the job by itself, but it
+ * should still be reported so deletions aren't silently invisible in CI.
+ */
+export function collectRemovedStories(): string[] {
+  const jsFiles = new Set(listHtmlFiles(JS_DIR));
+  return listHtmlFiles(BASELINE_DOM)
+    .filter((file) => !jsFiles.has(file))
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
 // Collect parity diffs: Python output vs JS baselines
 // ---------------------------------------------------------------------------
 

--- a/tests/scripts/review-server.ts
+++ b/tests/scripts/review-server.ts
@@ -13,8 +13,11 @@ import { join } from "path";
 import { exec } from "child_process";
 import {
   collectDiffs,
+  collectRemovedStories,
   acceptStory,
+  removeBaselineStory,
   formatDomDiff,
+  escapeHtml,
   ROOT,
   type DiffEntry,
 } from "./diff-utils.js";
@@ -37,7 +40,10 @@ pullSnapshots(getSnapshotBranchName(), join(ROOT, "__snapshots__"));
 // In-memory state
 // ---------------------------------------------------------------------------
 
-const diffs: DiffEntry[] = collectDiffs();
+// "Removed" stories (baseline exists, story no longer captured) are
+// first-class DiffEntry("removed") entries too — they must be reviewed and
+// accepted (which deletes the baseline) like any other diff.
+const diffs: DiffEntry[] = [...collectDiffs(), ...collectRemovedStories()];
 /** path → pixel diff result */
 const pixelDiffs = new Map<string, PixelDiffResult | null>();
 
@@ -156,19 +162,37 @@ function handleGetScreenshot(
 function handleGetDomDiff(res: ServerResponse, path: string): void {
   const entry = findEntry(path);
   if (!entry) return respondError(res, 404, "Not found");
-  if (!entry.beforeDom || !entry.afterDom) {
-    respond(res, 200, "text/html", "<em>No DOM diff available.</em>");
+  if (entry.beforeDom && entry.afterDom) {
+    respond(
+      res,
+      200,
+      "text/html",
+      formatDomDiff(entry.beforeDom, entry.afterDom)
+    );
     return;
   }
-  const html = formatDomDiff(entry.beforeDom, entry.afterDom);
-  respond(res, 200, "text/html", html);
+  if (entry.beforeDom) {
+    // Removed: no "after" DOM — show the baseline that would be deleted.
+    respond(
+      res,
+      200,
+      "text/html",
+      `<pre style="margin:0;white-space:pre-wrap;padding:12px;">${escapeHtml(entry.beforeDom)}</pre>`
+    );
+    return;
+  }
+  respond(res, 200, "text/html", "<em>No DOM diff available.</em>");
 }
 
 function handleAccept(res: ServerResponse, path: string): void {
   const entry = findEntry(path);
   if (!entry) return respondError(res, 404, "Not found");
   try {
-    acceptStory(path);
+    if (entry.kind === "removed") {
+      removeBaselineStory(path);
+    } else {
+      acceptStory(path);
+    }
     entry.status = "accepted";
     respondJson(res, { ok: true });
   } catch (e) {
@@ -188,7 +212,11 @@ function handleAcceptAll(res: ServerResponse): void {
   for (const entry of diffs) {
     if (entry.status === "pending") {
       try {
-        acceptStory(entry.path);
+        if (entry.kind === "removed") {
+          removeBaselineStory(entry.path);
+        } else {
+          acceptStory(entry.path);
+        }
         entry.status = "accepted";
       } catch (e) {
         errors.push(`${entry.path}: ${String(e)}`);
@@ -254,6 +282,7 @@ function serveApp(res: ServerResponse): void {
     .kind-regression { color: #f38ba8; }
     .kind-new { color: #89b4fa; }
     .kind-parity { color: #fab387; }
+    .kind-removed { color: #9399b2; }
     .status-accepted { color: #a6e3a1 !important; }
     .status-rejected { color: #f38ba8 !important; }
 
@@ -369,6 +398,7 @@ function serveApp(res: ServerResponse): void {
           <h4 style="font-size:12px;color:#666;margin:0 0 6px;">After (current)</h4>
           <div style="background:#fff;border:1px solid #e0e0e0;border-radius:6px;padding:12px;min-height:80px;display:flex;align-items:flex-start;justify-content:center;">
             <img id="sbs-after" style="max-width:100%;display:block;" />
+            <div id="sbs-no-after" style="color:#aaa;font-size:13px;padding:32px;display:none;">Story removed — no current render</div>
           </div>
         </div>
       </div>
@@ -494,7 +524,7 @@ function serveApp(res: ServerResponse): void {
     if (strobeInterval) { clearInterval(strobeInterval); strobeInterval = null; }
   }
 
-  function startStrobe(hasBefore) {
+  function startStrobe(hasBefore, singleLabel, singleColor) {
     stopStrobe();
     const imgAfter = document.getElementById('img-after');
     const imgBefore = document.getElementById('img-before');
@@ -502,8 +532,8 @@ function serveApp(res: ServerResponse): void {
 
     if (!hasBefore) {
       imgBefore.style.opacity = '0';
-      label.textContent = 'After (new)';
-      label.style.background = '#3498db';
+      label.textContent = singleLabel || 'After (new)';
+      label.style.background = singleColor || '#3498db';
       return;
     }
 
@@ -545,7 +575,7 @@ function serveApp(res: ServerResponse): void {
     document.getElementById('main-title').textContent = path;
     const badge = document.getElementById('main-kind-badge');
     badge.textContent = entry.kind.toUpperCase();
-    const kindColors = { regression: '#e74c3c', new: '#3498db', parity: '#e67e22' };
+    const kindColors = { regression: '#e74c3c', new: '#3498db', parity: '#e67e22', removed: '#7f8c8d' };
     badge.style.background = (kindColors[entry.kind] || '#888') + '22';
     badge.style.color = kindColors[entry.kind] || '#888';
     badge.style.border = '1px solid ' + (kindColors[entry.kind] || '#888');
@@ -553,6 +583,11 @@ function serveApp(res: ServerResponse): void {
     badge.style.padding = '2px 10px';
     badge.style.fontSize = '11px';
     badge.style.fontWeight = '700';
+
+    const acceptBtn = document.getElementById('btn-accept');
+    acceptBtn.textContent = entry.kind === 'removed'
+      ? '✖ Accept removal — delete baseline'
+      : '✓ Accept';
 
     document.getElementById('empty-state').style.display = 'none';
 
@@ -589,7 +624,20 @@ function serveApp(res: ServerResponse): void {
     const sbsBefore = document.getElementById('sbs-before');
     const sbsAfter = document.getElementById('sbs-after');
     const noBefore = document.getElementById('sbs-no-before');
+    const noAfter = document.getElementById('sbs-no-after');
 
+    if (entry.kind === 'removed') {
+      sbsBefore.src = '/api/screenshot/before/' + encodeURIComponent(entry.path);
+      sbsBefore.style.display = 'block';
+      noBefore.style.display = 'none';
+      sbsAfter.src = '';
+      sbsAfter.style.display = 'none';
+      noAfter.style.display = 'block';
+      return;
+    }
+
+    noAfter.style.display = 'none';
+    sbsAfter.style.display = 'block';
     sbsAfter.src = '/api/screenshot/after/' + encodeURIComponent(entry.path);
     if (entry.kind !== 'new') {
       sbsBefore.src = '/api/screenshot/before/' + encodeURIComponent(entry.path);
@@ -607,6 +655,15 @@ function serveApp(res: ServerResponse): void {
   function renderStrobe(entry) {
     const imgAfter = document.getElementById('img-after');
     const imgBefore = document.getElementById('img-before');
+
+    if (entry.kind === 'removed') {
+      // No "after" state — show the baseline being deleted, no strobing.
+      imgAfter.src = '/api/screenshot/before/' + encodeURIComponent(entry.path);
+      imgBefore.style.display = 'none';
+      imgBefore.src = '';
+      startStrobe(false, 'Removed (baseline shown)', '#7f8c8d');
+      return;
+    }
 
     imgAfter.src = '/api/screenshot/after/' + encodeURIComponent(entry.path);
     if (entry.kind !== 'new') {

--- a/tests/scripts/update-baselines.ts
+++ b/tests/scripts/update-baselines.ts
@@ -4,9 +4,16 @@
  * Copies tmp/js/ → __snapshots__/dom/ and __snapshots__/screenshots/.
  */
 
-import { readdirSync, existsSync } from "fs";
+import { readdirSync, existsSync, rmSync } from "fs";
 import { join } from "path";
-import { acceptStory, JS_DIR, ROOT } from "./diff-utils.js";
+import {
+  acceptStory,
+  JS_DIR,
+  ROOT,
+  BASELINE_DOM,
+  BASELINE_SCREENSHOTS,
+  listHtmlFiles,
+} from "./diff-utils.js";
 import {
   getSnapshotBranchName,
   commitAndPushSnapshots,
@@ -27,6 +34,30 @@ function listFiles(dir: string, prefix = ""): string[] {
   return results;
 }
 
+/**
+ * Delete baseline dom/screenshot files for stories that no longer exist in
+ * the current capture. capture-js-dom.ts always renders the *full* story
+ * corpus (cleanOutDir: true), so anything in the baseline set but missing
+ * from JS_DIR is a genuinely removed (or renamed) story, not a partial
+ * capture. Without this, deleted stories' baselines accumulate on
+ * snapshots/<branch> forever, and compare.ts would re-report the same
+ * removal on every future PR.
+ */
+function pruneRemovedBaselines(currentHtmlFiles: Set<string>): string[] {
+  // An empty capture means something went wrong upstream, not that every
+  // story was deleted — never mass-prune on it.
+  if (currentHtmlFiles.size === 0) return [];
+  const pruned: string[] = [];
+  for (const file of listHtmlFiles(BASELINE_DOM)) {
+    if (currentHtmlFiles.has(file)) continue;
+    rmSync(join(BASELINE_DOM, file), { force: true });
+    const pngPath = join(BASELINE_SCREENSHOTS, file.replace(/\.html$/, ".png"));
+    if (existsSync(pngPath)) rmSync(pngPath, { force: true });
+    pruned.push(file);
+  }
+  return pruned;
+}
+
 function main() {
   console.log("=== Updating baselines ===\n");
 
@@ -37,15 +68,27 @@ function main() {
 
   const files = listFiles(JS_DIR);
   let count = 0;
+  const currentHtmlFiles = new Set<string>();
 
   for (const file of files) {
     if (file.endsWith(".html")) {
       acceptStory(file);
+      currentHtmlFiles.add(file);
       count++;
     }
   }
 
   console.log(`Updated ${count} story baseline(s).`);
+
+  const pruned = pruneRemovedBaselines(currentHtmlFiles);
+  if (pruned.length > 0) {
+    console.log(
+      `Pruned ${pruned.length} stale baseline(s) for removed stories:`
+    );
+    for (const file of pruned) {
+      console.log(`    - ${file}`);
+    }
+  }
 
   // Push the accepted baselines to the shared snapshots/<branch> ref ONLY in
   // CI: that branch is what CI fetches as its baseline, and CI renders on


### PR DESCRIPTION
Deleted stories were invisible to the visual-diff CI: `compare.ts` only enumerated current captures against baselines (so a baseline with no matching story was never mentioned anywhere — console, summary JSON, diff report, review site, or commit status), and the main-push baseline auto-update was purely additive, so stale baselines accumulated on `snapshots/<branch>` forever. Motivating case: #742 deletes the redundant `ribbon--layered` story and CI said nothing.

## Behavior

**Removals gate exactly like additions.** A removed story (baseline exists, story no longer captured) is a failing diff: `compare.ts` exits 1, the story appears as a `REMOVED` card in the diff report and the interactive review site (showing the old baseline render — there is no "after"), and it must be approved through the same accept flow as any other diff. Accepting a removal deletes the baseline (dom `.html` + screenshot `.png`):

- locally, via the review server (`removeBaselineStory`, symmetric to `acceptStory`);
- deployed, via the Cloudflare commit endpoint — the commit payload gains an additive `removals: string[]` field, implemented as Git Data API tree entries with `sha: null`, emitted only for paths confirmed present on the base tree (the API rejects deletes of absent paths). Old payloads with only `paths` behave identically.

After accepting, re-running CI fetches the updated `snapshots/<branch>` and goes green — the same loop new stories already use.

**Main-push auto-update prunes.** `update-baselines` deletes baselines for stories missing from the always-full capture (guarded against an empty capture), mirroring how it auto-accepts every other diff on main. So a merged deletion converges without manual cleanup.

`diff-summary.json` carries `removed`/`removedStories`; the commit-status description and a failure-path job-summary step list removals.

## Verification

Exercised locally with a removal-only fixture: `compare.ts` exits 1 and lists the removal; the diff report and review-site `data/` render the removal card with the baseline screenshot; the local review-server accept deletes the fixture baseline files. Type-check introduces no new errors (the `diff` TS7016 and PagesFunction/Playwright globals errors are pre-existing). Not exercisable locally: the deployed Worker delete path (code-reviewed against the Git Data API docs — `sha: null` tree entries delete, and require presence on the base tree), chunked commits mixing updates and removals, and the orphan-branch bootstrap with removals present — worth watching on this PR's first real removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)