### PR TITLE
Fix stale area imports left over from area→ribbon rename

### DIFF
--- a/packages/gofish-python/stories/forwardsyntax/ribbon.py
+++ b/packages/gofish-python/stories/forwardsyntax/ribbon.py
@@ -4,7 +4,7 @@ import math
 
 from gofish import (
     layer,
-    area,
+    ribbon,
     chart,
     clock,
     derive,
@@ -34,7 +34,7 @@ def basic(w=400, h=400):
     overlay = (
         chart(selectAll("bars"))
         .flow(group(by="species"))
-        .mark(area(opacity=0.8))
+        .mark(ribbon(opacity=0.8))
     )
     return layer([bars, overlay])
 
@@ -58,6 +58,6 @@ def polar(w=400, h=400):
     overlay = (
         chart(selectAll("bars"))
         .flow(group(by="species"))
-        .mark(area(opacity=0.8))
+        .mark(ribbon(opacity=0.8))
     )
     return layer({"coord": clock()}, [bars, overlay])

--- a/packages/gofish-python/tests/test_ast.py
+++ b/packages/gofish-python/tests/test_ast.py
@@ -19,7 +19,7 @@ from gofish import (
     rect,
     circle,
     line,
-    area,
+    ribbon,
     ellipse,
     petal,
     text,
@@ -284,11 +284,11 @@ class TestNewMarks:
 
     def test_text_mark(self):
         """Test text mark creation."""
-        m = text(fill="black", label="name")
+        m = text(fill="black", text="name")
         d = m.to_dict()
         assert d["type"] == "text"
         assert d["fill"] == "black"
-        assert d["label"] == "name"
+        assert d["text"] == "name"
 
     def test_image_mark(self):
         """Test image mark creation."""
@@ -303,8 +303,8 @@ class TestNewMarks:
         for mark_fn in [
             lambda: ellipse(w=10),
             lambda: petal(w=10),
-            lambda: text(fill="red"),
-            lambda: image(w=10),
+            lambda: text(fill="red", text="value"),
+            lambda: image(w=10, href="url"),
         ]:
             m = mark_fn().name("layer1")
             assert m._name == "layer1"


### PR DESCRIPTION
## Summary
- `packages/gofish-python/tests/test_ast.py` and `packages/gofish-python/stories/forwardsyntax/ribbon.py` still imported/used the `area` mark, which was renamed to `ribbon` in #637. This broke pytest collection for `test_ast.py` and both `test_ribbon_basic`/`test_ribbon_polar` in `test_stories.py`.
- Renamed those imports/usages to `ribbon`.
- `text(fill="black", label="name")` in `test_ast.py` used the old `label` kwarg; the descriptor-table codegen now requires a `text=` kwarg (see `gofish/_generated.py`), so updated to `text(fill="black", text="name")` and the `.name()` support test to pass `text="value"`.
- While fixing the above, the same test's `.name()` support loop also called `image(w=10)`, which now requires `href=` (same descriptor-codegen change) — added `href="url"` to unblock the test, matching the convention already used by `test_image_mark`.

## Not fixed (out of scope, unrelated)
- `tests/test_svg_export.py` and `tests/test_widget_protocol.py` fail locally with `FileNotFoundError: Widget bundle not found` — they need `gofish/_static/widget.esm.js`, which requires building the main JS lib first (`pnpm --filter gofish-graphics build` then `pnpm --filter gofish-python build:widget`); the latter currently fails locally trying to resolve `gofish-graphics` outside a full build. Pre-existing, unrelated to this rename.
- `packages/gofish-python/tests/test_ir.ipynb` and `notes/implementation.md` also reference `area` — left alone since they're a notebook and doc notes, not part of the pytest failures this issue calls out.

Closes #682

## Test plan
- [x] `python -m pytest tests/test_ast.py` — 48 passed
- [x] `python -m pytest tests/test_stories.py -k ribbon` — 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)