### PR TITLE
Add labelAngle axis option to rotate tick and category labels

### DIFF
--- a/apps/docs/docs/internals/frontend/axes.md
+++ b/apps/docs/docs/internals/frontend/axes.md
@@ -114,12 +114,12 @@ the same predicate `axisSide` already uses for its cross-flip check
 (`yUp || underCoord || isCONTINUOUS(space[1])` — this is dim-independent: it's
 really "does this node's own y mirror", not specific to the axis being labeled),
 canceling the render-time negation so the label lands at the literal screen angle
-regardless of the frame's orientation. A nonzero angle also switches the
-track-axis alignment from centered (`"middle"`) to the label's own anchor
-(`"start"`) — `tickMark`'s `Spread` alignment and `elaborateOrdinalAxis`'s
-`Constraint.align` — so the label's first character sits at the tick instead of
-centering the now-diagonal bbox on it. There is no "auto" rotation mode (deferred
-to #486) — this is a manual, always-on angle.
+regardless of the frame's orientation. Rotation never changes alignment: the
+track-axis alignment stays centered (`"middle"`) in both `tickMark`'s `Spread`
+alignment and `elaborateOrdinalAxis`'s `Constraint.align`, so a rotated label's
+(now-diagonal) bbox is centered on its tick exactly like an unrotated label's
+bbox would be. There is no "auto" rotation mode (deferred to #486) — this is a
+manual, always-on angle.
 
 **Per-tier selection.** A plain number applies uniformly to every tier of a
 nested ordinal axis (a grouped bar chart's inner year row and outer city row

--- a/apps/docs/docs/internals/frontend/axes.md
+++ b/apps/docs/docs/internals/frontend/axes.md
@@ -101,9 +101,10 @@ wherever `axisSide` put the line, so the two always land together.
 
 ### Label rotation (`labelAngle`)
 
-The public `axes: { x: { labelAngle: number } }` option (#746) rotates a tick or
-category label about its anchor, authored **screen-clockwise** to match
-Vega-Lite's `labelAngle`. It is threaded the same way `side` is —
+The public `axes: { x: { labelAngle: number | number[] } }` option (#746, extended
+to per-tier arrays afterward) rotates a tick or category label about its anchor,
+authored **screen-clockwise** to match Vega-Lite's `labelAngle`. It is threaded the
+same way `side` is —
 `elaborateAxes → elaborationsFor → elaborate{Continuous,Ordinal}Axis → tickMark` /
 `elaborateOrdinalAxis` — landing on the `Text` mark's `rotate` prop, which is
 applied in the node's own **y-up world frame** and gets negated at render time
@@ -117,10 +118,36 @@ regardless of the frame's orientation. A nonzero angle also switches the
 track-axis alignment from centered (`"middle"`) to the label's own anchor
 (`"start"`) — `tickMark`'s `Spread` alignment and `elaborateOrdinalAxis`'s
 `Constraint.align` — so the label's first character sits at the tick instead of
-centering the now-diagonal bbox on it. A grouped ordinal axis's inner and outer
-label tiers both receive the same resolved angle, since `labelAngles` is threaded
-unchanged through the recursive `elaborateAxes` walk. There is no "auto" rotation
-mode (deferred to #486) — this is a manual, always-on angle.
+centering the now-diagonal bbox on it. There is no "auto" rotation mode (deferred
+to #486) — this is a manual, always-on angle.
+
+**Per-tier selection.** A plain number applies uniformly to every tier of a
+nested ordinal axis (a grouped bar chart's inner year row and outer city row
+both rotate the same amount); an array is per-tier instead, indexed from the
+INNERMOST tier outward — `angleForTier(opt, tier)` picks `opt` itself when it's
+a number, or `opt[tier]` (possibly `undefined`, past the array's end) when it's
+an array. `elaborationsFor` needs to know which tier index `tier` a given
+ordinal-axis-owning node is, since **ordinal axes nest**: `resolveAxes` lets a
+distinct ordinal grouping claim its own axis at every depth (`_node.ts`'s
+`resolveAxes`), so a grouped bar chart has one node owning the city axis and,
+independently, one sibling-node-per-city each owning that city's year axis — a
+DEEPER call in the bottom-up `elaborateAxes` walk always elaborates an inner
+tier before an ancestor elaborates an outer one on the same dim.
+
+The tier index is computed by bubbling a per-dim `tierCounts: [number, number]`
+UP through the recursion, exactly like `titleAnchors` bubbles up axis-line
+anchors: `elaborateAxes` folds it as a `Math.max` over its own children's
+returned `tierCounts` (a node's tier count only depends on ITS OWN subtree, so
+sibling subtrees elsewhere in the tree — e.g. two independent grouped-bar
+regions — don't interfere with each other), then calls `elaborationsFor` with
+that folded value. Inside `elaborationsFor`, a node that claims an ordinal axis
+on dim `d` reads `tier = tierCounts[d]` (0 for the first — innermost — claim
+seen anywhere below it) as its OWN tier index, then increments
+`tierCounts[d]` by one before returning, so an ancestor claiming the same dim's
+next-outer tier reads the incremented count. Continuous/difference axes are
+always single-owner and single-tier (`resolveAxes`: "Continuous: single-owner —
+only the root-most unclaimed dim claims"), so they always resolve tier `0` —
+i.e. the number, or `array[0]`.
 
 The wrapper inherits the wrapped node's `key` and `_name`, so faceting and
 external refs keep resolving to it. After the rewrite, the whole tree's underlying

--- a/apps/docs/docs/internals/frontend/axes.md
+++ b/apps/docs/docs/internals/frontend/axes.md
@@ -114,12 +114,56 @@ the same predicate `axisSide` already uses for its cross-flip check
 (`yUp || underCoord || isCONTINUOUS(space[1])` — this is dim-independent: it's
 really "does this node's own y mirror", not specific to the axis being labeled),
 canceling the render-time negation so the label lands at the literal screen angle
-regardless of the frame's orientation. Rotation never changes alignment: the
-track-axis alignment stays centered (`"middle"`) in both `tickMark`'s `Spread`
-alignment and `elaborateOrdinalAxis`'s `Constraint.align`, so a rotated label's
-(now-diagonal) bbox is centered on its tick exactly like an unrotated label's
-bbox would be. There is no "auto" rotation mode (deferred to #486) — this is a
-manual, always-on angle.
+regardless of the frame's orientation. There is no "auto" rotation mode (deferred
+to #486) — this is a manual, always-on angle.
+
+**The hanging-point rule.** `resolveLabelRotation` (`axes/elaborate.tsx`) turns
+the authored angle `a` into a `LabelRotation` descriptor — `rotate` (the
+frame-resolved value passed to `Text`), `trackAlign`, and `textAnchor` — that
+governs how the label attaches to its tick/key along the TRACK axis (the axis's
+own direction): the label is anchored at whichever of its points ends up nearest
+the axis line, not at its rotated bbox's middle.
+
+- `a` is `0`/`undefined`: `trackAlign: "middle"` — plain bbox-middle centering,
+  IDENTICAL to the unrotated path (no rotation is even applied).
+- `|a| === 90`: also `trackAlign: "middle"` — the rotated column's bbox middle
+  already centers it horizontally on the tick.
+- `0 < a < 90` (slants down-right): `trackAlign: "baseline"`, `textAnchor:
+"start"` — the label hangs from its FIRST character (Vega-Lite's 45° look).
+- `-90 < a < 0` (slants up-right): `trackAlign: "baseline"`, `textAnchor: "end"`
+  — the label hangs from its LAST character (matplotlib's `ha="right"` look).
+
+`"baseline"` is `AlignAnchor`'s existing "pin the target's own local origin"
+mode (`_node.ts`'s `_pinAnchor`), and `Text`'s rotation is applied about that
+same local origin (`text.tsx`), so pinning `"baseline"` pins the rotation pivot
+directly — no bbox-edge arithmetic needed. `textAnchor` (a new `Text` prop)
+picks which end of the pre-rotation label sits at that origin: `"start"` (the
+default) puts the first character there, `"end"` puts the last character there,
+so the SAME `"baseline"` anchor reaches either hanging corner depending on the
+angle's sign. Accepted approximation: the origin sits on the label's baseline
+(`dominantBaseline: "auto"`), not the ascender-top corner an idealized "nearest
+point on the rotated bbox" derivation would use — the two differ by
+`ascent·sin(a)`, a couple of pixels at these sizes, invisible in practice.
+
+For an ordinal axis, `elaborateOrdinalAxis` expresses this directly:
+`Constraint.align`'s anchor accepts a per-child array
+(`[trackAlign, "middle"]`), so the label pivots to `"baseline"` while the key
+node it tracks stays `"middle"`-anchored on its own extent — one constraint,
+heterogeneous anchors. A continuous axis can't do the same by nesting the tick
+and label into one `tickMark` node the way the unrotated/±90° path does: an
+oblique label's rotated bbox is NOT symmetric about its pivot, so
+`positionAxis`'s per-tick `Constraint.position(pos(v), [tick])` — which defaults
+to `anchor: "middle"`, i.e. the target's bbox middle — would pin the PAIR's
+lopsided union bbox middle at the data value instead of the pivot, dragging the
+hanging point off the tick by however asymmetric the rotated label is. So for
+an oblique continuous axis, `elaborateContinuousAxis` keeps the tick bare
+(`tickRect`, unaffected by the label) and gives `positionAxis` a separate
+`tickLabel` builder: the DATA pin still targets the bare tick alone, and the
+label is a sibling related to it by the same heterogeneous
+`Constraint.align` + a cross-axis `Constraint.distribute`, mirroring
+`elaborateOrdinalAxis`'s approach. The unrotated/±90° path is untouched code
+(still `tickMark` + `Spread`'s uniform `"middle"` alignment), not just untouched
+geometry, so those angles stay pixel-identical to before the hanging-point rule.
 
 **Per-tier selection.** A plain number applies uniformly to every tier of a
 nested ordinal axis (a grouped bar chart's inner year row and outer city row

--- a/apps/docs/docs/internals/frontend/axes.md
+++ b/apps/docs/docs/internals/frontend/axes.md
@@ -99,6 +99,29 @@ direct far-edge seating (with the mirror suppressed) when it does not. `gofish.t
 computes the title's `sides` and the mirror-suppression (`xTitleSeatsFar`) to match
 wherever `axisSide` put the line, so the two always land together.
 
+### Label rotation (`labelAngle`)
+
+The public `axes: { x: { labelAngle: number } }` option (#746) rotates a tick or
+category label about its anchor, authored **screen-clockwise** to match
+Vega-Lite's `labelAngle`. It is threaded the same way `side` is —
+`elaborateAxes → elaborationsFor → elaborate{Continuous,Ordinal}Axis → tickMark` /
+`elaborateOrdinalAxis` — landing on the `Text` mark's `rotate` prop, which is
+applied in the node's own **y-up world frame** and gets negated at render time
+when that frame flips (`text.tsx`'s `flips ? -rotate : rotate`). Since
+`elaborationsFor` doesn't know the bake-time flip decision, it pre-negates using
+the same predicate `axisSide` already uses for its cross-flip check
+(`yUp || underCoord || isCONTINUOUS(space[1])` — this is dim-independent: it's
+really "does this node's own y mirror", not specific to the axis being labeled),
+canceling the render-time negation so the label lands at the literal screen angle
+regardless of the frame's orientation. A nonzero angle also switches the
+track-axis alignment from centered (`"middle"`) to the label's own anchor
+(`"start"`) — `tickMark`'s `Spread` alignment and `elaborateOrdinalAxis`'s
+`Constraint.align` — so the label's first character sits at the tick instead of
+centering the now-diagonal bbox on it. A grouped ordinal axis's inner and outer
+label tiers both receive the same resolved angle, since `labelAngles` is threaded
+unchanged through the recursive `elaborateAxes` walk. There is no "auto" rotation
+mode (deferred to #486) — this is a manual, always-on angle.
+
 The wrapper inherits the wrapped node's `key` and `_name`, so faceting and
 external refs keep resolving to it. After the rewrite, the whole tree's underlying
 space is recomputed (the cache is cleared); then normal layout runs, and each

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -1856,6 +1856,11 @@ for the API.
           "description": "Rotation in degrees, applied in the chart's y-up world frame about the text anchor.",
           "default": 0
         },
+        "textAnchor": {
+          "enum": ["start", "middle", "end"],
+          "description": "Where the text anchor — the local origin `rotate` pivots about and dims channels position — sits along the string: its first character, center, or last character.",
+          "default": "start"
+        },
         "name": {
           "type": "string"
         },

--- a/apps/docs/docs/js/api/core/render.md
+++ b/apps/docs/docs/js/api/core/render.md
@@ -69,6 +69,7 @@ axes: { x: { title: "Year" }, y: true }        // custom x title, inferred y tit
 axes: { x: { title: false }, y: true }         // suppress the inferred x title
 axes: { x: { side: "end" } }                   // seat the x-axis on the far edge
 axes: { x: { labelAngle: 45 } }                // rotate x tick/category labels 45°
+axes: { x: { labelAngle: [45] } }              // rotate only the innermost tier
 ```
 
 Each per-axis object also accepts `side: "start" | "end"`. By default a
@@ -82,11 +83,10 @@ that with the literal **frame-relative** seating: `"start"` is the near/origin e
 
 ### Rotating tick and category labels
 
-Each per-axis object also accepts `labelAngle: number` — degrees, **clockwise on
-screen**, matching Vega-Lite's `labelAngle`. It rotates both continuous tick labels
-and ordinal category labels on that axis, including every nested tier of a grouped
-ordinal axis (e.g. a two-level grouped bar chart's inner and outer category rows).
-This is useful when category labels would otherwise overlap at small chart sizes:
+Each per-axis object also accepts `labelAngle: number | number[]` — degrees,
+**clockwise on screen**, matching Vega-Lite's `labelAngle`. It rotates both
+continuous tick labels and ordinal category labels on that axis. This is useful
+when category labels would otherwise overlap at small chart sizes:
 
 ::: gofish
 
@@ -102,6 +102,25 @@ gf.chart(seafood)
 ```
 
 :::
+
+A **plain number** applies to every tier of a nested ordinal axis — e.g. a
+two-level grouped bar chart's inner (year) and outer (city) category rows both
+rotate the same amount. An **array** is per-tier instead, indexed from the
+INNERMOST tier outward: `labelAngle: [45]` rotates only the innermost row and
+leaves outer tiers unrotated; `[45, 0]` is the explicit two-tier form (same
+result). An index past the end of the array means unrotated. A continuous axis
+only ever has one tier, so it just uses the number, or `array[0]` for the array
+form.
+
+```js
+gf.chart(cityYear, { axes: { x: { labelAngle: [45] } } }) // year rotated, city upright
+  .flow(
+    gf.spread({ by: "city", dir: "x", spacing: 24 }),
+    gf.spread({ by: "year", dir: "x", spacing: 0 })
+  )
+  .mark(gf.rect({ h: "visitors", fill: "year" }))
+  .render(root, { w: 300, h: 210 });
+```
 
 There is currently no "auto" mode that rotates only when labels would collide —
 `labelAngle` is a manual, always-on rotation (auto-rotation is tracked in

--- a/apps/docs/docs/js/api/core/render.md
+++ b/apps/docs/docs/js/api/core/render.md
@@ -112,6 +112,13 @@ result). An index past the end of the array means unrotated. A continuous axis
 only ever has one tier, so it just uses the number, or `array[0]` for the array
 form.
 
+A rotated label is anchored at its **hanging point** — the point of the label
+nearest the axis line — rather than at its bounding box's middle: `0°` and
+`±90°` stay centered on the tick (unchanged from an unrotated label); any other
+angle hangs the label from whichever end sits closest to the axis, matching
+Vega-Lite's 45° look for a positive (clockwise) angle and matplotlib's
+`ha="right"` look for a negative one.
+
 ```js
 gf.chart(cityYear, { axes: { x: { labelAngle: [45] } } }) // year rotated, city upright
   .flow(

--- a/apps/docs/docs/js/api/core/render.md
+++ b/apps/docs/docs/js/api/core/render.md
@@ -68,6 +68,7 @@ axes: { x: true, y: false }                    // x only
 axes: { x: { title: "Year" }, y: true }        // custom x title, inferred y title
 axes: { x: { title: false }, y: true }         // suppress the inferred x title
 axes: { x: { side: "end" } }                   // seat the x-axis on the far edge
+axes: { x: { labelAngle: 45 } }                // rotate x tick/category labels 45°
 ```
 
 Each per-axis object also accepts `side: "start" | "end"`. By default a
@@ -78,6 +79,33 @@ their value axis at the bottom without any option. An explicit `side` overrides
 that with the literal **frame-relative** seating: `"start"` is the near/origin edge
 (top in a y-down frame, bottom in y-up) and `"end"` is the far edge — e.g.
 `{ x: { side: "end" } }` forces the x-axis onto the opposite edge from the default.
+
+### Rotating tick and category labels
+
+Each per-axis object also accepts `labelAngle: number` — degrees, **clockwise on
+screen**, matching Vega-Lite's `labelAngle`. It rotates both continuous tick labels
+and ordinal category labels on that axis, including every nested tier of a grouped
+ordinal axis (e.g. a two-level grouped bar chart's inner and outer category rows).
+This is useful when category labels would otherwise overlap at small chart sizes:
+
+::: gofish
+
+```js
+gf.chart(seafood)
+  .flow(gf.spread({ by: "lake", dir: "x" }))
+  .mark(gf.rect({ h: "count" }))
+  .render(root, {
+    w: 300,
+    h: 210,
+    axes: { x: { labelAngle: 45 }, y: true },
+  });
+```
+
+:::
+
+There is currently no "auto" mode that rotates only when labels would collide —
+`labelAngle` is a manual, always-on rotation (auto-rotation is tracked in
+[#486](https://github.com/gofish-graphics/gofish/issues/486)).
 
 `axes` is most naturally a `chart()`/`chart()` option (e.g.
 `gf.chart(data, { axes: true })`); it is also accepted directly on `.render()`, as

--- a/apps/docs/docs/js/api/marks/text.md
+++ b/apps/docs/docs/js/api/marks/text.md
@@ -18,24 +18,25 @@ gf.chart([{ label: "GoFish" }])
 ```ts
 text({ text, fill = "black", stroke?, strokeWidth = 0, fontSize = 12,
        fontFamily = "system-ui, sans-serif", fontStyle?, fontWeight?, rotate = 0,
-       debugBoundingBox = false, x?, y?, w?, h? })
+       textAnchor = "start", debugBoundingBox = false, x?, y?, w?, h? })
 ```
 
 ## Parameters
 
-| Option             | Type               | Description                                                                  |
-| ------------------ | ------------------ | ---------------------------------------------------------------------------- |
-| `text`             | `string \| number` | The string to render — a constant or a field name to read from data          |
-| `fill`             | `string`           | Fill color or field name for color encoding (default `"black"`)              |
-| `stroke`           | `string`           | Stroke color                                                                 |
-| `strokeWidth`      | `number`           | Stroke width (default `0`)                                                   |
-| `fontSize`         | `number`           | Font size in pixels (default `12`)                                           |
-| `fontFamily`       | `string`           | Font family (default `"system-ui, sans-serif"`)                              |
-| `fontStyle`        | `string`           | CSS font style, e.g. `"italic"`                                              |
-| `fontWeight`       | `number \| string` | CSS font weight, e.g. `300`, `700`, `"bold"`                                 |
-| `rotate`           | `number`           | Rotation in degrees about the anchor; `90` reads bottom-to-top for a y-title |
-| `debugBoundingBox` | `boolean`          | Draw the text's bounding box (for layout debugging)                          |
-| `x`, `y`, `w`, `h` | `number \| string` | Explicit position / size accessors                                           |
+| Option             | Type                           | Description                                                                                             |
+| ------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `text`             | `string \| number`             | The string to render — a constant or a field name to read from data                                     |
+| `fill`             | `string`                       | Fill color or field name for color encoding (default `"black"`)                                         |
+| `stroke`           | `string`                       | Stroke color                                                                                            |
+| `strokeWidth`      | `number`                       | Stroke width (default `0`)                                                                              |
+| `fontSize`         | `number`                       | Font size in pixels (default `12`)                                                                      |
+| `fontFamily`       | `string`                       | Font family (default `"system-ui, sans-serif"`)                                                         |
+| `fontStyle`        | `string`                       | CSS font style, e.g. `"italic"`                                                                         |
+| `fontWeight`       | `number \| string`             | CSS font weight, e.g. `300`, `700`, `"bold"`                                                            |
+| `rotate`           | `number`                       | Rotation in degrees about the anchor; `90` reads bottom-to-top for a y-title                            |
+| `textAnchor`       | `"start" \| "middle" \| "end"` | Which end of the text sits at its own local origin, the point `rotate` pivots about (default `"start"`) |
+| `debugBoundingBox` | `boolean`                      | Draw the text's bounding box (for layout debugging)                                                     |
+| `x`, `y`, `w`, `h` | `number \| string`             | Explicit position / size accessors                                                                      |
 
 ## Examples
 

--- a/apps/docs/docs/python/api/marks/text.md
+++ b/apps/docs/docs/python/api/marks/text.md
@@ -16,7 +16,7 @@ chart([{"label": "GoFish"}]).mark(
 ```python
 text(*, text=None, fill=None, stroke=None, strokeWidth=None, filter=None,
      fontSize=None, fontFamily=None, fontStyle=None, fontWeight=None,
-     debugBoundingBox=None, rotate=None,
+     debugBoundingBox=None, rotate=None, textAnchor=None,
      x=None, cx=None, x2=None, w=None, emX=None,
      y=None, cy=None, y2=None, h=None, emY=None,
      theta=None, thetaSize=None, r=None, rSize=None, key=None) -> Mark
@@ -27,21 +27,22 @@ Keyword-only (matches every existing call site, which already passes
 
 ## Parameters
 
-| Parameter                                                | Type           | Description                                                                   |
-| -------------------------------------------------------- | -------------- | ----------------------------------------------------------------------------- |
-| `text`                                                   | `str` \| `int` | The string to render — a constant, a field name, or a `(row) -> str` callable |
-| `fill`                                                   | `str`          | Fill color — a constant or a field name                                       |
-| `stroke`, `strokeWidth`                                  | `str`, `int`   | Outline color / width                                                         |
-| `filter`                                                 | `str`          | Raw SVG filter attribute                                                      |
-| `fontSize`                                               | `int` \| `str` | Font size in pixels (default 12)                                              |
-| `fontFamily`                                             | `str`          | Font family (default `"system-ui, sans-serif"`)                               |
-| `fontStyle`                                              | `str`          | CSS font style, e.g. `"italic"`                                               |
-| `fontWeight`                                             | `int` \| `str` | CSS font weight, e.g. `300`, `700`, `"bold"`                                  |
-| `debugBoundingBox`                                       | `bool`         | Draw the text's bounding box (for layout debugging)                           |
-| `rotate`                                                 | `int`          | Rotation in degrees about the text anchor                                     |
-| `x`, `cx`, `x2`, `w`, `emX`, `y`, `cy`, `y2`, `h`, `emY` | `int` \| `str` | Box-geometry position channels (position the text anchor)                     |
-| `theta`, `thetaSize`, `r`, `rSize`                       | `int` \| `str` | Polar coord-space aliases for `x`/`w`/`y`/`h`                                 |
-| `key`                                                    | `str`          | Internal per-node key override                                                |
+| Parameter                                                | Type           | Description                                                                                                                                  |
+| -------------------------------------------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `text`                                                   | `str` \| `int` | The string to render — a constant, a field name, or a `(row) -> str` callable                                                                |
+| `fill`                                                   | `str`          | Fill color — a constant or a field name                                                                                                      |
+| `stroke`, `strokeWidth`                                  | `str`, `int`   | Outline color / width                                                                                                                        |
+| `filter`                                                 | `str`          | Raw SVG filter attribute                                                                                                                     |
+| `fontSize`                                               | `int` \| `str` | Font size in pixels (default 12)                                                                                                             |
+| `fontFamily`                                             | `str`          | Font family (default `"system-ui, sans-serif"`)                                                                                              |
+| `fontStyle`                                              | `str`          | CSS font style, e.g. `"italic"`                                                                                                              |
+| `fontWeight`                                             | `int` \| `str` | CSS font weight, e.g. `300`, `700`, `"bold"`                                                                                                 |
+| `debugBoundingBox`                                       | `bool`         | Draw the text's bounding box (for layout debugging)                                                                                          |
+| `rotate`                                                 | `int`          | Rotation in degrees about the text anchor                                                                                                    |
+| `textAnchor`                                             | `str`          | `"start"` \| `"middle"` \| `"end"` — which end of the text sits at its own local origin, the point `rotate` pivots about (default `"start"`) |
+| `x`, `cx`, `x2`, `w`, `emX`, `y`, `cy`, `y2`, `h`, `emY` | `int` \| `str` | Box-geometry position channels (position the text anchor)                                                                                    |
+| `theta`, `thetaSize`, `r`, `rSize`                       | `int` \| `str` | Polar coord-space aliases for `x`/`w`/`y`/`h`                                                                                                |
+| `key`                                                    | `str`          | Internal per-node key override                                                                                                               |
 
 Returns a `Mark` for use in [`.mark()`](/python/api/core/mark).
 

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -81,21 +81,35 @@ const tickRect = (dim: 0 | 1): GoFishNode =>
  *  INNER element (facing the content) and the label the outer one, so the order
  *  follows `side`: with the axis on the near/start side the inner edge is the
  *  cross-`end`, so `[label, tick]`; on the far/end side the inner edge is the
- *  cross-`start`, so `[tick, label]`. */
+ *  cross-`start`, so `[tick, label]`.
+ *
+ *  `labelAngle` (already sign-resolved for this node's flip scope, see
+ *  `resolveLabelRotate`) rotates the label about its anchor. A `0`/`undefined`
+ *  angle keeps the default centered alignment along the track axis (pixel-
+ *  identical to no rotation); a nonzero angle switches the track-axis alignment
+ *  to `start` — the label's anchor (first character) sits at the tick instead
+ *  of centering the (now off-axis) rotated bbox on it, matching the
+ *  Vega-Lite `labelAngle` look. */
 function tickMark(
   dim: 0 | 1,
   label: string,
   name: string,
-  side: "start" | "end" = "start"
+  side: "start" | "end" = "start",
+  labelAngle?: number
 ): GoFishNode {
   const text = Text({
     text: label,
     fontSize: LABEL_FONT_SIZE,
     fill: AXIS_COLOR,
+    rotate: labelAngle,
   });
   const tick = tickRect(dim);
   return (Spread as any)(
-    { dir: crossName(dim), spacing: LABEL_TICK_GAP, alignment: "middle" },
+    {
+      dir: crossName(dim),
+      spacing: LABEL_TICK_GAP,
+      alignment: labelAngle ? "start" : "middle",
+    },
     side === "end" ? [tick, text] : [text, tick]
   ).name(name) as GoFishNode;
 }
@@ -273,7 +287,8 @@ function elaborateContinuousAxis(
   nice: [number, number],
   prefix: string,
   crossFloor?: number,
-  side: "start" | "end" = "start"
+  side: "start" | "end" = "start",
+  labelAngle?: number
 ): AxisElaboration {
   const [niceMin, niceMax] = nice;
   const tickValues = d3Ticks(niceMin, niceMax, TICK_COUNT);
@@ -283,7 +298,7 @@ function elaborateContinuousAxis(
     lineMin: niceMin,
     lineMax: niceMax,
     tickValues,
-    tickNode: (v, _i, name) => tickMark(dim, fmtNum(v), name, side),
+    tickNode: (v, _i, name) => tickMark(dim, fmtNum(v), name, side, labelAngle),
     crossFloor,
     side,
   });
@@ -342,20 +357,29 @@ function elaborateOrdinalAxis(
   space: Extract<UnderlyingSpace, { kind: "ordinal" }>,
   keyMap: Record<string, GoFishNode>,
   prefix: string,
-  side: "start" | "end" = "start"
+  side: "start" | "end" = "start",
+  labelAngle?: number
 ): AxisElaboration {
   const keys = (space.domain ?? []).filter((k) => keyMap[k] !== undefined);
   const trackAxis = dirName(dim); // labels track their key along the axis dim
   const gutterDir = crossName(dim); // labels sit in the cross gutter
   const lName = (i: number) => `${prefix}ol${i}`;
   const rName = (i: number) => `${prefix}or${i}`;
+  // A nonzero angle switches the track-axis alignment from centered to the
+  // label's own anchor (`start`, its first character) so the rotated label
+  // hangs off its key like a Vega-Lite `labelAngle` label instead of centering
+  // its rotated bbox on it.
+  const trackAlign = labelAngle ? "start" : "middle";
 
   const nodes: GoFishNode[] = [];
   keys.forEach((k, i) => {
     nodes.push(
-      Text({ text: k, fontSize: LABEL_FONT_SIZE, fill: AXIS_COLOR }).name(
-        lName(i)
-      )
+      Text({
+        text: k,
+        fontSize: LABEL_FONT_SIZE,
+        fill: AXIS_COLOR,
+        rotate: labelAngle,
+      }).name(lName(i))
     );
     nodes.push((ref(keyMap[k]) as any).name(rName(i)) as GoFishNode);
   });
@@ -365,7 +389,7 @@ function elaborateOrdinalAxis(
     keys.forEach((_, i) => {
       // Track the key along the axis dim …
       cs.push(
-        Constraint.align({ [trackAxis]: "middle" } as any, [
+        Constraint.align({ [trackAxis]: trackAlign } as any, [
           g[lName(i)],
           g[rName(i)],
         ])
@@ -438,7 +462,8 @@ function elaborationsFor(
   node: GoFishNode,
   sides: ["start" | "end" | undefined, "start" | "end" | undefined],
   yUp: boolean,
-  underCoord: boolean
+  underCoord: boolean,
+  labelAngles: [number | undefined, number | undefined] = [undefined, undefined]
 ): {
   constrained: AxisElaboration[];
   refBased: AxisElaboration[];
@@ -500,6 +525,21 @@ function elaborationsFor(
     const crossFlips = yUp || underCoord || isCONTINUOUS(space[cross(dim)]);
     return crossFlips ? "start" : "end";
   };
+  // `labelAngle` is authored screen-clockwise (Vega-Lite semantics), but the
+  // `Text` `rotate` prop is applied in this node's own y-up WORLD frame and
+  // gets negated at render time when that frame flips (see `text.tsx`'s
+  // `flips ? -rotate : rotate`). This node's frame flips iff a y-up mirror
+  // scope is active over it — the exact same predicate `axisSide` uses for
+  // its own cross-flip check (`yUp || underCoord || isCONTINUOUS(space[1])`,
+  // dim-independent since it's really "does THIS node's y mirror") — so we
+  // pre-negate here to cancel that render-time negation and land back on the
+  // literal screen angle regardless of the frame's orientation.
+  const frameFlips = yUp || underCoord || isCONTINUOUS(space[1]);
+  const resolvedLabelAngle = (dim: 0 | 1): number | undefined => {
+    const a = labelAngles[dim];
+    if (!a) return undefined;
+    return frameFlips ? -a : a;
+  };
   for (const dim of [0, 1] as (0 | 1)[]) {
     if (!owns(dim)) continue;
     const s = space[dim];
@@ -511,7 +551,8 @@ function elaborationsFor(
         nices[dim]!,
         prefix,
         crossFloor,
-        axisSide(dim)
+        axisSide(dim),
+        resolvedLabelAngle(dim)
       );
       constrained.push(e);
       anchors[dim] = e.anchor;
@@ -530,7 +571,14 @@ function elaborationsFor(
       // Ordinal axes keep the `start` default (they follow the content's own flip
       // like a category row); only continuous axes default to the bottom.
       refBased.push(
-        elaborateOrdinalAxis(dim, s, keyMap, prefix, sides[dim] ?? "start")
+        elaborateOrdinalAxis(
+          dim,
+          s,
+          keyMap,
+          prefix,
+          sides[dim] ?? "start",
+          resolvedLabelAngle(dim)
+        )
       );
     } else {
       continue;
@@ -574,7 +622,8 @@ export async function elaborateAxes(
     undefined,
   ],
   yUp = false,
-  underCoord = false
+  underCoord = false,
+  labelAngles: [number | undefined, number | undefined] = [undefined, undefined]
 ): Promise<{
   node: GoFishNode;
   changed: boolean;
@@ -594,7 +643,13 @@ export async function elaborateAxes(
   for (let i = 0; i < node.children.length; i++) {
     const child = node.children[i];
     if (child instanceof GoFishNode) {
-      const res = await elaborateAxes(child, sides, yUp, childUnderCoord);
+      const res = await elaborateAxes(
+        child,
+        sides,
+        yUp,
+        childUnderCoord,
+        labelAngles
+      );
       if (res.changed) changed = true;
       // A child's anchor fills a dim slot we haven't claimed yet.
       for (const dim of [0, 1] as (0 | 1)[]) {
@@ -613,7 +668,8 @@ export async function elaborateAxes(
     node,
     sides,
     yUp,
-    childUnderCoord
+    childUnderCoord,
+    labelAngles
   );
   // Any dim this node owns an axis on is claimed — its own anchor replaces
   // whatever bubbled up from children, INCLUDING replacing it with undefined

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -98,12 +98,10 @@ const tickRect = (dim: 0 | 1): GoFishNode =>
  *  cross-`start`, so `[tick, label]`.
  *
  *  `labelAngle` (already sign-resolved for this node's flip scope, see
- *  `resolveLabelRotate`) rotates the label about its anchor. A `0`/`undefined`
- *  angle keeps the default centered alignment along the track axis (pixel-
- *  identical to no rotation); a nonzero angle switches the track-axis alignment
- *  to `start` — the label's anchor (first character) sits at the tick instead
- *  of centering the (now off-axis) rotated bbox on it, matching the
- *  Vega-Lite `labelAngle` look. */
+ *  `resolveLabelRotate`) rotates the label about its anchor. Rotation never
+ *  changes alignment: the track-axis alignment stays centered regardless of
+ *  angle, so a rotated label's (now off-axis) rotated bbox is centered on the
+ *  tick exactly like an unrotated label's bbox would be. */
 function tickMark(
   dim: 0 | 1,
   label: string,
@@ -122,7 +120,7 @@ function tickMark(
     {
       dir: crossName(dim),
       spacing: LABEL_TICK_GAP,
-      alignment: labelAngle ? "start" : "middle",
+      alignment: "middle",
     },
     side === "end" ? [tick, text] : [text, tick]
   ).name(name) as GoFishNode;
@@ -379,11 +377,10 @@ function elaborateOrdinalAxis(
   const gutterDir = crossName(dim); // labels sit in the cross gutter
   const lName = (i: number) => `${prefix}ol${i}`;
   const rName = (i: number) => `${prefix}or${i}`;
-  // A nonzero angle switches the track-axis alignment from centered to the
-  // label's own anchor (`start`, its first character) so the rotated label
-  // hangs off its key like a Vega-Lite `labelAngle` label instead of centering
-  // its rotated bbox on it.
-  const trackAlign = labelAngle ? "start" : "middle";
+  // Rotation never changes alignment: the track-axis alignment stays centered
+  // regardless of `labelAngle`, so a rotated label's rotated bbox is centered
+  // on its key just like an unrotated label's bbox would be.
+  const trackAlign = "middle";
 
   const nodes: GoFishNode[] = [];
   keys.forEach((k, i) => {

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -9,6 +9,7 @@ import { Spread } from "../graphicalOperators/spread";
 import { layer } from "../graphicalOperators/layer";
 import { ref } from "../shapes/ref";
 import { Constraint } from "../constraints";
+import type { AlignAnchor } from "../constraints/shared";
 import { wrapPreservingIdentity, fmtNum } from "../elaborationUtils";
 import { datum } from "../data";
 import { ticks as d3Ticks, nice as d3Nice } from "d3-array";
@@ -79,6 +80,68 @@ function angleForTier(opt: LabelAngleOpt, tier: number): number | undefined {
   return Array.isArray(opt) ? opt[tier] : opt;
 }
 
+/**
+ * How a `labelAngle`-rotated label is anchored to its tick/key — the
+ * "hanging point" rule: the point of the rotated label nearest the axis line
+ * is the point placed at the band/tick center, not the rotated bbox's
+ * middle. `trackAlign` picks the `Constraint.align`/`Spread` anchor mode
+ * along the TRACK axis (the axis's own direction — horizontal for an
+ * x-axis); `textAnchor` picks which end of the (pre-rotation) label sits at
+ * its own local origin, i.e. the point `"baseline"` alignment pins (see
+ * `_node.ts`'s `_pinAnchor`: a `"baseline"` anchor places a node's local
+ * coordinate 0, not a bbox edge). `Text`'s rotation is applied about that
+ * same local origin (`text.tsx`), so pinning it IS pinning the rotation
+ * pivot.
+ *
+ * Rule (screen-clockwise angle `a`; a bottom x-axis is the easiest intuition,
+ * but the derivation only depends on the label's own local frame, not which
+ * axis or side owns it):
+ *  - `a` is 0/undefined: `trackAlign: "middle"` — plain bbox-middle
+ *    centering, IDENTICAL to the unrotated path (no rotation is applied at
+ *    all, so this case never even reaches `Text`'s `rotate`/`textAnchor`).
+ *  - `|a| === 90`: also `trackAlign: "middle"` — the rotated column's bbox
+ *    middle already centers it horizontally on the tick (explicit user
+ *    feedback: this must not regress).
+ *  - `0 < a < 90` (slants down-right): `trackAlign: "baseline"`,
+ *    `textAnchor: "start"` — the pivot is the FIRST character's origin, so
+ *    the label hangs from its start (Vega-Lite's 45° look).
+ *  - `-90 < a < 0` (slants up-right): `trackAlign: "baseline"`,
+ *    `textAnchor: "end"` — the pivot is the LAST character's origin, so the
+ *    label hangs from its end (matplotlib's `ha="right"` look).
+ *
+ * Caveat, deliberately accepted: the label's local origin sits on its
+ * baseline (`dominantBaseline: "auto"`, y=0 at the baseline), not the
+ * ascender-TOP corner a literal "nearest point on the rotated bbox" geometric
+ * derivation would use. The two differ by `ascent·sin(a)` — a couple of
+ * pixels at these font sizes/angles — which the constraint system can't
+ * express without extra bbox-edge arithmetic (`AlignAnchor` only has
+ * `start`/`middle`/`end`/`baseline`, no fractional point). Using the
+ * baseline pivot directly is visually indistinguishable here and needs no
+ * extra machinery.
+ */
+type LabelRotation = {
+  /** The (frame-resolved) degrees to pass to `Text`'s `rotate`. */
+  rotate: number;
+  trackAlign: "middle" | "baseline";
+  textAnchor: "start" | "end";
+};
+
+function resolveLabelRotation(
+  a: number | undefined,
+  frameFlips: boolean
+): LabelRotation | undefined {
+  if (!a) return undefined;
+  const rotate = frameFlips ? -a : a;
+  if (Math.abs(a) === 90) {
+    return { rotate, trackAlign: "middle", textAnchor: "start" };
+  }
+  return {
+    rotate,
+    trackAlign: "baseline",
+    textAnchor: a < 0 ? "end" : "start",
+  };
+}
+
 const dirName = (dim: 0 | 1) => (dim === 0 ? "x" : "y");
 const cross = (dim: 0 | 1): 0 | 1 => (1 - dim) as 0 | 1;
 const crossName = (dim: 0 | 1) => dirName(cross(dim));
@@ -97,11 +160,21 @@ const tickRect = (dim: 0 | 1): GoFishNode =>
  *  cross-`end`, so `[label, tick]`; on the far/end side the inner edge is the
  *  cross-`start`, so `[tick, label]`.
  *
- *  `labelAngle` (already sign-resolved for this node's flip scope, see
- *  `resolveLabelRotate`) rotates the label about its anchor. Rotation never
- *  changes alignment: the track-axis alignment stays centered regardless of
- *  angle, so a rotated label's (now off-axis) rotated bbox is centered on the
- *  tick exactly like an unrotated label's bbox would be. */
+ *  Used only for the "middle" hanging-point case (unrotated / ±90°, see
+ *  `LabelRotation`'s doc comment) — `elaborateContinuousAxis` bypasses this
+ *  for an oblique angle in favor of a bare tick (`tickRect`) plus a separate
+ *  sibling label positioned directly by `positionAxis`'s own constraints
+ *  (`tickLabel`). That split matters: `positionAxis` pins each tick at its
+ *  DATA value by the tick+label PAIR's own bbox middle (`Constraint.position`
+ *  defaults to `anchor: "middle"`); for "middle" alignment the pair's bbox
+ *  middle coincides with the shared tick/label centerline, so pinning it is
+ *  correct. An oblique label's rotated bbox is NOT symmetric about its
+ *  hanging-point pivot, so the pair's bbox middle would drift away from the
+ *  data value by however lopsided the rotated glyph box is — the exact bug
+ *  the hanging-point rule exists to avoid. Keeping a bare, unrotated,
+ *  symmetric tick as the thing `Constraint.position` pins sidesteps that: its
+ *  bbox middle IS its true center regardless of what the label next to it
+ *  does. */
 function tickMark(
   dim: 0 | 1,
   label: string,
@@ -221,6 +294,20 @@ function positionAxis(opts: {
   tickValues: number[];
   /** Build the node for tick i (labeled for continuous, bare for difference). */
   tickNode: (v: number, i: number, name: string) => GoFishNode;
+  /**
+   * Build a SEPARATE per-tick label, when the tick itself (`tickNode`) is
+   * bare — the oblique hanging-point path (see `elaborateContinuousAxis` and
+   * `tickMark`'s doc comment for why the label can't just be nested inside
+   * the tick node there). When given, each label ALIGNs to its tick
+   * (`labelRotation`'s track-axis anchor, heterogeneous when oblique — the
+   * label at its own pivot, the tick at "middle") and DISTRIBUTEs past it
+   * into the gutter; `Constraint.position`'s per-tick data pin still targets
+   * the bare tick alone, never the label.
+   */
+  tickLabel?: (v: number, i: number, name: string) => GoFishNode;
+  /** Shared hanging-point descriptor for `tickLabel` (see `LabelRotation`'s
+   *  doc comment) — only consulted when `tickLabel` is given. */
+  labelRotation?: LabelRotation;
   /** Extra labels placed at a data position (difference delta labels). */
   extraLabels?: { value: number; text: string }[];
   /** The other dim's scale floor, when it also carries a position-like axis —
@@ -234,11 +321,15 @@ function positionAxis(opts: {
   const lineName = `${prefix}line`;
   const tickName = (i: number) => `${prefix}t${i}`;
   const labelName = (i: number) => `${prefix}l${i}`;
+  const tickLabelName = (i: number) => `${prefix}tl${i}`;
   const pos = (v: number) =>
     (dim === 1 ? { y: datum(v) } : { x: datum(v) }) as any;
 
   const line = axisLine(dim, lineMin, lineMax, lineName);
   const tickNodes = tickValues.map((v, i) => opts.tickNode(v, i, tickName(i)));
+  const tickLabelNodes = opts.tickLabel
+    ? tickValues.map((v, i) => opts.tickLabel!(v, i, tickLabelName(i)))
+    : [];
   // Extra labels (difference deltas) are PLAIN text — no tick mark of their own,
   // or the axis ends up with a second row of ticks at the midpoints.
   const extra = opts.extraLabels ?? [];
@@ -250,6 +341,10 @@ function positionAxis(opts: {
 
   const constraints = (g: Record<string, any>) => {
     const ticks = tickValues.map((_, i) => g[tickName(i)]);
+    // Data pin: always the bare tick's own bbox (its "middle" anchor is its
+    // TRUE center regardless of what a sibling `tickLabel` does — see
+    // `tickMark`'s doc comment for why an oblique label can't be nested
+    // inside the pinned node).
     const cs: any[] = tickValues.map((v, i) =>
       Constraint.position(pos(v), [ticks[i]])
     );
@@ -261,6 +356,30 @@ function positionAxis(opts: {
     cs.push(
       ...gutterConstraints(dim, g, lineName, ticks, opts.crossFloor, side)
     );
+    if (opts.tickLabel) {
+      const trackAxis = dirName(dim);
+      const gutterDir = crossName(dim);
+      // Heterogeneous per-child anchor (see `positionAxis`'s `tickLabel` doc
+      // comment): the label pivots at its own origin when oblique; the tick
+      // keeps "middle" either way.
+      const anchors: AlignAnchor[] =
+        opts.labelRotation?.trackAlign === "baseline"
+          ? ["baseline", "middle"]
+          : ["middle", "middle"];
+      tickValues.forEach((_, i) => {
+        const label = g[tickLabelName(i)];
+        const tick = ticks[i];
+        cs.push(
+          Constraint.align({ [trackAxis]: anchors } as any, [label, tick])
+        );
+        cs.push(
+          Constraint.distribute(
+            { dir: gutterDir, spacing: LABEL_TICK_GAP },
+            side === "end" ? [tick, label] : [label, tick]
+          )
+        );
+      });
+    }
     // Each extra label is pinned at its data position along the axis, and —
     // having no tick of its own to provide an offset — DISTRIBUTEs off the
     // (now seated) line, at the same outer offset as the continuous labels
@@ -284,7 +403,7 @@ function positionAxis(opts: {
   // axis line's span (which may be narrower than the plot — a difference axis
   // spans the data width, a facet-owned axis spans its facet).
   return {
-    nodes: [line, ...tickNodes, ...labelNodes],
+    nodes: [line, ...tickNodes, ...tickLabelNodes, ...labelNodes],
     constraints,
     anchor: line,
   };
@@ -293,24 +412,47 @@ function positionAxis(opts: {
 /** One continuous (POSITION) axis. Mirrors the hand-drawn ContinuousYAxis.
  *  `nice` is the d3-niced [min, max] of the domain, computed once by
  *  `elaborationsFor` (the same pair feeds the other axis's `crossFloor`, so
- *  computing it in one place keeps the corner consistent). */
+ *  computing it in one place keeps the corner consistent).
+ *
+ *  `labelRotation`'s `trackAlign` picks how each tick's label is built (see
+ *  `tickMark`'s and `positionAxis`'s `tickLabel` doc comments for why): the
+ *  "middle" case (unrotated / ±90°) nests the label inside the tick node via
+ *  `tickMark`, unchanged from before the hanging-point rule; the "baseline"
+ *  (oblique) case keeps the tick bare and gives `positionAxis` a separate
+ *  `tickLabel` builder instead, so the data-position pin never targets the
+ *  (asymmetric, rotated) label's own bbox. */
 function elaborateContinuousAxis(
   dim: 0 | 1,
   nice: [number, number],
   prefix: string,
   crossFloor?: number,
   side: "start" | "end" = "start",
-  labelAngle?: number
+  labelRotation?: LabelRotation
 ): AxisElaboration {
   const [niceMin, niceMax] = nice;
   const tickValues = d3Ticks(niceMin, niceMax, TICK_COUNT);
+  const oblique = labelRotation?.trackAlign === "baseline";
   return positionAxis({
     dim,
     prefix,
     lineMin: niceMin,
     lineMax: niceMax,
     tickValues,
-    tickNode: (v, _i, name) => tickMark(dim, fmtNum(v), name, side, labelAngle),
+    tickNode: oblique
+      ? (_v, _i, name) => tickRect(dim).name(name)
+      : (v, _i, name) =>
+          tickMark(dim, fmtNum(v), name, side, labelRotation?.rotate),
+    tickLabel: oblique
+      ? (v, _i, name) =>
+          Text({
+            text: fmtNum(v),
+            fontSize: LABEL_FONT_SIZE,
+            fill: AXIS_COLOR,
+            rotate: labelRotation!.rotate,
+            textAnchor: labelRotation!.textAnchor,
+          }).name(name)
+      : undefined,
+    labelRotation,
     crossFloor,
     side,
   });
@@ -370,17 +512,23 @@ function elaborateOrdinalAxis(
   keyMap: Record<string, GoFishNode>,
   prefix: string,
   side: "start" | "end" = "start",
-  labelAngle?: number
+  labelRotation?: LabelRotation
 ): AxisElaboration {
   const keys = (space.domain ?? []).filter((k) => keyMap[k] !== undefined);
   const trackAxis = dirName(dim); // labels track their key along the axis dim
   const gutterDir = crossName(dim); // labels sit in the cross gutter
   const lName = (i: number) => `${prefix}ol${i}`;
   const rName = (i: number) => `${prefix}or${i}`;
-  // Rotation never changes alignment: the track-axis alignment stays centered
-  // regardless of `labelAngle`, so a rotated label's rotated bbox is centered
-  // on its key just like an unrotated label's bbox would be.
-  const trackAlign = "middle";
+  // Hanging-point rule (see `LabelRotation`'s doc comment): unrotated / ±90°
+  // keeps the plain bbox-middle centering used before (pixel-identical to the
+  // pre-hanging-point behavior); an oblique angle instead anchors the LABEL at
+  // its own rotation pivot (`"baseline"`) while the key node it tracks stays
+  // "middle"-anchored on its own extent — a heterogeneous per-child anchor,
+  // via `Constraint.align`'s anchor-array form.
+  const trackAnchors: AlignAnchor[] =
+    labelRotation?.trackAlign === "baseline"
+      ? ["baseline", "middle"]
+      : ["middle", "middle"];
 
   const nodes: GoFishNode[] = [];
   keys.forEach((k, i) => {
@@ -389,7 +537,8 @@ function elaborateOrdinalAxis(
         text: k,
         fontSize: LABEL_FONT_SIZE,
         fill: AXIS_COLOR,
-        rotate: labelAngle,
+        rotate: labelRotation?.rotate,
+        textAnchor: labelRotation?.textAnchor,
       }).name(lName(i))
     );
     nodes.push((ref(keyMap[k]) as any).name(rName(i)) as GoFishNode);
@@ -400,7 +549,7 @@ function elaborateOrdinalAxis(
     keys.forEach((_, i) => {
       // Track the key along the axis dim …
       cs.push(
-        Constraint.align({ [trackAxis]: trackAlign } as any, [
+        Constraint.align({ [trackAxis]: trackAnchors } as any, [
           g[lName(i)],
           g[rName(i)],
         ])
@@ -559,12 +708,16 @@ function elaborationsFor(
   // literal screen angle regardless of the frame's orientation.
   const frameFlips = yUp || underCoord || isCONTINUOUS(space[1]);
   // `tier` is 0 for a continuous/difference axis (always single-tier) or the
-  // bubbled-up ordinal tier index (0 = innermost) for an ordinal one.
-  const resolvedLabelAngle = (dim: 0 | 1, tier: number): number | undefined => {
-    const a = angleForTier(labelAngles[dim], tier);
-    if (!a) return undefined;
-    return frameFlips ? -a : a;
-  };
+  // bubbled-up ordinal tier index (0 = innermost) for an ordinal one. Returns
+  // the full hanging-point descriptor (see `LabelRotation`), not just the
+  // angle — `resolveLabelRotation` also derives the track-axis alignment mode
+  // and, for an oblique angle, which end of the label anchors the rotation
+  // pivot.
+  const resolvedLabelRotation = (
+    dim: 0 | 1,
+    tier: number
+  ): LabelRotation | undefined =>
+    resolveLabelRotation(angleForTier(labelAngles[dim], tier), frameFlips);
   const outTierCounts: [number, number] = [...tierCounts];
   for (const dim of [0, 1] as (0 | 1)[]) {
     if (!owns(dim)) continue;
@@ -578,7 +731,7 @@ function elaborationsFor(
         prefix,
         crossFloor,
         axisSide(dim),
-        resolvedLabelAngle(dim, 0)
+        resolvedLabelRotation(dim, 0)
       );
       constrained.push(e);
       anchors[dim] = e.anchor;
@@ -604,7 +757,7 @@ function elaborationsFor(
           keyMap,
           prefix,
           sides[dim] ?? "start",
-          resolvedLabelAngle(dim, tier)
+          resolvedLabelRotation(dim, tier)
         )
       );
       outTierCounts[dim] = tier + 1;

--- a/packages/gofish-graphics/src/ast/axes/elaborate.tsx
+++ b/packages/gofish-graphics/src/ast/axes/elaborate.tsx
@@ -65,6 +65,20 @@ export type AxisElaboration = {
   anchor?: GoFishNode;
 };
 
+/** A `labelAngle` value as authored: a plain number applies to every tier of
+ *  a nested ordinal axis; an array is per-tier, indexed from the INNERMOST
+ *  tier outward (see `AxisOptions.labelAngle` in `gofish.tsx`). */
+type LabelAngleOpt = number | number[] | undefined;
+
+/** Select the angle for a given ordinal tier (0 = innermost) — or, for a
+ *  continuous/difference axis (always a single tier), tier `0`. A plain
+ *  number applies uniformly; an array indexes by tier, `undefined` past its
+ *  end (unrotated). */
+function angleForTier(opt: LabelAngleOpt, tier: number): number | undefined {
+  if (opt === undefined) return undefined;
+  return Array.isArray(opt) ? opt[tier] : opt;
+}
+
 const dirName = (dim: 0 | 1) => (dim === 0 ? "x" : "y");
 const cross = (dim: 0 | 1): 0 | 1 => (1 - dim) as 0 | 1;
 const crossName = (dim: 0 | 1) => dirName(cross(dim));
@@ -457,13 +471,21 @@ function collectKeyMap(node: GoFishNode): Record<string, GoFishNode> {
  *    out AFTER the content is in its final (shifted) position — i.e. in an outer
  *    tier. Otherwise the ref captures the pre-shift position and the labels miss
  *    the continuous-axis gutter offset.
+ *
+ * `tierCounts` is the per-dim count of ordinal axis tiers already elaborated
+ * BELOW this node in the subtree (0 = none yet, i.e. this node — if it owns an
+ * ordinal axis — is the innermost tier); see `elaborateAxes` for how it's
+ * bubbled up. The returned `tierCounts` adds one per dim this node claimed an
+ * ordinal axis on, so an ancestor owning the same dim's outer tier reads the
+ * right index for a per-tier `labelAngle` array.
  */
 function elaborationsFor(
   node: GoFishNode,
   sides: ["start" | "end" | undefined, "start" | "end" | undefined],
   yUp: boolean,
   underCoord: boolean,
-  labelAngles: [number | undefined, number | undefined] = [undefined, undefined]
+  labelAngles: [LabelAngleOpt, LabelAngleOpt] = [undefined, undefined],
+  tierCounts: [number, number] = [0, 0]
 ): {
   constrained: AxisElaboration[];
   refBased: AxisElaboration[];
@@ -474,6 +496,9 @@ function elaborationsFor(
    *  all — including an ordinal one, which contributes no `anchors` entry. An
    *  owner CLAIMS the dim for title-anchoring purposes (see `elaborateAxes`). */
   owned: [boolean, boolean];
+  /** Per-dim ordinal-tier count, incremented for each dim this node claimed
+   *  an ordinal axis on (see the doc comment above). */
+  tierCounts: [number, number];
 } {
   const space = node._underlyingSpace;
   if (!space)
@@ -482,6 +507,7 @@ function elaborationsFor(
       refBased: [],
       anchors: [undefined, undefined],
       owned: [false, false],
+      tierCounts,
     };
   const owns = (dim: 0 | 1) => (dim === 0 ? node.axis.x : node.axis.y) === true;
   // Niced [min, max] per owned POSITION dim, computed ONCE: it feeds both that
@@ -535,11 +561,14 @@ function elaborationsFor(
   // pre-negate here to cancel that render-time negation and land back on the
   // literal screen angle regardless of the frame's orientation.
   const frameFlips = yUp || underCoord || isCONTINUOUS(space[1]);
-  const resolvedLabelAngle = (dim: 0 | 1): number | undefined => {
-    const a = labelAngles[dim];
+  // `tier` is 0 for a continuous/difference axis (always single-tier) or the
+  // bubbled-up ordinal tier index (0 = innermost) for an ordinal one.
+  const resolvedLabelAngle = (dim: 0 | 1, tier: number): number | undefined => {
+    const a = angleForTier(labelAngles[dim], tier);
     if (!a) return undefined;
     return frameFlips ? -a : a;
   };
+  const outTierCounts: [number, number] = [...tierCounts];
   for (const dim of [0, 1] as (0 | 1)[]) {
     if (!owns(dim)) continue;
     const s = space[dim];
@@ -552,7 +581,7 @@ function elaborationsFor(
         prefix,
         crossFloor,
         axisSide(dim),
-        resolvedLabelAngle(dim)
+        resolvedLabelAngle(dim, 0)
       );
       constrained.push(e);
       anchors[dim] = e.anchor;
@@ -570,6 +599,7 @@ function elaborationsFor(
       keyMap ??= collectKeyMap(node);
       // Ordinal axes keep the `start` default (they follow the content's own flip
       // like a category row); only continuous axes default to the bottom.
+      const tier = outTierCounts[dim];
       refBased.push(
         elaborateOrdinalAxis(
           dim,
@@ -577,9 +607,10 @@ function elaborationsFor(
           keyMap,
           prefix,
           sides[dim] ?? "start",
-          resolvedLabelAngle(dim)
+          resolvedLabelAngle(dim, tier)
         )
       );
+      outTierCounts[dim] = tier + 1;
     } else {
       continue;
     }
@@ -587,7 +618,7 @@ function elaborationsFor(
     if (dim === 0) node.axis.x = undefined;
     else node.axis.y = undefined;
   }
-  return { constrained, refBased, anchors, owned };
+  return { constrained, refBased, anchors, owned, tierCounts: outTierCounts };
 }
 
 /**
@@ -614,6 +645,16 @@ function elaborationsFor(
  * ambiguous here — they overwrite the same slot, so whichever sibling is
  * visited last wins. We don't try to disambiguate (a per-facet title is out of
  * scope); the chart-level title just tracks one of them.
+ *
+ * It also bubbles up `tierCounts` — the per-dim count of ordinal axis tiers
+ * elaborated so far in this subtree — purely as an output (nothing is passed
+ * DOWN for it): each dim is folded bottom-up as `max` over the node's own
+ * children, then incremented by `elaborationsFor` if this node itself claims
+ * an ordinal axis on that dim. That gives a node's ordinal axis a tier index
+ * of 0 for the innermost nesting (e.g. a grouped bar chart's year row) and 1
+ * for the next one out (its city row), which `elaborationsFor` uses to pick
+ * the right entry of a per-tier `labelAngle` array. Sibling subtrees don't
+ * interfere: each call only sees counts folded from ITS OWN children.
  */
 export async function elaborateAxes(
   node: GoFishNode,
@@ -623,17 +664,19 @@ export async function elaborateAxes(
   ],
   yUp = false,
   underCoord = false,
-  labelAngles: [number | undefined, number | undefined] = [undefined, undefined]
+  labelAngles: [LabelAngleOpt, LabelAngleOpt] = [undefined, undefined]
 ): Promise<{
   node: GoFishNode;
   changed: boolean;
   titleAnchors: [GoFishNode | undefined, GoFishNode | undefined];
+  tierCounts: [number, number];
 }> {
   let changed = false;
   const titleAnchors: [GoFishNode | undefined, GoFishNode | undefined] = [
     undefined,
     undefined,
   ];
+  const tierCounts: [number, number] = [0, 0];
   // A `coord` (polar/clock) fixes its own frame orientation, so any axis inside
   // it flips with the coord rather than seating on the far edge directly. Track
   // whether we are under one so `axisSide` keeps the near/"start" seating there.
@@ -656,6 +699,7 @@ export async function elaborateAxes(
         if (titleAnchors[dim] === undefined && res.titleAnchors[dim]) {
           titleAnchors[dim] = res.titleAnchors[dim];
         }
+        tierCounts[dim] = Math.max(tierCounts[dim], res.tierCounts[dim]);
       }
       if (res.node !== child) {
         node.children[i] = res.node;
@@ -664,12 +708,19 @@ export async function elaborateAxes(
     }
   }
 
-  const { constrained, refBased, anchors, owned } = elaborationsFor(
+  const {
+    constrained,
+    refBased,
+    anchors,
+    owned,
+    tierCounts: nextTierCounts,
+  } = elaborationsFor(
     node,
     sides,
     yUp,
     childUnderCoord,
-    labelAngles
+    labelAngles,
+    tierCounts
   );
   // Any dim this node owns an axis on is claimed — its own anchor replaces
   // whatever bubbled up from children, INCLUDING replacing it with undefined
@@ -680,7 +731,7 @@ export async function elaborateAxes(
   }
 
   if (constrained.length === 0 && refBased.length === 0) {
-    return { node, changed, titleAnchors };
+    return { node, changed, titleAnchors, tierCounts: nextTierCounts };
   }
 
   // Move identity off the content onto whatever ends up outermost (so the
@@ -730,7 +781,12 @@ export async function elaborateAxes(
     return outerRoot;
   });
 
-  return { node: root, changed: true, titleAnchors };
+  return {
+    node: root,
+    changed: true,
+    titleAnchors,
+    tierCounts: nextTierCounts,
+  };
 }
 
 // ── Axis titles ──────────────────────────────────────────────────────────────

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -112,10 +112,18 @@ export type AxisOptions =
       /** Rotate tick/category labels by this many degrees, clockwise on screen
        *  — matches Vega-Lite's `labelAngle` (e.g. `45` slants a label down to
        *  the right, `90` reads top-to-bottom). Manual only: there is no
-       *  "auto" collision-avoidance mode (deferred, see #486). Applies to
-       *  both continuous tick labels and ordinal category labels on the axis
-       *  it's set on, including every nested tier of a grouped ordinal axis. */
-      labelAngle?: number;
+       *  "auto" collision-avoidance mode (deferred, see #486).
+       *
+       *  A plain **number** applies to every tier of a nested ordinal axis
+       *  (e.g. both the city and year rows of a grouped bar chart). An
+       *  **array** is per-tier, indexed from the INNERMOST tier outward —
+       *  `[45]` rotates only the innermost category row (e.g. the year row
+       *  directly under grouped bars) and leaves outer tiers (e.g. the city
+       *  row) unrotated; `[45, 0]` is the explicit two-tier form. An index
+       *  beyond the array's length means unrotated/undefined. A continuous
+       *  axis has a single tier: it uses the number, or `array[0]` for the
+       *  array form. */
+      labelAngle?: number | number[];
     };
 
 /** Per-dim axis `side` AS AUTHORED — `undefined` where the caller did not specify
@@ -131,11 +139,14 @@ export function resolveAxisSides(
 }
 
 /** Per-dim `labelAngle` AS AUTHORED — `undefined` where unset, matching
- *  `resolveAxisSides`'s shape. */
+ *  `resolveAxisSides`'s shape. A `number` applies to every tier; a
+ *  `number[]` is per-tier, innermost first (see `AxisOptions.labelAngle`). */
 export function resolveAxisLabelAngles(
   axes: AxesOptions | undefined
-): [number | undefined, number | undefined] {
-  const angleOf = (o: AxisOptions | undefined): number | undefined =>
+): [number | number[] | undefined, number | number[] | undefined] {
+  const angleOf = (
+    o: AxisOptions | undefined
+  ): number | number[] | undefined =>
     o && typeof o === "object" ? o.labelAngle : undefined;
   if (axes && typeof axes === "object")
     return [angleOf(axes.x), angleOf(axes.y)];

--- a/packages/gofish-graphics/src/ast/gofish.tsx
+++ b/packages/gofish-graphics/src/ast/gofish.tsx
@@ -106,7 +106,17 @@ export type AxesOptions = boolean | { x?: AxisOptions; y?: AxisOptions };
  *  frame-relative seating. */
 export type AxisOptions =
   | boolean
-  | { title?: string | false; side?: "start" | "end" };
+  | {
+      title?: string | false;
+      side?: "start" | "end";
+      /** Rotate tick/category labels by this many degrees, clockwise on screen
+       *  — matches Vega-Lite's `labelAngle` (e.g. `45` slants a label down to
+       *  the right, `90` reads top-to-bottom). Manual only: there is no
+       *  "auto" collision-avoidance mode (deferred, see #486). Applies to
+       *  both continuous tick labels and ordinal category labels on the axis
+       *  it's set on, including every nested tier of a grouped ordinal axis. */
+      labelAngle?: number;
+    };
 
 /** Per-dim axis `side` AS AUTHORED — `undefined` where the caller did not specify
  *  one, so the elaboration can tell an explicit `"start"` (literal frame-relative
@@ -117,6 +127,18 @@ export function resolveAxisSides(
   const sideOf = (o: AxisOptions | undefined): "start" | "end" | undefined =>
     o && typeof o === "object" ? o.side : undefined;
   if (axes && typeof axes === "object") return [sideOf(axes.x), sideOf(axes.y)];
+  return [undefined, undefined];
+}
+
+/** Per-dim `labelAngle` AS AUTHORED — `undefined` where unset, matching
+ *  `resolveAxisSides`'s shape. */
+export function resolveAxisLabelAngles(
+  axes: AxesOptions | undefined
+): [number | undefined, number | undefined] {
+  const angleOf = (o: AxisOptions | undefined): number | undefined =>
+    o && typeof o === "object" ? o.labelAngle : undefined;
+  if (axes && typeof axes === "object")
+    return [angleOf(axes.x), angleOf(axes.y)];
   return [undefined, undefined];
 }
 
@@ -291,7 +313,13 @@ export async function layout(
     // handled axis flags; the new subtree is then re-resolved below. A flag the
     // pass doesn't handle (e.g. an UNDEFINED space) is inert — nothing else
     // consumes `node.axis`.
-    const elaborated = await elaborateAxes(child, resolveAxisSides(axes), yUp);
+    const elaborated = await elaborateAxes(
+      child,
+      resolveAxisSides(axes),
+      yUp,
+      false,
+      resolveAxisLabelAngles(axes)
+    );
     titleAnchors = elaborated.titleAnchors;
     if (elaborated.changed) {
       child = elaborated.node;

--- a/packages/gofish-graphics/src/ast/shapes/text.tsx
+++ b/packages/gofish-graphics/src/ast/shapes/text.tsx
@@ -188,6 +188,7 @@ export const Text = ({
   fontWeight,
   debugBoundingBox = false,
   rotate = 0,
+  textAnchor = "start",
   ...fancyDims
 }: {
   key?: string;
@@ -205,11 +206,19 @@ export const Text = ({
    *  text anchor. `rotate: 90` yields a conventional y-axis title — it reads
    *  bottom-to-top with glyph tops facing left. */
   rotate?: number;
+  /** Which end of the (pre-rotation) text sits at the node's own local
+   *  origin — the point `rotate` pivots about, and the point an `align`/
+   *  `position` constraint's `"baseline"` anchor pins (see `_node.ts`'s
+   *  `_pinAnchor`). Defaults to `"start"` (the first character), matching
+   *  ordinary left-to-right text flow; `"end"` pivots at the last character
+   *  instead — used for an obliquely-rotated label that should hang from its
+   *  end rather than its start (see `axes/elaborate.tsx`'s hanging-point
+   *  rule for rotated axis labels). */
+  textAnchor?: "start" | "middle" | "end";
 } & FancyDims<MaybeValue<number>>) => {
   // `embedded` is authored by the resolveEmbedding pass — see rect.tsx.
   const dims = elaborateDims(fancyDims);
 
-  const textAnchor = "start";
   const dominantBaseline = "auto";
 
   const node = new GoFishNode(

--- a/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
@@ -89,3 +89,43 @@ export const AxesSuppressedTitle: StoryObj<Args> = {
   render: (args: Args) =>
     renderBar(args, { x: { title: false }, y: true }),
 };
+
+// labelAngle (#746): a nested grouped bar chart (city, then year) at a small
+// thumbnail size, where the unrotated category labels would collide under the
+// bars. Two-tier x axis: labelAngle applies to both the inner (year) and
+// outer (city) label rows.
+const cityYear = [
+  { city: "Austin", year: "2022", visitors: 42 },
+  { city: "Austin", year: "2023", visitors: 58 },
+  { city: "Austin", year: "2024", visitors: 71 },
+  { city: "Boston", year: "2022", visitors: 55 },
+  { city: "Boston", year: "2023", visitors: 49 },
+  { city: "Boston", year: "2024", visitors: 63 },
+  { city: "Chicago", year: "2022", visitors: 38 },
+  { city: "Chicago", year: "2023", visitors: 44 },
+  { city: "Chicago", year: "2024", visitors: 51 },
+];
+
+function renderGroupedBar(args: Args, labelAngle: number): HTMLElement {
+  const container = initializeContainer();
+
+  chart(cityYear, { axes: { x: { labelAngle } } })
+    .flow(
+      spread({ by: "city", dir: "x", spacing: 24 }),
+      spread({ by: "year", dir: "x", spacing: 0 })
+    )
+    .mark(rect({ h: "visitors", fill: "year" }))
+    .render(container, { w: args.w, h: args.h });
+
+  return container;
+}
+
+export const GroupedLabelAngle45: StoryObj<Args> = {
+  args: { w: 300, h: 210 },
+  render: (args: Args) => renderGroupedBar(args, 45),
+};
+
+export const GroupedLabelAngle90: StoryObj<Args> = {
+  args: { w: 300, h: 210 },
+  render: (args: Args) => renderGroupedBar(args, 90),
+};

--- a/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Bar/BarAxesPermutations.stories.tsx
@@ -106,7 +106,10 @@ const cityYear = [
   { city: "Chicago", year: "2024", visitors: 51 },
 ];
 
-function renderGroupedBar(args: Args, labelAngle: number): HTMLElement {
+function renderGroupedBar(
+  args: Args,
+  labelAngle: number | number[]
+): HTMLElement {
   const container = initializeContainer();
 
   chart(cityYear, { axes: { x: { labelAngle } } })
@@ -128,4 +131,16 @@ export const GroupedLabelAngle45: StoryObj<Args> = {
 export const GroupedLabelAngle90: StoryObj<Args> = {
   args: { w: 300, h: 210 },
   render: (args: Args) => renderGroupedBar(args, 90),
+};
+
+// Per-tier labelAngle array: [45] rotates only the innermost (year) row,
+// leaving the outer (city) row upright.
+export const GroupedLabelAngleInner45: StoryObj<Args> = {
+  args: { w: 300, h: 210 },
+  render: (args: Args) => renderGroupedBar(args, [45]),
+};
+
+export const GroupedLabelAngleInner90: StoryObj<Args> = {
+  args: { w: 300, h: 210 },
+  render: (args: Args) => renderGroupedBar(args, [90]),
 };

--- a/packages/gofish-ir/src/frontend/descriptors.ts
+++ b/packages/gofish-ir/src/frontend/descriptors.ts
@@ -615,6 +615,11 @@ export const LEAF_MARKS: Record<string, ConstructDescriptor> = {
         default: 0,
         doc: "Rotation in degrees, applied in the chart's y-up world frame about the text anchor.",
       },
+      textAnchor: {
+        type: t.enum("start", "middle", "end"),
+        default: "start",
+        doc: "Where the text anchor — the local origin `rotate` pivots about and dims channels position — sits along the string: its first character, center, or last character.",
+      },
     },
   }),
 

--- a/packages/gofish-python/gofish/_generated.py
+++ b/packages/gofish-python/gofish/_generated.py
@@ -210,7 +210,7 @@ def petal(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = N
             _kw[_k] = _channel(_v)
     return Mark("petal", **_kw)
 
-def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = None, x: Optional[Union[int, float, str]] = None, cx: Optional[Union[int, float, str]] = None, x2: Optional[Union[int, float, str]] = None, w: Optional[Union[int, float, str]] = None, emX: Optional[bool] = None, y: Optional[Union[int, float, str]] = None, cy: Optional[Union[int, float, str]] = None, y2: Optional[Union[int, float, str]] = None, h: Optional[Union[int, float, str]] = None, emY: Optional[bool] = None, theta: Optional[Union[int, float, str]] = None, thetaSize: Optional[Union[int, float, str]] = None, r: Optional[Union[int, float, str]] = None, rSize: Optional[Union[int, float, str]] = None, key: Optional[str] = None, text: str, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, filter: Optional[str] = None, fontSize: Optional[float] = None, fontFamily: Optional[str] = None, fontStyle: Optional[str] = None, fontWeight: Optional[Union[float, str]] = None, debugBoundingBox: Optional[bool] = None, rotate: Optional[float] = None) -> Mark:
+def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = None, x: Optional[Union[int, float, str]] = None, cx: Optional[Union[int, float, str]] = None, x2: Optional[Union[int, float, str]] = None, w: Optional[Union[int, float, str]] = None, emX: Optional[bool] = None, y: Optional[Union[int, float, str]] = None, cy: Optional[Union[int, float, str]] = None, y2: Optional[Union[int, float, str]] = None, h: Optional[Union[int, float, str]] = None, emY: Optional[bool] = None, theta: Optional[Union[int, float, str]] = None, thetaSize: Optional[Union[int, float, str]] = None, r: Optional[Union[int, float, str]] = None, rSize: Optional[Union[int, float, str]] = None, key: Optional[str] = None, text: str, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, filter: Optional[str] = None, fontSize: Optional[float] = None, fontFamily: Optional[str] = None, fontStyle: Optional[str] = None, fontWeight: Optional[Union[float, str]] = None, debugBoundingBox: Optional[bool] = None, rotate: Optional[float] = None, textAnchor: Optional[str] = None) -> Mark:
     """A text label. Box geometry via the shared dims channels positions the text anchor.
 
     Args:
@@ -239,6 +239,7 @@ def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = No
         fontWeight: CSS font-weight (e.g. 300, 700, "bold").
         debugBoundingBox: Default false.
         rotate: Rotation in degrees, applied in the chart's y-up world frame about the text anchor. Default 0.
+        textAnchor: Where the text anchor — the local origin `rotate` pivots about and dims channels position — sits along the string: its first character, center, or last character. Default "start".
     """
     _kw: Dict[str, Any] = {}
     for _k, _v in [
@@ -270,6 +271,7 @@ def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = No
         ("fontWeight", fontWeight),
         ("debugBoundingBox", debugBoundingBox),
         ("rotate", rotate),
+        ("textAnchor", textAnchor),
     ]:
         if _v is not None:
             _kw[_k] = _channel(_v)

--- a/tests/python-stories/forward-syntax-v3/bar/test_axes_permutations.py
+++ b/tests/python-stories/forward-syntax-v3/bar/test_axes_permutations.py
@@ -58,3 +58,40 @@ def story_axes_custom_xtitle():
 
 def story_axes_suppressed_title():
     return _story({"x": {"title": False}, "y": True})
+
+
+# labelAngle (#746): a nested grouped bar chart (city, then year) at a small
+# thumbnail size, where the unrotated category labels would collide under the
+# bars. Two-tier x axis: labelAngle applies to both the inner (year) and
+# outer (city) label rows.
+CITY_YEAR = [
+    {"city": "Austin", "year": "2022", "visitors": 42},
+    {"city": "Austin", "year": "2023", "visitors": 58},
+    {"city": "Austin", "year": "2024", "visitors": 71},
+    {"city": "Boston", "year": "2022", "visitors": 55},
+    {"city": "Boston", "year": "2023", "visitors": 49},
+    {"city": "Boston", "year": "2024", "visitors": 63},
+    {"city": "Chicago", "year": "2022", "visitors": 38},
+    {"city": "Chicago", "year": "2023", "visitors": 44},
+    {"city": "Chicago", "year": "2024", "visitors": 51},
+]
+
+
+def _grouped_bar(label_angle):
+    return (
+        chart(CITY_YEAR, axes={"x": {"labelAngle": label_angle}})
+        .flow(
+            spread(by="city", dir="x", spacing=24),
+            spread(by="year", dir="x", spacing=0),
+        )
+        .mark(rect(h="visitors", fill="year")),
+        {"w": 300, "h": 210},
+    )
+
+
+def story_grouped_label_angle45():
+    return _grouped_bar(45)
+
+
+def story_grouped_label_angle90():
+    return _grouped_bar(90)

--- a/tests/python-stories/forward-syntax-v3/bar/test_axes_permutations.py
+++ b/tests/python-stories/forward-syntax-v3/bar/test_axes_permutations.py
@@ -95,3 +95,13 @@ def story_grouped_label_angle45():
 
 def story_grouped_label_angle90():
     return _grouped_bar(90)
+
+
+# Per-tier labelAngle array: [45]/[90] rotates only the innermost (year) row,
+# leaving the outer (city) row upright.
+def story_grouped_label_angle_inner45():
+    return _grouped_bar([45])
+
+
+def story_grouped_label_angle_inner90():
+    return _grouped_bar([90])

--- a/tests/python-stories/shapes/test_text_marks.py
+++ b/tests/python-stories/shapes/test_text_marks.py
@@ -3,9 +3,11 @@
 Text mark layout: spreads of styled text labels (vertical, middle-aligned,
 horizontal) plus a text mark spread against an ellipse. JS `For(...)` is
 array-map sugar and becomes a list comprehension. The JS stories pass
-`textAnchor: "start"` to text(), but it is a no-op in JS (the renderer
-hardcodes "start") and is not an IR field, so it is omitted here.
-PolarText is exempt (raw JS coordinate-transform closure).
+`textAnchor: "start"`, which is now a real IR field (it positions the
+rotation pivot/local origin at the text's first character, center, or last
+character) — ported here too, even though "start" is also the default.
+PolarText is exempt (raw JS coordinate-transform closure, unrelated to
+textAnchor).
 """
 
 from gofish import ellipse, spread, text
@@ -27,6 +29,7 @@ def _label_texts():
             fill=label["color"],
             fontSize=28,
             fontFamily=FONT_FAMILY,
+            textAnchor="start",
             debugBoundingBox=True,
         )
         for label in LABELS


### PR DESCRIPTION
## What this does

Adds a `labelAngle` option to `AxisOptions` so users can rotate axis tick and category labels:

```ts
chart(data)
  .flow(spread("city"), spread("year"))
  .mark(rect({ h: "value" }))
  .render(container, { w: 300, h: 210, axes: { x: { labelAngle: 45 } } });
```

The angle is in degrees, clockwise on screen, matching Vega-Lite's `labelAngle`. A plain number applies to both continuous tick labels and ordinal category labels on the axis it is set on, including every tier of a nested grouped axis.

An array form gives per-tier control, indexed from the innermost tier outward. `labelAngle: [45]` rotates only the innermost category row (the crowded one) and leaves outer tiers upright, and `[45, 0]` is the explicit two-tier form. Tiers past the end of the array stay unrotated. Internally each nested ordinal axis owner learns its tier index from a per-dim counter bubbled up through the bottom-up elaboration walk, alongside the existing anchor bubbling. The motivating case is small renders of grouped bar charts, e.g. 300x210 slide thumbnails, where the category labels under the bars collide.

## Screenshots

`labelAngle: 45` on a nested grouped bar chart at 300x210 (the #746 scenario):

![grouped bars with 45 degree labels](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-747/grouped-label-angle-45.png)

`labelAngle: 90`:

![grouped bars with 90 degree labels](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-747/grouped-label-angle-90.png)

`labelAngle: [45]`, inner year row rotated, outer city row upright:

![grouped bars with only inner labels rotated 45 degrees](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-747/grouped-label-angle-inner-45.png)

`labelAngle: [90]`:

![grouped bars with only inner labels rotated 90 degrees](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-747/grouped-label-angle-inner-90.png)

## Implementation notes

- Axis labels are ordinary `Text` marks built during axis elaboration, and `Text` already supports `rotate` with a rotation-aware bbox, so the layout accounts for the rotated footprint automatically. The outer category row of a grouped axis moves down to clear the rotated inner labels without any new constraints.
- `Text.rotate` is applied in the node's y-up world frame and is negated at render time when that frame flips. The elaboration pre-negates the authored angle with the same flip predicate, so `labelAngle: 45` always means literal screen-clockwise 45 degrees.
- Anchoring follows one geometric rule: each label hangs from the point of the rotated label nearest the axis, and that point sits at the band/tick center. At 0 and 90 degrees that point is an edge midpoint, so those labels are centered exactly as before; at oblique angles the label hangs from its first character (45, the Vega-Lite look) or last character (-45, the matplotlib look). Implemented by pinning the text's rotation pivot via the existing baseline anchor rather than bbox-edge arithmetic.
- Supporting this made `textAnchor: "start" | "middle" | "end"` on the text mark a real, working option (it was previously authored-but-dropped). It is exposed through the IR descriptor table to Python and documented on both text-mark doc pages. One existing story (`shapes/text-marks--polar-text`) already authored `textAnchor: "middle"` and now honors it — its visual baseline change in CI is intentional.
- The default (unrotated) path is unchanged: `pnpm capture-diff main` shows no existing story moved, and the 90-degree stories are byte-identical before and after the hanging-point change.
- Python needs no wrapper change because the `axes` render option passes through untyped. The two new stories have Python ports, and both render byte-identical normalized DOM between JS and Python.
- There is no automatic mode. Deciding rotation from actual label widths needs post-solve information, and elaboration runs before the constraint solve, so the automatic version is deferred to the choice operator work in #486, where `labelAngle: "auto"` is the reserved spelling. See https://github.com/gofish-graphics/gofish-graphics/issues/486#issuecomment-4939165166.

Note on where this option lives: #646 and #649 discuss retiring the render-level `axes` option in favor of chart options and a `.axis()` modifier. The `labelAngle` semantics carry over unchanged wherever the axes surface ends up, and the per-tier array form would likely dissolve into plain per-owner options once axes attach to nodes (see the comment on #649).

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)



