### PR TITLE
Fix TypeError rendering a .layer() chain through the widget

### DIFF
--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -2981,19 +2981,21 @@ class LayerBuilder:
         Returns:
             GoFishChartWidget instance that will display in Jupyter
         """
-        import base64
-        import json
         from .widget import GoFishChartWidget
         from .arrow_utils import dataframe_to_arrow, empty_placeholder_arrow_bytes
         import pandas as pd
 
-        def _serialize_child_data(child: ChartBuilder) -> str:
-            """Serialize a child chart's data to base64 Arrow bytes."""
+        def _serialize_child_data(child: ChartBuilder) -> bytes:
+            """Serialize a child chart's data to raw Arrow IPC bytes.
+
+            ``GoFishChartWidget`` owns the base64/JSON wire encoding (see
+            ``arrow_dict`` there) — this only ever hands it plain bytes.
+            """
             # Ref-data tiers borrow nodes from a sibling; empty `chart()`
             # scopes (previous-tier) inherit the preceding tier's marks
             # JS-side — neither ships rows of its own.
             if isinstance(child.data, _RefProxy) or child._uses_previous_marks():
-                return base64.b64encode(empty_placeholder_arrow_bytes()).decode("ascii")
+                return empty_placeholder_arrow_bytes()
 
             if isinstance(child.data, pd.DataFrame):
                 df = child.data
@@ -3003,9 +3005,9 @@ class LayerBuilder:
                 df = pd.DataFrame(child.data)
 
             if len(df) == 0:
-                return base64.b64encode(empty_placeholder_arrow_bytes()).decode("ascii")
+                return empty_placeholder_arrow_bytes()
 
-            return base64.b64encode(dataframe_to_arrow(df)).decode("ascii")
+            return dataframe_to_arrow(df)
 
         # Serialize each child's data and collect derive functions
         arrow_dict: dict = {}
@@ -3015,12 +3017,11 @@ class LayerBuilder:
             for op in _collect_derive_operators(child.operators):
                 derive_functions[op.lambda_id] = op.fn
 
