### PR TITLE
Convert ViolinPlot parity exemption from file-level to per-export

### DIFF
--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -61,15 +61,6 @@ packages/gofish-graphics/stories/bluefish/DFSCQ.stories.tsx
 # the same low-level vocabulary as QuantumCircuit/Pulley/PythonTutor
 # above, not yet expressible via the fluent chart() pipeline.
 packages/gofish-graphics/stories/bluefish/OhmParseTree.stories.tsx
-#
-# ViolinPlot is ported too (tests/python-stories/low-level-syntax/
-# test_violin_plot.py) but stays exempt: the JS story uses `fast-kde`'s
-# density1d, while the idiomatic Python port uses `scipy.stats.gaussian_kde`.
-# The violins render with the same structure/colors/layout but the KDE curve
-# differs (different bandwidth/extent), so it can't byte-match the JS DOM.
-# capture-python skips file-level-exempt stories, so this port is validated
-# (IR + render) without failing the byte-parity gate.
-packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx
 
 # Per-export exemption — PolarText constructs a raw custom coordinate
 # transform inline ({ type, transform: ([r, theta]) => ..., domain }), an
@@ -157,6 +148,17 @@ packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_Spaci
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadX_Spacing_AlignEnd
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadX_CenterToCenter
 packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_Reversed
+
+# Per-export exemption for ViolinPlot.stories.tsx — the JS story uses
+# `fast-kde`'s density1d, while the idiomatic Python port
+# (tests/python-stories/low-level-syntax/test_violin_plot.py) uses
+# `scipy.stats.gaussian_kde`. Both produce a real KDE curve over the same
+# data with the same violin structure/colors/layout, but the two libraries'
+# default bandwidth/extent choices diverge, so the rendered curve can't
+# byte-match the JS baseline — an accepted algorithm divergence, not a
+# missing feature. The port IS captured and IR-validated (mark/operator
+# structure, data, options); only the pixel-for-pixel DOM diff is skipped.
+packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx::Default
 
 # ---------------------------------------------------------------------------
 # gofish-gotree (the GoTree tree-DSL package) — exempt from Python parity.

--- a/tests/scripts/capture-python-dom.ts
+++ b/tests/scripts/capture-python-dom.ts
@@ -100,10 +100,15 @@ function discoverPythonStories(): PythonStory[] {
 /**
  * Python files (relative to TESTS_DIR) whose JS source story is **file-level
  * exempt** in `.python-sync-exempt`. A Python port may still exist and be
- * committed (e.g. the ViolinPlot scipy port, whose KDE intentionally diverges
- * from the JS `fast-kde` baseline), but an exempt story is excluded from the
- * byte-parity gate — so we skip capturing it rather than emit a snapshot that
- * `compare-python` would (correctly) flag as a mismatch.
+ * committed (e.g. NestedMosaicChart's fluent-pipeline port, which can't
+ * cross the derive RPC because of its function fill), but an exempt story is
+ * excluded from the byte-parity gate — so we skip capturing it rather than
+ * emit a snapshot that `compare-python` would (correctly) flag as a
+ * mismatch. Stories that only need the byte-diff skipped (the algorithm
+ * genuinely diverges but the port IS captured/IR-validated, e.g. ViolinPlot's
+ * scipy vs. fast-kde KDE) use the per-export `file::Export` tier instead —
+ * see `loadExportExemptParityPaths` in compare-python.ts, which skips only
+ * the byte diff for those.
  */
 function loadExemptPythonFiles(): Set<string> {
   const exemptFile = join(TESTS_DIR, ".python-sync-exempt");
@@ -504,7 +509,7 @@ async function main() {
       );
 
       // Skip stories whose JS source is file-level parity-exempt — the port
-      // is intentionally not byte-identical (e.g. ViolinPlot's scipy KDE).
+      // isn't expressible at all (e.g. NestedMosaicChart's function fill).
       if (exemptPythonFiles.has(story.file)) {
         console.log("SKIP (JS story is parity-exempt)");
         skipped++;


### PR DESCRIPTION
Fixes item 1 of #775.

## Problem

The ViolinPlot Python port (`tests/python-stories/low-level-syntax/test_violin_plot.py`) uses `scipy.stats.gaussian_kde` while the JS story uses `fast-kde`'s `density1d`. The two libraries make different bandwidth and extent choices, so the rendered KDE curve can never byte-match the JS DOM. That divergence is accepted.

The problem was the exemption tier. The story was listed *file-level* in `tests/.python-sync-exempt`, and `capture-python-dom.ts` skips file-level-exempt stories entirely. So the Python port was never captured, rendered, or IR-validated in CI, even though the exemption comment claimed it was "validated (IR + render) without failing the byte-parity gate."

## Fix

Move the entry to the *per-export* tier:

```
packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx::Default
```

Per-export entries (the `file::Export` form, same as the existing `Constraints.stories.tsx::SpreadX_CenterToCenter` precedent) ARE captured and IR-validated by `capture-python-dom.ts`; only the byte diff in `compare-python.ts` is skipped. The exemption comment now describes the divergence (scipy `gaussian_kde` vs fast-kde `density1d`) and what IS validated. The doc comments in `capture-python-dom.ts` that used ViolinPlot as the file-level example are updated to describe the two tiers accurately.

## Verification (local, venv python + scipy, Playwright chromium)

Capture — the story is now captured and IR-validated instead of skipped:

```
python_stories.low_level_syntax.test_violin_plot::story_default → low-level-syntax/violin-plot--default ... OK
Done: 204 captured, 0 failed, 0 skipped
```

Compare — only the byte diff is skipped:

```
SKIP (export parity-exempt): low-level-syntax/violin-plot--default.html
```

(The other local mismatches are the known Mac vs Linux text-metric drift against the `snapshots/main` baselines, unrelated to this change.)

`check-python-sync-all` passes: 0 missing exports, and ViolinPlot no longer appears in the file-level exempt-warn list.

Item 2 of #775 (Python docs-gallery presence) is blocked on #448 and stays open.

Advances #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)