### PR TITLE
Support .label() on operators (#702)

### DIFF
--- a/apps/docs/docs/internals/frontend/operator-factory.md
+++ b/apps/docs/docs/internals/frontend/operator-factory.md
@@ -68,6 +68,10 @@ operator's own options. That distinction matters for operators like `scatter`:
 scatter's discrete placement encoding, while `y: 50` belongs to the outer
 translation wrapper.
 
+The operator (traversal) form also gets `.label(accessor, options?)` — see
+section 7 below. Unlike `.translate`, it's operator-form-only: the combinator
+form has no `split` step to attach a per-group label to.
+
 ## 2. The split → fmap → combine shape
 
 Pick any layout operator and you'll find the same three steps — a fan-out
@@ -271,7 +275,48 @@ Operators created with `createOperator` automatically support
 composes the ordinary split/channel/combine pipeline with a structural
 translation wrapper around the produced node.
 
-## 7. The relationship with `createMark`
+## 7. `.label()` on the operator (traversal) form
+
+`stack({ by: "class", dir: "y" }).label(accessor, options?)` labels each
+**group** the split produces, rather than each mark instance. It is not
+built on the `createModifier`/`attachModifiers` system section 8 describes
+(that system decorates a _mark_; the operator form needs to affect the
+_execution_ of a still-being-called operator, after `.label()` has already
+returned). Instead:
+
+- `dual`'s operator branch closes over a `let labelState` that starts
+  `undefined`. `.label()` (`attachLabelOption`) mutates it; the operator's
+  execution closure reads the current value each time it runs (once per
+  `.flow()` render), so `.label()` can be called any time before render,
+  in any position in the chain.
+- In the per-leaf loop (where `applyMark` turns one split leaf into node(s)),
+  if `labelState` is set, every node the leaf produced gets `node.datum ??=
+leaf` (the leaf's own subdata — usually the rows array `split` handed it)
+  and `node.label(labelState.accessor, labelState.options)`. Stamping
+  `datum` here is what makes `resolveLabels()`'s "a node with its own datum
+  keeps its own label instead of propagating it to children" gate fire at
+  the group level — the same effect the pre-#702 manual workaround achieved
+  by hand (see the "Label on Spread" story, which now uses the operator
+  form instead).
+- `.translate()` wraps the operator in a _new_ function object (`translated`
+  in `translateOperator`), so `.label()` needs to reach the SAME `labelState`
+  regardless of which wrapper the caller holds. `translateOperator` doesn't
+  attach a fresh label-modifier — it delegates: `translated.label(...)`
+  calls the base operator's own `.label(...)`, which mutates the base
+  operator's closed-over `labelState`. That's what makes both
+  `.translate().label()` and `.label().translate()` work identically.
+- Serialization mirrors the mark-side `labelModifier`'s `tag` hook (the
+  string-vs-function-accessor logic is factored into a shared
+  `labelIRField` helper): a string accessor becomes `tag.label = {accessor,
+...options}`; a function accessor warns and is dropped from the emitted
+  IR. `.translate()`'s wrapper has no tag of its own by default (the
+  wrapped function is new), so `translateOperator` copies the base
+  operator's `__serialize` tag onto the wrapper and stamps `tag.translate`
+  — without that copy, a translated operator would silently serialize as
+  the opaque `{type: "derive"}` fallback, losing both `translate` and any
+  chained `.label()`.
+
+## 8. The relationship with `createMark`
 
 The two factories are siblings:
 
@@ -346,7 +391,7 @@ that produces `Spread`, `Scatter`, etc. is `createNodeOperator`
 whose output is a single `GoFishNode`, not the dual-mode shape that
 `createOperator` returns.
 