-        arrow_data = json.dumps(arrow_dict)
         spec = self.to_ir()
 
         widget = GoFishChartWidget(
             spec=spec,
-            arrow_data=arrow_data,
+            arrow_dict=arrow_dict,
             derive_functions=derive_functions,
             width=w,
             height=h,

--- a/packages/gofish-python/gofish/widget.py
+++ b/packages/gofish-python/gofish/widget.py
@@ -8,6 +8,7 @@ in Jupyter and marimo.
 """
 
 import base64
+import json
 import uuid
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -49,7 +50,8 @@ class GoFishChartWidget(anywidget.AnyWidget):
     def __init__(
         self,
         spec: Dict[str, Any],
-        arrow_data: bytes,
+        arrow_data: Optional[bytes] = None,
+        arrow_dict: Optional[Dict[str, bytes]] = None,
         derive_functions: Optional[Dict[str, Callable]] = None,
         width: int = 800,
         height: int = 600,
@@ -68,12 +70,31 @@ class GoFishChartWidget(anywidget.AnyWidget):
             )
         esm_code = bundle_path.read_text(encoding="utf-8")
 
-        arrow_data_b64 = base64.b64encode(arrow_data).decode("utf-8")
+        # The `arrow_data` trait carries one of two wire shapes, mirroring the
+        # two ways JS's `renderChart` (widget-src/index.ts) branches on
+        # `spec.type`: a single chart gets one base64-encoded Arrow IPC
+        # stream; a layer gets a JSON object mapping child index -> that same
+        # base64 encoding, one entry per tier (`renderLayer` does
+        # `JSON.parse` then looks up `arrowDict[String(i)]`). Exactly one of
+        # `arrow_data` (single chart) / `arrow_dict` (layer) must be passed —
+        # this constructor owns all base64/JSON encoding so callers only ever
+        # hand it raw bytes, never pre-formatted wire strings (see #683).
+        if (arrow_data is None) == (arrow_dict is None):
+            raise ValueError(
+                "GoFishChartWidget requires exactly one of `arrow_data` "
+                "(single chart) or `arrow_dict` (layer, keyed by child index)"
+            )
+        if arrow_dict is not None:
+            arrow_data_trait = json.dumps(
+                {key: base64.b64encode(value).decode("ascii") for key, value in arrow_dict.items()}
+            )
+        else:
+            arrow_data_trait = base64.b64encode(arrow_data).decode("utf-8")
 
         super().__init__(
             _esm=esm_code,
             spec=spec,
-            arrow_data=arrow_data_b64,
+            arrow_data=arrow_data_trait,
             width=width,
             height=height,
             axes=axes,

--- a/packages/gofish-python/tests/test_widget_protocol.py
+++ b/packages/gofish-python/tests/test_widget_protocol.py
@@ -6,6 +6,7 @@ and drive its ``derive_request`` trait the way the JS bundle would.
 """
 
 import base64
+import json
 from typing import Any, Dict
 
 import pandas as pd
@@ -13,6 +14,7 @@ import pyarrow as pa
 import pyarrow.ipc as pa_ipc
 import pytest
 
+from gofish import chart, layer, rect
 from gofish.arrow_utils import dataframe_to_arrow
 from gofish.widget import GoFishChartWidget
 
@@ -160,3 +162,67 @@ class TestRenderResultStatus:
         assert widget.done is True
         assert widget.result is False
         assert widget.error == "boom"
+
+
+class TestArrowDataWireShape:
+    """`arrow_data` carries two distinct wire shapes (#683): a single chart's
+    Arrow bytes get base64-encoded directly, while a layer's per-child bytes
+    are wrapped in a JSON object keyed by child index. `GoFishChartWidget`
+    must build the right shape for whichever of `arrow_data`/`arrow_dict` it
+    receives, and reject the ambiguous case of both/neither.
+    """
+
+    def test_single_chart_arrow_data_is_plain_base64(self):
+        raw = dataframe_to_arrow(pd.DataFrame([{"x": 1}]))
+        widget = GoFishChartWidget(
+            spec={"data": None, "operators": [], "mark": {"type": "rect"}, "options": {}, "zOrder": None},
+            arrow_data=raw,
+            width=400,
+            height=300,
+        )
+        assert base64.b64decode(widget.arrow_data) == raw
+
+    def test_layer_arrow_dict_is_json_of_base64_by_index(self):
+        raw0 = dataframe_to_arrow(pd.DataFrame([{"x": 1}]))
+        raw1 = dataframe_to_arrow(pd.DataFrame([{"x": 2}]))
+        widget = GoFishChartWidget(
+            spec={"type": "layer", "charts": [], "options": {}},
+            arrow_dict={"0": raw0, "1": raw1},
+            width=400,
+            height=300,
+        )
+        decoded = json.loads(widget.arrow_data)
+        assert base64.b64decode(decoded["0"]) == raw0
+        assert base64.b64decode(decoded["1"]) == raw1
+
+    def test_requires_exactly_one_of_arrow_data_or_arrow_dict(self):
+        spec = {"data": None, "operators": [], "mark": {"type": "rect"}, "options": {}, "zOrder": None}
+        with pytest.raises(ValueError):
+            GoFishChartWidget(spec=spec, width=400, height=300)
+        with pytest.raises(ValueError):
+            GoFishChartWidget(
+                spec=spec,
+                arrow_data=b"x",
+                arrow_dict={"0": b"y"},
+                width=400,
+                height=300,
+            )
+
+    def test_layer_builder_render_does_not_raise(self):
+        """Regression test for #683: rendering a `.layer()` chain through the
+        widget path used to raise `TypeError: a bytes-like object is
+        required, not 'str'` because `LayerBuilder.render` handed the widget
+        a JSON string where it expected raw Arrow bytes.
+        """
+        c1 = chart([{"x": 1, "y": 2}]).mark(rect(h="y").name("bars"))
+        c2 = chart([{"x": 1, "y": 3}]).mark(rect(h="y").name("more_bars"))
+
+        widget = layer([c1, c2]).render()
+
+        assert widget.spec["type"] == "layer"
+        decoded = json.loads(widget.arrow_data)
+        assert set(decoded.keys()) == {"0", "1"}
+        for b64 in decoded.values():
+            buf = base64.b64decode(b64)
+            reader = pa_ipc.open_stream(pa.BufferReader(buf))
+            assert reader.read_all().num_rows == 1


### PR DESCRIPTION
## Summary
- `GoFishChartWidget.__init__` always ran `base64.b64encode(arrow_data)`, assuming `arrow_data` was always raw Arrow IPC bytes for a single chart.
- `LayerBuilder.render` instead built a JSON string (an index → base64 dict, matching the `renderLayer` contract in `widget-src/index.ts`) and passed that string in as `arrow_data`, so any `.layer()` chain rendered through the widget crashed with `TypeError: a bytes-like object is required, not 'str'`.
- Fix: give `GoFishChartWidget` an explicit `arrow_dict: Dict[str, bytes]` parameter (raw bytes per child index) alongside `arrow_data: bytes` (raw bytes for a single chart). The widget now owns all base64/JSON wire encoding for both shapes; callers only ever pass raw bytes. `LayerBuilder.render` was simplified to collect raw Arrow bytes per child and hand them to `arrow_dict` instead of pre-encoding a JSON string itself.

This is a real dual wire-shape, not an incidental one: JS's `renderChart` (`widget-src/index.ts`) genuinely branches on `spec.type === "layer"` — a single chart decodes `arrow_data` directly as base64 Arrow bytes, while a layer `JSON.parse`s it and looks up `arrowDict[String(i)]` per child. The bug was that this contract lived only on the JS side and in `LayerBuilder.render`'s ad hoc encoding, while `widget.py`'s constructor didn't know about it. Centralizing both encodings in `GoFishChartWidget.__init__` (selected by which of two explicit, named parameters the caller passes) makes the two-shape contract explicit in one place instead of re-derived per caller.

## Test plan
- [x] Added `TestArrowDataWireShape` in `packages/gofish-python/tests/test_widget_protocol.py`: single-chart `arrow_data` round-trips as plain base64, `arrow_dict` round-trips as JSON-of-base64-by-index, exactly-one-of validation, and a regression test constructing a real `.layer([...])` chain and rendering it through the widget path (previously raised `TypeError`).
- [x] `uv run pytest --ignore=tests/test_ast.py` → 65 passed, 2 xfailed (the 2 `test_ast.py`/`test_stories.py` failures on `area` import are pre-existing, unrelated to this change — an unported JS `area` mark, confirmed failing identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)