### PR TITLE
Fuse relational marks in .mark() position (blank-fusion sugar)

### DIFF
--- a/apps/docs/docs/internals/frontend/mark-factory.md
+++ b/apps/docs/docs/internals/frontend/mark-factory.md
@@ -302,6 +302,39 @@ This is what lets `line()`/`ribbon()` sit under the marks they connect with no
 zOrder incantation needed, in every call form including the low-level
 combinator one.
 
+### Blank-fusion: `.mark(R(opts))` sugar
+
+The **bag** and **`by`-split bag** forms above are also reachable through a
+syntactic rewrite at `ChartBuilder.mark()` (`src/ast/marks/chartBuilder.ts`):
+placing a relational mark directly in `.mark()` position elaborates to an
+invisible anchor tier plus a connector tier —
+
+```
+.mark(R(opts))  ⇒  .mark(blank(anchor(opts))).layer(R(opts))
+```
+
+`anchor(opts)` is exactly `opts`'s `{w, h, emX, emY}` subset (`pickAnchorOpts`
+in chart.ts) — the rest (fill, stroke, curve, `by`, …) stays on the connector
+unchanged, since `produce` only reads the fields it knows about. The factory
+tags every bag-form / by-split-form mark it returns with a
+`__relationalFusable = { opts, makeAnchor }` descriptor (`makeAnchor` is a
+pre-bound `blank(...)` call, kept out of chartBuilder.ts to avoid a
+chart.ts ↔ chartBuilder.ts import cycle); `modifierMethod` in
+createOperator.ts propagates the tag through `.name()`/`.label()`/`.zOrder()`
+chaining so those still target the connector. The pairwise `{from, to}` form
+is never tagged.
+
+`ChartBuilder.mark()` only rewrites when the chart's own data still needs
+anchors drawn for it (`!usesPreviousLayerMarks() && !(data instanceof
+GoFishRef)`) — a relational mark applied directly to an already-drawn refs
+bag (`chart(selectAll("bars")).mark(ribbon(opts))`, or an empty-scope
+`chart()` tier inside `.layer(...)`) keeps its direct bag-form meaning
+unfused, since there's nothing to anchor. A `by`-split connector's `fill` may
+be a shared field name rather than a literal color; `resolveGroupFill` in
+chart.ts resolves it per group via `inferColor` (same channel helper
+`createMark` uses) before it reaches `Connect`, reading a representative row
+off the group's ref bag.
+
 ## Prior art
 
 `createMark` is most directly inspired by **Encodable** (Wongsuphasawat,

--- a/apps/docs/docs/internals/frontend/operator-factory.md
+++ b/apps/docs/docs/internals/frontend/operator-factory.md
@@ -294,6 +294,15 @@ user-chained name without parsing the `__serialize` tag. (An earlier
 in favor of `.layer()`, which generalizes the pattern to every tier — see
 [The Mark Factory](/internals/frontend/mark-factory#createrelationalmark-connectors-as-marks).)
 
+`modifierMethod` also propagates any `__relationalFusable` tag from the base
+mark onto the wrapped one (alongside the `__kind` tag it already carried) —
+the blank-fusion descriptor `createRelationalMark` stamps on bag-form /
+by-split-form relational marks (see
+[The Mark Factory](/internals/frontend/mark-factory#blank-fusion-mark-r-opts-sugar)).
+Without this, `ribbon(opts).name("area")` would lose the tag the moment
+`.name(...)` wraps it in a new function, and `.mark(ribbon(opts).name("area"))`
+would silently stop fusing.
+
 A modifier's `apply(node, layerContext, datum, ...args)` receives the
 **per-instance datum** the mark was called with — the same value the shape
 factory saw — so a modifier can produce a _data-driven_ value rather than a

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -2170,6 +2170,22 @@ for the API.
           ],
           "description": "Bag form: partition the operand refs by this field (or field(...) accessor) and draw one connector per group."
         },
+        "emX": {
+          "type": "boolean",
+          "description": "Blank-fusion anchor key: placed directly in `.mark()` position, `line(opts)` elaborates to an invisible anchor tier (a `blank()` carrying just `{w, h, emX, emY}`) plus this connector — see the `mark` construct's doc. Ignored by `line` itself."
+        },
+        "emY": {
+          "type": "boolean",
+          "description": "Blank-fusion anchor key — see `emX`. Ignored by `line` itself."
+        },
+        "w": {
+          "$ref": "#/$defs/ChannelValue",
+          "description": "Blank-fusion anchor key — see `emX`. Ignored by `line` itself."
+        },
+        "h": {
+          "$ref": "#/$defs/ChannelValue",
+          "description": "Blank-fusion anchor key — see `emX`. Ignored by `line` itself."
+        },
         "name": {
           "type": "string"
         },
@@ -2241,6 +2257,22 @@ for the API.
             }
           ],
           "description": "Bag form: partition the operand refs by this field (or field(...) accessor) and draw one connector per group."
+        },
+        "emX": {
+          "type": "boolean",
+          "description": "Blank-fusion anchor key: placed directly in `.mark()` position, `ribbon(opts)` elaborates to an invisible anchor tier (a `blank()` carrying just `{w, h, emX, emY}`) plus this connector — see the `mark` construct's doc. Ignored by `ribbon` itself."
+        },
+        "emY": {
+          "type": "boolean",
+          "description": "Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself."
+        },
+        "w": {
+          "$ref": "#/$defs/ChannelValue",
+          "description": "Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself."
+        },
+        "h": {
+          "$ref": "#/$defs/ChannelValue",
+          "description": "Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself."
         },
         "name": {
           "type": "string"

--- a/apps/docs/docs/js/api/core/layer.md
+++ b/apps/docs/docs/js/api/core/layer.md
@@ -20,6 +20,74 @@ tier's marks as scope, uniformly:
   component-level annotation: it ignores the scope entirely, since its channels
   have no ref-bag semantics to read.
 
+## Blank-fusion: skip `.layer()` entirely for a fresh chart
+
+When the connector's anchors don't exist yet either — there's no earlier tier
+to draw from, just raw data — `line()`/`ribbon()` can go straight in `.mark()`
+position and skip `.layer()` altogether:
+
+::: gofish
+
+```js
+gf.chart(seafood, { axes: true })
+  .flow(
+    gf.spread({ by: "lake", dir: "x", spacing: 64 }),
+    gf.stack({ by: gf.field("species").sort("count"), dir: "y" })
+  )
+  .mark(gf.ribbon({ h: "count", fill: "species", by: "species", opacity: 0.8 }))
+  .render(root, { w: 400, h: 320 });
+```
+
+:::
+
+### Desugaring
+
+A relational mark placed directly in `.mark()` position elaborates to an
+invisible anchor tier plus a connector tier:
+
+```
+.mark(R(opts))  ⇒  .mark(blank(anchor(opts))).layer(R(opts))
+```
+
+`anchor(opts)` is exactly the `{w, h, emX, emY}` subset of `opts` — the purely
+spatial keys `blank()` itself accepts. Everything else (`fill`, `stroke`,
+`strokeWidth`, `strokeDasharray`, `opacity`, `curve`, `dir`, `mixBlendMode`,
+`by`, `source`, `target`) stays on the connector, matching what you'd write by
+hand:
+
+```js
+// Fused
+chart(seafood, { axes: true })
+  .flow(
+    spread({ by: "lake", dir: "x", spacing: 64 }),
+    stack({ by: "species", dir: "y" })
+  )
+  .mark(ribbon({ h: "count", fill: "species", by: "species", opacity: 0.8 }));
+
+// ...is sugar for the explicit two-tier form:
+chart(seafood, { axes: true })
+  .flow(
+    spread({ by: "lake", dir: "x", spacing: 64 }),
+    stack({ by: "species", dir: "y" })
+  )
+  .mark(blank({ h: "count" }))
+  .layer(ribbon({ fill: "species", by: "species", opacity: 0.8 }));
+```
+
+A `.name(...)`/`.label(...)`/`.zOrder(...)` chained onto the relational mark
+names/labels/orders the **connector** (the anchor tier still gets `.layer()`'s
+usual auto-naming). This rule only fires when the chart's data still needs
+anchors drawn for it — a relational mark applied directly to an existing bag
+of refs (`chart(selectAll("bars")).mark(ribbon(opts))`, or the bare-mark tier
+form documented above) keeps its unfused, direct-connect meaning; only the
+pairwise `{from, to}` form is never fused either, since it already consumes
+ref-bearing rows in `.mark()` position.
+
+Reach for the explicit `.mark(blank(...)).layer(...)` form instead when the
+anchor needs options besides `{w, h, emX, emY}` (a visible rect anchor, for
+instance — see [`Ribbon`](/js/api/marks/ribbon)'s bar-chart example) or when
+you want the anchor and connector opts kept visually separate.
+
 ## Ribbon — one-line sugar with `by`
 
 The simple case — draw a ribbon over the marks you just drew, split into one

--- a/apps/docs/docs/js/api/marks/line.md
+++ b/apps/docs/docs/js/api/marks/line.md
@@ -27,20 +27,21 @@ gf.layer([
 ## Signature
 
 ```ts
-line({ stroke?, strokeWidth = 1, strokeDasharray?, opacity?, curve = "auto", by?, from?, to? })
+line({ stroke?, strokeWidth = 1, strokeDasharray?, opacity?, curve = "auto", by?, from?, to?, w?, h?, emX?, emY? })
 ```
 
 ## Parameters
 
-| Option            | Type                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                |
-| ----------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stroke`          | `string`                                 | Line color                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `strokeWidth`     | `number`                                 | Line thickness                                                                                                                                                                                                                                                                                                                                                                                             |
-| `strokeDasharray` | `string`                                 | Raw SVG `stroke-dasharray` (e.g. `"12"`) for a dashed line; same option name as `enclose`                                                                                                                                                                                                                                                                                                                  |
-| `opacity`         | `number`                                 | Opacity (0–1)                                                                                                                                                                                                                                                                                                                                                                                              |
-| `curve`           | `"straight" \| "bezier" \| CurveSpec`    | Screen-space path shape; default `"auto"` auto-smooths continuous line charts with a centripetal Catmull-Rom spline                                                                                                                                                                                                                                                                                        |
-| `by`              | `string \| FieldExpr \| (ref) => string` | Partitions the operand bag (the array of refs) into groups and draws one polyline per group. Same grammar as any operator's `by` — bare field name, key function, or [`field(...)`](/js/api/operators/spread#field-expression-pipeline) accessor. Resolves against the refs' own datum automatically (no `datum.` prefix), same as `group({ by })`. Composes with an upstream `group()` as a nested split. |
-| `from`, `to`      | `string`                                 | Pairwise form: column names holding the two endpoint refs                                                                                                                                                                                                                                                                                                                                                  |
+| Option                 | Type                                     | Description                                                                                                                                                                                                                                                                                                                                                                                                |
+| ---------------------- | ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stroke`               | `string`                                 | Line color                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `strokeWidth`          | `number`                                 | Line thickness                                                                                                                                                                                                                                                                                                                                                                                             |
+| `strokeDasharray`      | `string`                                 | Raw SVG `stroke-dasharray` (e.g. `"12"`) for a dashed line; same option name as `enclose`                                                                                                                                                                                                                                                                                                                  |
+| `opacity`              | `number`                                 | Opacity (0–1)                                                                                                                                                                                                                                                                                                                                                                                              |
+| `curve`                | `"straight" \| "bezier" \| CurveSpec`    | Screen-space path shape; default `"auto"` auto-smooths continuous line charts with a centripetal Catmull-Rom spline                                                                                                                                                                                                                                                                                        |
+| `by`                   | `string \| FieldExpr \| (ref) => string` | Partitions the operand bag (the array of refs) into groups and draws one polyline per group. Same grammar as any operator's `by` — bare field name, key function, or [`field(...)`](/js/api/operators/spread#field-expression-pipeline) accessor. Resolves against the refs' own datum automatically (no `datum.` prefix), same as `group({ by })`. Composes with an upstream `group()` as a nested split. |
+| `from`, `to`           | `string`                                 | Pairwise form: column names holding the two endpoint refs                                                                                                                                                                                                                                                                                                                                                  |
+| `w`, `h`, `emX`, `emY` | `number \| string \| boolean`            | **Ignored by `line` itself.** Blank-fusion anchor keys: read only when `line(opts)` is placed directly in `.mark()` position, where they become the invisible anchor tier's `blank({w, h, emX, emY})` opts. See [`.layer()`'s blank-fusion section](/js/api/core/layer#blank-fusion-skip-layer-entirely-for-a-fresh-chart).                                                                                |
 
 When `curve` is omitted (`"auto"`), `line` inspects the connected points: if they
 share a continuous connection axis it smooths them with a centripetal Catmull-Rom
@@ -79,6 +80,28 @@ zBelow-by-default paint order and the desugaring to the explicit `layer([...])`
 
 - `selectAll` form below (which is still what you want to connect _another_
   chart's marks).
+
+## Sugar: `.mark(line(...))` (blank-fusion)
+
+When there's no earlier tier at all — just raw data that needs both fresh
+anchors and a connector — place `line(...)` directly in `.mark()` position and
+skip `.layer()` too:
+
+```ts
+chart(data)
+  .flow(scatter({ by: "lake", x: "x", y: "y" }))
+  .mark(line({ stroke: "steelblue", strokeWidth: 2 }));
+
+// ...is sugar for the explicit two-tier form:
+chart(data)
+  .flow(scatter({ by: "lake", x: "x", y: "y" }))
+  .mark(blank())
+  .layer(line({ stroke: "steelblue", strokeWidth: 2 }));
+```
+
+See [`.layer()`'s blank-fusion section](/js/api/core/layer#blank-fusion-skip-layer-entirely-for-a-fresh-chart)
+for the full desugaring rule (the `{w, h, emX, emY}` anchor/connector key
+split, `.name()` chaining, and when the rule doesn't fire).
 
 ## Example
 

--- a/apps/docs/docs/js/api/marks/line.md
+++ b/apps/docs/docs/js/api/marks/line.md
@@ -103,6 +103,12 @@ See [`.layer()`'s blank-fusion section](/js/api/core/layer#blank-fusion-skip-lay
 for the full desugaring rule (the `{w, h, emX, emY}` anchor/connector key
 split, `.name()` chaining, and when the rule doesn't fire).
 
+The `w`/`h`/`emX`/`emY` anchor channels are only meaningful when `line` gets to
+synthesize its own anchors this way; passing them to a `line` that instead
+connects already-drawn marks (an empty-scope `chart()` tier inside `.layer()`,
+or `chart(selectAll(...))`/`chart(ref(...))`) is an error, since there's
+nothing left for them to anchor.
+
 ## Example
 
 ```ts

--- a/apps/docs/docs/js/api/marks/ribbon.md
+++ b/apps/docs/docs/js/api/marks/ribbon.md
@@ -108,6 +108,12 @@ See [`.layer()`'s blank-fusion section](/js/api/core/layer#blank-fusion-skip-lay
 for the full desugaring rule (the `{w, h, emX, emY}` anchor/connector key
 split, `.name()` chaining, and when the rule doesn't fire).
 
+The `w`/`h`/`emX`/`emY` anchor channels are only meaningful when `ribbon` gets
+to synthesize its own anchors this way; passing them to a `ribbon` that
+instead connects already-drawn marks (an empty-scope `chart()` tier inside
+`.layer()`, or `chart(selectAll(...))`/`chart(ref(...))`) is an error, since
+there's nothing left for them to anchor.
+
 ## Example
 
 ```ts

--- a/apps/docs/docs/js/api/marks/ribbon.md
+++ b/apps/docs/docs/js/api/marks/ribbon.md
@@ -26,21 +26,22 @@ gf.layer([
 ## Signature
 
 ```ts
-ribbon({ stroke?, strokeWidth = 0, opacity?, mixBlendMode = "normal", dir = "x", curve = "auto", by?, from?, to? })
+ribbon({ stroke?, strokeWidth = 0, opacity?, mixBlendMode = "normal", dir = "x", curve = "auto", by?, from?, to?, w?, h?, emX?, emY? })
 ```
 
 ## Parameters
 
-| Option         | Type                                     | Description                                                                                                                                                                                                                                                                                                                                                                                            |
-| -------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `stroke`       | `string`                                 | Stroke color                                                                                                                                                                                                                                                                                                                                                                                           |
-| `strokeWidth`  | `number`                                 | Stroke width                                                                                                                                                                                                                                                                                                                                                                                           |
-| `opacity`      | `number`                                 | Opacity (0–1)                                                                                                                                                                                                                                                                                                                                                                                          |
-| `mixBlendMode` | `"normal" \| "multiply"`                 | Blend mode                                                                                                                                                                                                                                                                                                                                                                                             |
-| `dir`          | `"x" \| "y"`                             | Direction axis                                                                                                                                                                                                                                                                                                                                                                                         |
-| `curve`        | `"straight" \| "bezier" \| CurveSpec`    | Screen-space band shape; default `"auto"` (see below)                                                                                                                                                                                                                                                                                                                                                  |
-| `by`           | `string \| FieldExpr \| (ref) => string` | Partitions the operand bag (the array of refs) into groups and draws one band per group. Same grammar as any operator's `by` — bare field name, key function, or [`field(...)`](/js/api/operators/spread#field-expression-pipeline) accessor. Resolves against the refs' own datum automatically (no `datum.` prefix), same as `group({ by })`. Composes with an upstream `group()` as a nested split. |
-| `from`, `to`   | `string`                                 | Pairwise form: column names holding the two endpoint refs                                                                                                                                                                                                                                                                                                                                              |
+| Option                 | Type                                     | Description                                                                                                                                                                                                                                                                                                                                                                                            |
+| ---------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `stroke`               | `string`                                 | Stroke color                                                                                                                                                                                                                                                                                                                                                                                           |
+| `strokeWidth`          | `number`                                 | Stroke width                                                                                                                                                                                                                                                                                                                                                                                           |
+| `opacity`              | `number`                                 | Opacity (0–1)                                                                                                                                                                                                                                                                                                                                                                                          |
+| `mixBlendMode`         | `"normal" \| "multiply"`                 | Blend mode                                                                                                                                                                                                                                                                                                                                                                                             |
+| `dir`                  | `"x" \| "y"`                             | Direction axis                                                                                                                                                                                                                                                                                                                                                                                         |
+| `curve`                | `"straight" \| "bezier" \| CurveSpec`    | Screen-space band shape; default `"auto"` (see below)                                                                                                                                                                                                                                                                                                                                                  |
+| `by`                   | `string \| FieldExpr \| (ref) => string` | Partitions the operand bag (the array of refs) into groups and draws one band per group. Same grammar as any operator's `by` — bare field name, key function, or [`field(...)`](/js/api/operators/spread#field-expression-pipeline) accessor. Resolves against the refs' own datum automatically (no `datum.` prefix), same as `group({ by })`. Composes with an upstream `group()` as a nested split. |
+| `from`, `to`           | `string`                                 | Pairwise form: column names holding the two endpoint refs                                                                                                                                                                                                                                                                                                                                              |
+| `w`, `h`, `emX`, `emY` | `number \| string \| boolean`            | **Ignored by `ribbon` itself.** Blank-fusion anchor keys: read only when `ribbon(opts)` is placed directly in `.mark()` position, where they become the invisible anchor tier's `blank({w, h, emX, emY})` opts. See [`.layer()`'s blank-fusion section](/js/api/core/layer#blank-fusion-skip-layer-entirely-for-a-fresh-chart).                                                                        |
 
 `curve` accepts the strings `"straight"` or `"bezier"`, or a `CurveSpec` factory:
 `straight()`, `bezier()`, `orthogonal()`, `arc({ direction: "up" | "down" })`, or
@@ -78,6 +79,34 @@ zBelow-by-default paint order and the desugaring to the explicit `layer([...])`
 
 - `selectAll` form below (which is still what you want to trace _another_
   chart's marks).
+
+## Sugar: `.mark(ribbon(...))` (blank-fusion)
+
+When there's no earlier tier at all — just raw data that needs both fresh
+anchors and a connector — place `ribbon(...)` directly in `.mark()` position
+and skip `.layer()` too. This is the fused spelling of the [Area chart](/js/examples/area-chart)
+and [Ridgeline chart](/js/examples/ridgeline-chart) gallery examples:
+
+```ts
+chart(seafood, { axes: true })
+  .flow(spread({ by: "lake", dir: "x", spacing: 64 }))
+  .mark(ribbon({ h: "count", opacity: 0.8 }));
+
+// ...is sugar for the explicit two-tier form:
+chart(seafood, { axes: true })
+  .flow(spread({ by: "lake", dir: "x", spacing: 64 }))
+  .mark(blank({ h: "count" }))
+  .layer(ribbon({ opacity: 0.8 }));
+```
+
+A `by`-split ribbon's `fill` can be a shared field name (each group is
+homogeneous in it): `ribbon({ h: "count", fill: "species", by: "species" })`
+resolves `fill` through the color scale per group, the same as it would if
+`fill` were declared on an explicit anchor `blank()`.
+
+See [`.layer()`'s blank-fusion section](/js/api/core/layer#blank-fusion-skip-layer-entirely-for-a-fresh-chart)
+for the full desugaring rule (the `{w, h, emX, emY}` anchor/connector key
+split, `.name()` chaining, and when the rule doesn't fire).
 
 ## Example
 

--- a/apps/docs/docs/python/api/core/layer.md
+++ b/apps/docs/docs/python/api/core/layer.md
@@ -20,6 +20,68 @@ tier's marks as scope, uniformly:
   component-level annotation: it ignores the scope entirely, since its
   channels have no ref-bag semantics to read.
 
+## Blank-fusion: skip `.layer()` entirely for a fresh chart
+
+When the connector's anchors don't exist yet either — there's no earlier tier
+to draw from, just raw data — `line(...)`/`ribbon(...)` can go straight in
+`.mark()` position and skip `.layer()` altogether:
+
+```python
+from gofish import chart, spread, stack, field, ribbon
+
+chart(seafood, axes=True).flow(
+    spread(by="lake", dir="x", spacing=64),
+    stack(by=field("species").sort("count"), dir="y"),
+).mark(
+    ribbon(h="count", fill="species", by="species", opacity=0.8)
+).render(w=400, h=320)
+```
+
+### Desugaring
+
+A relational mark placed directly in `.mark()` position elaborates to an
+invisible anchor tier plus a connector tier:
+
+```
+.mark(R(opts))  ⇒  .mark(blank(anchor(opts))).layer(R(opts))
+```
+
+`anchor(opts)` is exactly the `w`/`h`/`emX`/`emY` subset of `opts` — the purely
+spatial keys `blank()` itself accepts. Everything else (`fill`, `stroke`,
+`strokeWidth`, `strokeDasharray`, `opacity`, `curve`, `dir`, `mixBlendMode`,
+`by`, `source`, `target`) stays on the connector, matching what you'd write by
+hand:
+
+```python
+# Fused
+chart(seafood, axes=True).flow(
+    spread(by="lake", dir="x", spacing=64),
+    stack(by="species", dir="y"),
+).mark(ribbon(h="count", fill="species", by="species", opacity=0.8))
+
+# ...is sugar for the explicit two-tier form:
+chart(seafood, axes=True).flow(
+    spread(by="lake", dir="x", spacing=64),
+    stack(by="species", dir="y"),
+).mark(blank(h="count")).layer(
+    ribbon(fill="species", by="species", opacity=0.8)
+)
+```
+
+A `.name(...)`/`.label(...)`/`.zOrder(...)` chained onto the relational mark
+names/labels/orders the **connector** (the anchor tier still gets `.layer()`'s
+usual auto-naming). This rule only fires when the chart's data still needs
+anchors drawn for it — a relational mark applied directly to an existing bag
+of refs (`chart(selectAll("bars")).mark(ribbon(...))`, or the bare-mark tier
+form documented above) keeps its unfused, direct-connect meaning; only the
+pairwise `from_`/`to` form is never fused either, since it already consumes
+ref-bearing rows in `.mark()` position.
+
+Reach for the explicit `.mark(blank(...)).layer(...)` form instead when the
+anchor needs options besides `w`/`h`/`emX`/`emY` (a visible rect anchor, for
+instance — see [`ribbon`](/python/api/marks/ribbon)'s bar-chart example) or
+when you want the anchor and connector opts kept visually separate.
+
 ## Ribbon — one-line sugar with `by`
 
 The simple case — draw a ribbon over the marks you just drew, split into one

--- a/apps/docs/docs/python/api/marks/line.md
+++ b/apps/docs/docs/python/api/marks/line.md
@@ -22,19 +22,20 @@ layer([
 ## Signature
 
 ```python
-line(stroke=None, strokeWidth=None, strokeDasharray=None, opacity=None, curve=None, by=None) -> Mark
+line(stroke=None, strokeWidth=None, strokeDasharray=None, opacity=None, curve=None, by=None, w=None, h=None, emX=None, emY=None) -> Mark
 ```
 
 ## Parameters
 
-| Parameter         | Type                            | Description                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ----------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stroke`          | `str`                           | Line color                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `strokeWidth`     | `int`                           | Line width in pixels                                                                                                                                                                                                                                                                                                                                                                                          |
-| `strokeDasharray` | `str`                           | Raw SVG `stroke-dasharray` (e.g. `"12"`) for a dashed line                                                                                                                                                                                                                                                                                                                                                    |
-| `opacity`         | `float`                         | Opacity, `0`–`1`                                                                                                                                                                                                                                                                                                                                                                                              |
-| `curve`           | `str \| dict`                   | Path shape; default `"auto"`, which auto-smooths continuous line charts                                                                                                                                                                                                                                                                                                                                       |
-| `by`              | `str \| field(...) \| Callable` | Partitions the operand bag (the list of refs) into groups and draws one polyline per group. Same grammar as any operator's `by` — bare field name, key function, or [`field(...)`](/python/api/operators/spread#field-expression-pipeline) accessor. Resolves against the refs' own datum automatically (no `datum.` prefix), same as `group(by=...)`. Composes with an upstream `group()` as a nested split. |
+| Parameter              | Type                            | Description                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ---------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stroke`               | `str`                           | Line color                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `strokeWidth`          | `int`                           | Line width in pixels                                                                                                                                                                                                                                                                                                                                                                                          |
+| `strokeDasharray`      | `str`                           | Raw SVG `stroke-dasharray` (e.g. `"12"`) for a dashed line                                                                                                                                                                                                                                                                                                                                                    |
+| `opacity`              | `float`                         | Opacity, `0`–`1`                                                                                                                                                                                                                                                                                                                                                                                              |
+| `curve`                | `str \| dict`                   | Path shape; default `"auto"`, which auto-smooths continuous line charts                                                                                                                                                                                                                                                                                                                                       |
+| `by`                   | `str \| field(...) \| Callable` | Partitions the operand bag (the list of refs) into groups and draws one polyline per group. Same grammar as any operator's `by` — bare field name, key function, or [`field(...)`](/python/api/operators/spread#field-expression-pipeline) accessor. Resolves against the refs' own datum automatically (no `datum.` prefix), same as `group(by=...)`. Composes with an upstream `group()` as a nested split. |
+| `w`, `h`, `emX`, `emY` | `int \| float \| str \| bool`   | **Ignored by `line` itself.** Blank-fusion anchor keys: read only when `line(...)` is placed directly in `.mark()` position, where they become the invisible anchor tier's `blank(w=..., h=..., emX=..., emY=...)` opts. See [`.layer()`'s blank-fusion section](/python/api/core/layer#blank-fusion-skip-layer-entirely-for-a-fresh-chart).                                                                  |
 
 Returns a `Mark` for use in [`.mark()`](/python/api/core/mark).
 
@@ -71,6 +72,27 @@ See [`.layer()`](/python/api/core/layer) for the full semantics, including the
 zBelow-by-default paint order and the desugaring to the explicit
 `layer([...])` + `selectAll` form (which is still what you want to connect
 _another_ chart's marks).
+
+## Sugar: `.mark(line(...))` (blank-fusion)
+
+When there's no earlier tier at all — just raw data that needs both fresh
+anchors and a connector — place `line(...)` directly in `.mark()` position and
+skip `.layer()` too:
+
+```python
+chart(catch_locations).flow(
+    scatter(by="lake", x="x", y="y")
+).mark(line())
+
+# ...is sugar for the explicit two-tier form:
+chart(catch_locations).flow(
+    scatter(by="lake", x="x", y="y")
+).mark(blank()).layer(line())
+```
+
+See [`.layer()`'s blank-fusion section](/python/api/core/layer#blank-fusion-skip-layer-entirely-for-a-fresh-chart)
+for the full desugaring rule (the `w`/`h`/`emX`/`emY` anchor/connector key
+split, `.name()` chaining, and when the rule doesn't fire).
 
 ## Examples
 

--- a/apps/docs/docs/python/api/marks/line.md
+++ b/apps/docs/docs/python/api/marks/line.md
@@ -94,6 +94,12 @@ See [`.layer()`'s blank-fusion section](/python/api/core/layer#blank-fusion-skip
 for the full desugaring rule (the `w`/`h`/`emX`/`emY` anchor/connector key
 split, `.name()` chaining, and when the rule doesn't fire).
 
+The `w`/`h`/`emX`/`emY` anchor channels are only meaningful when `line` gets to
+synthesize its own anchors this way; passing them to a `line` that instead
+connects already-drawn marks (an empty-scope `chart()` tier inside `.layer()`,
+or `chart(selectAll(...))`/`chart(ref(...))`) is an error, since there's
+nothing left for them to anchor.
+
 ## Examples
 
 ```python

--- a/apps/docs/docs/python/api/marks/ribbon.md
+++ b/apps/docs/docs/python/api/marks/ribbon.md
@@ -102,6 +102,12 @@ See [`.layer()`'s blank-fusion section](/python/api/core/layer#blank-fusion-skip
 for the full desugaring rule (the `w`/`h`/`emX`/`emY` anchor/connector key
 split, `.name()` chaining, and when the rule doesn't fire).
 
+The `w`/`h`/`emX`/`emY` anchor channels are only meaningful when `ribbon` gets
+to synthesize its own anchors this way; passing them to a `ribbon` that
+instead connects already-drawn marks (an empty-scope `chart()` tier inside
+`.layer()`, or `chart(selectAll(...))`/`chart(ref(...))`) is an error, since
+there's nothing left for them to anchor.
+
 ## Examples
 
 ```python

--- a/apps/docs/docs/python/api/marks/ribbon.md
+++ b/apps/docs/docs/python/api/marks/ribbon.md
@@ -23,20 +23,21 @@ layer([
 
 ```python
 ribbon(stroke=None, strokeWidth=None, opacity=None, mixBlendMode=None,
-     dir=None, curve=None, by=None) -> Mark
+     dir=None, curve=None, by=None, w=None, h=None, emX=None, emY=None) -> Mark
 ```
 
 ## Parameters
 
-| Parameter      | Type                            | Description                                                                                                                                                                                                                                                                                                                                                                                               |
-| -------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stroke`       | `str`                           | Outline color                                                                                                                                                                                                                                                                                                                                                                                             |
-| `strokeWidth`  | `int`                           | Outline width in pixels                                                                                                                                                                                                                                                                                                                                                                                   |
-| `opacity`      | `float`                         | Opacity, `0`–`1`                                                                                                                                                                                                                                                                                                                                                                                          |
-| `mixBlendMode` | `str`                           | CSS blend mode for overlapping areas                                                                                                                                                                                                                                                                                                                                                                      |
-| `dir`          | `str`                           | Direction the ribbon fills toward                                                                                                                                                                                                                                                                                                                                                                         |
-| `curve`        | `str \| dict`                   | Screen-space path shape; default `"auto"`                                                                                                                                                                                                                                                                                                                                                                 |
-| `by`           | `str \| field(...) \| Callable` | Partitions the operand bag (the list of refs) into groups and draws one band per group. Same grammar as any operator's `by` — bare field name, key function, or [`field(...)`](/python/api/operators/spread#field-expression-pipeline) accessor. Resolves against the refs' own datum automatically (no `datum.` prefix), same as `group(by=...)`. Composes with an upstream `group()` as a nested split. |
+| Parameter              | Type                            | Description                                                                                                                                                                                                                                                                                                                                                                                               |
+| ---------------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `stroke`               | `str`                           | Outline color                                                                                                                                                                                                                                                                                                                                                                                             |
+| `strokeWidth`          | `int`                           | Outline width in pixels                                                                                                                                                                                                                                                                                                                                                                                   |
+| `opacity`              | `float`                         | Opacity, `0`–`1`                                                                                                                                                                                                                                                                                                                                                                                          |
+| `mixBlendMode`         | `str`                           | CSS blend mode for overlapping areas                                                                                                                                                                                                                                                                                                                                                                      |
+| `dir`                  | `str`                           | Direction the ribbon fills toward                                                                                                                                                                                                                                                                                                                                                                         |
+| `curve`                | `str \| dict`                   | Screen-space path shape; default `"auto"`                                                                                                                                                                                                                                                                                                                                                                 |
+| `by`                   | `str \| field(...) \| Callable` | Partitions the operand bag (the list of refs) into groups and draws one band per group. Same grammar as any operator's `by` — bare field name, key function, or [`field(...)`](/python/api/operators/spread#field-expression-pipeline) accessor. Resolves against the refs' own datum automatically (no `datum.` prefix), same as `group(by=...)`. Composes with an upstream `group()` as a nested split. |
+| `w`, `h`, `emX`, `emY` | `int \| float \| str \| bool`   | **Ignored by `ribbon` itself.** Blank-fusion anchor keys: read only when `ribbon(...)` is placed directly in `.mark()` position, where they become the invisible anchor tier's `blank(w=..., h=..., emX=..., emY=...)` opts. See [`.layer()`'s blank-fusion section](/python/api/core/layer#blank-fusion-skip-layer-entirely-for-a-fresh-chart).                                                          |
 
 Returns a `Mark` for use in [`.mark()`](/python/api/core/mark).
 
@@ -74,6 +75,32 @@ See [`.layer()`](/python/api/core/layer) for the full semantics, including the
 zBelow-by-default paint order and the desugaring to the explicit
 `layer([...])` + `selectAll` form (which is still what you want to trace
 _another_ chart's marks).
+
+## Sugar: `.mark(ribbon(...))` (blank-fusion)
+
+When there's no earlier tier at all — just raw data that needs both fresh
+anchors and a connector — place `ribbon(...)` directly in `.mark()` position
+and skip `.layer()` too:
+
+```python
+chart(lake_totals).flow(
+    spread(by="lake", dir="x", spacing=64)
+).mark(ribbon(h="count", opacity=0.8))
+
+# ...is sugar for the explicit two-tier form:
+chart(lake_totals).flow(
+    spread(by="lake", dir="x", spacing=64)
+).mark(blank(h="count")).layer(ribbon(opacity=0.8))
+```
+
+A `by`-split ribbon's `fill` can be a shared field name (each group is
+homogeneous in it): `ribbon(h="count", fill="species", by="species")`
+resolves `fill` through the color scale per group, the same as it would if
+`fill` were declared on an explicit anchor `blank()`.
+
+See [`.layer()`'s blank-fusion section](/python/api/core/layer#blank-fusion-skip-layer-entirely-for-a-fresh-chart)
+for the full desugaring rule (the `w`/`h`/`emX`/`emY` anchor/connector key
+split, `.name()` chaining, and when the rule doesn't fire).
 
 ## Examples
 

--- a/packages/gofish-graphics/package.json
+++ b/packages/gofish-graphics/package.json
@@ -39,7 +39,7 @@
     "fetch-titanic-passengers": "node scripts/fetch-titanic-passengers.mjs",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "pnpm run test:path && pnpm run test:font && pnpm run test:bbox && pnpm run test:solver && pnpm run test:space && pnpm run test:measure && pnpm run test:embedding && pnpm run test:confluence && pnpm run test:coord-confluence && pnpm run test:coord-paint-order && pnpm run test:serialize && pnpm run test:display-list && pnpm run test:interaction",
+    "test": "pnpm run test:path && pnpm run test:font && pnpm run test:bbox && pnpm run test:solver && pnpm run test:space && pnpm run test:measure && pnpm run test:embedding && pnpm run test:confluence && pnpm run test:coord-confluence && pnpm run test:coord-paint-order && pnpm run test:serialize && pnpm run test:display-list && pnpm run test:interaction && pnpm run test:fusion",
     "test:space": "tsx src/tests/space.test.ts",
     "test:measure": "tsx src/tests/measure.test.ts",
     "test:embedding": "tsx src/tests/embedding.test.ts",
@@ -52,6 +52,7 @@
     "test:font": "tsx src/tests/fontUtils.test.ts",
     "test:bbox": "tsx src/tests/bbox.test.ts",
     "test:serialize": "pnpm run build && tsx src/tests/serialize.test.ts",
+    "test:fusion": "pnpm run build && tsx src/tests/fusion.test.ts",
     "test:interaction": "pnpm run build && node --conditions browser --import tsx src/tests/interaction.test.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -412,10 +412,28 @@ function pickAnchorOpts(opts: Record<string, any>): Record<string, any> {
  * The pairwise `{from, to}` form is never tagged: it already consumes rows
  * with ref columns directly in `.mark()` position and keeps its existing
  * (unfused) behavior.
+ *
+ * Also carries `type` and `anchorKeys` (the subset of `ANCHOR_KEYS` actually
+ * present in `opts`, keyed off `!== undefined` rather than `in` so an
+ * explicitly-passed `undefined` doesn't count) — `ChartBuilder.mark()` reads
+ * these to throw when the mark lands on the UNFUSED path (an empty-scope tier
+ * or refs data) while still carrying anchor keys that would otherwise be
+ * silently inert. Threading them here (rather than importing `ANCHOR_KEYS` /
+ * `pickAnchorOpts` into chartBuilder.ts) avoids an import cycle: this module
+ * already imports `ChartBuilder` FROM chartBuilder.ts.
  */
-function tagRelationalFusable(mark: object, opts: Record<string, any>): void {
+function tagRelationalFusable(
+  mark: object,
+  type: string,
+  opts: Record<string, any>
+): void {
+  const anchorOpts = pickAnchorOpts(opts);
   (mark as any).__relationalFusable = {
+    type,
     opts,
+    anchorKeys: Object.keys(anchorOpts).filter(
+      (k) => anchorOpts[k] !== undefined
+    ),
     makeAnchor: () => blank(pickAnchorOpts(opts)),
   };
 }
@@ -520,7 +538,7 @@ export function createRelationalMark<O extends RelationalMarkOptions>(
       };
       const result = nameableMark(mark);
       (result as any).__serialize = { type, opts };
-      tagRelationalFusable(result, opts);
+      tagRelationalFusable(result, type, opts);
       return result;
     }
 
@@ -529,7 +547,7 @@ export function createRelationalMark<O extends RelationalMarkOptions>(
       tagRelationalOperands((await produce(opts, d)) as GoFishNode, d);
     const result = nameableMark(mark);
     (result as any).__serialize = { type, opts };
-    tagRelationalFusable(result, opts);
+    tagRelationalFusable(result, type, opts);
     return result;
   }
   return relational;

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -16,7 +16,7 @@ import type { Token } from "../createName";
 import { type ColorConfig } from "../colorSchemes";
 
 export type { ColorConfig };
-import { inferSize } from "../channels";
+import { inferSize, inferColor } from "../channels";
 import { isLive, evalLiveStatic, type LiveValue } from "../../interaction/live";
 import { rect as generatedRect } from "../shapes/rect";
 import { Ellipse } from "../shapes/ellipse";
@@ -377,6 +377,74 @@ function tagRelationalOperands<T extends GoFishAST>(
   return node;
 }
 
+// Anchor-tier keys the blank-fusion rewrite rule (see the doc-comment above
+// and `ChartBuilder.mark`) carves off a relational mark's opts: purely
+// spatial, nothing paint- or path-related. Everything else (fill, stroke,
+// strokeWidth, strokeDasharray, opacity, curve, dir, mixBlendMode, by,
+// source, target) stays with the connector.
+const ANCHOR_KEYS = ["w", "h", "emX", "emY"] as const;
+
+function pickAnchorOpts(opts: Record<string, any>): Record<string, any> {
+  const anchor: Record<string, any> = {};
+  for (const k of ANCHOR_KEYS) {
+    if (k in opts) anchor[k] = opts[k];
+  }
+  return anchor;
+}
+
+/**
+ * Tag a bag-form / by-split-form relational mark with the blank-fusion
+ * descriptor `ChartBuilder.mark()` reads when the mark is placed directly in
+ * `.mark()` position (instead of after an explicit anchor tier via
+ * `.layer(...)`):
+ *
+ *   .mark(R(opts))  ⇒  .mark(blank(anchor(opts))).layer(R(opts))
+ *
+ * `anchor(opts)` is exactly the `{w, h, emX, emY}` subset (`pickAnchorOpts`);
+ * the connector tier is simply the mark AS GIVEN — `produce` (the factory's
+ * second argument) only reads the fields it knows about, so the leftover
+ * spatial keys are inert on the connector side and no opts-splitting is
+ * needed there. `makeAnchor` is a pre-bound `blank(...)` call rather than a
+ * bare opts object: `blank` lives in this module, and `ChartBuilder.mark()`
+ * lives in chartBuilder.ts, which this module already imports FROM —
+ * importing `blank` the other way would cycle.
+ *
+ * The pairwise `{from, to}` form is never tagged: it already consumes rows
+ * with ref columns directly in `.mark()` position and keeps its existing
+ * (unfused) behavior.
+ */
+function tagRelationalFusable(mark: object, opts: Record<string, any>): void {
+  (mark as any).__relationalFusable = {
+    opts,
+    makeAnchor: () => blank(pickAnchorOpts(opts)),
+  };
+}
+
+/**
+ * A `by`-split connector's `fill` may be a shared field name (e.g.
+ * `ribbon({ fill: "species", by: "species" })`) rather than a literal color —
+ * each group is homogeneous in that field by construction whenever it names
+ * the split field itself (or another field the split happens to agree on),
+ * so resolve it once per group into a concrete `Value`, the same way a
+ * per-item mark's color channel would (`inferColor`), instead of leaking the
+ * bare field name through to `Connect` as a literal (invalid) CSS color.
+ * A no-op for literal colors, `Value`s, and undefined — `inferColor` itself
+ * tells a field name from a literal (falls through unchanged when the string
+ * isn't a key of the sampled row).
+ */
+function resolveGroupFill<O extends RelationalMarkOptions>(
+  opts: O,
+  groupRefs: GoFishRef[]
+): O {
+  const fill = (opts as any).fill;
+  if (typeof fill !== "string") return opts;
+  const rows = groupRefs.flatMap((r) =>
+    Array.isArray(r.datum) ? r.datum : [r.datum]
+  );
+  const resolved = inferColor(fill, rows);
+  return resolved === undefined ? opts : ({ ...opts, fill: resolved } as O);
+}
+
 export function createRelationalMark<O extends RelationalMarkOptions>(
   type: string,
   produce: (opts: O, children: GoFishAST[]) => any
@@ -441,8 +509,9 @@ export function createRelationalMark<O extends RelationalMarkOptions>(
             const groupRefs = (
               Array.isArray(group) ? group : [group]
             ) as GoFishRef[];
+            const groupOpts = resolveGroupFill(opts, groupRefs);
             return tagRelationalOperands(
-              (await produce(opts, groupRefs)) as GoFishNode,
+              (await produce(groupOpts, groupRefs)) as GoFishNode,
               groupRefs
             );
           })
@@ -451,6 +520,7 @@ export function createRelationalMark<O extends RelationalMarkOptions>(
       };
       const result = nameableMark(mark);
       (result as any).__serialize = { type, opts };
+      tagRelationalFusable(result, opts);
       return result;
     }
 
@@ -459,6 +529,7 @@ export function createRelationalMark<O extends RelationalMarkOptions>(
       tagRelationalOperands((await produce(opts, d)) as GoFishNode, d);
     const result = nameableMark(mark);
     (result as any).__serialize = { type, opts };
+    tagRelationalFusable(result, opts);
     return result;
   }
   return relational;
@@ -488,6 +559,15 @@ export type LineOptions = {
   // `line({ by: "series" })` over a bag of point refs draws one polyline per
   // series. Composes with an upstream `group()` as a nested split.
   by?: SplitBy;
+  // Anchor-tier keys for the blank-fusion sugar: placing `line(opts)` directly
+  // in `.mark()` position elaborates to `.mark(blank({w,h,emX,emY})).layer(line(opts))`
+  // (see `createRelationalMark`'s `tagRelationalFusable`). Purely spatial —
+  // `line`'s own `produce` ignores them; they only size/position the
+  // invisible anchor blank() the sugar synthesizes.
+  w?: number | string;
+  h?: number | string;
+  emX?: boolean;
+  emY?: boolean;
 };
 
 // `line` — a center-mode connector (the "line" component): the path between the
@@ -531,6 +611,15 @@ export type RibbonOptions = {
   // `ribbon({ by: "species" })` over a bag of bar refs draws one band per
   // species. Composes with an upstream `group()` as a nested split.
   by?: SplitBy;
+  // Anchor-tier keys for the blank-fusion sugar: placing `ribbon(opts)` directly
+  // in `.mark()` position elaborates to `.mark(blank({w,h,emX,emY})).layer(ribbon(opts))`
+  // (see `createRelationalMark`'s `tagRelationalFusable`). Purely spatial —
+  // `ribbon`'s own `produce` ignores them; they only size/position the
+  // invisible anchor blank() the sugar synthesizes.
+  w?: number | string;
+  h?: number | string;
+  emX?: boolean;
+  emY?: boolean;
 };
 
 // `ribbon` — an edge-mode connector: a filled band between the facing edges of

--- a/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
+++ b/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
@@ -171,6 +171,22 @@ export function resolveRefData(
 }
 
 /**
+ * True when chart data is already a bag of refs — a single `GoFishRef`
+ * (`ref(...)`/`selectAll(...)` used as chart data) or a non-empty array of
+ * them (`LayerBuilder.resolve()`'s `withData(prevRefs)` shape: one resolved
+ * ref per node the previous tier named). Names the "data is already refs,
+ * nothing to anchor" concept for `mark()`'s blank-fusion guard. Any NEW
+ * refs-bag shape `LayerBuilder` (or `selectAll`) starts producing must be
+ * added HERE, not at call sites.
+ */
+function dataIsRefs(data: unknown): boolean {
+  return (
+    data instanceof GoFishRef ||
+    (Array.isArray(data) && data.length > 0 && data[0] instanceof GoFishRef)
+  );
+}
+
+/**
  * Stash the chained `.name(...)` value directly on a mark function, so a
  * user-chained name can be detected without relying on the `__serialize` tag
  * (absent on untagged custom marks, and it omits Tokens). Every `.name()`
@@ -315,27 +331,16 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     // inheriting the previous tier's marks inside `.layer(...)` — has nothing
     // to anchor: the incoming data already IS (or will become) the refs bag
     // the connector reads. `usesPreviousLayerMarks()` catches the empty-scope
-    // case; `this.data instanceof GoFishRef` catches the explicit
-    // `selectAll(...)`/`ref(...)` case.
+    // case; `dataIsRefs` catches every already-refs data shape — the explicit
+    // `selectAll(...)`/`ref(...)` case and `LayerBuilder.resolve()`'s
+    // `withData(prevRefs)` array shape (defense in depth: `ensureNamedMark`
+    // bypasses this method entirely, but a future direct `.mark()` call could
+    // still see that shape).
     const fusable = (mark as any)?.__relationalFusable as
       | { opts: Record<string, any>; makeAnchor: () => Mark<any> }
       | undefined;
     const dataNeedsAnchors =
-      !this.usesPreviousLayerMarks() &&
-      !(this.data instanceof GoFishRef) &&
-      // Defense in depth: `LayerBuilder.resolve()`'s `tier.withData(prevRefs)`
-      // shape — a plain `Array` of already-resolved `GoFishRef`s (one per
-      // node the previous tier named), not a single `GoFishRef` instance —
-      // has nothing to anchor either, same as the `usesPreviousLayerMarks()`
-      // and `instanceof GoFishRef` cases above. This mirrors `ensureNamedMark`
-      // (see its comment), which must bypass this method entirely rather than
-      // rely on this guard, but a future direct `.mark()` call could still
-      // see this exact shape, so guard against it here too.
-      !(
-        Array.isArray(this.data) &&
-        this.data.length > 0 &&
-        this.data[0] instanceof GoFishRef
-      );
+      !this.usesPreviousLayerMarks() && !dataIsRefs(this.data);
     if (fusable && dataNeedsAnchors) {
       return this.mark(fusable.makeAnchor() as unknown as Mark<TOutput>).layer(
         mark as Mark<any>
@@ -434,13 +439,12 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     // `finalMark` CAN still be a still-tagged `__relationalFusable` mark here:
     // `LayerBuilder.resolve()` calls `tier.withData(prevRefs)` on an
     // empty-scope tier before calling `ensureNamedMark`, which sets `data` to
-    // a plain `Array` of already-resolved `GoFishRef`s — not a `GoFishRef`
-    // instance — a shape `mark()`'s `dataNeedsAnchors` guard now also
-    // excludes, but renaming must not depend on that guard staying in sync
-    // with every refs-bag shape `LayerBuilder` can produce. `.name()`
-    // propagates tags, so `named` still carries `__relationalFusable`, and
-    // re-entering `mark(named)` here would return a `LayerBuilder` — breaking
-    // this method's `ChartBuilder`-returning contract with a lying cast, and
+    // a plain `Array` of already-resolved `GoFishRef`s — a shape `dataIsRefs`
+    // covers, but renaming must not depend on the guard staying in sync with
+    // every refs-bag shape `LayerBuilder` can produce. `.name()` propagates
+    // tags, so `named` still carries `__relationalFusable`, and re-entering
+    // `mark(named)` here would return a `LayerBuilder` — breaking this
+    // method's `ChartBuilder`-returning contract with a lying cast, and
     // blowing up later in `resolve()` (`tier.withLayerContext is not a
     // function`). Building the `ChartBuilder` directly sidesteps `mark()`'s
     // fusion logic entirely, which is correct: fusion was already decided

--- a/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
+++ b/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
@@ -337,13 +337,37 @@ export class ChartBuilder<TInput, TOutput = TInput> {
     // bypasses this method entirely, but a future direct `.mark()` call could
     // still see that shape).
     const fusable = (mark as any)?.__relationalFusable as
-      | { opts: Record<string, any>; makeAnchor: () => Mark<any> }
+      | {
+          type: string;
+          opts: Record<string, any>;
+          anchorKeys: string[];
+          makeAnchor: () => Mark<any>;
+        }
       | undefined;
     const dataNeedsAnchors =
       !this.usesPreviousLayerMarks() && !dataIsRefs(this.data);
     if (fusable && dataNeedsAnchors) {
       return this.mark(fusable.makeAnchor() as unknown as Mark<TOutput>).layer(
         mark as Mark<any>
+      );
+    }
+
+    // Fusion was skipped — this mark connects existing marks (an empty-scope
+    // `chart()` tier, or a chart whose data is already refs), so any anchor
+    // keys it's still carrying (`w`/`h`/`emX`/`emY`) have nothing to anchor
+    // and would silently do nothing. That's exactly the kind of
+    // user-wrote-X/system-did-Y disagreement that should be a loud error
+    // rather than a quiet no-op.
+    if (fusable && fusable.anchorKeys.length > 0) {
+      const keys = fusable.anchorKeys;
+      const plural = keys.length > 1;
+      throw new Error(
+        `${fusable.type}({ ${keys.join(", ")} }): anchor channel${plural ? "s" : ""} ` +
+          `(${keys.join(", ")}) ${plural ? "have" : "has"} no effect here — this ` +
+          `${fusable.type} connects EXISTING marks (an empty-scope chart() tier, ` +
+          `or a chart over refs), so there's nothing to anchor. Remove ${
+            plural ? "them" : "it"
+          }, or chart() over raw rows so ${fusable.type} can synthesize its own anchor tier.`
       );
     }
 

--- a/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
+++ b/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
@@ -321,7 +321,21 @@ export class ChartBuilder<TInput, TOutput = TInput> {
       | { opts: Record<string, any>; makeAnchor: () => Mark<any> }
       | undefined;
     const dataNeedsAnchors =
-      !this.usesPreviousLayerMarks() && !(this.data instanceof GoFishRef);
+      !this.usesPreviousLayerMarks() &&
+      !(this.data instanceof GoFishRef) &&
+      // Defense in depth: `LayerBuilder.resolve()`'s `tier.withData(prevRefs)`
+      // shape — a plain `Array` of already-resolved `GoFishRef`s (one per
+      // node the previous tier named), not a single `GoFishRef` instance —
+      // has nothing to anchor either, same as the `usesPreviousLayerMarks()`
+      // and `instanceof GoFishRef` cases above. This mirrors `ensureNamedMark`
+      // (see its comment), which must bypass this method entirely rather than
+      // rely on this guard, but a future direct `.mark()` call could still
+      // see this exact shape, so guard against it here too.
+      !(
+        Array.isArray(this.data) &&
+        this.data.length > 0 &&
+        this.data[0] instanceof GoFishRef
+      );
     if (fusable && dataNeedsAnchors) {
       return this.mark(fusable.makeAnchor() as unknown as Mark<TOutput>).layer(
         mark as Mark<any>
@@ -415,14 +429,32 @@ export class ChartBuilder<TInput, TOutput = TInput> {
       return { builder: this, name: existing };
     }
     const named = (this.finalMark as any).name(autoName) as Mark<TOutput>;
-    // `this.finalMark` was already stored by a prior `.mark()` call, so it's
-    // never itself a fusable relational mark (fusion resolves at `.mark()`
-    // call time into an anchor `ChartBuilder` + connector tier — see
-    // `mark()`'s doc-comment) — `.name(...)` on it can't reintroduce the
-    // `__relationalFusable` tag, so `this.mark(named)` always takes the
-    // plain-mark branch and stays a `ChartBuilder`.
+    // Construct the renamed builder DIRECTLY (mirroring the plain-mark branch
+    // of `mark()`) rather than calling `this.mark(named)`. This tier's
+    // `finalMark` CAN still be a still-tagged `__relationalFusable` mark here:
+    // `LayerBuilder.resolve()` calls `tier.withData(prevRefs)` on an
+    // empty-scope tier before calling `ensureNamedMark`, which sets `data` to
+    // a plain `Array` of already-resolved `GoFishRef`s — not a `GoFishRef`
+    // instance — a shape `mark()`'s `dataNeedsAnchors` guard now also
+    // excludes, but renaming must not depend on that guard staying in sync
+    // with every refs-bag shape `LayerBuilder` can produce. `.name()`
+    // propagates tags, so `named` still carries `__relationalFusable`, and
+    // re-entering `mark(named)` here would return a `LayerBuilder` — breaking
+    // this method's `ChartBuilder`-returning contract with a lying cast, and
+    // blowing up later in `resolve()` (`tier.withLayerContext is not a
+    // function`). Building the `ChartBuilder` directly sidesteps `mark()`'s
+    // fusion logic entirely, which is correct: fusion was already decided
+    // (and skipped) when this mark was first attached.
     return {
-      builder: this.mark(named) as ChartBuilder<TInput, TOutput>,
+      builder: new ChartBuilder(
+        this.data,
+        this.options,
+        this.operators,
+        named,
+        this.layerContext,
+        this.nodeZOrder,
+        this.nodeName
+      ),
       name: autoName,
     };
   }

--- a/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
+++ b/packages/gofish-graphics/src/ast/marks/chartBuilder.ts
@@ -265,22 +265,74 @@ export class ChartBuilder<TInput, TOutput = TInput> {
   // callback (issue #243): an empty-scope child (`chart()` / `chart(options)`)
   // inherits the incoming partition datum; a child with its own data is drawn
   // as-is per partition.
+  //
+  // Blank-fusion sugar: a relational mark (`line()`/`ribbon()`) placed
+  // directly here elaborates to an invisible anchor tier plus a connector
+  // tier —
+  //
+  //   .mark(R(opts))  ⇒  .mark(blank(anchor(opts))).layer(R(opts))
+  //
+  // `createRelationalMark` (chart.ts) tags every bag-form / by-split-form
+  // mark it produces with `__relationalFusable = { opts, makeAnchor }` —
+  // never the pairwise `{from, to}` form, which already consumes ref-bearing
+  // rows directly in `.mark()` position and keeps its existing (unfused)
+  // meaning. `makeAnchor()` is a pre-bound `blank({w, h, emX, emY})` call (the
+  // anchor-key subset of `opts`); the connector tier is simply `mark` AS
+  // GIVEN — the factory's `produce` only reads the fields it knows about, so
+  // the leftover spatial keys are inert there. Any `.name()`/`.label()`/
+  // `.zOrder()` already chained onto `mark` rides along unchanged and applies
+  // to the CONNECTOR; the anchor tier gets `LayerBuilder`'s usual
+  // auto-naming. This returns a `LayerBuilder`, not a `ChartBuilder` — like
+  // the explicit two-tier form it desugars to, the result supports further
+  // `.layer(...)` chaining and the render/toSVG/... terminals, but not
+  // `ChartBuilder`-only methods (`.name()` on the chart itself, further
+  // `.mark()`/`.flow()`) or use as a nested `.layer(...)` tier.
   mark(
     mark: Mark<TOutput> | ChartBuilder<any, any>
-  ): ChartBuilder<TInput, TOutput> {
-    const finalMark =
-      mark instanceof ChartBuilder
-        ? (((d: TOutput, _key, layerContext) =>
-            (mark.usesPreviousLayerMarks()
-              ? mark.withData(d)
-              : mark
-            ).withLayerContext(layerContext ?? {})) as Mark<TOutput>)
-        : mark;
+  ): ChartBuilder<TInput, TOutput> | LayerBuilder {
+    if (mark instanceof ChartBuilder) {
+      const finalMark = ((d: TOutput, _key, layerContext) =>
+        (mark.usesPreviousLayerMarks()
+          ? mark.withData(d)
+          : mark
+        ).withLayerContext(layerContext ?? {})) as Mark<TOutput>;
+      return new ChartBuilder(
+        this.data,
+        this.options,
+        this.operators,
+        finalMark,
+        this.layerContext,
+        this.nodeZOrder,
+        this.nodeName
+      );
+    }
+
+    // Only fuse when this chart's data is genuine per-row data that still
+    // needs anchors drawn for it. The OTHER well-established bag-form usage —
+    // a relational mark applied directly to a bag of ALREADY-drawn refs, e.g.
+    // `chart(selectAll("bars")).flow(group({by})).mark(ribbon(opts))` (the
+    // ribbon connects the existing bars) or an empty-scope `chart()` tier
+    // inheriting the previous tier's marks inside `.layer(...)` — has nothing
+    // to anchor: the incoming data already IS (or will become) the refs bag
+    // the connector reads. `usesPreviousLayerMarks()` catches the empty-scope
+    // case; `this.data instanceof GoFishRef` catches the explicit
+    // `selectAll(...)`/`ref(...)` case.
+    const fusable = (mark as any)?.__relationalFusable as
+      | { opts: Record<string, any>; makeAnchor: () => Mark<any> }
+      | undefined;
+    const dataNeedsAnchors =
+      !this.usesPreviousLayerMarks() && !(this.data instanceof GoFishRef);
+    if (fusable && dataNeedsAnchors) {
+      return this.mark(fusable.makeAnchor() as unknown as Mark<TOutput>).layer(
+        mark as Mark<any>
+      );
+    }
+
     return new ChartBuilder(
       this.data,
       this.options,
       this.operators,
-      finalMark,
+      mark,
       this.layerContext,
       this.nodeZOrder,
       this.nodeName
@@ -363,7 +415,16 @@ export class ChartBuilder<TInput, TOutput = TInput> {
       return { builder: this, name: existing };
     }
     const named = (this.finalMark as any).name(autoName) as Mark<TOutput>;
-    return { builder: this.mark(named), name: autoName };
+    // `this.finalMark` was already stored by a prior `.mark()` call, so it's
+    // never itself a fusable relational mark (fusion resolves at `.mark()`
+    // call time into an anchor `ChartBuilder` + connector tier — see
+    // `mark()`'s doc-comment) — `.name(...)` on it can't reintroduce the
+    // `__relationalFusable` tag, so `this.mark(named)` always takes the
+    // plain-mark branch and stays a `ChartBuilder`.
+    return {
+      builder: this.mark(named) as ChartBuilder<TInput, TOutput>,
+      name: autoName,
+    };
   }
 
   /** The render-time metadata threaded from the root tier: resolved axes/color

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -234,6 +234,15 @@ function modifierMethod(
     // Preserve the kind tag so applyMark dispatches correctly through the
     // wrapped mark, then let the modifier stamp its own metadata.
     withMarkKind(wrapped, getMarkKind(base));
+    // Preserve the blank-fusion descriptor (see chart.ts's
+    // `tagRelationalFusable`) through `.name()`/`.label()`/`.zOrder()`
+    // chaining, so `.mark(ribbon(opts).name("area"))` still fuses — the
+    // descriptor names the ORIGINAL opts, which this chaining never changes,
+    // and the connector tier ends up being `wrapped` itself (which still
+    // applies the name/label/zOrder when invoked).
+    if ((base as any).__relationalFusable) {
+      (wrapped as any).__relationalFusable = (base as any).__relationalFusable;
+    }
     cfg.tag?.(wrapped, base, ...args);
     return redecorate(wrapped);
   };

--- a/packages/gofish-graphics/src/tests/fusion.test.ts
+++ b/packages/gofish-graphics/src/tests/fusion.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Regression test for the "blank fusion" bug in `ChartBuilder.mark()` /
+ * `ensureNamedMark()` (chartBuilder.ts).
+ *
+ * Repro shape (mirrors the real `Benchmarks/Envelope` and `Benchmarks/Trend`
+ * stories in `stories/bench/Benchmarks.stories.tsx`): a multi-tier `.layer()`
+ * chain where a MIDDLE tier is an empty-scope `chart().flow(group({by}))`
+ * whose mark is a relational mark (`line()`, tagged `__relationalFusable`).
+ * Fusion is correctly skipped when that tier's `.mark()` is first called
+ * (`usesPreviousLayerMarks()` is true), so the still-tagged relational mark is
+ * stored as `finalMark`. Because a LATER tier follows, `LayerBuilder.resolve()`
+ * calls `tier.withData(prevRefs)` (an Array of `GoFishRef`, not a `GoFishRef`
+ * instance) and then `tier.ensureNamedMark(...)`. Before the fix,
+ * `ensureNamedMark` re-invoked `this.mark(named)`, re-entering the fusion
+ * guard against the `withData(prevRefs)` shape, wrongly re-firing fusion and
+ * returning a `LayerBuilder` instead of a `ChartBuilder` — which blew up
+ * later in `resolve()` with `tier.withLayerContext is not a function`.
+ *
+ * Run: `pnpm build && tsx src/tests/fusion.test.ts` (wired as
+ * `pnpm test:fusion`). Imports from `dist` for the same lodash-ESM reason as
+ * `serialize.test.ts` / `displayListEmit.test.ts`.
+ */
+
+// @ts-ignore -- dist may not exist at typecheck time; the test script builds first.
+import * as GoFish from "../../dist/index.js";
+
+const { chart, group, scatter, circle, line, text } = GoFish as any;
+
+declare const process: { exit(code: number): never };
+
+let passed = 0;
+let failed = 0;
+function check(name: string, ok: boolean, detail?: string): void {
+  if (ok) {
+    passed += 1;
+    console.log(`  ok  ${name}`);
+  } else {
+    failed += 1;
+    console.error(`  FAIL ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+async function main() {
+  console.log(
+    "\n# Blank-fusion regression — .layer() chain with an empty-scope relational middle tier"
+  );
+
+  const data = [
+    { id: 0, family: "a", x: 0, y: 1 },
+    { id: 1, family: "a", x: 1, y: 2 },
+    { id: 2, family: "b", x: 0, y: 3 },
+    { id: 3, family: "b", x: 1, y: 4 },
+  ];
+
+  // Root tier: real row data + a plain (non-relational) mark.
+  // Middle tier: empty-scope chart().flow(group({by})).mark(line()) — line()
+  // is a relational mark (createRelationalMark), tagged __relationalFusable.
+  // Because a following tier exists, LayerBuilder.resolve() will call
+  // ensureNamedMark on this middle tier during resolve — the exact path that
+  // was broken.
+  // Trailing tier: any following tier so ensureNamedMark actually runs.
+  let node: any;
+  let threw: unknown;
+  try {
+    node = await chart(data, { w: 200, h: 200 })
+      .flow(scatter({ by: "id", x: "x", y: "y" }))
+      .mark(circle({ r: 3, fill: "family" }).name("dots"))
+      .layer(
+        chart()
+          .flow(group({ by: "family" }))
+          .mark(line({ strokeWidth: 1.5 }))
+      )
+      .layer(text({ text: "caption" }))
+      .resolve();
+  } catch (e) {
+    threw = e;
+  }
+
+  check(
+    "three-tier .layer() chain with an empty-scope relational middle tier resolves without throwing",
+    threw === undefined,
+    threw instanceof Error ? threw.message : String(threw)
+  );
+  check("resolve() produced a node", node !== undefined && node !== null);
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  if (failed > 0) process.exit(1);
+}
+
+main();

--- a/packages/gofish-graphics/src/tests/fusion.test.ts
+++ b/packages/gofish-graphics/src/tests/fusion.test.ts
@@ -24,7 +24,8 @@
 // @ts-ignore -- dist may not exist at typecheck time; the test script builds first.
 import * as GoFish from "../../dist/index.js";
 
-const { chart, group, scatter, circle, line, text } = GoFish as any;
+const { chart, group, scatter, circle, line, ribbon, text, selectAll } =
+  GoFish as any;
 
 declare const process: { exit(code: number): never };
 
@@ -82,6 +83,89 @@ async function main() {
     threw instanceof Error ? threw.message : String(threw)
   );
   check("resolve() produced a node", node !== undefined && node !== null);
+
+  console.log(
+    "\n# Anchor channels on a relational mark that will NOT fuse must throw at .mark() call time"
+  );
+
+  // Empty-scope tier (`usesPreviousLayerMarks()`) + a relational mark carrying
+  // an anchor key (`h`) — the mark connects the previous tier's existing
+  // marks, so `h` has nothing to anchor and must be a loud error, thrown
+  // synchronously when `.mark()` is called (not deferred to `.resolve()`).
+  let anchorOnEmptyScopeThrew: unknown;
+  try {
+    chart()
+      .flow(group({ by: "family" }))
+      .mark(line({ h: "count" }));
+  } catch (e) {
+    anchorOnEmptyScopeThrew = e;
+  }
+  check(
+    "empty-scope tier: line({ h }) throws synchronously at .mark() call time",
+    anchorOnEmptyScopeThrew instanceof Error &&
+      /\bh\b/.test((anchorOnEmptyScopeThrew as Error).message)
+  );
+
+  // Same empty-scope shape, but with NO anchor keys — the existing happy path
+  // (also exercised end-to-end by the three-tier test above) must stay legal.
+  let noAnchorOnEmptyScopeThrew: unknown;
+  try {
+    chart()
+      .flow(group({ by: "family" }))
+      .mark(line({ strokeWidth: 1.5 }));
+  } catch (e) {
+    noAnchorOnEmptyScopeThrew = e;
+  }
+  check(
+    "empty-scope tier: line() with no anchor keys stays legal",
+    noAnchorOnEmptyScopeThrew === undefined,
+    noAnchorOnEmptyScopeThrew instanceof Error
+      ? noAnchorOnEmptyScopeThrew.message
+      : String(noAnchorOnEmptyScopeThrew)
+  );
+
+  // Chart data already refs (selectAll(...)) + an anchor key — same
+  // "connects existing marks" situation via the OTHER unfused path
+  // (`dataIsRefs`), must also throw at .mark() call time.
+  let anchorOnRefsDataThrew: unknown;
+  try {
+    chart(selectAll("dots")).mark(ribbon({ h: "count" }));
+  } catch (e) {
+    anchorOnRefsDataThrew = e;
+  }
+  check(
+    "refs-data chart: ribbon({ h }) throws synchronously at .mark() call time",
+    anchorOnRefsDataThrew instanceof Error &&
+      /\bh\b/.test((anchorOnRefsDataThrew as Error).message)
+  );
+
+  // Fused path: a relational mark WITH anchor keys directly over raw row
+  // data (a non-empty, non-refs scope) must still fuse and render, not throw.
+  const rows = [
+    { lake: "a", count: 3 },
+    { lake: "b", count: 5 },
+  ];
+  let fusedRibbonNode: any;
+  let fusedRibbonThrew: unknown;
+  try {
+    fusedRibbonNode = await chart(rows, { w: 200, h: 200 })
+      .flow(scatter({ by: "lake", x: "lake", y: "count" }))
+      .mark(ribbon({ h: "count" }))
+      .resolve();
+  } catch (e) {
+    fusedRibbonThrew = e;
+  }
+  check(
+    "fused path: ribbon({ h }) directly over raw row data does not throw",
+    fusedRibbonThrew === undefined,
+    fusedRibbonThrew instanceof Error
+      ? fusedRibbonThrew.message
+      : String(fusedRibbonThrew)
+  );
+  check(
+    "fused path: ribbon({ h }) over raw row data produced a node",
+    fusedRibbonNode !== undefined && fusedRibbonNode !== null
+  );
 
   console.log(`\n${passed} passed, ${failed} failed`);
   if (failed > 0) process.exit(1);

--- a/packages/gofish-graphics/stories/forwardsyntax/Area.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Area.stories.tsx
@@ -38,8 +38,7 @@ export const Basic: StoryObj<Args> = {
     const lakes = 6;
     chart(seafood, { axes: true })
       .flow(spread({ by: "lake", dir: "x", spacing: args.w / (lakes - 1) }))
-      .mark(blank({ h: "count" }))
-      .layer(ribbon({ opacity: 0.8 }))
+      .mark(ribbon({ h: "count", opacity: 0.8 }))
       .render(container, {
         w: args.w,
         h: args.h,

--- a/packages/gofish-graphics/stories/forwardsyntax/LineChart.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/LineChart.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/html";
 import { initializeContainer } from "../helper";
 import { catchLocationsArray } from "../../src/data/catch";
 import { drivingShifts } from "../../src/data/drivingShifts";
-import { chart, line, blank } from "../../src/lib";
+import { chart, line } from "../../src/lib";
 import { scatter } from "../../src/lib";
 
 const meta: Meta = {
@@ -27,8 +27,7 @@ export const Default: StoryObj<Args> = {
 
     chart(catchLocationsArray, { axes: true })
       .flow(scatter({ by: "lake", x: "x", y: "y" }))
-      .mark(blank())
-      .layer(line())
+      .mark(line())
       .render(container, {
         w: args.w,
         h: args.h,
@@ -53,8 +52,7 @@ export const GasPrices: StoryObj<Args> = {
 
     chart(drivingShifts, { axes: true })
       .flow(scatter({ by: "year", x: "year", y: "gas" }))
-      .mark(blank())
-      .layer(line({ stroke: "steelblue", strokeWidth: 2 }))
+      .mark(line({ stroke: "steelblue", strokeWidth: 2 }))
       .render(container, {
         w: args.w,
         h: args.h,

--- a/packages/gofish-graphics/stories/forwardsyntax/RidgelineChart.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/RidgelineChart.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/html";
 import { initializeContainer } from "../helper";
 import { seafood } from "../../src/data/catch";
-import { chart, spread, blank } from "../../src/lib";
+import { chart, spread } from "../../src/lib";
 import { ribbon } from "../../src/lib";
 
 const meta: Meta = {
@@ -37,8 +37,15 @@ export const Default: StoryObj<Args> = {
         spread({ by: "lake", dir: "x", spacing: 80 }),
         spread({ by: "species", dir: "y", spacing: -16 })
       )
-      .mark(blank({ h: "count", fill: "species" }))
-      .layer(ribbon({ by: "species", opacity: 0.8, mixBlendMode: "normal" }))
+      .mark(
+        ribbon({
+          h: "count",
+          fill: "species",
+          by: "species",
+          opacity: 0.8,
+          mixBlendMode: "normal",
+        })
+      )
       .render(container, {
         w: args.w,
         h: args.h,

--- a/packages/gofish-ir/src/frontend/descriptors.ts
+++ b/packages/gofish-ir/src/frontend/descriptors.ts
@@ -707,6 +707,22 @@ export const LEAF_MARKS: Record<string, ConstructDescriptor> = {
         type: t.union(t.string, t.ref("FieldAccessor")),
         doc: "Bag form: partition the operand refs by this field (or field(...) accessor) and draw one connector per group.",
       },
+      emX: {
+        type: t.boolean,
+        doc: "Blank-fusion anchor key: placed directly in `.mark()` position, `line(opts)` elaborates to an invisible anchor tier (a `blank()` carrying just `{w, h, emX, emY}`) plus this connector — see the `mark` construct's doc. Ignored by `line` itself.",
+      },
+      emY: {
+        type: t.boolean,
+        doc: "Blank-fusion anchor key — see `emX`. Ignored by `line` itself.",
+      },
+      w: {
+        ...ch.num(),
+        doc: "Blank-fusion anchor key — see `emX`. Ignored by `line` itself.",
+      },
+      h: {
+        ...ch.num(),
+        doc: "Blank-fusion anchor key — see `emX`. Ignored by `line` itself.",
+      },
     },
   }),
 
@@ -728,6 +744,22 @@ export const LEAF_MARKS: Record<string, ConstructDescriptor> = {
       by: {
         type: t.union(t.string, t.ref("FieldAccessor")),
         doc: "Bag form: partition the operand refs by this field (or field(...) accessor) and draw one connector per group.",
+      },
+      emX: {
+        type: t.boolean,
+        doc: "Blank-fusion anchor key: placed directly in `.mark()` position, `ribbon(opts)` elaborates to an invisible anchor tier (a `blank()` carrying just `{w, h, emX, emY}`) plus this connector — see the `mark` construct's doc. Ignored by `ribbon` itself.",
+      },
+      emY: {
+        type: t.boolean,
+        doc: "Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself.",
+      },
+      w: {
+        ...ch.num(),
+        doc: "Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself.",
+      },
+      h: {
+        ...ch.num(),
+        doc: "Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself.",
       },
     },
   }),

--- a/packages/gofish-python/gofish/_generated.py
+++ b/packages/gofish-python/gofish/_generated.py
@@ -737,7 +737,7 @@ def _treemap_combinator_opts(*, w: Optional[Union[int, float, str]] = None, h: O
             opts[_k] = _v
     return opts
 
-def _line_opts(*, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, strokeDasharray: Optional[str] = None, opacity: Optional[float] = None, mixBlendMode: Optional[str] = None, curve: Optional[Any] = None, dir: Optional[str] = None, source: Optional[Any] = None, target: Optional[Any] = None, from_: Optional[str] = None, to: Optional[str] = None, by: Optional[Any] = None, debug: Optional[bool] = None) -> Dict[str, Any]:
+def _line_opts(*, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, strokeDasharray: Optional[str] = None, opacity: Optional[float] = None, mixBlendMode: Optional[str] = None, curve: Optional[Any] = None, dir: Optional[str] = None, source: Optional[Any] = None, target: Optional[Any] = None, from_: Optional[str] = None, to: Optional[str] = None, by: Optional[Any] = None, emX: Optional[bool] = None, emY: Optional[bool] = None, w: Optional[Union[int, float, str]] = None, h: Optional[Union[int, float, str]] = None, debug: Optional[bool] = None) -> Dict[str, Any]:
     """Center-mode connector — the path between the centers of consecutive marks (the drop-in for the removed `connect`). Bag form over a ref array, or pairwise `{from, to}` form over rows with two ref columns.
 
     Args:
@@ -748,6 +748,10 @@ def _line_opts(*, fill: Optional[str] = None, stroke: Optional[str] = None, stro
         from_: Pairwise form: column holding the source ref.
         to: Pairwise form: column holding the target ref.
         by: Bag form: partition the operand refs by this field (or field(...) accessor) and draw one connector per group.
+        emX: Blank-fusion anchor key: placed directly in `.mark()` position, `line(opts)` elaborates to an invisible anchor tier (a `blank()` carrying just `{w, h, emX, emY}`) plus this connector — see the `mark` construct's doc. Ignored by `line` itself.
+        emY: Blank-fusion anchor key — see `emX`. Ignored by `line` itself.
+        w: Blank-fusion anchor key — see `emX`. Ignored by `line` itself.
+        h: Blank-fusion anchor key — see `emX`. Ignored by `line` itself.
         debug: Factory-only dev flag; the JS factory strips it (FACTORY_ONLY_KEYS) before layout.
     """
     opts: Dict[str, Any] = {}
@@ -765,13 +769,17 @@ def _line_opts(*, fill: Optional[str] = None, stroke: Optional[str] = None, stro
         ("from", from_),
         ("to", to),
         ("by", by),
+        ("emX", emX),
+        ("emY", emY),
+        ("w", w),
+        ("h", h),
         ("debug", debug),
     ]:
         if _v is not None:
             opts[_k] = _v
     return opts
 
-def _ribbon_opts(*, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, opacity: Optional[float] = None, mixBlendMode: Optional[str] = None, dir: Optional[str] = None, curve: Optional[Any] = None, from_: Optional[str] = None, to: Optional[str] = None, by: Optional[Any] = None, debug: Optional[bool] = None) -> Dict[str, Any]:
+def _ribbon_opts(*, fill: Optional[str] = None, stroke: Optional[str] = None, strokeWidth: Optional[float] = None, opacity: Optional[float] = None, mixBlendMode: Optional[str] = None, dir: Optional[str] = None, curve: Optional[Any] = None, from_: Optional[str] = None, to: Optional[str] = None, by: Optional[Any] = None, emX: Optional[bool] = None, emY: Optional[bool] = None, w: Optional[Union[int, float, str]] = None, h: Optional[Union[int, float, str]] = None, debug: Optional[bool] = None) -> Dict[str, Any]:
     """Edge-mode connector — a filled band between the facing edges of consecutive marks (areas, streamgraphs, sankey ribbons).
 
     Args:
@@ -779,6 +787,10 @@ def _ribbon_opts(*, fill: Optional[str] = None, stroke: Optional[str] = None, st
         mixBlendMode: Default "normal".
         curve: Screen-space band-edge shape (straight() | bezier()). Omitted = "auto" (bezier).
         by: Bag form: partition the operand refs by this field (or field(...) accessor) and draw one connector per group.
+        emX: Blank-fusion anchor key: placed directly in `.mark()` position, `ribbon(opts)` elaborates to an invisible anchor tier (a `blank()` carrying just `{w, h, emX, emY}`) plus this connector — see the `mark` construct's doc. Ignored by `ribbon` itself.
+        emY: Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself.
+        w: Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself.
+        h: Blank-fusion anchor key — see `emX`. Ignored by `ribbon` itself.
         debug: Factory-only dev flag; the JS factory strips it (FACTORY_ONLY_KEYS) before layout.
     """
     opts: Dict[str, Any] = {}
@@ -793,6 +805,10 @@ def _ribbon_opts(*, fill: Optional[str] = None, stroke: Optional[str] = None, st
         ("from", from_),
         ("to", to),
         ("by", by),
+        ("emX", emX),
+        ("emY", emY),
+        ("w", w),
+        ("h", h),
         ("debug", debug),
     ]:
         if _v is not None:

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -2490,6 +2490,10 @@ def line(
     from_: Optional[str] = None,
     to: Optional[str] = None,
     by: Optional[Union[str, "FieldAccessor"]] = None,
+    emX: Optional[bool] = None,
+    emY: Optional[bool] = None,
+    w: Optional[Union[int, float, str]] = None,
+    h: Optional[Union[int, float, str]] = None,
 ) -> Mark:
     """Line mark — a center-mode connector (the path between mark centers).
 
@@ -2506,6 +2510,11 @@ def line(
 
     ``strokeDasharray`` (e.g. ``"12"``) draws a dashed line, matching
     ``enclose``'s option of the same name.
+
+    ``emX``/``emY``/``w``/``h`` are blank-fusion anchor keys: placed directly
+    in ``.mark(...)`` position, ``line(...)`` elaborates to an invisible
+    anchor tier (a ``blank()`` carrying just these four keys) plus this
+    connector. ``line`` itself ignores them.
     """
     kwargs = _line_opts(
         dir=dir,
@@ -2521,6 +2530,10 @@ def line(
         from_=from_,
         to=to,
         by=by,
+        emX=emX,
+        emY=emY,
+        w=w,
+        h=h,
     )
     if children is not None:
         return Mark("line", _children=list(children), **kwargs)
@@ -2540,6 +2553,10 @@ def ribbon(
     from_: Optional[str] = None,
     to: Optional[str] = None,
     by: Optional[Union[str, "FieldAccessor"]] = None,
+    emX: Optional[bool] = None,
+    emY: Optional[bool] = None,
+    w: Optional[Union[int, float, str]] = None,
+    h: Optional[Union[int, float, str]] = None,
 ) -> Mark:
     """Ribbon mark — an edge-mode connector: a filled band between the facing
     edges of consecutive marks (areas, streamgraphs, sankey ribbons).
@@ -2550,6 +2567,11 @@ def ribbon(
     ``by=...`` (partition the ref bag by a field and draw one ribbon per
     group), and pairwise form ``ribbon(from_=..., to=...)`` (one band per row,
     after :func:`resolve`).
+
+    ``emX``/``emY``/``w``/``h`` are blank-fusion anchor keys: placed directly
+    in ``.mark(...)`` position, ``ribbon(...)`` elaborates to an invisible
+    anchor tier (a ``blank()`` carrying just these four keys) plus this
+    connector. ``ribbon`` itself ignores them.
     """
     kwargs = _ribbon_opts(
         dir=dir,
@@ -2562,6 +2584,10 @@ def ribbon(
         from_=from_,
         to=to,
         by=by,
+        emX=emX,
+        emY=emY,
+        w=w,
+        h=h,
     )
     if children is not None:
         return Mark("ribbon", _children=list(children), **kwargs)

--- a/tests/python-stories/forward-syntax-v3/test_area.py
+++ b/tests/python-stories/forward-syntax-v3/test_area.py
@@ -14,8 +14,7 @@ def story_basic():
     return (
         chart(SEAFOOD)
         .flow(spread(by="lake", dir="x", spacing=w / (lakes - 1)))
-        .mark(blank(h="count"))
-        .layer(ribbon(opacity=0.8)),
+        .mark(ribbon(h="count", opacity=0.8)),
         {"w": w, "h": 300, "axes": True},
     )
 

--- a/tests/python-stories/forward-syntax-v3/test_line_chart.py
+++ b/tests/python-stories/forward-syntax-v3/test_line_chart.py
@@ -1,6 +1,6 @@
 """Equivalent of LineChart.stories.tsx — Forward Syntax V3/Line Chart."""
 
-from gofish import chart, scatter, blank, line
+from gofish import chart, scatter, line
 from python_stories.data import CATCH_LOCATIONS_ARRAY, DRIVING_SHIFTS
 
 
@@ -8,8 +8,7 @@ def story_default():
     return (
         chart(CATCH_LOCATIONS_ARRAY)
         .flow(scatter(by="lake", x="x", y="y"))
-        .mark(blank())
-        .layer(line()),
+        .mark(line()),
         {"w": 400, "h": 400, "axes": True},
     )
 
@@ -18,7 +17,6 @@ def story_gas_prices():
     return (
         chart(DRIVING_SHIFTS)
         .flow(scatter(by="year", x="year", y="gas"))
-        .mark(blank())
-        .layer(line(stroke="steelblue", strokeWidth=2)),
+        .mark(line(stroke="steelblue", strokeWidth=2)),
         {"w": 500, "h": 400, "axes": True},
     )

--- a/tests/python-stories/forward-syntax-v3/test_ridgeline_chart.py
+++ b/tests/python-stories/forward-syntax-v3/test_ridgeline_chart.py
@@ -1,6 +1,6 @@
 """Equivalent of RidgelineChart.stories.tsx — Forward Syntax V3/Ridgeline Chart."""
 
-from gofish import chart, spread, blank, ribbon
+from gofish import chart, spread, ribbon
 from python_stories.data import SEAFOOD
 
 
@@ -11,7 +11,14 @@ def story_default():
             spread(by="lake", dir="x", spacing=80),
             spread(by="species", dir="y", spacing=-16),
         )
-        .mark(blank(h="count", fill="species"))
-        .layer(ribbon(by="species", opacity=0.8, mixBlendMode="normal")),
+        .mark(
+            ribbon(
+                h="count",
+                fill="species",
+                by="species",
+                opacity=0.8,
+                mixBlendMode="normal",
+            )
+        ),
         {"w": 500, "h": 300},
     )


### PR DESCRIPTION
## What this does

A relational mark placed directly in `.mark()` position now elaborates to an invisible anchor tier plus a connector tier. The rule is one rewrite:

```
.mark(R(opts))  =>  .mark(blank(anchor(opts))).layer(R(opts))
```

`anchor(opts)` is exactly the spatial subset `{w, h, emX, emY}`. Everything else (fill, stroke, strokeWidth, strokeDasharray, opacity, curve, dir, mixBlendMode, by, source, target) stays with the connector. This is pure sugar over the `.layer()` machinery from #745 and adds no layout semantics.

Simple line and area charts lose their boilerplate tier:

```ts
// before                                  // after
.flow(scatter({ by: "year",               .flow(scatter({ by: "year",
                x: "year", y: "gas" }))                    x: "year", y: "gas" }))
.mark(blank())                             .mark(line({ stroke: "steelblue" }))
.layer(line({ stroke: "steelblue" }))
```

and a ridgeline becomes one chain: `.mark(ribbon({ h: "count", fill: "species", by: "species" }))`.

## Boundaries of the rule

- The pairwise `{from, to}` form is never fused. It already consumes ref-bearing rows directly in `.mark()`.
- Fusion only fires when the chart's data still needs anchors drawn. A relational mark over an existing refs bag, e.g. `chart(selectAll("bars")).flow(group({ by })).mark(ribbon())` or an empty-scope `chart()` tier inside `.layer()`, keeps its unfused meaning of connecting the existing marks. The guard is one predicate, `dataIsRefs`, which owns the "data is already refs" concept.
- Anchor channels on a mark that will NOT fuse are a loud error at `.mark()` call time, not a silent no-op: `line({ h })` on an empty-scope tier or a refs-data chart throws, naming the dead keys and both ways out.
- A `by`-split connector now resolves a field-valued `fill` per group through the color scale, since each group is homogeneous in the split field. This is what lets `fill` move off the anchor.
- Stacked area and streamgraph stories deliberately stay in the two-tier form, and `blank()` stays available. See the design notes on #290 for the related question of `.stack()` as a mark method, which this neither implements nor blocks.

## Fix that rode along

The first cut crashed multi-tier `.layer()` chains whose relational tier had a following tier (Benchmarks Envelope and Trend): `ensureNamedMark` re-entered `mark()` after `LayerBuilder` had swapped in the previous tier's refs array, and the guard misread that array as row data, re-firing fusion mid-resolve. `ensureNamedMark` now constructs the renamed builder directly (fusion is decided exactly once, when the mark is first attached), and a three-tier regression test in `fusion.test.ts` locks it in.

## Verification

- Migrated stories (Line Chart Default and GasPrices, Area Basic, Ridgeline Chart) render byte-identical PNGs before and after (`cmp` on `capture-one` output).
- Full `pnpm capture-diff origin/main` sweep: the only changed story is the ridgeline's benign DOM reshuffle from the intentional migration (pixels identical).
- Full `gofish-graphics` test suite passes, including the new fusion suite (throw cases + happy paths + the three-tier regression).

## Cross-language checklist

- Descriptor table gained `w`/`h`/`emX`/`emY` on line and ribbon; `gofish-ir` rebuilt and the IR schema synced.
- Python wrappers regenerated (`_generated.py`) plus the hand-written `line()`/`ribbon()` kwargs in `ast.py`; parity stories for the three migrated charts moved to the fused form; `validate-python-ir` passes.
- Both reconstruction sites (serialize registry and the parity harness) funnel through `ChartBuilder.mark()`, so fusion applies to deserialized IR with no changes.
- Docs updated in the same change: `js/` and `python/` pages for line, ribbon, and layer document the fused form, the key routing, and the anchor-channel error; internals essays covering the edited sources updated and `check-backlinks` is clean.

## Follow-ups

- #749 — `LayerBuilder` has no `.toJSON()`, so a fused chart cannot be IR-serialized from the JS side (pre-existing gap, the explicit two-tier form has it too).
- #751 — record chart data kind (rows/refs/inherit) at construction so the fusion guard dispatches on a declared kind instead of `dataIsRefs` shape checks.
- A dedicated fusion round-trip case in `serialize.test.ts` would be a nice addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)