-## 8. Prior art
+## 9. Prior art
 
 `createOperator` extends the per-component channel-grammar pattern from
 **Encodable** (Wongsuphasawat, IEEE VIS 2020 —
@@ -367,7 +412,7 @@ The two-call-shapes design (combinator and operator/traversal) — where the
 multiplicity comes from the marks array vs. the data partitions — is novel
 to `createOperator`; Encodable doesn't address layout multiplicity.
 
-## 9. Pointers
+## 10. Pointers
 
 - The factory: `src/ast/marks/createOperator.ts`.
 - Existing operators (each colocated with their low-level layout):

--- a/apps/docs/docs/internals/frontend/operator-factory.md
+++ b/apps/docs/docs/internals/frontend/operator-factory.md
@@ -305,16 +305,34 @@ leaf` (the leaf's own subdata — usually the rows array `split` handed it)
   calls the base operator's own `.label(...)`, which mutates the base
   operator's closed-over `labelState`. That's what makes both
   `.translate().label()` and `.label().translate()` work identically.
+- `resolveLabelText` (`ast/labels/labelPlacement.ts`) resolves the accessor
+  in one of three ways, depending on both the accessor's shape and the
+  datum's shape:
+  - A **bare string** over the group's array-of-rows datum must be constant
+    across every row (true by construction for a `by`-field, since every row
+    in the group shares that value) — `resolveLabelText` throws a loud error
+    if it isn't, rather than silently reading just the first row. Over a
+    scalar (non-array) datum it just reads the field directly.
+  - A **`field(...)` aggregate** (`field("count").sum()`/`.mean()`/`.count()`/
+    `.distinct()`) folds the group's rows to one value via `evalFieldValues`
+    (the same evaluator the `by`/`size`/`pos` channel pipelines use) — this is
+    the spelling for a group-total or group-mean label.
+  - A **function** accessor is the raw escape hatch: it receives the whole
+    leaf (the rows array) and returns whatever it wants, e.g.
+    `(rows) => rows.length`.
 - Serialization mirrors the mark-side `labelModifier`'s `tag` hook (the
-  string-vs-function-accessor logic is factored into a shared
-  `labelIRField` helper): a string accessor becomes `tag.label = {accessor,
-...options}`; a function accessor warns and is dropped from the emitted
-  IR. `.translate()`'s wrapper has no tag of its own by default (the
-  wrapped function is new), so `translateOperator` copies the base
-  operator's `__serialize` tag onto the wrapper and stamps `tag.translate`
-  — without that copy, a translated operator would silently serialize as
-  the opaque `{type: "derive"}` fallback, losing both `translate` and any
-  chained `.label()`.
+  accessor-shape logic is factored into a shared `labelIRField` helper,
+  checked in order string → field-expression → function): a string accessor
+  becomes `tag.label = {accessor, ...options}`; a `field(...)` accessor
+  serializes via its own `.toJSON()` (the `FieldExprWire` shape) into
+  `tag.label = {accessor: {type: "field", name, measure?, ops?}, ...options}`;
+  a function accessor warns and is dropped from the emitted IR (functions
+  aren't serializable). `.translate()`'s wrapper has no tag of its own by
+  default (the wrapped function is new), so `translateOperator` copies the
+  base operator's `__serialize` tag onto the wrapper and stamps
+  `tag.translate` — without that copy, a translated operator would silently
+  serialize as the opaque `{type: "derive"}` fallback, losing both
+  `translate` and any chained `.label()`.
 
 ## 8. The relationship with `createMark`
 

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -797,6 +797,9 @@ for the API.
         "type": {
           "const": "derive"
         },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
+        },
         "lambdaId": {
           "type": "string",
           "description": "Python-bridge handle for the remote callable."
@@ -830,6 +833,9 @@ for the API.
       "properties": {
         "type": {
           "const": "resolve"
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "cols": {
           "type": "array",
@@ -869,6 +875,9 @@ for the API.
         "type": {
           "const": "join"
         },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
+        },
         "on": {
           "type": "string",
           "description": "Shared key field matched between the incoming rows and `right`."
@@ -903,6 +912,9 @@ for the API.
       "properties": {
         "type": {
           "const": "spread"
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "by": {
           "oneOf": [
@@ -984,6 +996,9 @@ for the API.
         "type": {
           "const": "stack"
         },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
+        },
         "by": {
           "oneOf": [
             {
@@ -1061,6 +1076,9 @@ for the API.
         "type": {
           "const": "group"
         },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
+        },
         "by": {
           "oneOf": [
             {
@@ -1094,6 +1112,9 @@ for the API.
       "properties": {
         "type": {
           "const": "scatter"
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "by": {
           "oneOf": [
@@ -1166,6 +1187,9 @@ for the API.
       "properties": {
         "type": {
           "const": "table"
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "by": {
           "type": "object",
@@ -1255,6 +1279,9 @@ for the API.
       "properties": {
         "type": {
           "const": "treemap"
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "w": {
           "$ref": "#/$defs/ChannelValue"

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -797,9 +797,6 @@ for the API.
         "type": {
           "const": "derive"
         },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
-        },
         "lambdaId": {
           "type": "string",
           "description": "Python-bridge handle for the remote callable."
@@ -810,6 +807,9 @@ for the API.
             "type": "string"
           },
           "description": "Measure provenance a transform (e.g. bin) declares for its output columns — output field name → measure."
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "translate": {
           "$ref": "#/$defs/Translate"
@@ -834,9 +834,6 @@ for the API.
         "type": {
           "const": "resolve"
         },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
-        },
         "cols": {
           "type": "array",
           "items": {
@@ -851,6 +848,9 @@ for the API.
         "key": {
           "type": "string",
           "description": "Explicit match field; defaults to the producing operator's `by`."
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "translate": {
           "$ref": "#/$defs/Translate"
@@ -875,9 +875,6 @@ for the API.
         "type": {
           "const": "join"
         },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
-        },
         "on": {
           "type": "string",
           "description": "Shared key field matched between the incoming rows and `right`."
@@ -889,6 +886,9 @@ for the API.
             "properties": {}
           },
           "description": "The right-hand table, inlined as JSON rows."
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "translate": {
           "$ref": "#/$defs/Translate"
@@ -912,9 +912,6 @@ for the API.
       "properties": {
         "type": {
           "const": "spread"
-        },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
         },
         "by": {
           "oneOf": [
@@ -973,6 +970,9 @@ for the API.
           "$ref": "#/$defs/ChannelValue",
           "description": "Per-entry stack-axis extent (field/datum-sized children); a field(...).normalize() accessor makes it a space-filling spine."
         },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
+        },
         "translate": {
           "$ref": "#/$defs/Translate"
         },
@@ -995,9 +995,6 @@ for the API.
       "properties": {
         "type": {
           "const": "stack"
-        },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
         },
         "by": {
           "oneOf": [
@@ -1053,6 +1050,9 @@ for the API.
           "$ref": "#/$defs/ChannelValue",
           "description": "Per-entry stack-axis extent (field/datum-sized children); a field(...).normalize() accessor makes it a space-filling spine."
         },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
+        },
         "translate": {
           "$ref": "#/$defs/Translate"
         },
@@ -1076,9 +1076,6 @@ for the API.
         "type": {
           "const": "group"
         },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
-        },
         "by": {
           "oneOf": [
             {
@@ -1089,6 +1086,9 @@ for the API.
             }
           ],
           "description": "Field to group rows by; also accepts a field(...) accessor carrying domain ops (sort/reverse/bin)."
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "translate": {
           "$ref": "#/$defs/Translate"
@@ -1112,9 +1112,6 @@ for the API.
       "properties": {
         "type": {
           "const": "scatter"
-        },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
         },
         "by": {
           "oneOf": [
@@ -1165,6 +1162,9 @@ for the API.
         "h": {
           "$ref": "#/$defs/ChannelValue"
         },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
+        },
         "translate": {
           "$ref": "#/$defs/Translate"
         },
@@ -1187,9 +1187,6 @@ for the API.
       "properties": {
         "type": {
           "const": "table"
-        },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
         },
         "by": {
           "type": "object",
@@ -1230,6 +1227,9 @@ for the API.
           "type": "number",
           "description": "Explicit column count (falls back to the number of distinct column keys)."
         },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
+        },
         "translate": {
           "$ref": "#/$defs/Translate"
         },
@@ -1245,7 +1245,7 @@ for the API.
       }
     },
     "LogOperator": {
-      "description": "Debug pass-through: logs each row (optionally under `label`) and forwards it unchanged.",
+      "description": "Debug pass-through: logs each row (optionally under `prefix`) and forwards it unchanged.",
       "type": "object",
       "required": ["type"],
       "additionalProperties": true,
@@ -1253,9 +1253,12 @@ for the API.
         "type": {
           "const": "log"
         },
-        "label": {
+        "prefix": {
           "type": "string",
-          "description": "Console label prefix."
+          "description": "Console prefix string."
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "translate": {
           "$ref": "#/$defs/Translate"
@@ -1279,9 +1282,6 @@ for the API.
       "properties": {
         "type": {
           "const": "treemap"
-        },
-        "label": {
-          "$ref": "#/$defs/LabelIR"
         },
         "w": {
           "$ref": "#/$defs/ChannelValue"
@@ -1339,6 +1339,9 @@ for the API.
         "leafIntrinsicRadiusField": {
           "type": "string",
           "description": "When set, each leaf is laid out in a square of side min(leafW, leafH, 2*datum[field])."
+        },
+        "label": {
+          "$ref": "#/$defs/LabelIR"
         },
         "translate": {
           "$ref": "#/$defs/Translate"

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -683,7 +683,14 @@ for the API.
           "required": ["accessor"],
           "properties": {
             "accessor": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/$defs/FieldAccessor"
+                }
+              ]
             },
             "position": {
               "type": "string"

--- a/apps/docs/docs/js/api/core/mark.md
+++ b/apps/docs/docs/js/api/core/mark.md
@@ -136,15 +136,34 @@ chart(data)
 ```
 
 At execution time, every node a split leaf (one group's rows) produces gets
-stamped with that leaf's own subdata — a string accessor reads a field off
-the group's first row (the same unwrap a mark-level string accessor uses);
-a function accessor instead receives the **whole group** (an array of rows),
-so it can compute an aggregate label (e.g. `(rows) => rows.length`). This
-replaces the older pattern of manually stamping `node.datum` before calling
-`node.label(...)` on an already-resolved chart (see the "Label on Spread"
-story for the equivalent hand-rolled version). As with mark-level `.label`,
-a string accessor round-trips through the [IR](/internals/python/bridge); a
-function accessor can't be serialized and is dropped with a console warning.
+stamped with that leaf's own subdata, and the accessor resolves one of three
+ways:
+
+- **A bare field name** (`"class"` above) must be constant across every row
+  in the group — true by construction for a `by` field, since every row in
+  the group shares that value. If it isn't actually constant, this is a
+  spec error and `.label()` throws loudly rather than silently reading one
+  row's value:
+
+  ```
+  [gofish] .label("count"): field is not constant within the group; use an
+  aggregate like field("count").mean()
+  ```
+
+- **A `field(...)` aggregate** (`field("count").sum()` / `.mean()` /
+  `.count()` / `.distinct()`) folds the group's rows to one value — use this
+  for a group total or mean, e.g. `.label(field("count").sum())` to label a
+  stacked segment with its total row count.
+- **A function accessor** receives the **whole group** (an array of rows),
+  so it can compute any custom aggregate label (e.g. `(rows) => rows.length`).
+
+This replaces the older pattern of manually stamping `node.datum` before
+calling `node.label(...)` on an already-resolved chart (see the "Label on
+Spread" story for the equivalent hand-rolled version). As with mark-level
+`.label`, a string or `field(...)` accessor round-trips through the
+[IR](/internals/python/bridge) — a `field(...)` accessor serializes as its
+own `{type: "field", name, ops}` wire object; a function accessor can't be
+serialized and is dropped with a console warning.
 
 `.label()` and `.translate()` chain in either order:
 

--- a/apps/docs/docs/js/api/core/mark.md
+++ b/apps/docs/docs/js/api/core/mark.md
@@ -119,3 +119,36 @@ chart(data)
   .flow(scatter({ by: "lake", x: "lake" }).translate({ y: 50 }))
   .mark(rect({ w: 0.1, h: "count" }));
 ```
+
+### `.label()` on operators {#operator-label}
+
+Every dual-mode operator (`spread`, `stack`, `group`, `scatter`, `table`,
+`treemap` — anything with an operator (traversal) form inside `.flow(...)`)
+also accepts `.label(accessor, options?)`, with the same signature as a
+mark's `.label()` (see the [labels guide](/js/guides/labels)). Chaining it on
+the operator instead of the mark labels the **group**, not each individual
+mark instance:
+
+```ts
+chart(data)
+  .flow(stack({ by: "class", dir: "y" }).label("class", { position: "center" }))
+  .mark(rect({ h: "count" }));
+```
+
+At execution time, every node a split leaf (one group's rows) produces gets
+stamped with that leaf's own subdata — a string accessor reads a field off
+the group's first row (the same unwrap a mark-level string accessor uses);
+a function accessor instead receives the **whole group** (an array of rows),
+so it can compute an aggregate label (e.g. `(rows) => rows.length`). This
+replaces the older pattern of manually stamping `node.datum` before calling
+`node.label(...)` on an already-resolved chart (see the "Label on Spread"
+story for the equivalent hand-rolled version). As with mark-level `.label`,
+a string accessor round-trips through the [IR](/internals/python/bridge); a
+function accessor can't be serialized and is dropped with a console warning.
+
+`.label()` and `.translate()` chain in either order:
+
+```ts
+stack({ by: "class", dir: "y" }).translate({ y: 8 }).label("class");
+stack({ by: "class", dir: "y" }).label("class").translate({ y: 8 });
+```

--- a/apps/docs/docs/js/api/operators/log.md
+++ b/apps/docs/docs/js/api/operators/log.md
@@ -5,14 +5,14 @@ Logs the current data to the console at the point it appears in [`.flow()`](/js/
 ## Signature
 
 ```ts
-log(label?)
+log(prefix?)
 ```
 
 ## Parameters
 
-| Parameter | Type     | Description                             |
-| --------- | -------- | --------------------------------------- |
-| `label`   | `string` | Optional label to prefix the log output |
+| Parameter | Type     | Description                                  |
+| --------- | -------- | -------------------------------------------- |
+| `prefix`  | `string` | Optional prefix to prepend to the log output |
 
 ## Example
 

--- a/apps/docs/docs/js/guides/labels.md
+++ b/apps/docs/docs/js/guides/labels.md
@@ -123,6 +123,25 @@ gf.chart(seafood, { axes: true })
 
 :::
 
+## Labeling a group instead of a mark instance
+
+`.label()` also chains on an operator returned by `.flow(...)` (`spread`,
+`stack`, `group`, `scatter`, `table`, `treemap`), not just on a mark. This
+labels each **group** the operator produces — one label per split leaf —
+instead of one label per mark instance:
+
+```ts
+chart(data)
+  .flow(stack({ by: "class", dir: "y" }).label("class", { position: "center" }))
+  .mark(rect({ h: "count" }));
+```
+
+A string accessor reads a field off the group's first row, same as on a
+mark; a function accessor receives the group's whole row array, so it can
+compute an aggregate (`(rows) => rows.length`). See
+[`.label()` on operators](/js/api/core/mark#operator-label) for the full
+semantics.
+
 ## Custom label text
 
 Pass a function instead of a field name for computed labels.

--- a/apps/docs/docs/js/guides/labels.md
+++ b/apps/docs/docs/js/guides/labels.md
@@ -136,10 +136,37 @@ chart(data)
   .mark(rect({ h: "count" }));
 ```
 
-A string accessor reads a field off the group's first row, same as on a
-mark; a function accessor receives the group's whole row array, so it can
-compute an aggregate (`(rows) => rows.length`). See
-[`.label()` on operators](/js/api/core/mark#operator-label) for the full
+The accessor you pass here has three forms, and which one you need depends
+on what you're labeling:
+
+- **A bare field name** (`"class"` above) must be constant across every row
+  in the group — true by construction for a `by` field, since every row in
+  the group shares that value. If the field's value actually varies from row
+  to row, `.label()` throws a loud error rather than silently picking one
+  row's value:
+
+  ```
+  [gofish] .label("count"): field is not constant within the group; use an
+  aggregate like field("count").mean()
+  ```
+
+- **A `field(...)` aggregate** folds the group's rows to one value — this is
+  the spelling for a group total or mean, e.g. a stacked bar's segment count:
+
+  ```ts
+  chart(data)
+    .flow(stack({ by: "class", dir: "y" }).label(field("count").sum()))
+    .mark(rect({ h: "count" }));
+  ```
+
+  `field(...)` also supports `.mean()`, `.count()`, and `.distinct()` — see
+  the [field-expression pipeline](/js/api/operators/spread#field-expression-pipeline).
+
+- **A function accessor** is the raw escape hatch: it receives the group's
+  whole row array and returns whatever text it computes, e.g.
+  `(rows) => rows.length`.
+
+See [`.label()` on operators](/js/api/core/mark#operator-label) for the full
 semantics.
 
 ## Custom label text
@@ -157,18 +184,20 @@ Pass a function instead of a field name for computed labels.
 ## Examples
 
 ```ts
-// Outset labels on a bar chart
-.mark(rect({ h: "count" }).label("count"))
+// Outset labels on a bar chart, one bar per lake — "count" is a real per-row
+// field, so a bare string label needs a group total, not a bare field read
+.mark(rect({ h: "count" }).label(field("count").sum()))
 
-// Center labels on stacked bars
+// Center labels on stacked bars — one bar per (lake, species) pair, so
+// "count" is already constant within each bar's group
 .mark(rect({ h: "count", fill: "species" }).label("count", { position: "center" }))
 
-// Right-aligned labels on horizontal bars
-.mark(rect({ w: "count" }).label("count", { position: "outset-right", offset: 15 }))
+// Right-aligned labels on horizontal bars (group total again)
+.mark(rect({ w: "count" }).label(field("count").sum(), { position: "outset-right", offset: 15 }))
 
 // Heatmap with auto-contrast
 .mark(rect({ fill: "value" }).label("value", { position: "center", fontSize: 11 }))
 
-// Rotated labels above bars
+// Rotated labels above bars, labeled by the (constant) by-field
 .mark(rect({ h: "count" }).label("lake", { position: "outset", rotate: 60 }))
 ```

--- a/apps/docs/docs/python/api/core/mark.md
+++ b/apps/docs/docs/python/api/core/mark.md
@@ -80,3 +80,37 @@ it binds the previous tier's marks.
 The older callback form `mark(lambda data: chart(data, ...).flow(...).mark(...))`
 still works and is equivalent — the function receives each group's data slice and
 returns a nested chart.
+
+## Labeling a mark
+
+Call `.label(accessor, position=..., font_size=..., color=..., offset=..., min_space=..., rotate=...)`
+on a mark to attach a deferred text label, mirroring JS's `.label(accessor, options?)`:
+
+```python
+rect(h="count").label("count", position="center", font_size=10)
+```
+
+`accessor` is a field name read off the mark's datum. Python has no
+function-accessor form (JS accepts a callback there); use a field name.
+
+### `.label()` on operators {#operator-label}
+
+Every dual-mode operator (`spread`, `stack`, `group`, `scatter`, `table`,
+`treemap`) also accepts `.label(accessor, ...)`, with the same kwargs as
+`Mark.label`. Chaining it on the operator instead of the mark labels the
+**group**, not each individual mark instance — every node a split leaf (one
+group's rows) produces gets stamped with that leaf's own subdata, and
+`accessor` reads a field off the group's first row:
+
+```python
+chart(data).flow(
+    stack(by="class", dir="y").label("class", position="center")
+).mark(rect(h="count"))
+```
+
+`.label()` and `.translate()` chain in either order:
+
+```python
+stack(by="class", dir="y").translate(y=8).label("class")
+stack(by="class", dir="y").label("class").translate(y=8)
+```

--- a/apps/docs/docs/python/api/core/mark.md
+++ b/apps/docs/docs/python/api/core/mark.md
@@ -90,8 +90,9 @@ on a mark to attach a deferred text label, mirroring JS's `.label(accessor, opti
 rect(h="count").label("count", position="center", font_size=10)
 ```
 
-`accessor` is a field name read off the mark's datum. Python has no
-function-accessor form (JS accepts a callback there); use a field name.
+`accessor` is either a plain field name (a string) or a `field(...)`
+aggregate. Python has no function-accessor form (JS accepts a callback
+there); use one of these two instead.
 
 ### `.label()` on operators {#operator-label}
 
@@ -100,7 +101,28 @@ Every dual-mode operator (`spread`, `stack`, `group`, `scatter`, `table`,
 `Mark.label`. Chaining it on the operator instead of the mark labels the
 **group**, not each individual mark instance — every node a split leaf (one
 group's rows) produces gets stamped with that leaf's own subdata, and
-`accessor` reads a field off the group's first row:
+`accessor` resolves one of two ways:
+
+- **A bare field name** (`"class"` below) must be constant across every row
+  in the group — true by construction for a `by` field, since every row in
+  the group shares that value. If it isn't actually constant, this is a
+  spec error and `.label()` raises loudly rather than silently reading one
+  row's value:
+
+  ```
+  [gofish] .label("count"): field is not constant within the group; use an
+  aggregate like field("count").mean()
+  ```
+
+- **A `field(...)` aggregate** (`field("count").sum()` / `.mean()` /
+  `.count()` / `.distinct()`) folds the group's rows to one value — use this
+  for a group total or mean:
+
+  ```python
+  chart(data).flow(
+      stack(by="class", dir="y").label(field("count").sum(), position="center")
+  ).mark(rect(h="count"))
+  ```
 
 ```python
 chart(data).flow(

--- a/apps/docs/docs/python/api/operators/log.md
+++ b/apps/docs/docs/python/api/operators/log.md
@@ -17,14 +17,14 @@ chart(seafood).flow(
 ## Signature
 
 ```python
-log(label=None) -> Operator
+log(prefix=None) -> Operator
 ```
 
 ## Parameters
 
 | Parameter | Type  | Description                            |
 | --------- | ----- | -------------------------------------- |
-| `label`   | `str` | Optional prefix for the console output |
+| `prefix`  | `str` | Optional prefix for the console output |
 
 Returns an `Operator` for use inside [`.flow()`](/python/api/core/flow).
 

--- a/apps/docs/docs/python/api/operators/spread.md
+++ b/apps/docs/docs/python/api/operators/spread.md
@@ -31,7 +31,6 @@ spread(*, by=None, dir, **options) -> Operator
 | `glue`      | `bool`                                   | Glue children together: collapse data-driven sizes into a single positional axis at this level. [`stack`](/python/api/operators/stack) sets this.                                                                                                                                                            |
 | `w`, `h`    | `int` \| `str`                           | Fixed pixel size, or a field name sizing this operator's own box from data (data-driven operator extent — e.g. a mosaic's column width).                                                                                                                                                                     |
 | `size`      | `int` \| `str` \| `field(...)` \| `list` | Per-entry stack-axis extent — a field name, a [`field(...)`](#field-expression-pipeline) accessor, or an explicit list with one value per split entry. `size=field("count").normalize()` makes the stack axis a **space-filling spine**. See [Space-filling spines](#space-filling-spines-mosaic-marimekko). |
-| `label`     | `bool`                                   | Whether to emit an axis label for the partition field.                                                                                                                                                                                                                                                       |
 
 Returns an `Operator` for use inside [`.flow()`](/python/api/core/flow).
 

--- a/apps/docs/docs/python/api/operators/stack.md
+++ b/apps/docs/docs/python/api/operators/stack.md
@@ -11,7 +11,7 @@ from gofish import chart, spread, stack, rect
 
 chart(seafood, axes=True).flow(
     spread(by="lake", dir="x"),
-    stack(by="species", dir="y", label=False),
+    stack(by="species", dir="y"),
 ).mark(rect(h="count", fill="species")).render(w=500, h=300)
 ```
 
@@ -36,7 +36,6 @@ low-level form behind the v1 `stackX`/`stackY` operators).
 | `alignment` | `str`                                    | Cross-axis alignment of the stacked groups.                                                                                                                                                                                                                                                                                       |
 | `w`, `h`    | `int` \| `str`                           | Fixed pixel size, or a field name sizing this operator's own box from data (data-driven operator extent — e.g. a mosaic's column width).                                                                                                                                                                                          |
 | `size`      | `int` \| `str` \| `field(...)` \| `list` | Per-entry stack-axis extent — a field name, a `field(...)` accessor, or an explicit list. `size=field("count").normalize()` makes the stacking axis a **space-filling spine** (the mosaic/marimekko conditional axis). See [`spread` → Space-filling spines](/python/api/operators/spread#space-filling-spines-mosaic-marimekko). |
-| `label`     | `bool`                                   | Whether to emit an axis label for the partition field.                                                                                                                                                                                                                                                                            |
 
 Returns an `Operator` for use inside [`.flow()`](/python/api/core/flow).
 

--- a/packages/gofish-graphics/src/ast/labels/labelPlacement.ts
+++ b/packages/gofish-graphics/src/ast/labels/labelPlacement.ts
@@ -1,6 +1,11 @@
 import { Direction, Size } from "../dims";
+import { evalFieldValues, FieldExpr, FieldExprWire } from "../fieldExpr";
 
-export type LabelAccessor<D = any> = string | ((d: D) => string);
+export type LabelAccessor<D = any> =
+  | string
+  | FieldExprWire
+  | FieldExpr
+  | ((d: D) => string);
 
 export interface LabelOptions {
   position?: LabelPosition;
@@ -15,11 +20,60 @@ export interface LabelSpec<D = any> extends LabelOptions {
   accessor: LabelAccessor<D>;
 }
 
+/** Is this accessor a field-expression (either the `FieldExpr` class or its
+ *  deserialized `FieldExprWire` wire form)? Mirrors the duck-typed check in
+ *  `fieldExpr.ts`'s `getFieldOps`. */
+const isFieldExprAccessor = (
+  accessor: unknown
+): accessor is FieldExprWire | FieldExpr =>
+  accessor instanceof FieldExpr ||
+  (accessor !== null &&
+    typeof accessor === "object" &&
+    (accessor as any).type === "field");
+
+/**
+ * Resolve a label's display text for one datum.
+ *
+ * - Function accessor: call it directly — the raw, non-serializable escape
+ *   hatch. Unchanged behavior.
+ * - Field-expression accessor (`field(name).sum()`/`.mean()`/etc., or its
+ *   wire form): evaluate the aggregate over the datum's rows via
+ *   `evalFieldValues`. A scalar (non-array) datum is treated as a single-row
+ *   group (wrapped as `[datum]`).
+ * - Bare string accessor over an ARRAY datum (the group-label case, e.g. a
+ *   spread/stack group): the field must be constant across the group's rows
+ *   (this is always true for a `by`-field, by construction). If it isn't,
+ *   this is a user-spec error and throws loudly rather than silently reading
+ *   just the first row.
+ * - Bare string accessor over a scalar datum: read the field directly off it,
+ *   unchanged.
+ * - Null/undefined datum: "" unchanged.
+ */
 export function resolveLabelText(accessor: LabelAccessor, datum: any): string {
   if (typeof accessor === "function") return String(accessor(datum) ?? "");
   if (datum == null) return "";
-  const obj = Array.isArray(datum) ? datum[0] : datum;
-  return obj?.[accessor] != null ? String(obj[accessor]) : "";
+
+  if (isFieldExprAccessor(accessor)) {
+    const rows: any[] = Array.isArray(datum) ? datum : [datum];
+    const { values } = evalFieldValues(accessor, rows);
+    return values[0] != null ? String(values[0]) : "";
+  }
+
+  if (Array.isArray(datum)) {
+    if (datum.length === 0) return "";
+    const values = datum.map((row) => row?.[accessor]);
+    const first = values[0];
+    const homogeneous = values.every((v) => v === first);
+    if (!homogeneous) {
+      throw new Error(
+        `[gofish] .label("${accessor}"): field is not constant within the ` +
+          `group; use an aggregate like field("${accessor}").mean()`
+      );
+    }
+    return first != null ? String(first) : "";
+  }
+
+  return datum?.[accessor] != null ? String(datum[accessor]) : "";
 }
 
 export type LabelSide = "inset" | "outset";

--- a/packages/gofish-graphics/src/ast/labels/labelPlacement.ts
+++ b/packages/gofish-graphics/src/ast/labels/labelPlacement.ts
@@ -56,7 +56,18 @@ export function resolveLabelText(accessor: LabelAccessor, datum: any): string {
   if (isFieldExprAccessor(accessor)) {
     const rows: any[] = Array.isArray(datum) ? datum : [datum];
     const { values } = evalFieldValues(accessor, rows);
-    return values[0] != null ? String(values[0]) : "";
+    // Without an aggregate op, evalFieldValues returns one value per row;
+    // hold that to the same group-constant rule as a bare string accessor so
+    // `.label(field("age"))` can't silently read just the first row.
+    const first = values[0];
+    if (values.length > 1 && !values.every((v) => v === first)) {
+      throw new Error(
+        `[gofish] .label(field("${accessor.name}")): field is not constant ` +
+          `within the group; use an aggregate like ` +
+          `field("${accessor.name}").mean()`
+      );
+    }
+    return first != null ? String(first) : "";
   }
 
   if (Array.isArray(datum)) {

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -104,15 +104,15 @@ export const normalize = <T, K extends keyof T>(
   }));
 };
 
-export function log<T>(label?: string): Operator<T, T> {
+export function log<T>(prefix?: string): Operator<T, T> {
   const op: Operator<T, T> = async (mark: Mark<T>) => {
     return (async (
       d: T,
       key?: string | number,
       layerContext?: LayerContext
     ) => {
-      if (label) {
-        console.log(label, d);
+      if (prefix) {
+        console.log(prefix, d);
       } else {
         console.log(d);
       }
@@ -121,7 +121,7 @@ export function log<T>(label?: string): Operator<T, T> {
   };
   (op as any).__serialize = {
     type: "log",
-    opts: label !== undefined ? { label } : {},
+    opts: prefix !== undefined ? { prefix } : {},
   };
   return op;
 }

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -317,6 +317,39 @@ export const nameModifier = createModifier<[layerName: string | symbol]>({
   },
 });
 
+/**
+ * Compute the IR-serializable form of a `.label(accessor, options)` call, or
+ * `undefined` when the accessor can't round-trip. Shared by the mark-side
+ * `labelModifier` and the operator-form `.label()` (createOperator's `dual`)
+ * so both surfaces warn identically on a function accessor.
+ */
+function labelIRField(
+  accessor: LabelAccessor,
+  options?: LabelOptions
+): Record<string, unknown> | undefined {
+  if (typeof accessor === "string") {
+    return {
+      accessor,
+      ...(options && typeof options === "object" ? options : {}),
+    };
+  }
+  if (
+    typeof accessor === "function" &&
+    typeof console !== "undefined" &&
+    typeof console.warn === "function"
+  ) {
+    // Function accessors can't be JSON-serialized. The caller stays
+    // serializable (the rest of the tag propagates) but the label is
+    // dropped from the emitted IR. Matches `dataToIR`'s warn precedent.
+    console.warn(
+      "[gofish-ir] .label(fn): function accessors aren't serializable; " +
+        "label will be omitted from the emitted IR. Use a string field " +
+        "name if you need the label to round-trip."
+    );
+  }
+  return undefined;
+}
+
 /** `.label(accessor, options?)` — defers label placement on each node. */
 export const labelModifier = createModifier<
   [accessor: LabelAccessor, options?: LabelOptions]
@@ -327,25 +360,8 @@ export const labelModifier = createModifier<
   },
   tag: (wrapped, base, accessor, options) => {
     propagateSerialize(base, wrapped, (tag) => {
-      if (typeof accessor === "string") {
-        tag.label = {
-          accessor,
-          ...(options && typeof options === "object" ? options : {}),
-        };
-      } else if (
-        typeof accessor === "function" &&
-        typeof console !== "undefined" &&
-        typeof console.warn === "function"
-      ) {
-        // Function accessors can't be JSON-serialized. The mark stays
-        // serializable (the rest of the tag propagates) but the label is
-        // dropped from the emitted IR. Matches `dataToIR`'s warn precedent.
-        console.warn(
-          "[gofish-ir] .label(fn): function accessors aren't serializable; " +
-            "label will be omitted from the emitted IR. Use a string field " +
-            "name if you need the label to round-trip."
-        );
-      }
+      const field = labelIRField(accessor, options);
+      if (field) tag.label = field;
     });
   },
 });
@@ -571,6 +587,10 @@ export type DualModeOperator<Datum, Options> = {
 
 export type TranslatableOperator<T, U> = Operator<T, U> & {
   translate(opts: TranslateModifierOptions): TranslatableOperator<T, U>;
+  label(
+    accessor: LabelAccessor,
+    options?: LabelOptions
+  ): TranslatableOperator<T, U>;
 };
 
 function attachTranslateOption<T extends object>(
@@ -585,6 +605,28 @@ function attachTranslateOption<T extends object>(
   return target;
 }
 
+/**
+ * Attach `.label(accessor, options?)` to an operator (traversal form).
+ * `setLabel` is the mutation the executing operator's closure consults —
+ * see `dual`'s operator branch, where a `let labelState` (read at execution
+ * time, once per `.flow()` run) is stamped onto each per-leaf node alongside
+ * `node.datum ??= leaf`. Returns `target` so the call chains like `.translate`.
+ */
+function attachLabelOption<T extends object>(
+  target: T,
+  setLabel: (accessor: LabelAccessor, options?: LabelOptions) => void
+): T {
+  Object.defineProperty(target, "label", {
+    value: (accessor: LabelAccessor, options?: LabelOptions) => {
+      setLabel(accessor, options);
+      return target;
+    },
+    writable: true,
+    configurable: true,
+  });
+  return target;
+}
+
 function translateOperator<T, U>(
   operator: Operator<T, U>,
   opts: TranslateModifierOptions
@@ -593,9 +635,19 @@ function translateOperator<T, U>(
     const arranged = await operator(mark);
     return translateMark(arranged, opts) as Mark<T>;
   };
-  return attachTranslateOption(translated, (next) =>
+  const withTranslate = attachTranslateOption(translated, (next) =>
     translateOperator(translated, next)
   ) as TranslatableOperator<T, U>;
+  // Delegate `.label()` to the base operator's own setter so the pending-
+  // label state (closed over inside the base operator's execution closure)
+  // stays shared no matter which chain order produced this wrapper —
+  // `.translate().label()` and `.label().translate()` both land here.
+  if (typeof (operator as any).label === "function") {
+    attachLabelOption(withTranslate, (accessor, options) => {
+      (operator as any).label(accessor, options);
+    });
+  }
+  return withTranslate;
 }
 
 /**
@@ -826,6 +878,13 @@ export function createOperator<Datum, Options extends Record<string, any>>(
       return combinator;
     }
     // Operator (traversal) form: split d, apply mark per leaf, layout.
+    // `.label(accessor, options?)` is chained AFTER `dual(opts)` returns, so
+    // the pending state lives in this closed-over `let` and is read fresh
+    // each time the operator executes (once per `.flow()` run) — see the
+    // per-leaf stamp below and `setLabel`/`attachLabelOption` at the bottom.
+    let labelState:
+      | { accessor: LabelAccessor; options?: LabelOptions }
+      | undefined;
     const operator: Operator<Datum[], Datum[]> = async (mark) => {
       return (async (
         d: Datum[],
@@ -915,6 +974,20 @@ export function createOperator<Datum, Options extends Record<string, any>>(
                 }
               }
             }
+            // `.label(accessor, options)` chained on this operator: stamp
+            // every node this leaf produced with the leaf's own subdata (so
+            // `resolveLabels`'s "a node with datum keeps its own label" gate
+            // fires — mirrors the manual LabelOnSpread workaround) and defer
+            // placement via `node.label`. A string accessor reads off the
+            // group's first row (`resolveLabelText`'s existing unwrap); a
+            // function accessor receives the whole leaf, enabling aggregate
+            // labels (e.g. `(rows) => rows.length`).
+            if (labelState) {
+              for (const node of leafNodes) {
+                if (node.datum === undefined) node.datum = leaf;
+                node.label(labelState.accessor, labelState.options);
+              }
+            }
             return leafNodes;
           })
         );
@@ -948,9 +1021,19 @@ export function createOperator<Datum, Options extends Record<string, any>>(
         opts: payload,
       };
     }
-    return attachTranslateOption(operator, (translateOpts) =>
+    const withTranslate = attachTranslateOption(operator, (translateOpts) =>
       translateOperator(operator, translateOpts)
     ) as TranslatableOperator<Datum[], Datum[]>;
+    attachLabelOption(withTranslate, (accessor, options) => {
+      labelState = { accessor, options };
+      const tag = (operator as any).__serialize;
+      if (tag) {
+        const field = labelIRField(accessor, options);
+        if (field) tag.label = field;
+        else delete tag.label;
+      }
+    });
+    return withTranslate;
   }
   return dual as DualModeOperator<Datum, Options>;
 }

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -635,6 +635,16 @@ function translateOperator<T, U>(
     const arranged = await operator(mark);
     return translateMark(arranged, opts) as Mark<T>;
   };
+  // `translated` is a NEW function object wrapping `operator`, so it starts
+  // with no `__serialize` tag of its own. Without copying the base
+  // operator's tag forward (and stamping `translate`), `operatorToIR`'s
+  // `readTag` would find nothing here and silently fall back to the opaque
+  // `{type: "derive"}` IR — losing both `.translate()` and any chained
+  // `.label()` from the wire.
+  const baseTag = (operator as any).__serialize;
+  if (baseTag) {
+    (translated as any).__serialize = { ...baseTag, translate: opts };
+  }
   const withTranslate = attachTranslateOption(translated, (next) =>
     translateOperator(translated, next)
   ) as TranslatableOperator<T, U>;
@@ -645,6 +655,12 @@ function translateOperator<T, U>(
   if (typeof (operator as any).label === "function") {
     attachLabelOption(withTranslate, (accessor, options) => {
       (operator as any).label(accessor, options);
+      const tag = (translated as any).__serialize;
+      if (tag) {
+        const field = labelIRField(accessor, options);
+        if (field) tag.label = field;
+        else delete tag.label;
+      }
     });
   }
   return withTranslate;

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -46,7 +46,7 @@ import {
   hasNormalizeOp,
   splitAtNormalize,
   applyEntryNormalize,
-  type FieldExpr,
+  FieldExpr,
 } from "../fieldExpr";
 import type { LabelAccessor, LabelOptions } from "../labels/labelPlacement";
 import type { NameableMark } from "../withGoFish";
@@ -330,6 +330,18 @@ function labelIRField(
   if (typeof accessor === "string") {
     return {
       accessor,
+      ...(options && typeof options === "object" ? options : {}),
+    };
+  }
+  if (
+    accessor instanceof FieldExpr ||
+    (accessor !== null &&
+      typeof accessor === "object" &&
+      (accessor as any).type === "field")
+  ) {
+    const wire = accessor instanceof FieldExpr ? accessor.toJSON() : accessor;
+    return {
+      accessor: wire,
       ...(options && typeof options === "object" ? options : {}),
     };
   }
@@ -994,10 +1006,12 @@ export function createOperator<Datum, Options extends Record<string, any>>(
             // every node this leaf produced with the leaf's own subdata (so
             // `resolveLabels`'s "a node with datum keeps its own label" gate
             // fires — mirrors the manual LabelOnSpread workaround) and defer
-            // placement via `node.label`. A string accessor reads off the
-            // group's first row (`resolveLabelText`'s existing unwrap); a
-            // function accessor receives the whole leaf, enabling aggregate
-            // labels (e.g. `(rows) => rows.length`).
+            // placement via `node.label`. A string accessor must be constant
+            // across the group's rows (true by construction for a `by`-field —
+            // `resolveLabelText` throws otherwise); a `field(...)` aggregate
+            // accessor (e.g. `field("count").sum()`) folds the group's rows to
+            // one value; a function accessor receives the whole leaf, enabling
+            // arbitrary aggregate labels (e.g. `(rows) => rows.length`).
             if (labelState) {
               for (const node of leafNodes) {
                 if (node.datum === undefined) node.datum = leaf;

--- a/packages/gofish-graphics/src/serialize/fromJSON.ts
+++ b/packages/gofish-graphics/src/serialize/fromJSON.ts
@@ -257,18 +257,10 @@ export function mapOperator(
   const { type, translate, label, ...opts } = op as Record<string, any>;
   const factory = OPERATOR_MAP[type as string];
   if (!factory) return null;
-  // `log`'s own `label` field (a plain string console prefix) rides in
-  // `opts` and must reach its factory unchanged — only re-add it there;
-  // every other operator's `label` is the `.label(accessor, options?)`
-  // chain (LabelIR shape), handled below via the operator's own method.
-  let operator =
-    type === "log"
-      ? factory({ ...opts, label }, bridge)
-      : factory(opts, bridge);
+  let operator = factory(opts, bridge);
   if (
     operator &&
     label !== undefined &&
-    type !== "log" &&
     typeof (operator as any).label === "function"
   ) {
     const { accessor, ...labelOpts } = label as { accessor: any } & Record<

--- a/packages/gofish-graphics/src/serialize/fromJSON.ts
+++ b/packages/gofish-graphics/src/serialize/fromJSON.ts
@@ -254,10 +254,32 @@ export function mapOperator(
   op: OperatorSpec,
   bridge?: DeriveBridge
 ): Operator<any, any> | null {
-  const { type, translate, ...opts } = op as Record<string, any>;
+  const { type, translate, label, ...opts } = op as Record<string, any>;
   const factory = OPERATOR_MAP[type as string];
   if (!factory) return null;
-  const operator = factory(opts, bridge);
+  // `log`'s own `label` field (a plain string console prefix) rides in
+  // `opts` and must reach its factory unchanged — only re-add it there;
+  // every other operator's `label` is the `.label(accessor, options?)`
+  // chain (LabelIR shape), handled below via the operator's own method.
+  let operator =
+    type === "log"
+      ? factory({ ...opts, label }, bridge)
+      : factory(opts, bridge);
+  if (
+    operator &&
+    label !== undefined &&
+    type !== "log" &&
+    typeof (operator as any).label === "function"
+  ) {
+    const { accessor, ...labelOpts } = label as { accessor: any } & Record<
+      string,
+      any
+    >;
+    operator = (operator as any).label(
+      accessor,
+      Object.keys(labelOpts).length > 0 ? labelOpts : undefined
+    );
+  }
   if (
     operator &&
     translate &&

--- a/packages/gofish-graphics/src/serialize/registry.ts
+++ b/packages/gofish-graphics/src/serialize/registry.ts
@@ -209,7 +209,7 @@ export const OPERATOR_MAP: Record<
   scatter: (opts) => scatter(opts as any),
   table: (opts) => table(opts as any),
   treemap: (opts) => treemapOperator(opts as any),
-  log: (opts) => log(opts.label),
+  log: (opts) => log(opts.prefix),
 };
 
 /**

--- a/packages/gofish-graphics/src/serialize/toJSON.ts
+++ b/packages/gofish-graphics/src/serialize/toJSON.ts
@@ -35,8 +35,15 @@ interface SerializeTag {
   children?: Mark<any>[] | Promise<Mark<any>[]>;
   /** Set when `.name(layerName)` is chained on a mark. Strings pass through; Tokens become bridge-style sentinels. */
   name?: string | { __gofish_token: string; __tag: string };
-  /** Set when `.label(accessor, options)` is chained on a mark (object form). */
+  /** Set when `.label(accessor, options)` is chained on a mark (object form),
+   *  or on an operator's traversal form (createOperator.ts's `translateOperator`
+   *  / bottom-of-`dual` attachment). */
   label?: { accessor: string; [k: string]: unknown };
+  /** Set when `.translate({x, y})` is chained on an operator (traversal
+   *  form) — `translateOperator` copies the base operator's tag forward onto
+   *  its wrapper and stamps this field so the structural pixel offset
+   *  reaches the wire (mirrors `TranslatableIR.translate` in gofish-ir). */
+  translate?: { x?: number; y?: number };
 }
 
 function readTag(value: unknown): SerializeTag | undefined {
@@ -202,14 +209,16 @@ function operatorToIR(op: Operator<any, any>): Frontend.OperatorIR {
     // represents these as `{ type: "derive" }`.
     return { type: "derive" } as Frontend.DeriveOperator;
   }
-  // `.label(accessor, options)` chained on the operator (traversal) form
-  // lands in `tag.label`, mirroring how a chained mark `.label()` surfaces
-  // as a top-level field in `markToIR` — see createOperator.ts's
-  // `attachLabelOption`.
+  // `.label(accessor, options)` / `.translate({x, y})` chained on the
+  // operator (traversal) form land in `tag.label` / `tag.translate`,
+  // mirroring how a chained mark `.label()` surfaces as a top-level field in
+  // `markToIR` — see createOperator.ts's `attachLabelOption` /
+  // `translateOperator`.
   return {
     type: tag.type,
     ...tag.opts,
     ...(tag.label !== undefined ? { label: tag.label } : {}),
+    ...(tag.translate !== undefined ? { translate: tag.translate } : {}),
   } as Frontend.OperatorIR;
 }
 

--- a/packages/gofish-graphics/src/serialize/toJSON.ts
+++ b/packages/gofish-graphics/src/serialize/toJSON.ts
@@ -202,7 +202,15 @@ function operatorToIR(op: Operator<any, any>): Frontend.OperatorIR {
     // represents these as `{ type: "derive" }`.
     return { type: "derive" } as Frontend.DeriveOperator;
   }
-  return { type: tag.type, ...tag.opts } as Frontend.OperatorIR;
+  // `.label(accessor, options)` chained on the operator (traversal) form
+  // lands in `tag.label`, mirroring how a chained mark `.label()` surfaces
+  // as a top-level field in `markToIR` — see createOperator.ts's
+  // `attachLabelOption`.
+  return {
+    type: tag.type,
+    ...tag.opts,
+    ...(tag.label !== undefined ? { label: tag.label } : {}),
+  } as Frontend.OperatorIR;
 }
 
 async function markToIR(mark: Mark<any>): Promise<Frontend.MarkIR> {

--- a/packages/gofish-graphics/src/serialize/toJSON.ts
+++ b/packages/gofish-graphics/src/serialize/toJSON.ts
@@ -37,8 +37,10 @@ interface SerializeTag {
   name?: string | { __gofish_token: string; __tag: string };
   /** Set when `.label(accessor, options)` is chained on a mark (object form),
    *  or on an operator's traversal form (createOperator.ts's `translateOperator`
-   *  / bottom-of-`dual` attachment). */
-  label?: { accessor: string; [k: string]: unknown };
+   *  / bottom-of-`dual` attachment). `accessor` is a bare field name or a
+   *  `field(...)` aggregate's serialized `FieldExprWire` (`{type: "field", ...}`)
+   *  — see `labelIRField` in createOperator.ts. */
+  label?: { accessor: string | AnyObject; [k: string]: unknown };
   /** Set when `.translate({x, y})` is chained on an operator (traversal
    *  form) — `translateOperator` copies the base operator's tag forward onto
    *  its wrapper and stamps this field so the structural pixel offset

--- a/packages/gofish-graphics/src/tests/serialize.test.ts
+++ b/packages/gofish-graphics/src/tests/serialize.test.ts
@@ -642,6 +642,23 @@ async function main() {
       "empty array datum resolves to empty string, no throw",
       resolveLabelText("lake", []) === ""
     );
+
+    // A field(...) accessor WITHOUT an aggregate op gets the same
+    // group-constant rule as a bare string — no first-row backdoor.
+    let fieldThrew = false;
+    try {
+      resolveLabelText(field("count").toJSON(), rows);
+    } catch (e) {
+      fieldThrew = true;
+    }
+    check(
+      "aggregate-less field accessor over heterogeneous rows throws",
+      fieldThrew
+    );
+    check(
+      "aggregate-less field accessor over homogeneous rows resolves",
+      resolveLabelText(field("lake").toJSON(), homogeneousRows) === "A"
+    );
   }
 
   // Round-trip after .name() — fromJSON should recreate the named mark.

--- a/packages/gofish-graphics/src/tests/serialize.test.ts
+++ b/packages/gofish-graphics/src/tests/serialize.test.ts
@@ -420,6 +420,112 @@ async function main() {
     );
   }
 
+  // -------------------------------------------------------------------------
+  // Chained .label() on operators (#702) — the traversal form used inside
+  // .flow(...), not the mark-level .label() tested above.
+  // -------------------------------------------------------------------------
+  console.log("\n# Chained .label() on operators survives toJSON (#702)");
+
+  const groupData = [
+    { lake: "A", species: "trout", count: 12 },
+    { lake: "A", species: "bass", count: 8 },
+    { lake: "B", species: "trout", count: 5 },
+  ];
+
+  // String accessor: appears in the emitted IR and survives fromJSON.
+  {
+    check(
+      ".label exists on stack(...) operator",
+      typeof stack({ by: "lake", dir: "x" }).label === "function"
+    );
+    check(
+      ".label exists on spread(...) operator",
+      typeof spread({ by: "lake", dir: "x" }).label === "function"
+    );
+
+    const built = chart(groupData)
+      .flow(
+        stack({ by: "lake", dir: "x" }).label("lake", {
+          position: "outset-top",
+        })
+      )
+      .mark(rect({ h: "count", fill: "species" }));
+    const doc = await built.toJSON();
+    validateDoc(doc, "chart with chained operator .label()");
+    const op = (doc.root as Frontend.ChartIR).operators![0] as any;
+    check("operator .label() preserved as object", typeof op.label === "object");
+    check("operator .label() accessor preserved", op.label?.accessor === "lake");
+    check(
+      "operator .label() options preserved",
+      op.label?.position === "outset-top"
+    );
+
+    const rebuilt = Serialize.buildChart(
+      doc.root,
+      groupData,
+      undefined,
+      Serialize.makeTokenResolver()
+    );
+    const doc2 = await rebuilt.toJSON();
+    const op2 = (doc2.root as Frontend.ChartIR).operators![0] as any;
+    check(
+      "round-trip preserves operator .label()",
+      op2.label?.accessor === "lake" && op2.label?.position === "outset-top"
+    );
+  }
+
+  // Function accessor: warns and is omitted from the emitted IR.
+  {
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+    let op: any;
+    try {
+      const built = chart(groupData)
+        .flow(spread({ by: "lake", dir: "x" }).label((d: any) => d[0]?.lake))
+        .mark(rect({ h: "count" }));
+      const doc = await built.toJSON();
+      op = (doc.root as Frontend.ChartIR).operators![0] as any;
+    } finally {
+      console.warn = originalWarn;
+    }
+    check(
+      "function accessor on operator .label() warns",
+      warnings.length === 1 && /function accessors aren't serializable/.test(
+        String(warnings[0]?.[0])
+      )
+    );
+    check("function accessor omitted from operator IR", op.label === undefined);
+  }
+
+  // `.translate().label()` and `.label().translate()` both serialize both
+  // fields, regardless of chain order (createOperator.ts's translateOperator
+  // delegates .label() back to the base operator's own setter).
+  {
+    const translateThenLabel = scatter({ by: "lake", x: "count" })
+      .translate({ y: 5 })
+      .label("lake");
+    const labelThenTranslate = scatter({ by: "lake", x: "count" })
+      .label("lake")
+      .translate({ y: 5 });
+
+    for (const [name, op] of [
+      ["translate().label()", translateThenLabel],
+      ["label().translate()", labelThenTranslate],
+    ] as const) {
+      const built = chart(groupData).flow(op).mark(rect({ h: "count" }));
+      const doc = await built.toJSON();
+      const opIR = (doc.root as Frontend.ChartIR).operators![0] as any;
+      check(
+        `${name} serializes translate`,
+        opIR.translate?.y === 5
+      );
+      check(`${name} serializes label`, opIR.label?.accessor === "lake");
+    }
+  }
+
   // Round-trip after .name() — fromJSON should recreate the named mark.
   {
     const built = chart([{ a: 1 }]).mark(

--- a/packages/gofish-graphics/src/tests/serialize.test.ts
+++ b/packages/gofish-graphics/src/tests/serialize.test.ts
@@ -235,7 +235,7 @@ async function main() {
   }
 
   // -------------------------------------------------------------------------
-  // Log operator with a label.
+  // Log operator with a prefix.
   // -------------------------------------------------------------------------
   {
     const c = chart([{ a: 1 }])
@@ -245,7 +245,7 @@ async function main() {
     validateDoc(doc, "log chart");
     const ops = (doc.root as Frontend.ChartIR).operators!;
     check("log operator", ops[0].type === "log");
-    check("log label preserved", (ops[0] as any).label === "debug-label");
+    check("log prefix preserved", (ops[0] as any).prefix === "debug-label");
   }
 
   // -------------------------------------------------------------------------

--- a/packages/gofish-graphics/src/tests/serialize.test.ts
+++ b/packages/gofish-graphics/src/tests/serialize.test.ts
@@ -10,6 +10,7 @@
  */
 
 import { Frontend } from "gofish-ir";
+import { resolveLabelText } from "../ast/labels/labelPlacement";
 // Import from the built dist rather than source: lodash's named exports
 // don't survive Node ESM resolution without bundling, but the Vite-built
 // dist has them inlined. Run `pnpm build` first.
@@ -524,6 +525,123 @@ async function main() {
       );
       check(`${name} serializes label`, opIR.label?.accessor === "lake");
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // Field-expression accessor on .label() (group-total aggregate labels) —
+  // the redesign that replaced silently reading a group's first row.
+  // -------------------------------------------------------------------------
+  console.log("\n# field(...) aggregate accessor on .label() survives toJSON");
+
+  // Mark-level .label(field(...).sum())
+  {
+    const built = chart(groupData)
+      .flow(stack({ by: "lake", dir: "x" }))
+      .mark(rect({ h: "count" }).label(field("count").sum()));
+    const doc = await built.toJSON();
+    validateDoc(doc, "chart with mark field-expr .label()");
+    const mark = (doc.root as Frontend.ChartIR).mark as any;
+    check(
+      "mark field-expr .label() accessor serialized as wire object",
+      mark.label?.accessor?.type === "field" &&
+        mark.label?.accessor?.name === "count" &&
+        mark.label?.accessor?.ops?.[0]?.op === "sum"
+    );
+
+    const rebuilt = Serialize.buildChart(
+      doc.root,
+      groupData,
+      undefined,
+      Serialize.makeTokenResolver()
+    );
+    const doc2 = await rebuilt.toJSON();
+    const mark2 = (doc2.root as Frontend.ChartIR).mark as any;
+    check(
+      "round-trip preserves mark field-expr .label()",
+      mark2.label?.accessor?.type === "field" &&
+        mark2.label?.accessor?.name === "count" &&
+        mark2.label?.accessor?.ops?.[0]?.op === "sum"
+    );
+  }
+
+  // Operator-level .label(field(...).sum())
+  {
+    const built = chart(groupData)
+      .flow(stack({ by: "lake", dir: "x" }).label(field("count").sum()))
+      .mark(rect({ h: "count" }));
+    const doc = await built.toJSON();
+    validateDoc(doc, "chart with operator field-expr .label()");
+    const op = (doc.root as Frontend.ChartIR).operators![0] as any;
+    check(
+      "operator field-expr .label() accessor serialized as wire object",
+      op.label?.accessor?.type === "field" &&
+        op.label?.accessor?.name === "count" &&
+        op.label?.accessor?.ops?.[0]?.op === "sum"
+    );
+
+    const rebuilt = Serialize.buildChart(
+      doc.root,
+      groupData,
+      undefined,
+      Serialize.makeTokenResolver()
+    );
+    const doc2 = await rebuilt.toJSON();
+    const op2 = (doc2.root as Frontend.ChartIR).operators![0] as any;
+    check(
+      "round-trip preserves operator field-expr .label()",
+      op2.label?.accessor?.type === "field" &&
+        op2.label?.accessor?.name === "count" &&
+        op2.label?.accessor?.ops?.[0]?.op === "sum"
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // resolveLabelText: heterogeneous bare-string accessor over an array datum
+  // throws loudly instead of silently reading the first row.
+  // -------------------------------------------------------------------------
+  console.log("\n# resolveLabelText homogeneity check");
+  {
+    const rows = [
+      { lake: "A", count: 12 },
+      { lake: "A", count: 8 },
+      { lake: "B", count: 5 },
+    ];
+    let threw = false;
+    let message = "";
+    try {
+      resolveLabelText("lake", rows);
+    } catch (e) {
+      threw = true;
+      message = String((e as Error).message);
+    }
+    check(
+      "heterogeneous bare-string accessor over an array datum throws",
+      threw && message.includes("lake")
+    );
+
+    // Homogeneous case (a real `by`-field) still resolves normally.
+    const homogeneousRows = rows.filter((r) => r.lake === "A");
+    check(
+      "homogeneous bare-string accessor over an array datum resolves",
+      resolveLabelText("lake", homogeneousRows) === "A"
+    );
+
+    // An aggregate accessor over the same heterogeneous rows works fine.
+    // (`.toJSON()` here — `field` comes from the built dist bundle in this
+    // test file, a different module instance than the `FieldExpr` class
+    // `resolveLabelText` imports from source, so `instanceof` wouldn't
+    // match; the wire form is what real cross-boundary accessors look like
+    // anyway, e.g. after a JSON round-trip through fromJSON.)
+    check(
+      "field(...).sum() over a heterogeneous array datum resolves",
+      resolveLabelText(field("count").sum().toJSON(), rows) === "25"
+    );
+
+    // Empty array does not throw — no rows, no label.
+    check(
+      "empty array datum resolves to empty string, no throw",
+      resolveLabelText("lake", []) === ""
+    );
   }
 
   // Round-trip after .name() — fromJSON should recreate the named mark.

--- a/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
@@ -41,7 +41,7 @@ export const Default: StoryObj<Args> = {
     const container = initializeContainer();
     chart(seafood, { axes: true })
       .flow(spread({ by: "lake",  dir: "x" }))
-      .mark(rect({ h: "count" }).label("count"))
+      .mark(rect({ h: "count" }).label(field("count").sum()))
       .render(container, { w: args.w, h: args.h });
     return container;
   },
@@ -88,7 +88,7 @@ export const Above: StoryObj<Args> = {
     const container = initializeContainer();
     chart(seafood, { axes: true })
       .flow(spread({ by: "lake",  dir: "x" }))
-      .mark(rect({ h: "count" }).label("count", { position: "outset" }))
+      .mark(rect({ h: "count" }).label(field("count").sum(), { position: "outset" }))
       .render(container, { w: args.w, h: args.h });
     return container;
   },
@@ -153,7 +153,7 @@ export const Right: StoryObj<Args> = {
     const container = initializeContainer();
     chart(seafood, { axes: true })
       .flow(spread({ by: "lake",  dir: "y" }))
-      .mark(rect({ w: "count" }).label("count", { position: "outset-right", offset: 15 }))
+      .mark(rect({ w: "count" }).label(field("count").sum(), { position: "outset-right", offset: 15 }))
       .render(container, { w: args.w, h: args.h });
     return container;
   },
@@ -258,7 +258,7 @@ export const AllPositions: StoryObj<{ w: number; h: number }> = {
 
       chart(seafood, { axes: false })
         .flow(spread({ by: "lake",  dir: "x" }))
-        .mark(rect({ h: "count" }).label("count", { position: pos, fontSize: 9 }))
+        .mark(rect({ h: "count" }).label(field("count").sum(), { position: pos, fontSize: 9 }))
         .render(container, { w: args.w, h: args.h });
     }
 
@@ -271,7 +271,9 @@ export const AllPositions: StoryObj<{ w: number; h: number }> = {
 // split leaf (a lake's rows) gets its produced node stamped with the leaf's
 // own subdata and a deferred label — resolveLabels then keeps the label at
 // the group level instead of propagating it down to each species bar.
-// Result: one label per lake group, centred above the pair of bars.
+// Result: one label per lake group, centred above the pair of bars. `"lake"`
+// is constant across every row in the group (it's the `by` field itself), so
+// the bare-string accessor just works — no aggregate needed.
 
 export const LabelOnSpread: StoryObj<Args> = {
   name: "Label on Spread",
@@ -301,8 +303,10 @@ export const LabelOnSpread: StoryObj<Args> = {
 // ─── Label on stack (per-group label, #702) ───────────────────────────────────
 // `.label(accessor)` chained directly on a `stack({by, dir})` operator: each
 // class's leaf produces one rect, stamped with that leaf's own rows and a
-// deferred label reading `pclass` off the group's first row — one label per
-// stacked segment, no manual datum-stamping workaround needed.
+// deferred label reading `pclass` off the group's rows — one label per
+// stacked segment, no manual datum-stamping workaround needed. `"pclass"` is
+// constant across every row in the group (it's the `by` field itself), so
+// the bare-string accessor just works — no aggregate needed.
 
 export const LabelOnStackOperator: StoryObj<Args> = {
   name: "Label on Stack operator (per-group)",
@@ -312,6 +316,32 @@ export const LabelOnStackOperator: StoryObj<Args> = {
     chart(titanicPassengers, { axes: false })
       .flow(
         stack({ by: "pclass", dir: "y" }).label("pclass", {
+          position: "center",
+          fontSize: 14,
+          color: "white",
+        })
+      )
+      .mark(rect({ w: 120, h: field("survived").count() }))
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  }
+};
+
+// ─── Label on stack (group-total aggregate label, #702 redesign) ─────────────
+// `.label(field("count").sum())` chained directly on a `stack({by, dir})`
+// operator: the accessor is a `field(...)` aggregate, not a bare field name,
+// so it folds each group's rows to their SUM rather than requiring the field
+// to be constant across the group. One label per stacked class, showing the
+// class's total passenger count (not any single row's value).
+
+export const LabelOnStackAggregate: StoryObj<Args> = {
+  name: "Label on Stack operator (group total)",
+  args: { w: 260, h: 300 },
+  render: (args) => {
+    const container = initializeContainer();
+    chart(titanicPassengers, { axes: false })
+      .flow(
+        stack({ by: "pclass", dir: "y" }).label(field("survived").count(), {
           position: "center",
           fontSize: 14,
           color: "white",
@@ -398,7 +428,7 @@ export const Rotated: StoryObj<Args> = {
       chart(seafood, { axes: true })
         .flow(spread({ by: "lake",  dir: "x" }))
         .mark(
-          rect({ h: "count" }).label("count", { position: "outset-top", rotate })
+          rect({ h: "count" }).label(field("count").sum(), { position: "outset-top", rotate })
         )
         .render(container, { w: args.w, h: args.h });
     }

--- a/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
@@ -18,6 +18,7 @@ import {
   type LabelPosition,
 } from "../../src/ast/labels/labelPlacement";
 import data from "vega-datasets";
+import { titanicPassengers } from "../../src/data/titanicPassengers";
 
 const meta: Meta = {
   title: "Forward Syntax V3/Labels",
@@ -266,9 +267,10 @@ export const AllPositions: StoryObj<{ w: number; h: number }> = {
 };
 
 // ─── Label on spread (group label) ────────────────────────────────────────────
-// The label is on the spread combinator, not on individual marks.
-// Because the spread carries its own datum, resolveLabels keeps the label
-// at the group level instead of propagating it down to each child rect.
+// `.label(accessor, options?)` chained on the operator (not the mark): each
+// split leaf (a lake's rows) gets its produced node stamped with the leaf's
+// own subdata and a deferred label — resolveLabels then keeps the label at
+// the group level instead of propagating it down to each species bar.
 // Result: one label per lake group, centred above the pair of bars.
 
 export const LabelOnSpread: StoryObj<Args> = {
@@ -277,18 +279,45 @@ export const LabelOnSpread: StoryObj<Args> = {
   render: (args) => {
     const container = initializeContainer();
     chart(seafood, { axes: false })
-      .flow(spread({ by: "lake",  dir: "x", spacing: 50 }))
+      .flow(
+        spread({ by: "lake", dir: "x", spacing: 50 }).label("lake", {
+          position: "outset-top-start",
+          fontSize: 13,
+          offset: 50,
+          rotate: 60,
+        })
+      )
       .mark(async (d: any) => {
-        const node = await chart(d)
-          .flow(stack({ by: "species",  dir: "x" }))
+        return chart(d)
+          .flow(stack({ by: "species", dir: "x" }))
           .mark(rect({ h: "count" as any, fill: "species" as any }))
           .resolve();
-        // Stamp datum so resolveLabels keeps the label at group level
-        // instead of propagating it down to each species bar
-        (node as any).datum = d[0];
-        node.label("lake", { position: "outset-top-start", fontSize: 13, offset: 50, rotate: 60 });
-        return node;
       })
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  }
+};
+
+// ─── Label on stack (per-group label, #702) ───────────────────────────────────
+// `.label(accessor)` chained directly on a `stack({by, dir})` operator: each
+// class's leaf produces one rect, stamped with that leaf's own rows and a
+// deferred label reading `pclass` off the group's first row — one label per
+// stacked segment, no manual datum-stamping workaround needed.
+
+export const LabelOnStackOperator: StoryObj<Args> = {
+  name: "Label on Stack operator (per-group)",
+  args: { w: 260, h: 300 },
+  render: (args) => {
+    const container = initializeContainer();
+    chart(titanicPassengers, { axes: false })
+      .flow(
+        stack({ by: "pclass", dir: "y" }).label("pclass", {
+          position: "center",
+          fontSize: 14,
+          color: "white",
+        })
+      )
+      .mark(rect({ w: 120, h: field("survived").count() }))
       .render(container, { w: args.w, h: args.h });
     return container;
   }

--- a/packages/gofish-ir/src/frontend/descriptors.ts
+++ b/packages/gofish-ir/src/frontend/descriptors.ts
@@ -197,12 +197,9 @@ export const PY_LEAF_BASE_KWARGS: FieldGroup = group({
  *
  *  `label` is the `.label(accessor, options?)` chain (createOperator.ts's
  *  `attachLabelOption`) available on every dual-mode operator (spread/stack/
- *  group/scatter/table/treemap). `log` is the one operator descriptor that
- *  declares its OWN `label` field (a plain string console-prefix, unrelated
- *  to the chain — `log` isn't built via `createOperator` and never gets
- *  `.label()`); `walkOperator` in validate.ts merges base fields BEFORE the
- *  per-type descriptor's own fields so `log`'s own `label: string` entry
- *  wins there, matching its real wire shape. */
+ *  group/scatter/table/treemap). `log` doesn't carry this field at all — it
+ *  isn't built via `createOperator` and never gets `.label()`; its own
+ *  console-prefix option is the unrelated `prefix` field on `LogOperator`. */
 export const OPERATOR_BASE_FIELDS: FieldGroup = group({
   label: { type: t.ref("LabelIR") },
   translate: { type: t.ref("TranslateIR") },
@@ -448,9 +445,9 @@ export const OPERATORS: Record<string, ConstructDescriptor> = {
   }),
 
   log: operator("log", {
-    doc: "Debug pass-through: logs each row (optionally under `label`) and forwards it unchanged.",
+    doc: "Debug pass-through: logs each row (optionally under `prefix`) and forwards it unchanged.",
     fields: {
-      label: { type: t.string, doc: "Console label prefix." },
+      prefix: { type: t.string, doc: "Console prefix string." },
     },
   }),
 

--- a/packages/gofish-ir/src/frontend/descriptors.ts
+++ b/packages/gofish-ir/src/frontend/descriptors.ts
@@ -188,7 +188,7 @@ export const MARK_BASE_FIELDS: FieldGroup = group({
 export const PY_LEAF_BASE_KWARGS: FieldGroup = group({
   label: {
     type: t.union(t.boolean, t.string),
-    doc: "Value label: `True` for defaults or a field name (`.label()` shorthand).",
+    doc: "Value label: `True` for defaults or a field name (`.label()` shorthand). A field name is a bare string; it must be constant across a group's rows (errors otherwise) — an aggregate needs the explicit `.label(field(...).sum())` form instead.",
   },
   debug: MARK_BASE_FIELDS.debug,
 });
@@ -199,7 +199,11 @@ export const PY_LEAF_BASE_KWARGS: FieldGroup = group({
  *  `attachLabelOption`) available on every dual-mode operator (spread/stack/
  *  group/scatter/table/treemap). `log` doesn't carry this field at all — it
  *  isn't built via `createOperator` and never gets `.label()`; its own
- *  console-prefix option is the unrelated `prefix` field on `LogOperator`. */
+ *  console-prefix option is the unrelated `prefix` field on `LogOperator`.
+ *  The `accessor` a `LabelIR` object carries may be a bare string (must be
+ *  constant across the group's rows — true by construction for a `by`-field —
+ *  or it throws) or a `field(...)` aggregate (`.sum()`/`.mean()`/etc.) folding
+ *  the group's rows to one value, e.g. `.label(field("count").sum())`. */
 export const OPERATOR_BASE_FIELDS: FieldGroup = group({
   label: { type: t.ref("LabelIR") },
   translate: { type: t.ref("TranslateIR") },

--- a/packages/gofish-ir/src/frontend/descriptors.ts
+++ b/packages/gofish-ir/src/frontend/descriptors.ts
@@ -193,8 +193,18 @@ export const PY_LEAF_BASE_KWARGS: FieldGroup = group({
   debug: MARK_BASE_FIELDS.debug,
 });
 
-/** Every operator carries these (BaseIRNode + TranslatableIR in schema.ts). */
+/** Every operator carries these (BaseIRNode + TranslatableIR in schema.ts).
+ *
+ *  `label` is the `.label(accessor, options?)` chain (createOperator.ts's
+ *  `attachLabelOption`) available on every dual-mode operator (spread/stack/
+ *  group/scatter/table/treemap). `log` is the one operator descriptor that
+ *  declares its OWN `label` field (a plain string console-prefix, unrelated
+ *  to the chain — `log` isn't built via `createOperator` and never gets
+ *  `.label()`); `walkOperator` in validate.ts merges base fields BEFORE the
+ *  per-type descriptor's own fields so `log`'s own `label: string` entry
+ *  wins there, matching its real wire shape. */
 export const OPERATOR_BASE_FIELDS: FieldGroup = group({
+  label: { type: t.ref("LabelIR") },
   translate: { type: t.ref("TranslateIR") },
   debug: {
     type: t.boolean,

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -124,6 +124,11 @@ function buildOperatorDefs(): Record<string, unknown> {
       additionalProperties: true,
       properties: {
         type: { const: descriptor.type },
+        // Base `.label(accessor, options?)` chain (LabelIR), spread BEFORE
+        // the per-type `properties` so `log`'s own `label` (a plain string
+        // console prefix, unrelated to the chain) overrides it below —
+        // matches validate.ts's `walkOperator` merge order.
+        label: { $ref: "#/$defs/LabelIR" },
         ...properties,
         translate: { $ref: "#/$defs/Translate" },
         origin: { $ref: "#/$defs/Origin" },

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -605,7 +605,9 @@ export const FRONTEND_IR_JSON_SCHEMA = {
           type: "object",
           required: ["accessor"],
           properties: {
-            accessor: { type: "string" },
+            accessor: {
+              oneOf: [{ type: "string" }, { $ref: "#/$defs/FieldAccessor" }],
+            },
             position: { type: "string" },
             fontSize: { type: "number" },
             color: { type: "string" },

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -124,12 +124,10 @@ function buildOperatorDefs(): Record<string, unknown> {
       additionalProperties: true,
       properties: {
         type: { const: descriptor.type },
-        // Base `.label(accessor, options?)` chain (LabelIR), spread BEFORE
-        // the per-type `properties` so `log`'s own `label` (a plain string
-        // console prefix, unrelated to the chain) overrides it below —
-        // matches validate.ts's `walkOperator` merge order.
-        label: { $ref: "#/$defs/LabelIR" },
         ...properties,
+        // Base `.label(accessor, options?)` chain (LabelIR) — matches
+        // validate.ts's `walkOperator` merge order.
+        label: { $ref: "#/$defs/LabelIR" },
         translate: { $ref: "#/$defs/Translate" },
         origin: { $ref: "#/$defs/Origin" },
         meta: { $ref: "#/$defs/Meta" },

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -357,14 +357,10 @@ export interface LogOperator
     TranslatableIR,
     OperatorFlagsIR {
   type: "log";
-  /** Console label prefix (`log(label)`) — NOT the `.label(accessor, options)`
-   *  chain other operators (spread/stack/group/scatter/table/treemap) carry.
-   *  `log` isn't built via `createOperator`'s `dual()`, so it never gets that
-   *  chainable; this field is a plain string and stays that way deliberately
-   *  — the two `label` wire fields share a name across operator types but not
-   *  a shape (`descriptors.ts`'s `walkOperator` field-merge order lets this
-   *  per-type entry win over the shared `LabelIR` base field for validation). */
-  label?: string;
+  /** Console prefix string for `log(prefix)`; unrelated to the operator-level
+   *  `.label(accessor, options)` chain, which `log` doesn't support since it
+   *  isn't built via `createOperator`'s `dual()`. */
+  prefix?: string;
 }
 
 /**

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -637,12 +637,16 @@ export interface BridgeLambdaSentinel {
  *
  *   label: true     — show a label with default styling
  *   label: "field"  — label using this field accessor, defaults elsewhere
+ *
+ * The object form's `accessor` may also be a {@link FieldAccessor} — e.g.
+ * `label: field("count").sum()` — labeling a group with an aggregate over its
+ * rows, rather than a bare field that must be constant within the group.
  */
 export type LabelIR =
   | true
   | string
   | {
-      accessor: string;
+      accessor: string | FieldAccessor;
       position?: string;
       fontSize?: number;
       color?: string;

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -240,6 +240,11 @@ export interface SpreadOperator
     TranslatableIR,
     OperatorFlagsIR {
   type: "spread";
+  /** Set via `.label(accessor, options?)` chained on the operator: each
+   *  split leaf's produced node(s) get a deferred label over the leaf's own
+   *  subdata. String accessors round-trip; function accessors don't (see
+   *  `LabelIR`/`labelIRField` in createOperator.ts). */
+  label?: LabelIR;
   by?: string | FieldAccessor;
   dir?: "x" | "y";
   spacing?: number;
@@ -268,6 +273,8 @@ export interface StackOperator
     TranslatableIR,
     OperatorFlagsIR {
   type: "stack";
+  /** See `SpreadOperator.label` — `stack` is `spread({glue: true})` re-tagged. */
+  label?: LabelIR;
   by?: string | FieldAccessor;
   dir?: "x" | "y";
   /** Spread-parity passthrough: the JS `stack` is `Spread({...props, glue:
@@ -294,6 +301,8 @@ export interface GroupOperator
     TranslatableIR,
     OperatorFlagsIR {
   type: "group";
+  /** See `SpreadOperator.label`. */
+  label?: LabelIR;
   by: string | FieldAccessor;
 }
 
@@ -302,6 +311,8 @@ export interface ScatterOperator
     TranslatableIR,
     OperatorFlagsIR {
   type: "scatter";
+  /** See `SpreadOperator.label`. */
+  label?: LabelIR;
   by?: string | FieldAccessor;
   x?: ChannelValue;
   y?: ChannelValue;
@@ -334,6 +345,8 @@ export interface TableOperator
     TranslatableIR,
     OperatorFlagsIR {
   type: "table";
+  /** See `SpreadOperator.label`. */
+  label?: LabelIR;
   by: { x: string; y: string };
   spacing?: number | [number, number];
   numCols?: number;
@@ -344,6 +357,13 @@ export interface LogOperator
     TranslatableIR,
     OperatorFlagsIR {
   type: "log";
+  /** Console label prefix (`log(label)`) — NOT the `.label(accessor, options)`
+   *  chain other operators (spread/stack/group/scatter/table/treemap) carry.
+   *  `log` isn't built via `createOperator`'s `dual()`, so it never gets that
+   *  chainable; this field is a plain string and stays that way deliberately
+   *  — the two `label` wire fields share a name across operator types but not
+   *  a shape (`descriptors.ts`'s `walkOperator` field-merge order lets this
+   *  per-type entry win over the shared `LabelIR` base field for validation). */
   label?: string;
 }
 
@@ -360,6 +380,8 @@ export interface TreemapOperator
     TranslatableIR,
     OperatorFlagsIR {
   type: "treemap";
+  /** See `SpreadOperator.label`. */
+  label?: LabelIR;
   /** Field to partition rows by; also accepts a field(...) accessor carrying
    *  domain ops (sort/reverse/bin/dropNulls). Without `by`, one leaf is
    *  emitted per row. */

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -1097,7 +1097,28 @@ function walkLabel(node: unknown, path: string, ctx: Context): void {
     });
     return;
   }
-  expectField(node, "accessor", path, ctx, expectString);
+  if (!("accessor" in node) || node.accessor === undefined) {
+    ctx.errors.push({
+      path: `${path}.accessor`,
+      message: 'required field "accessor" is missing',
+    });
+  } else if (typeof node.accessor === "string") {
+    // bare field name — fine
+  } else if (isObject(node.accessor)) {
+    if (node.accessor.type !== "field") {
+      ctx.errors.push({
+        path: `${path}.accessor.type`,
+        message: `expected type "field", got ${JSON.stringify(node.accessor.type)}`,
+      });
+    } else {
+      walkFieldAccessor(node.accessor, `${path}.accessor`, ctx);
+    }
+  } else {
+    ctx.errors.push({
+      path: `${path}.accessor`,
+      message: `expected a string or field(...) accessor object, got ${typeNameOf(node.accessor)}`,
+    });
+  }
   optionalField(node, "position", path, ctx, expectString);
   optionalField(node, "fontSize", path, ctx, expectNumber);
   optionalField(node, "color", path, ctx, expectString);

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -528,15 +528,10 @@ function walkOperator(node: unknown, path: string, ctx: Context): void {
   // `debug`/`label` (OPERATOR_BASE_FIELDS) ride every operator: `debug` is a
   // factory-only dev flag JS strips before layout; `label` is the
   // `.label(accessor, options?)` chain available on dual-mode operators.
-  // Base `label` is spread BEFORE the per-type descriptor fields (unlike
-  // `debug`, spread after) so `log`'s own `label: string` field — an
-  // unrelated console-prefix, not the chain — wins the merge and validates
-  // against its real (string, not LabelIR) wire shape. See the comment on
-  // OPERATOR_BASE_FIELDS in descriptors.ts.
   const fields = descriptor
     ? {
-        label: OPERATOR_BASE_FIELDS.label,
         ...resolveFields(descriptor),
+        label: OPERATOR_BASE_FIELDS.label,
         debug: OPERATOR_BASE_FIELDS.debug,
       }
     : {};

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -525,10 +525,20 @@ function walkOperator(node: unknown, path: string, ctx: Context): void {
   walkBaseFields(node, path, ctx);
   optionalField(node, "translate", path, ctx, walkTranslate);
   const descriptor = OPERATORS[node.type];
-  // `debug` (OPERATOR_BASE_FIELDS) rides every operator: a factory-only dev
-  // flag JS strips before layout, but real producers put it on the wire.
+  // `debug`/`label` (OPERATOR_BASE_FIELDS) ride every operator: `debug` is a
+  // factory-only dev flag JS strips before layout; `label` is the
+  // `.label(accessor, options?)` chain available on dual-mode operators.
+  // Base `label` is spread BEFORE the per-type descriptor fields (unlike
+  // `debug`, spread after) so `log`'s own `label: string` field — an
+  // unrelated console-prefix, not the chain — wins the merge and validates
+  // against its real (string, not LabelIR) wire shape. See the comment on
+  // OPERATOR_BASE_FIELDS in descriptors.ts.
   const fields = descriptor
-    ? { ...resolveFields(descriptor), debug: OPERATOR_BASE_FIELDS.debug }
+    ? {
+        label: OPERATOR_BASE_FIELDS.label,
+        ...resolveFields(descriptor),
+        debug: OPERATOR_BASE_FIELDS.debug,
+      }
     : {};
   walkDescriptorFields(node, path, ctx, fields, [
     "type",

--- a/packages/gofish-ir/src/tests/descriptors.test.ts
+++ b/packages/gofish-ir/src/tests/descriptors.test.ts
@@ -94,7 +94,7 @@ const SCHEMA_OPERATOR_KEYS: Record<string, readonly string[]> = {
     "h",
   ],
   table: ["by", "spacing", "numCols"],
-  log: ["label"],
+  log: ["prefix"],
   treemap: [
     "w",
     "h",

--- a/packages/gofish-ir/src/tests/schema.test.ts
+++ b/packages/gofish-ir/src/tests/schema.test.ts
@@ -322,8 +322,8 @@ check(
 );
 
 check(
-  "log with non-string label rejected",
-  !validate(chart([{ type: "log", label: 5 }])).valid
+  "log with non-string prefix rejected",
+  !validate(chart([{ type: "log", prefix: 5 }])).valid
 );
 
 check(

--- a/packages/gofish-python/gofish/_generated.py
+++ b/packages/gofish-python/gofish/_generated.py
@@ -163,7 +163,7 @@ def petal(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = N
     """A polar-only wedge/petal shape (Petal.tsx). Box geometry via the shared dims channels.
 
     Args:
-        label: Value label: `True` for defaults or a field name (`.label()` shorthand).
+        label: Value label: `True` for defaults or a field name (`.label()` shorthand). A field name is a bare string; it must be constant across a group's rows (errors otherwise) — an aggregate needs the explicit `.label(field(...).sum())` form instead.
         debug: Dev-only console.log flag; stripped before layout (FACTORY_ONLY_KEYS).
         x: Left edge position.
         cx: Center x.
@@ -214,7 +214,7 @@ def text(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = No
     """A text label. Box geometry via the shared dims channels positions the text anchor.
 
     Args:
-        label: Value label: `True` for defaults or a field name (`.label()` shorthand).
+        label: Value label: `True` for defaults or a field name (`.label()` shorthand). A field name is a bare string; it must be constant across a group's rows (errors otherwise) — an aggregate needs the explicit `.label(field(...).sum())` form instead.
         debug: Factory-only dev flag; the JS factory strips it (FACTORY_ONLY_KEYS) before layout.
         x: Left edge position.
         cx: Center x.
@@ -279,7 +279,7 @@ def image(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = N
     """An embedded raster/SVG image. Box geometry via the shared dims channels.
 
     Args:
-        label: Value label: `True` for defaults or a field name (`.label()` shorthand).
+        label: Value label: `True` for defaults or a field name (`.label()` shorthand). A field name is a bare string; it must be constant across a group's rows (errors otherwise) — an aggregate needs the explicit `.label(field(...).sum())` form instead.
         debug: Dev-only console.log flag; stripped before layout (FACTORY_ONLY_KEYS).
         x: Left edge position.
         cx: Center x.
@@ -332,7 +332,7 @@ def polygon(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] =
     """A closed polygon defined by explicit local-coordinate points (y-up). No dims channels — the bbox is computed from `points`.
 
     Args:
-        label: Value label: `True` for defaults or a field name (`.label()` shorthand).
+        label: Value label: `True` for defaults or a field name (`.label()` shorthand). A field name is a bare string; it must be constant across a group's rows (errors otherwise) — an aggregate needs the explicit `.label(field(...).sum())` form instead.
         debug: Dev-only console.log flag; stripped before layout (FACTORY_ONLY_KEYS).
         points: Vertex list, at least 3 points.
         fill: Default "black".
@@ -357,7 +357,7 @@ def blank(*, label: Optional[Union[bool, str]] = None, debug: Optional[bool] = N
     """An invisible sizing/positioning guide — a transparent rect with a restricted channel set (no x/y/cx/cy/x2/y2/theta/r — position it via a layout operator).
 
     Args:
-        label: Value label: `True` for defaults or a field name (`.label()` shorthand).
+        label: Value label: `True` for defaults or a field name (`.label()` shorthand). A field name is a bare string; it must be constant across a group's rows (errors otherwise) — an aggregate needs the explicit `.label(field(...).sum())` form instead.
         debug: Dev-only console.log flag. Genuinely serializes on the wire today (found while grounding this table) but carries no rendering meaning.
         w: Default 0.
         h: Default 0.

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -13,6 +13,7 @@ class Operator:
         self.op_type = op_type
         self.kwargs = kwargs
         self._translate: Optional[dict] = None
+        self._label: Optional[dict] = None
 
     def translate(
         self,
@@ -27,9 +28,50 @@ class Operator:
         operator's own channel grammar.
         """
         new_op = type(self)(self.op_type, **self.kwargs)
+        new_op._label = self._label
         new_op._translate = {
             k: v for k, v in {"x": x, "y": y}.items() if v is not None
         }
+        return new_op
+
+    def label(
+        self,
+        accessor: str,
+        position: Optional[str] = None,
+        fontSize: Optional[int] = None,
+        color: Optional[str] = None,
+        offset: Optional[int] = None,
+        minSpace: Optional[int] = None,
+        rotate: Optional[int] = None,
+    ) -> "Operator":
+        """Attach a per-group label to this operator (traversal form).
+
+        Mirrors JS ``stack({by, dir}).label(accessor, options?)``: at
+        execution time, every node a split leaf produces gets stamped with
+        the leaf's own subdata and a deferred label. `accessor` is a field
+        name read off the group's first row — mirrors `Mark.label`'s
+        signature/kwargs exactly (Python has no function-accessor form; use
+        a string field name).
+
+        Returns:
+            New Operator (same subclass as self) with the label set.
+        """
+        new_op = type(self)(self.op_type, **self.kwargs)
+        new_op._translate = self._translate
+        label_spec: Dict[str, Any] = {"accessor": accessor}
+        if position is not None:
+            label_spec["position"] = position
+        if fontSize is not None:
+            label_spec["fontSize"] = fontSize
+        if color is not None:
+            label_spec["color"] = color
+        if offset is not None:
+            label_spec["offset"] = offset
+        if minSpace is not None:
+            label_spec["minSpace"] = minSpace
+        if rotate is not None:
+            label_spec["rotate"] = rotate
+        new_op._label = label_spec
         return new_op
 
     def to_dict(self) -> dict:
@@ -37,6 +79,8 @@ class Operator:
         d = {"type": self.op_type, **self.kwargs}
         if self._translate:
             d["translate"] = self._translate
+        if self._label:
+            d["label"] = self._label
         return d
 
 
@@ -63,10 +107,23 @@ class DeriveOperator(Operator):
         """Translate a derived operator while preserving its lambda handle."""
         new_op = DeriveOperator(self.fn, self.provenance)
         new_op.lambda_id = self.lambda_id
+        new_op._label = self._label
         new_op._translate = {
             k: v for k, v in {"x": x, "y": y}.items() if v is not None
         }
         return new_op
+
+    def label(self, *args, **kwargs) -> "DeriveOperator":
+        """`derive(fn)` has no JS-side `.label()` — it isn't built via
+        `createOperator`'s dual-mode traversal form, so there's no per-leaf
+        split to stamp a label onto. Raise rather than silently no-op.
+        """
+        raise NotImplementedError(
+            "derive(fn) does not support .label() — it's a data transform, "
+            "not a layout operator with per-group leaves to label. Chain "
+            ".label() on the layout operator (stack/spread/group/scatter/"
+            "table/treemap) instead."
+        )
 
     def to_dict(self) -> dict:
         """Convert to dict - return lambda ID (+ measure provenance, if any)."""

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -36,7 +36,7 @@ class Operator:
 
     def label(
         self,
-        accessor: str,
+        accessor: Union[str, "FieldAccessor"],
         position: Optional[str] = None,
         fontSize: Optional[int] = None,
         color: Optional[str] = None,
@@ -48,17 +48,27 @@ class Operator:
 
         Mirrors JS ``stack({by, dir}).label(accessor, options?)``: at
         execution time, every node a split leaf produces gets stamped with
-        the leaf's own subdata and a deferred label. `accessor` is a field
-        name read off the group's first row — mirrors `Mark.label`'s
-        signature/kwargs exactly (Python has no function-accessor form; use
-        a string field name).
+        the leaf's own subdata and a deferred label.
+
+        `accessor` is either:
+
+        - a plain field name (``str``) — must be constant across every row
+          in the group (true by construction for a ``by`` field); raises
+          loudly at render time otherwise.
+        - a ``field(...)`` aggregate (``field("count").sum()`` /
+          ``.mean()`` / ``.count()`` / ``.distinct()``), folding the
+          group's rows to one value — use this for a group total/mean.
+
+        Python has no function-accessor form; use one of the above.
 
         Returns:
             New Operator (same subclass as self) with the label set.
         """
         new_op = type(self)(self.op_type, **self.kwargs)
         new_op._translate = self._translate
-        label_spec: Dict[str, Any] = {"accessor": accessor}
+        label_spec: Dict[str, Any] = {
+            "accessor": dict(accessor) if isinstance(accessor, FieldAccessor) else accessor
+        }
         if position is not None:
             label_spec["position"] = position
         if fontSize is not None:
@@ -403,7 +413,7 @@ class Mark:
 
     def label(
         self,
-        accessor: str,
+        accessor: Union[str, "FieldAccessor"],
         position: Optional[str] = None,
         fontSize: Optional[int] = None,
         color: Optional[str] = None,
@@ -415,7 +425,11 @@ class Mark:
         Attach a label to this mark.
 
         Args:
-            accessor: Field name to use as label text
+            accessor: Field name to use as label text (must be constant
+                across the datum's rows when the datum is a group of rows —
+                true by construction for a `by` field; raises otherwise), or
+                a `field(...)` aggregate (`field("count").sum()`, etc.)
+                folding the group's rows to one value.
             position: Label position (e.g. "center", "outset-top", "inset-bottom-start")
             fontSize: Font size in pixels
             color: Label color (auto-contrasted if omitted)
@@ -430,7 +444,9 @@ class Mark:
             self.mark_type, _children=self._children, **self.kwargs
         )
         self._copy_meta(new_mark)
-        label_spec: Dict[str, Any] = {"accessor": accessor}
+        label_spec: Dict[str, Any] = {
+            "accessor": dict(accessor) if isinstance(accessor, FieldAccessor) else accessor
+        }
         if position is not None:
             label_spec["position"] = position
         if fontSize is not None:

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -1827,19 +1827,19 @@ def table(
     return Operator("table", **_table_opts(**options))
 
 
-def log(label: Optional[str] = None) -> Operator:
+def log(prefix: Optional[str] = None) -> Operator:
     """
     Log operator - logs data to the console for debugging.
 
     Args:
-        label: Optional label to prefix the log output
+        prefix: Optional prefix to prepend to the log output
 
     Returns:
         Operator object
     """
     kwargs: Dict[str, Any] = {}
-    if label is not None:
-        kwargs["label"] = label
+    if prefix is not None:
+        kwargs["prefix"] = prefix
     return Operator("log", **kwargs)
 
 

--- a/packages/gofish-python/tests/test_ast.py
+++ b/packages/gofish-python/tests/test_ast.py
@@ -72,20 +72,20 @@ class TestOperators:
         op2 = derive(fn)
         assert op1.lambda_id != op2.lambda_id
 
-    def test_log_operator_no_label(self):
-        """Test log operator without label."""
+    def test_log_operator_no_prefix(self):
+        """Test log operator without prefix."""
         op = log()
         assert op.op_type == "log"
         d = op.to_dict()
         assert d["type"] == "log"
-        assert "label" not in d
+        assert "prefix" not in d
 
-    def test_log_operator_with_label(self):
-        """Test log operator with label."""
+    def test_log_operator_with_prefix(self):
+        """Test log operator with prefix."""
         op = log("my label")
         d = op.to_dict()
         assert d["type"] == "log"
-        assert d["label"] == "my label"
+        assert d["prefix"] == "my label"
 
 
 class TestMarkName:

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -366,11 +366,29 @@ function mapOperator(
   op: OperatorSpec,
   deriveServerUrl?: string
 ): Operator<any, any> | null {
-  const { type, translate, ...opts } = op;
+  const { type, translate, label, ...opts } = op;
   const applyTranslate = <T>(operator: T): T =>
     translate && typeof (operator as any).translate === "function"
       ? ((operator as any).translate(translate) as T)
       : operator;
+  // `.label(accessor, options?)` chained on the operator (traversal) form —
+  // every operator below except `log` (whose own `label` is an unrelated
+  // console-prefix string, re-added to `opts` in that case instead).
+  const applyLabel = <T>(operator: T): T =>
+    label !== undefined &&
+    type !== "log" &&
+    typeof (operator as any).label === "function"
+      ? (() => {
+          const { accessor, ...labelOpts } = label as {
+            accessor: any;
+          } & Record<string, any>;
+          return (operator as any).label(
+            accessor,
+            Object.keys(labelOpts).length > 0 ? labelOpts : undefined
+          ) as T;
+        })()
+      : operator;
+  if (type === "log") opts.label = label;
 
   switch (type) {
     case "derive": {
@@ -413,11 +431,11 @@ function mapOperator(
     // `dir`, etc. as keyword args. The previous `field`-positional shape
     // was stale and silently miscalled most ops.
     case "spread":
-      return applyTranslate(spread(opts as any));
+      return applyTranslate(applyLabel(spread(opts as any)));
     case "stack":
-      return applyTranslate(stack(opts as any));
+      return applyTranslate(applyLabel(stack(opts as any)));
     case "group":
-      return applyTranslate(group(opts as any));
+      return applyTranslate(applyLabel(group(opts as any)));
     case "resolve":
       return applyTranslate(
         resolve(opts.cols as string[], {
@@ -430,11 +448,11 @@ function mapOperator(
         join(opts.right as any[], { on: opts.on as string })
       );
     case "scatter":
-      return applyTranslate(scatter(opts as any));
+      return applyTranslate(applyLabel(scatter(opts as any)));
     case "table":
-      return applyTranslate(table(opts as any));
+      return applyTranslate(applyLabel(table(opts as any)));
     case "treemap":
-      return applyTranslate(treemap(opts as any));
+      return applyTranslate(applyLabel(treemap(opts as any)));
     case "log":
       return applyTranslate(logOp(opts.label));
     default:

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -371,13 +371,9 @@ function mapOperator(
     translate && typeof (operator as any).translate === "function"
       ? ((operator as any).translate(translate) as T)
       : operator;
-  // `.label(accessor, options?)` chained on the operator (traversal) form —
-  // every operator below except `log` (whose own `label` is an unrelated
-  // console-prefix string, re-added to `opts` in that case instead).
+  // `.label(accessor, options?)` chained on the operator (traversal) form.
   const applyLabel = <T>(operator: T): T =>
-    label !== undefined &&
-    type !== "log" &&
-    typeof (operator as any).label === "function"
+    label !== undefined && typeof (operator as any).label === "function"
       ? (() => {
           const { accessor, ...labelOpts } = label as {
             accessor: any;
@@ -388,7 +384,6 @@ function mapOperator(
           ) as T;
         })()
       : operator;
-  if (type === "log") opts.label = label;
 
   switch (type) {
     case "derive": {
@@ -454,7 +449,7 @@ function mapOperator(
     case "treemap":
       return applyTranslate(applyLabel(treemap(opts as any)));
     case "log":
-      return applyTranslate(logOp(opts.label));
+      return applyTranslate(logOp(opts.prefix));
     default:
       console.warn(`Unknown operator type: ${type}`);
       return null;

--- a/tests/python-stories/forward-syntax-v3/test_labels.py
+++ b/tests/python-stories/forward-syntax-v3/test_labels.py
@@ -6,6 +6,8 @@ stories (AllPositions, Rotated), the async mark-as-function story
 per `tests/.python-sync-exempt`.
 """
 
+import pandas as pd
+
 from gofish import (
     chart,
     derive,
@@ -173,6 +175,24 @@ def story_heatmap_with_labels():
             )
         ),
         {"w": 420, "h": 280, "axes": True},
+    )
+
+
+# ─── label on stack operator (per-group, #702) ──────────────────────────────
+
+def story_label_on_stack_operator():
+    titanic_passengers = pd.read_json(
+        "packages/gofish-graphics/src/data/titanicPassengers.json"
+    )
+    return (
+        chart(titanic_passengers)
+        .flow(
+            stack(by="pclass", dir="y").label(
+                "pclass", position="center", fontSize=14, color="white"
+            )
+        )
+        .mark(rect(w=120, h=field("survived").count())),
+        {"w": 260, "h": 300, "axes": False},
     )
 
 

--- a/tests/python-stories/forward-syntax-v3/test_labels.py
+++ b/tests/python-stories/forward-syntax-v3/test_labels.py
@@ -29,7 +29,7 @@ def story_default():
     return (
         chart(SEAFOOD)
         .flow(spread(by="lake", dir="x"))
-        .mark(rect(h="count").label("count")),
+        .mark(rect(h="count").label(field("count").sum())),
         {"w": 400, "h": 300, "axes": True},
     )
 
@@ -58,7 +58,7 @@ def story_above():
     return (
         chart(SEAFOOD)
         .flow(spread(by="lake", dir="x"))
-        .mark(rect(h="count").label("count", position="outset")),
+        .mark(rect(h="count").label(field("count").sum(), position="outset")),
         {"w": 400, "h": 300, "axes": True},
     )
 
@@ -110,7 +110,7 @@ def story_right():
         .flow(spread(by="lake", dir="y"))
         .mark(
             rect(w="count").label(
-                "count", position="outset-right", offset=15
+                field("count").sum(), position="outset-right", offset=15
             )
         ),
         {"w": 400, "h": 300, "axes": True},
@@ -189,6 +189,27 @@ def story_label_on_stack_operator():
         .flow(
             stack(by="pclass", dir="y").label(
                 "pclass", position="center", fontSize=14, color="white"
+            )
+        )
+        .mark(rect(w=120, h=field("survived").count())),
+        {"w": 260, "h": 300, "axes": False},
+    )
+
+
+# ─── label on stack operator (group total, #702 redesign) ──────────────────
+
+def story_label_on_stack_aggregate():
+    titanic_passengers = pd.read_json(
+        "packages/gofish-graphics/src/data/titanicPassengers.json"
+    )
+    return (
+        chart(titanic_passengers)
+        .flow(
+            stack(by="pclass", dir="y").label(
+                field("survived").count(),
+                position="center",
+                fontSize=14,
+                color="white",
             )
         )
         .mark(rect(w=120, h=field("survived").count())),


### PR DESCRIPTION
Closes #702.

`.label(accessor, options?)` now chains on the operator form of `spread`, `stack`, `group`, `scatter`, `table`, and `treemap`, not just on marks.

```js
chart(titanicPassengers)
  .flow(
    stack({ by: "pclass", dir: "y" }).label("pclass", { position: "center", color: "white" })
  )
  .mark(rect({ w: 120, h: field("survived").count() }))
```

At layout time, every node a split group produces is stamped with that group's rows as its datum and with a deferred label. Because the node then has its own datum, `resolveLabels` keeps the label at the group level instead of pushing it down to each child. This is what the LabelOnSpread story did by hand with `.resolve()` and a manual datum stamp, and that story now uses the new chain instead.

## Accessor semantics (one rule for every group label)

A label accessor over a group's rows resolves by one of three forms. The rule is the same one pandas `groupby` and the Vega-Lite `text` encoding use: group keys pass through, and any other column needs an explicit aggregate.

- **Bare string**, e.g. `.label("pclass")`: the field must be constant across the group's rows, which is always true for a `by` field. The constant value is the label. If the field varies within the group, rendering fails with an error that names the field and suggests an aggregate. There is no silent first-row fallback anywhere anymore, including through a `field(...)` accessor that lacks an aggregate op.
- **Field expression**, e.g. `.label(field("count").sum())`: the aggregate folds the group's rows to one value. This reuses the field-expression pipeline and its existing IR form, so it round-trips to Python.
- **Function**, e.g. `.label((rows) => rows.length)`: the raw escape hatch. It receives the group's row array and does not serialize (the existing warning).

The same rule replaced the old `datum[0]` unwrap for combinator-mark group labels, so mark-level and operator-level labels behave identically. Five existing label demo stories turned out to depend on the old behavior, and their labels were wrong: they labeled a bar with the first row's `count` while the bar's height was the sum over the group. They now use `field("count").sum()` and show the number the bar actually draws. Their geometry is unchanged.

## Breaking rename: log's `label` option is now `prefix`

The `log` operator's console-prefix string option was also called `label`, which collided with the new chain. It is renamed to `prefix` across JS, IR, and Python with no compatibility alias, which removed all the collision special-casing from the validator and `fromJSON` and closes off the Python case where `.label()` on a `log()` would have corrupted its IR.

## Wire and Python

- `LabelIR.accessor` is now `string | FieldAccessor`, where `FieldAccessor` is the same IR type the `by` and `size` channels already use.
- The IR schema, descriptor table, validator, and JSON schema all cover the operator `label` field and the field-expression accessor.
- Both JS reconstruction sites, `fromJSON` and the parity harness, apply the label when they rebuild an operator.
- Python `Operator.label(...)` and `Mark.label(...)` accept a field name or a `field(...)` accessor and mirror the JS kwargs. `derive(fn).label()` raises with an error that points at the layout operators, since a derive has no groups to label.

## Also in this PR

A pre-existing serialization gap is fixed: a chained operator `.translate()` never reached the wire. The translate wrapper did not carry the base operator's `__serialize` tag, so a translated operator degraded to an opaque `{type: "derive"}` in the IR. The chain-order round-trip tests required this fix.

## Verification

- The serialize suite covers the string round-trip, the field-expression round-trip on both a mark and an operator, the heterogeneous-field error (bare string and aggregate-less `field(...)` alike), the function-accessor warn-and-omit path, and both `.label()`/`.translate()` chain orders. 93 checks pass.
- `pnpm capture-diff` against the branch base reports exactly seven diffs: the two new stories added, and the five migrated demo stories whose label text was corrected. Every changed story has identical geometry, and only the text differs.
- Every Python parity story in the labels group renders normalized DOM byte-identical to the JS capture on the same machine, including both new stories.
- tsc, gofish-ir build, schema sync, backlinks, Python codegen (no diff), validate-python-ir, and the docs build are all clean.

## Screenshots

The new LabelOnStackOperator story, one centered label per stacked group from `stack({ by: "pclass" }).label("pclass")`:

![label on stack operator](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-750/labels--label-on-stack-operator.png)

The new LabelOnStackAggregate story, group totals from `.label(field("survived").count())`:

![label on stack aggregate](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-750/labels--label-on-stack-aggregate.png)

The rewritten LabelOnSpread story, identical output to the old manual workaround:

![label on spread](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-750/labels--label-on-spread.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
