### PR TITLE
Bridge selectAll-label / ref-datum mark-fns to Python (#591)

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -81,6 +81,9 @@ jobs:
       - name: gofish-graphics tests (path + font + bbox + solver + serialize)
         run: pnpm --filter gofish-graphics test
 
+      - name: gofish-python widget Arrow transport tests
+        run: pnpm --filter gofish-python test:arrow-transport
+
   python-ir-validation:
     needs: changes
     if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.relevant == 'true' }}

--- a/apps/docs/docs/internals/frontend/serialization.md
+++ b/apps/docs/docs/internals/frontend/serialization.md
@@ -161,6 +161,33 @@ absolute-vs-weight mixing, measure-unit checks) lives in ONE place, JS-side:
   `cut(source, opts)` returns a `Promise<GoFishNode>[]` that combinators accept
   directly as children (see `mapMarkChildren` in `fromJSON.ts`).
 
+**`mark-fn` over refs** (#591) — a Python `.mark(fn)` callback isn't limited
+to receiving plain data rows: when the callback's `data` is a bag of
+`GoFishRef`s (e.g. the `.layer(chart().flow(group(...)).mark(fn))` shape that
+labels a bar chart's totals), each `GoFishRef` argument crosses the RPC
+serialized as an `{"__inputRef": i, "datum": <rows>}` sentinel rather than as
+a live node reference — a `GoFishRef` is a class instance over the render's
+layer registry, not JSON. `serializeMarkFnInput` in `fromJSON.ts` builds these
+sentinels from the real ref array right before the RPC call and keeps that
+array in closure; the Python side (`_InputRef` in `gofish/ast.py`) wraps each
+sentinel back into an object whose `.datum` reads naturally. The callback may
+return a `ChartBuilder` (as before) or — new — a bare `Mark`, wired as
+`{"type": "raw-mark", "mark": <mark-tree>}` (the same shape `Mark.to_ir()`
+uses at the top level), which lets it embed one of its `_InputRef` arguments
+directly in the returned layout (mirroring JS `spread({...}, [d[0],
+text(...)])`). `mapMark` resolves any `{"__inputRef": i}` sentinel found
+inside that returned mark tree back to `inputRefs[i]` — the _original_ live
+`GoFishRef` from the closure, not a reconstructed stand-in, so the ref's
+identity (and anything already registered against it, e.g. a name from an
+earlier tier) survives. A `.name(...)` call on the Python `_InputRef` (#556)
+rides along as a `name` field on the sentinel and is applied to the resolved
+ref before it's returned, since `GoFishRef.name()` mutates in place — this is
+how a per-slice label overlay (`Cut.stories.tsx::ImageCutWithLabels`) can
+`.constrain(...)` against a ref it only received through the bridge. The test
+harness (`tests/harness/main.ts`) carries an equivalent
+`serializeMarkFnInput`/`__inputRef` implementation, since it renders from raw
+IR over plain HTTP rather than through the shared `fromJSON.ts`/widget path.
+
 There is no `connect` field on the wire. `.layer(...)` — the one way to
 overlay a connector — always serializes as an ordinary `LayerIR` tier: an
 empty `chart()` scope crosses as a `ChartIR` whose `data` is

--- a/apps/docs/docs/python/api/core/mark.md
+++ b/apps/docs/docs/python/api/core/mark.md
@@ -81,6 +81,40 @@ The older callback form `mark(lambda data: chart(data, ...).flow(...).mark(...))
 still works and is equivalent — the function receives each group's data slice and
 returns a nested chart.
 
+## Mark-fn over refs — value labels
+
+When a callback's `data` is a bag of **refs** (rather than plain rows) — e.g.
+inside an empty-scope [`.layer(...)`](/python/api/core/layer) tier that groups
+the previous tier's own marks — each item exposes the underlying node's bound
+data via `.datum`, and the callback may return a raw combinator `Mark`
+(`spread([...])`, `stack([...])`, …) that embeds one of those refs directly,
+rather than only a nested `chart(...)`. This is how a bar chart gets a total
+label above each bar, drawn as a sibling of the bar itself rather than a
+separate chart:
+
+::: gofish example:bar-chart-with-value-labels hidden
+:::
+
+```python
+from gofish import chart, spread, rect, text, group
+
+def label_mark(d):
+    total = sum(row["count"] for row in d[0].datum)
+    return spread([d[0], text(text=str(total))], dir="y", alignment="middle", spacing=10)
+
+chart(seafood, axes=True).flow(spread(by="lake", dir="x")).mark(
+    rect(h="count")
+).layer(
+    chart().flow(group(by="lake")).mark(label_mark)
+).render(w=400, h=400)
+```
+
+`d[0]` is the ref for that lake's bar; `d[0].datum` is that lake's bag of
+species rows (an aggregate), so `sum(row["count"] for row in d[0].datum)` is
+the lake's total catch. Embedding `d[0]` in the returned `spread([...])`
+places the label as a sibling of the bar it labels, using the bar's own
+placed position and size — no separate positioning logic needed.
+
 ## Labeling a mark
 
 Call `.label(accessor, position=..., font_size=..., color=..., offset=..., rotate=..., font_family=..., font_weight=..., font_style=...)`

--- a/packages/gofish-graphics/src/lib.ts
+++ b/packages/gofish-graphics/src/lib.ts
@@ -76,6 +76,13 @@ export { bin } from "./ast/transforms";
 // Shapes
 export { ref } from "./ast/shapes/ref";
 
+// The ref runtime class itself (not just the `ref(...)` factory) — needed by
+// consumers that must distinguish "a resolved node ref" from "a plain data
+// row" at runtime, e.g. the Python-bridge mark-fn plumbing (issue #591) that
+// serializes each `GoFishRef` argument as an `{__inputRef, datum}` sentinel
+// before it crosses the RPC boundary.
+export { GoFishRef } from "./ast/_ref";
+
 // Datum projection — `pluck(ref, "species")` returns the full set of distinct
 // values for a field across a selected node's rows ("every possible value");
 // `project(ref, "species")` is its collapsing sibling — the single value when

--- a/packages/gofish-graphics/src/serialize/fromJSON.ts
+++ b/packages/gofish-graphics/src/serialize/fromJSON.ts
@@ -21,6 +21,7 @@ import { createName, type Token } from "../ast/createName";
 import { Constraint } from "../ast/constraints";
 import { palette, gradient } from "../ast/colorSchemes";
 import { ref } from "../ast/shapes/ref";
+import { GoFishRef } from "../ast/_ref";
 import type { Frontend } from "gofish-ir";
 import {
   COMBINATOR_FACTORIES,
@@ -310,12 +311,13 @@ export function mapOperator(
 export function mapMarkChildren(
   specs: MarkSpec[],
   bridge: DeriveBridge | undefined,
-  resolveToken: TokenResolver
+  resolveToken: TokenResolver,
+  inputRefs?: any[]
 ): any[] {
   const out: any[] = [];
   for (const child of specs as any[]) {
     if (child && child.type === "cut") {
-      const sourceMark = mapMark(child.source, bridge, resolveToken);
+      const sourceMark = mapMark(child.source, bridge, resolveToken, inputRefs);
       // Pure cut requires an array `size`; the field-name-string sugar is only
       // valid in the chart `.mark(cut(...))` (data-bound expand) form.
       const slices = cutSlices(sourceMark as any, {
@@ -325,17 +327,48 @@ export function mapMarkChildren(
       });
       out.push(...slices);
     } else {
-      out.push(mapMark(child as MarkSpec, bridge, resolveToken));
+      out.push(mapMark(child as MarkSpec, bridge, resolveToken, inputRefs));
     }
   }
   return out;
 }
 
-/** Build a single mark from its IR spec. Recurses into combinator children. */
+/**
+ * Serialize a mark-fn's input array for the RPC bridge. Each `GoFishRef` (the
+ * shape `.flow(group(...)).mark((refs) => ...)` hands the callback — see
+ * `createRelationalMark`'s `by`-split bag form and `createOperator.ts`'s
+ * per-item `applyMark`) can't cross JSON as-is (it's a live class instance
+ * over the render's layer registry), so it's replaced with an
+ * `{__inputRef: i, datum}` sentinel carrying just its bound datum. The
+ * Python wrapper reconstructs an `_InputRef` Mark from the sentinel so
+ * `d[0].datum` reads naturally, and can round-trip `d[0]` itself back into a
+ * returned mark tree (`resolveInputRefs` below undoes the substitution using
+ * the same index against the original `GoFishRef` array). Plain data rows
+ * (the pre-#591 mark-fn contract, e.g. Scatter's pie-glyph story) pass
+ * through unchanged.
+ */
+function serializeMarkFnInput(data: any): { rows: any[]; inputRefs?: any[] } {
+  const items = Array.isArray(data) ? data : [data];
+  if (!items.some((item) => item instanceof GoFishRef)) {
+    return { rows: items };
+  }
+  const rows = items.map((item, i) =>
+    item instanceof GoFishRef ? { __inputRef: i, datum: item.datum } : item
+  );
+  return { rows, inputRefs: items };
+}
+
+/** Build a single mark from its IR spec. Recurses into combinator children.
+ *  `inputRefs`, when supplied, is the array of real `GoFishRef`s a mark-fn was
+ *  invoked with — an `{__inputRef: i}` sentinel anywhere in the (possibly
+ *  Python-returned) mark tree resolves back to `inputRefs[i]`, letting a
+ *  Python mark-fn embed the ref it was handed directly in its returned
+ *  layout (mirrors JS `spread({...}, [d[0], text(...)])`). */
 export function mapMark(
   markSpec: MarkSpec,
   bridge: DeriveBridge | undefined,
-  resolveToken: TokenResolver
+  resolveToken: TokenResolver,
+  inputRefs?: any[]
 ): Mark<any> {
   const spec = markSpec as any;
   const applyTranslate = <T>(mark: T): T =>
@@ -343,9 +376,31 @@ export function mapMark(
       ? ((mark as any).translate(spec.translate) as T)
       : mark;
 
-  // Mark-as-function: Python registered a `(data) -> ChartBuilder` lambda.
-  // The JS Mark fetches a chart IR per invocation (via the bridge) and
-  // rebuilds a ChartBuilder JS-side.
+  // `{__inputRef: i}` sentinel — round-trip back to the real `GoFishRef` a
+  // mark-fn was invoked with (see `serializeMarkFnInput`), rather than
+  // reconstructing a new mark from the spec.
+  if (typeof spec.__inputRef === "number") {
+    if (!inputRefs) {
+      throw new Error(
+        "encountered an { __inputRef } sentinel but no input refs were supplied " +
+          "— this mark tree must be returned from a mark-fn invocation"
+      );
+    }
+    const inputRef = inputRefs[spec.__inputRef];
+    // `.name(...)` on the Python `_InputRef` (issue #556) — `GoFishRef.name()`
+    // mutates in place and returns `this`, so this renames the SAME live ref
+    // the rest of the tree already shares (e.g. the stem/bar this ref also
+    // points at), letting an enclosing `.layer([...]).constrain(...)` target
+    // it by name.
+    if (spec.name != null && typeof (inputRef as any)?.name === "function") {
+      (inputRef as any).name(resolveNameField(spec.name, resolveToken));
+    }
+    return inputRef;
+  }
+
+  // Mark-as-function: Python registered a `(data) -> ChartBuilder | Mark`
+  // lambda. The JS Mark fetches a chart (or raw-mark) IR per invocation (via
+  // the bridge) and rebuilds it JS-side.
   if (spec.type === "mark-fn") {
     const lambdaId = spec.lambdaId as string;
     if (!bridge) {
@@ -354,19 +409,39 @@ export function mapMark(
       );
     }
     return (async (data: any, _key: any, _layerContext: any) => {
-      const rows = Array.isArray(data) ? data : [data];
+      const { rows, inputRefs: newInputRefs } = serializeMarkFnInput(data);
       const result = await bridge.applyLambda(lambdaId, rows);
-      // Returns a ChartBuilder which functionally behaves as a Mark in
-      // the deserialization pipeline; cast through `unknown` to express
+      // Returns a ChartBuilder or a raw Mark, both of which behave as a Mark
+      // in the deserialization pipeline; cast through `unknown` to express
       // that the deserializer is honoring the existing widget contract.
-      // mark-fn returns a one-element list; row[0] is the chart-spec dict.
+      // mark-fn returns a one-element list; row[0] is the chart/mark-spec dict.
       // Round-trip transport may wrap it under the first column.
       const first = result[0];
-      const chartSpec =
+      const resultSpec =
         first && typeof first === "object" && Object.keys(first).length === 1
           ? first[Object.keys(first)[0]]
           : first;
-      const cs = chartSpec as ChartSpec;
+      // A bare Mark returned by the Python mark-fn (e.g. `spread([...])`)
+      // serializes as `{type: "raw-mark", mark: ...}` — mirrors the
+      // top-level raw-mark IR (`Mark.to_ir()`), reused here since a mark-fn
+      // result is structurally the same "just a mark tree" shape.
+      if (
+        resultSpec &&
+        typeof resultSpec === "object" &&
+        (resultSpec as any).type === "raw-mark"
+      ) {
+        // Returned un-invoked: `resolveMarkResult` (the caller, one level up)
+        // already knows how to call a function-shaped Mark with
+        // `(undefined, undefined, layerContext)` — mirrors the ChartBuilder
+        // branch below, which is likewise returned rather than resolved here.
+        return mapMark(
+          (resultSpec as any).mark as MarkSpec,
+          bridge,
+          resolveToken,
+          newInputRefs
+        );
+      }
+      const cs = resultSpec as ChartSpec;
       const data2 = Array.isArray((cs as any).data)
         ? ((cs as any).data as Record<string, any>[])
         : [];
@@ -387,7 +462,12 @@ export function mapMark(
   // public `offset` operator, which accepts a Mark child and resolves it.
   if (spec.type === "offset") {
     const childSpecs = (spec.children ?? []) as MarkSpec[];
-    const [childMark] = mapMarkChildren(childSpecs, bridge, resolveToken);
+    const [childMark] = mapMarkChildren(
+      childSpecs,
+      bridge,
+      resolveToken,
+      inputRefs
+    );
     return applyTranslate(
       offsetOp({ x: spec.x, y: spec.y }, [
         childMark as any,
@@ -401,7 +481,12 @@ export function mapMark(
   // combinator CHILD is instead expanded into its N slice nodes IN PLACE — see
   // `mapMarkChildren` — so extent resolution lives in ONE place, JS-side.)
   if (spec.type === "cut") {
-    const sourceMark = mapMark(spec.source as MarkSpec, bridge, resolveToken);
+    const sourceMark = mapMark(
+      spec.source as MarkSpec,
+      bridge,
+      resolveToken,
+      inputRefs
+    );
     let mark = cutMark({
       source: sourceMark as any,
       dir: spec.dir,
@@ -428,7 +513,8 @@ export function mapMark(
     const childMarks = mapMarkChildren(
       (spec.children ?? []) as MarkSpec[],
       bridge,
-      resolveToken
+      resolveToken,
+      inputRefs
     );
     // Resolve color/coord configs (e.g. a `layer({coord: polar()})` carries
     // its coord transform in the combinator options, not chart options).

--- a/packages/gofish-python/gofish/arrow_utils.py
+++ b/packages/gofish-python/gofish/arrow_utils.py
@@ -104,3 +104,38 @@ def arrow_to_dataframe(arrow_bytes: bytes) -> pd.DataFrame:
     table = reader.read_all()
     return table.to_pandas()
 
+
+def arrow_to_records(arrow_bytes: bytes) -> list:
+    """
+    Convert Apache Arrow bytes back to a list of plain-dict rows.
+
+    Deliberately bypasses `arrow_to_dataframe`/pandas for this: pandas'
+    `to_pandas()` decodes a `list<struct>` column (the JS-side widget
+    transport's explicit-schema encoding for a mark-fn's multi-row `datum`
+    bag — see `widget-src/arrowTransport.ts`, issue #783) into a numpy
+    `ndarray` of dicts rather than a plain Python `list` of dicts, which
+    doesn't match the plain-JSON-over-HTTP shape the parity test harness's
+    derive server hands a mark-fn (`tests/scripts/derive-server.py`).
+    `pyarrow.Array.to_pylist()` decodes straight to native Python
+    containers — `list`/`dict`/`None`/scalars — for every level of
+    nesting, so a `list<struct>` column round-trips to exactly a
+    `list[dict]`, and a struct field missing from some bag rows (ragged
+    but homogeneous data — the encoder fills those with a column-level
+    null) comes back as `None`.
+
+    Args:
+        arrow_bytes: Arrow IPC format bytes
+
+    Returns:
+        A list of dicts, one per row, in column order.
+
+    Example:
+        >>> rows = arrow_to_records(arrow_bytes)
+    """
+    reader = pa.ipc.open_stream(arrow_bytes)
+    table = reader.read_all()
+    columns = {name: table.column(name).to_pylist() for name in table.column_names}
+    return [
+        {name: columns[name][i] for name in table.column_names}
+        for i in range(table.num_rows)
+    ]

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -599,6 +599,58 @@ class Mark:
         return self.render()._repr_mimebundle_(include=include, exclude=exclude)
 
 
+class _InputRef(Mark):
+    """A `GoFishRef` handed into a mark-fn lambda, reconstructed Python-side
+    (issue #591).
+
+    JS's `.flow(group(...)).mark((refs) => ...)` invokes the callback with an
+    array of live `GoFishRef`s (one per group) — e.g. `d[0]` in
+    `BarWithLabels.stories.tsx`'s label mark-fn, whose `.datum` is the group's
+    row bag. A `GoFishRef` can't cross the derive RPC as-is (it's a class
+    instance over the render's layer registry, not JSON), so the JS side
+    (`serializeMarkFnInput` in `fromJSON.ts`/`main.ts`) replaces each ref
+    argument with an `{"__inputRef": i, "datum": ...}` sentinel; the derive
+    server wraps every such sentinel back into one of these before calling
+    the user's function, so `d[0].datum` reads exactly like the JS story.
+
+    `to_dict()` emits `{"type": "ref", "__inputRef": i}` — no `datum`, since
+    the datum already made the trip once and the JS side round-trips the
+    sentinel back to the *original* live ref object by index rather than
+    reconstructing one from the (re-serialized) datum. This lets a mark-fn
+    embed the ref directly in its returned layout (mirrors JS
+    `spread({...}, [d[0], text(...)])`).
+
+    `.name(...)` (issue #556 — a named ref surviving a mark-fn round trip, so
+    an enclosing `.layer([...]).constrain(...)` can target it by name, e.g.
+    `Cut.stories.tsx::ImageCutWithLabels`'s `d.name("slice")`) is overridden
+    rather than inherited from `Mark`: JS `GoFishRef.name()` MUTATES the ref
+    in place and returns `this` (not a fresh copy — the ref's identity, not
+    just its `_name`, is what the rest of the tree shares), so this mirrors
+    that instead of `Mark.name()`'s clone-a-new-instance pattern (which would
+    also fail here: `type(self)(self.mark_type, ...)` doesn't match
+    `_InputRef.__init__`'s `(index, datum)` signature).
+    """
+
+    def __init__(self, index: int, datum: Any):
+        super().__init__("ref")
+        self.index = index
+        self.datum = datum
+
+    def name(self, name_or_token: Union[str, "Token"]) -> "_InputRef":
+        self._name = name_or_token
+        return self
+
+    def to_dict(self) -> dict:
+        d: dict = {"type": "ref", "__inputRef": self.index}
+        if self._name is not None:
+            d["name"] = (
+                self._name.to_dict()
+                if isinstance(self._name, Token)
+                else self._name
+            )
+        return d
+
+
 # The generated factory layer (packages/gofish-python/gofish/_generated.py)
 # imports `Mark` / `_channel` from this module, so it can only be imported
 # here AFTER both are defined (circular import, resolved by Python's partial

--- a/packages/gofish-python/gofish/widget.py
+++ b/packages/gofish-python/gofish/widget.py
@@ -15,7 +15,7 @@ from typing import Any, Callable, Dict, List, Optional
 import anywidget
 import traitlets
 
-from .arrow_utils import arrow_to_dataframe, dataframe_to_arrow
+from .arrow_utils import arrow_to_records, dataframe_to_arrow
 
 
 class GoFishChartWidget(anywidget.AnyWidget):
@@ -113,8 +113,13 @@ class GoFishChartWidget(anywidget.AnyWidget):
             if fn is None:
                 raise ValueError(f"Derive function with ID {lambda_id} not found")
 
-            df = arrow_to_dataframe(base64.b64decode(arrow_b64))
-            result = fn(df.to_dict("records"))
+            # `arrow_to_records` (not `arrow_to_dataframe(...).to_dict("records")`)
+            # so a `list<struct>` column (a mark-fn's `datum` multi-row bag,
+            # #783) decodes to a plain `list[dict]` rather than a numpy
+            # `ndarray` of dicts — matching what the parity harness's derive
+            # server hands the same function over its plain-JSON transport.
+            rows = arrow_to_records(base64.b64decode(arrow_b64))
+            result = fn(rows)
 
             try:
                 import pandas as pd

--- a/packages/gofish-python/package.json
+++ b/packages/gofish-python/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build:widget": "node build-widget.mjs",
     "gen": "pnpm --dir ../gofish-ir run build && tsx scripts/generate.ts",
-    "test": "uv run pytest"
+    "test": "uv run pytest",
+    "test:arrow-transport": "tsx widget-src/arrowTransport.test.ts"
   },
   "dependencies": {
     "apache-arrow": "^14.0.0",

--- a/packages/gofish-python/tests/test_arrow_transport.py
+++ b/packages/gofish-python/tests/test_arrow_transport.py
@@ -1,0 +1,156 @@
+"""Tests for the Python-side decode contract of the widget RPC transport
+(issue #783).
+
+The JS-side encoder (`widget-src/arrowTransport.ts`) builds an explicit
+Arrow schema per RPC call instead of relying on `Arrow.tableFromJSON`'s
+inference (which can't handle a `list<struct>` column at all — the shape
+of a mark-fn's `{__inputRef, datum}` sentinel when the ref's bound datum
+is a multi-row bag). These tests build the equivalent Arrow IPC bytes
+directly with pyarrow (mirroring what the JS encoder produces) and assert
+on `arrow_to_records`'s decode contract: a `list<struct>` column must come
+back as a plain `list[dict]`, not a numpy `ndarray` of dicts, so a mark-fn
+sees the exact same shape whether it runs over this Arrow transport or the
+parity test harness's plain-JSON transport (`tests/scripts/derive-server.py`).
+"""
+
+import base64
+import json
+
+import pyarrow as pa
+import pytest
+
+from gofish.arrow_utils import arrow_to_records
+from gofish.widget import GoFishChartWidget
+
+
+def _ipc_bytes(table: pa.Table) -> bytes:
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    return sink.getvalue().to_pybytes()
+
+
+class TestArrowToRecords:
+    def test_flat_table(self):
+        table = pa.table({"x": pa.array([1.0, 2.0]), "name": pa.array(["a", "b"])})
+        records = arrow_to_records(_ipc_bytes(table))
+        assert records == [{"x": 1.0, "name": "a"}, {"x": 2.0, "name": "b"}]
+
+    def test_single_row_struct(self):
+        struct_type = pa.struct([("x", pa.float64()), ("label", pa.string())])
+        table = pa.table(
+            {
+                "__inputRef": pa.array([0.0], type=pa.float64()),
+                "datum": pa.array([{"x": 1.0, "label": "a"}], type=struct_type),
+            }
+        )
+        records = arrow_to_records(_ipc_bytes(table))
+        assert records == [{"__inputRef": 0.0, "datum": {"x": 1.0, "label": "a"}}]
+
+    def test_multi_row_bag_decodes_to_plain_list_of_dicts(self):
+        """The #783 repro shape: a mark-fn's `datum` bound to a group's
+        multiple rows, transported as a `list<struct>` column."""
+        struct_type = pa.struct([("x", pa.float64()), ("label", pa.string())])
+        list_type = pa.list_(struct_type)
+        table = pa.table(
+            {
+                "__inputRef": pa.array([0.0, 1.0], type=pa.float64()),
+                "datum": pa.array(
+                    [
+                        [{"x": 1.0, "label": "a"}, {"x": 2.0, "label": "b"}],
+                        [{"x": 3.0, "label": "c"}],
+                    ],
+                    type=list_type,
+                ),
+            }
+        )
+        records = arrow_to_records(_ipc_bytes(table))
+
+        assert records[0]["datum"] == [{"x": 1.0, "label": "a"}, {"x": 2.0, "label": "b"}]
+        assert records[1]["datum"] == [{"x": 3.0, "label": "c"}]
+        # The whole point of #783: plain `list`, not a numpy `ndarray`.
+        assert isinstance(records[0]["datum"], list)
+        assert isinstance(records[0]["datum"][0], dict)
+        # Round-trips cleanly through JSON too — further evidence there's no
+        # numpy/pandas type hiding in the decoded shape.
+        json.dumps(records)
+
+    def test_ragged_keys_missing_key_becomes_none(self):
+        """A struct field present in some bag rows and absent in others —
+        the encoder fills the gap with a column-level null; decode must
+        surface that as `None`, not drop the key or raise."""
+        struct_type = pa.struct([("x", pa.float64()), ("label", pa.string())])
+        list_type = pa.list_(struct_type)
+        table = pa.table(
+            {
+                "datum": pa.array(
+                    [[{"x": 1.0, "label": "a"}, {"x": 2.0, "label": None}]],
+                    type=list_type,
+                ),
+            }
+        )
+        records = arrow_to_records(_ipc_bytes(table))
+        assert records[0]["datum"][1] == {"x": 2.0, "label": None}
+
+    def test_empty_bag_decodes_to_empty_list(self):
+        struct_type = pa.struct([("x", pa.float64())])
+        list_type = pa.list_(struct_type)
+        table = pa.table(
+            {
+                "__inputRef": pa.array([0.0], type=pa.float64()),
+                "datum": pa.array([[]], type=list_type),
+            }
+        )
+        records = arrow_to_records(_ipc_bytes(table))
+        assert records == [{"__inputRef": 0.0, "datum": []}]
+        assert isinstance(records[0]["datum"], list)
+
+
+class TestWidgetMarkFnBagContract:
+    """End-to-end through the real trait observer (`_on_derive_request`),
+    not just the arrow_utils helper — confirms widget.py actually calls
+    `arrow_to_records` (plain list[dict] rows) rather than the old
+    `arrow_to_dataframe(...).to_dict("records")` path (numpy-wrapped bags).
+    """
+
+    def test_mark_fn_receives_plain_list_of_dicts_for_a_bag(self):
+        seen = {}
+
+        def mark_fn(rows):
+            seen["rows"] = rows
+            return [{"ok": True}]
+
+        widget = GoFishChartWidget(
+            spec={"data": None, "mark": {"type": "rect"}, "operators": [], "options": {}, "zOrder": None},
+            arrow_data=b"",
+            derive_functions={"mark-fn-1": mark_fn},
+            width=400,
+            height=300,
+        )
+
+        struct_type = pa.struct([("x", pa.float64()), ("label", pa.string())])
+        list_type = pa.list_(struct_type)
+        table = pa.table(
+            {
+                "__inputRef": pa.array([0.0], type=pa.float64()),
+                "datum": pa.array(
+                    [[{"x": 1.0, "label": "a"}, {"x": 2.0, "label": None}]],
+                    type=list_type,
+                ),
+            }
+        )
+        arrow_b64 = base64.b64encode(_ipc_bytes(table)).decode("utf-8")
+
+        widget.derive_request = {
+            "request_id": "r-0",
+            "lambda_id": "mark-fn-1",
+            "arrow_b64": arrow_b64,
+        }
+
+        assert "result_b64" in widget.derive_response, widget.derive_response
+        rows = seen["rows"]
+        assert isinstance(rows, list)
+        assert isinstance(rows[0], dict)
+        bag = rows[0]["datum"]
+        assert isinstance(bag, list)
+        assert bag == [{"x": 1.0, "label": "a"}, {"x": 2.0, "label": None}]

--- a/packages/gofish-python/tests/test_stories.py
+++ b/packages/gofish-python/tests/test_stories.py
@@ -73,6 +73,14 @@ class TestForwardsyntaxBar:
         from stories.forwardsyntax.bar.bar_sorted_stacked import default
         _assert_valid_ir(default())
 
+    def test_bar_with_labels(self):
+        # A `.layer(...)` chain whose second tier is a mark-fn over refs
+        # (issue #591's ref/datum bridge) — `to_ir()` alone doesn't exercise
+        # the mark-fn's lambda body (that only runs over the derive RPC), but
+        # it does confirm the LayerBuilder assembles correctly.
+        from stories.forwardsyntax.bar.bar_with_labels import default
+        _assert_valid_layer_ir(default())
+
 
 # ---------------------------------------------------------------------------
 # Forward Syntax — other charts
@@ -198,15 +206,8 @@ class TestPieStories:
 # Blocked stories — xfail for remaining unsupported features
 # ---------------------------------------------------------------------------
 
-_V1_REASON = "requires v1 primitives (Spread, ref) — not yet in Python wrapper"
-
 
 class TestBlockedStories:
-
-    @pytest.mark.xfail(raises=NotImplementedError, reason=_V1_REASON, strict=True)
-    def test_bar_with_labels(self):
-        from stories.forwardsyntax.bar.bar_with_labels import default
-        default()
 
     @pytest.mark.xfail(raises=NotImplementedError, reason="requires nested chart as mark function — not yet supported", strict=True)
     def test_scatter_with_pie_glyphs(self):

--- a/packages/gofish-python/widget-src/arrowTransport.test.ts
+++ b/packages/gofish-python/widget-src/arrowTransport.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Tests for `buildArrowTable` — the explicit-schema Arrow encoder that
+ * replaced `Arrow.tableFromJSON` for the widget RPC transport (issue #783).
+ *
+ * Every case round-trips through `tableToIPC` / `tableFromIPC` (the same
+ * IPC bytes that cross the anywidget bridge to Python) and asserts on the
+ * decoded shape, so these tests exercise the exact encoding this module
+ * produces, not just its intermediate `Arrow.Table`.
+ */
+
+import * as Arrow from "apache-arrow";
+import { buildArrowTable } from "./arrowTransport";
+
+// This file is runnable as a script in Node, but the repo doesn't necessarily
+// include Node type definitions in all TS contexts.
+declare const process: any;
+
+function roundTrip(rows: Record<string, any>[]): Arrow.Table {
+  const table = buildArrowTable(rows);
+  const bytes = Arrow.tableToIPC(table);
+  return Arrow.tableFromIPC(bytes);
+}
+
+function structToJSON(row: any): any {
+  return row && typeof row.toJSON === "function" ? row.toJSON() : row;
+}
+
+function listToPlain(vec: any): any[] {
+  return Array.from(vec, (item: any) => {
+    if (item && typeof item.toJSON === "function") return structToJSON(item);
+    return item;
+  });
+}
+
+function testFlatTable(): boolean {
+  console.log("Test: flat table (plain scalar columns)");
+  const rows = [
+    { x: 1, name: "a", ok: true },
+    { x: 2, name: "b", ok: false },
+  ];
+  const table = roundTrip(rows);
+  if (table.numRows !== 2) {
+    console.log(`  ✗ expected 2 rows, got ${table.numRows}`);
+    return false;
+  }
+  const xs = table.getChild("x")!.toArray();
+  const names = table.getChild("name")!.toArray();
+  const oks = table.getChild("ok")!.toArray();
+  if (xs[0] !== 1 || xs[1] !== 2) {
+    console.log(`  ✗ x column mismatch: ${xs}`);
+    return false;
+  }
+  if (names[0] !== "a" || names[1] !== "b") {
+    console.log(`  ✗ name column mismatch: ${names}`);
+    return false;
+  }
+  if (oks[0] !== true || oks[1] !== false) {
+    console.log(`  ✗ ok column mismatch: ${oks}`);
+    return false;
+  }
+  console.log("  ✓ PASSED");
+  return true;
+}
+
+function testSingleRowStruct(): boolean {
+  console.log("Test: single-row struct column (previously-working case)");
+  const rows = [{ __inputRef: 0, datum: { x: 1, label: "a" } }];
+  const table = roundTrip(rows);
+  const datum = structToJSON(table.getChild("datum")!.get(0));
+  if (datum.x !== 1 || datum.label !== "a") {
+    console.log(`  ✗ datum mismatch: ${JSON.stringify(datum)}`);
+    return false;
+  }
+  console.log("  ✓ PASSED");
+  return true;
+}
+
+function testMultiRowBag(): boolean {
+  console.log("Test: multi-row bag (list<struct> — the #783 repro)");
+  const rows = [
+    {
+      __inputRef: 0,
+      datum: [
+        { x: 1, label: "a" },
+        { x: 2, label: "b" },
+      ],
+    },
+    { __inputRef: 1, datum: [{ x: 3, label: "c" }] },
+  ];
+  const table = roundTrip(rows);
+  const bag0 = listToPlain(table.getChild("datum")!.get(0));
+  const bag1 = listToPlain(table.getChild("datum")!.get(1));
+  if (bag0.length !== 2 || bag0[0].x !== 1 || bag0[1].label !== "b") {
+    console.log(`  ✗ bag0 mismatch: ${JSON.stringify(bag0)}`);
+    return false;
+  }
+  if (bag1.length !== 1 || bag1[0].x !== 3) {
+    console.log(`  ✗ bag1 mismatch: ${JSON.stringify(bag1)}`);
+    return false;
+  }
+  console.log("  ✓ PASSED");
+  return true;
+}
+
+function testRaggedKeys(): boolean {
+  console.log("Test: ragged keys within a bag (missing key → null)");
+  const rows = [
+    {
+      datum: [
+        { x: 1, label: "a" },
+        { x: 2 }, // no `label` key at all
+      ],
+    },
+  ];
+  const table = roundTrip(rows);
+  const bag = listToPlain(table.getChild("datum")!.get(0));
+  if (bag[0].label !== "a") {
+    console.log(`  ✗ bag[0].label mismatch: ${JSON.stringify(bag[0])}`);
+    return false;
+  }
+  if (bag[1].label !== null || bag[1].x !== 2) {
+    console.log(
+      `  ✗ bag[1] should have label=null, x=2, got ${JSON.stringify(bag[1])}`
+    );
+    return false;
+  }
+  console.log("  ✓ PASSED");
+  return true;
+}
+
+function testEmptyBag(): boolean {
+  console.log("Test: empty bag (datum: [])");
+  const rows = [{ __inputRef: 0, datum: [] }];
+  const table = roundTrip(rows);
+  const bag = listToPlain(table.getChild("datum")!.get(0));
+  if (bag.length !== 0) {
+    console.log(`  ✗ expected empty list, got ${JSON.stringify(bag)}`);
+    return false;
+  }
+  console.log("  ✓ PASSED");
+  return true;
+}
+
+function testConflictingTypesThrow(): boolean {
+  console.log("Test: conflicting types across rows throws loudly");
+  const rows = [{ a: 1 }, { a: "x" }];
+  try {
+    buildArrowTable(rows);
+    console.log("  ✗ expected buildArrowTable to throw, but it didn't");
+    return false;
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (
+      !message.includes('"a"') ||
+      !message.includes("number") ||
+      !message.includes("string")
+    ) {
+      console.log(`  ✗ error message missing column/type detail: ${message}`);
+      return false;
+    }
+    console.log("  ✓ PASSED (threw:", message, ")");
+    return true;
+  }
+}
+
+function testConflictingNestedTypesThrow(): boolean {
+  console.log("Test: conflicting types within a bag field throws loudly");
+  const rows = [{ datum: [{ x: 1 }, { x: "oops" }] }];
+  try {
+    buildArrowTable(rows);
+    console.log("  ✗ expected buildArrowTable to throw, but it didn't");
+    return false;
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    if (!message.includes("datum[].x")) {
+      console.log(`  ✗ error message missing nested column path: ${message}`);
+      return false;
+    }
+    console.log("  ✓ PASSED (threw:", message, ")");
+    return true;
+  }
+}
+
+export function runArrowTransportTests(): boolean {
+  console.log("Running Arrow transport tests...\n");
+
+  const results = [
+    testFlatTable(),
+    testSingleRowStruct(),
+    testMultiRowBag(),
+    testRaggedKeys(),
+    testEmptyBag(),
+    testConflictingTypesThrow(),
+    testConflictingNestedTypesThrow(),
+  ];
+
+  const allPassed = results.every((r) => r);
+  console.log();
+  if (allPassed) {
+    console.log("✓ All Arrow transport tests passed!");
+  } else {
+    console.log("✗ Some Arrow transport tests failed");
+  }
+  return allPassed;
+}
+
+if (import.meta.url.endsWith(process.argv[1]?.replace(/\\/g, "/") || "")) {
+  const ok = runArrowTransportTests();
+  process.exit(ok ? 0 : 1);
+}

--- a/packages/gofish-python/widget-src/arrowTransport.ts
+++ b/packages/gofish-python/widget-src/arrowTransport.ts
@@ -1,0 +1,180 @@
+/**
+ * Explicit-schema Arrow table construction for the widget RPC transport
+ * (issue #783).
+ *
+ * `Arrow.tableFromJSON`'s built-in type inference only handles flat,
+ * JSON-primitive columns — it throws `Unable to infer Vector type from
+ * input values` on a column whose value is a *list of objects*
+ * (`list<struct>`), which is exactly the shape of a mark-fn's
+ * `{__inputRef, datum}` sentinel when the ref's bound datum is a
+ * multi-row bag (a `group(...)`'d ref — see `serializeMarkFnInput` in
+ * `gofish-graphics/src/serialize/fromJSON.ts`). A single-row struct datum
+ * happens to encode fine under `tableFromJSON`, which is why this only
+ * surfaced for the multi-row case.
+ *
+ * Rather than special-case that one sentinel shape, this builds an
+ * explicit Arrow type for every column (recursively, for nested lists and
+ * structs) by walking the actual row values, then hands that type to
+ * `Arrow.vectorFromArray` — which (unlike `tableFromJSON`) accepts an
+ * explicit type for arbitrary nested shapes instead of trying to infer
+ * one. This is generic RPC transport capability, not an `__inputRef`
+ * special case: it fixes encoding for *any* row shape with a nested
+ * array-of-objects column.
+ *
+ * Homogeneity assumption: rows within a nested bag (e.g. a group's row
+ * bag) are assumed to share one schema — a reasonable assumption since
+ * they come from one dataset. Missing keys are treated as null (ragged
+ * but homogeneous data is fine); a key present with genuinely conflicting
+ * types across rows (e.g. a string in one row, a number in another) is a
+ * loud error naming the column and the conflicting types, not a silent
+ * coercion.
+ */
+
+import * as Arrow from "apache-arrow";
+
+type Row = Record<string, any>;
+
+/** The handful of shapes a column's values can take, used to pick an Arrow type. */
+type ValueKind =
+  | "null"
+  | "boolean"
+  | "number"
+  | "bigint"
+  | "string"
+  | "date"
+  | "array"
+  | "object";
+
+function kindOf(value: any): ValueKind {
+  if (value === null || value === undefined) return "null";
+  if (Array.isArray(value)) return "array";
+  if (value instanceof Date) return "date";
+  const t = typeof value;
+  if (t === "boolean" || t === "number" || t === "bigint" || t === "string") {
+    return t as ValueKind;
+  }
+  if (t === "object") return "object";
+  throw new Error(`Cannot encode value of type "${t}" for Arrow transport`);
+}
+
+/**
+ * Infer an explicit Arrow type for a column (or a nested field/list-item)
+ * from its actual values, recursing into arrays (→ List) and objects (→
+ * Struct, unioning keys across all objects seen). Throws if the non-null
+ * values disagree on kind (e.g. string vs number) — see module doc.
+ */
+function inferType(values: readonly any[], path: string): Arrow.DataType {
+  const nonNull = values.filter((v) => v !== null && v !== undefined);
+  if (nonNull.length === 0) {
+    // No values to infer from (an all-null column, or an empty bag with no
+    // rows to look at for element shape). `Null` round-trips a column of
+    // all-null values fine, and an empty `List<Null>` still decodes back
+    // to an empty list — there's nothing more specific to infer.
+    return new Arrow.Null();
+  }
+
+  const kinds = new Set(nonNull.map(kindOf));
+  if (kinds.size > 1) {
+    throw new Error(
+      `Arrow transport: column "${path}" has conflicting types across rows ` +
+        `(${[...kinds].join(", ")}) — this bridge assumes rows sharing a ` +
+        `column share a type; coerce or split the data before sending it ` +
+        `across the RPC.`
+    );
+  }
+
+  const kind = [...kinds][0];
+  switch (kind) {
+    case "array": {
+      // The homogeneity assumption: every row's array in this column is a
+      // bag from the same dataset, so its elements share one schema too.
+      // Flatten all elements from all rows to infer one element type.
+      const elements: any[] = ([] as any[]).concat(...(nonNull as any[][]));
+      const itemType = inferType(elements, `${path}[]`);
+      return new Arrow.List(new Arrow.Field("item", itemType, true));
+    }
+    case "object": {
+      const keys = new Set<string>();
+      for (const obj of nonNull) {
+        for (const key of Object.keys(obj)) keys.add(key);
+      }
+      const fields = [...keys].map((key) => {
+        const subValues = nonNull.map((obj) => (key in obj ? obj[key] : null));
+        return new Arrow.Field(
+          key,
+          inferType(subValues, `${path}.${key}`),
+          true
+        );
+      });
+      return new Arrow.Struct(fields);
+    }
+    case "string":
+      return new Arrow.Utf8();
+    case "number":
+      return new Arrow.Float64();
+    case "boolean":
+      return new Arrow.Bool();
+    case "bigint":
+      return new Arrow.Int64();
+    case "date":
+      return new Arrow.DateMillisecond();
+    default:
+      throw new Error(
+        `Arrow transport: unsupported value kind "${kind}" for column "${path}"`
+      );
+  }
+}
+
+/**
+ * Reshape a value to exactly match `type` before handing it to
+ * `Arrow.vectorFromArray`. Needed because a plain object missing a key
+ * (rather than carrying that key with an explicit `null`) isn't
+ * automatically treated as null-for-that-field when nested inside a
+ * List/Struct type — `vectorFromArray` only fills gaps it's told about, so
+ * this walks the same List/Struct shape as `inferType` and fills them in.
+ */
+function normalizeForType(value: any, type: Arrow.DataType): any {
+  if (value === null || value === undefined) return null;
+  if (Arrow.DataType.isList(type)) {
+    const itemType = (type.children[0] as Arrow.Field).type;
+    return (value as any[]).map((v) => normalizeForType(v, itemType));
+  }
+  if (Arrow.DataType.isStruct(type)) {
+    const out: Row = {};
+    for (const field of type.children as Arrow.Field[]) {
+      const raw = field.name in value ? value[field.name] : null;
+      out[field.name] = normalizeForType(raw, field.type);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Build an Arrow Table from plain-object rows, inferring an explicit type
+ * per column (including nested list/struct columns) instead of relying on
+ * `Arrow.tableFromJSON`'s inference, which can't handle a `list<struct>`
+ * column at all. Always used uniformly — no fallback to `tableFromJSON` —
+ * so there's one code path and one set of encoding rules to reason about.
+ */
+export function buildArrowTable(rows: readonly Row[]): Arrow.Table {
+  const columnNames: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        columnNames.push(key);
+      }
+    }
+  }
+
+  const vectors: Record<string, Arrow.Vector> = {};
+  for (const name of columnNames) {
+    const rawValues = rows.map((row) => (name in row ? row[name] : null));
+    const type = inferType(rawValues, name);
+    const values = rawValues.map((v) => normalizeForType(v, type));
+    vectors[name] = Arrow.vectorFromArray(values, type as any);
+  }
+  return new Arrow.Table(vectors);
+}

--- a/packages/gofish-python/widget-src/index.ts
+++ b/packages/gofish-python/widget-src/index.ts
@@ -23,6 +23,7 @@ import {
   type ChartBuilder,
 } from "gofish-graphics";
 import type { Frontend } from "gofish-ir";
+import { buildArrowTable } from "./arrowTransport";
 
 // Type aliases pointing at the canonical IR schema. Internal usages below
 // keep the legacy `…Spec` names for readability.
@@ -104,24 +105,13 @@ function arrayToArrow(rows: Record<string, any>[]): Uint8Array {
   if (!rows || rows.length === 0) {
     throw new Error("Cannot serialize empty data to Arrow");
   }
-  // KNOWN GAP (#591 follow-up): `Arrow.tableFromJSON`'s naive type inference
-  // throws "Unable to infer Vector type from input values" for a column
-  // whose value is a list of objects (list<struct>) — e.g. the `datum` field
-  // of a `{__inputRef, datum}` mark-fn sentinel (see
-  // `gofish-graphics/src/serialize/fromJSON.ts`'s `serializeMarkFnInput`)
-  // when the ref's bound datum is a multi-row bag (a `group(...)`'d ref,
-  // as in the BarWithLabels/FlowerChart shape) rather than a single row.
-  // A single-row struct datum encodes fine (verified); only the
-  // multi-row-bag case fails. The parity test harness sidesteps this
-  // entirely (it transports rows as plain JSON over HTTP, not Arrow), which
-  // is how BarWithLabels/FlowerChart/ImageCutWithLabels were validated to
-  // byte-parity — but a REAL anywidget notebook rendering that same shape
-  // will hit this Arrow encoding error. Fixing it generally (teaching this
-  // bridge to fall back to a JSON transport for non-Arrow-inferable columns,
-  // for mark-fn rows and any other RPC payload alike) is more design work
-  // than #591's scope — tracked as a follow-up rather than patched here with
-  // a narrow special-case unwrap for just the `__inputRef` shape.
-  const table = Arrow.tableFromJSON(rows);
+  // Explicit-schema construction (issue #783) — see `arrowTransport.ts` for
+  // why `Arrow.tableFromJSON`'s inference isn't used here: it can't handle a
+  // `list<struct>` column at all (e.g. the `datum` field of an
+  // `{__inputRef, datum}` mark-fn sentinel when the ref's bound datum is a
+  // multi-row bag — a `group(...)`'d ref, as in the BarWithLabels/
+  // FlowerChart shape).
+  const table = buildArrowTable(rows);
 
   if (
     (Arrow as any).tableToIPC &&

--- a/packages/gofish-python/widget-src/index.ts
+++ b/packages/gofish-python/widget-src/index.ts
@@ -104,6 +104,23 @@ function arrayToArrow(rows: Record<string, any>[]): Uint8Array {
   if (!rows || rows.length === 0) {
     throw new Error("Cannot serialize empty data to Arrow");
   }
+  // KNOWN GAP (#591 follow-up): `Arrow.tableFromJSON`'s naive type inference
+  // throws "Unable to infer Vector type from input values" for a column
+  // whose value is a list of objects (list<struct>) — e.g. the `datum` field
+  // of a `{__inputRef, datum}` mark-fn sentinel (see
+  // `gofish-graphics/src/serialize/fromJSON.ts`'s `serializeMarkFnInput`)
+  // when the ref's bound datum is a multi-row bag (a `group(...)`'d ref,
+  // as in the BarWithLabels/FlowerChart shape) rather than a single row.
+  // A single-row struct datum encodes fine (verified); only the
+  // multi-row-bag case fails. The parity test harness sidesteps this
+  // entirely (it transports rows as plain JSON over HTTP, not Arrow), which
+  // is how BarWithLabels/FlowerChart/ImageCutWithLabels were validated to
+  // byte-parity — but a REAL anywidget notebook rendering that same shape
+  // will hit this Arrow encoding error. Fixing it generally (teaching this
+  // bridge to fall back to a JSON transport for non-Arrow-inferable columns,
+  // for mark-fn rows and any other RPC payload alike) is more design work
+  // than #591's scope — tracked as a follow-up rather than patched here with
+  // a narrow special-case unwrap for just the `__inputRef` shape.
   const table = Arrow.tableFromJSON(rows);
 
   if (

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -97,37 +97,23 @@ packages/gofish-graphics/stories/lowlevel/EncloseRefs.stories.tsx
 packages/gofish-graphics/stories/bench/Benchmarks.stories.tsx
 
 # Forward syntax stories needing unsupported features
-packages/gofish-graphics/stories/forwardsyntax/Bar/BarWithLabels.stories.tsx
+# BarWithLabels::Default is ported (#591 — ref/datum mark-fn bridge: each
+# `GoFishRef` a mark-fn receives crosses the RPC as an `{__inputRef, datum}`
+# sentinel and reconstructs Python-side as `_InputRef`, with `d[0]` itself
+# round-tripping back into a returned combinator mark). SpeciesCountPerLake
+# still needs `pluck()`, which has no Python wrapper yet.
+packages/gofish-graphics/stories/forwardsyntax/Bar/BarWithLabels.stories.tsx::SpeciesCountPerLake
 # LabeledChart uses a JS-side function-mark that composes resolved node refs
 # with fresh text — the refs can't cross the Python derive RPC, so it can't be
 # expressed with a Python mark-fn. (Ribbon/Layered and NodeLink ARE ported.)
 packages/gofish-graphics/stories/forwardsyntax/LabeledChart.stories.tsx
 
-# FlowerChart is a labeled-bar-chart shape: the stems are a real bar chart
-# (one chart, so their heights share a scale) and each flower is the stem's
-# "label", placed on top via `Chart(selectAll("stems")).flow(group(...)).mark(d
-# => spread([d[0], <petal fan built from d[0].datum>]))`. This is the same
-# bridge blocker as Cut.stories.tsx::ImageCutWithLabels and BarWithLabels: the
-# Python mark-fn runs over the RPC bridge and receives plain JSON rows, not the
-# JS ref nodes, so it can neither embed `d[0]` nor project `d[0].datum`.
-# Tracked by #591 (bridge selectAll-label / ref-datum mark-fns to Python).
-packages/gofish-graphics/stories/lowlevel/FlowerChart.stories.tsx
 
 # Forward syntax stories needing coord transforms other than clock
 # (clock is now supported)
 
 # (Vega-Lite ports were brought over from exempt to real parity tests;
 # see tests/python-stories/vega-lite/.)
-
-
-# Per-export exemption for Cut.stories.tsx — ImageCutWithLabels builds a
-# per-slice `layer(...)` inside a mark-as-function over `selectAll("part")`,
-# embedding each JS ref node directly (`d.name("slice")`) and reading its bound
-# datum (`d.datum.category`). The Python mark-fn runs over the RPC bridge and
-# receives plain JSON rows, not JS ref nodes, so it cannot embed the slice nodes
-# or project `.datum` — a wrapper project, not a port. The other 10 Cut exports
-# are ported (tests/python-stories/forward-syntax-v3/test_cut.py).
-packages/gofish-graphics/stories/forwardsyntax/Cut.stories.tsx::ImageCutWithLabels
 
 # Per-export exemptions for Labels.stories.tsx — these stories don't fit
 # the single-chart parity harness (they compose many charts in a flex div,

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -68,6 +68,7 @@ import {
   Treemap,
   setMeasureProvenance,
   PREVIOUS_LAYER_MARKS,
+  GoFishRef,
   type ChartBuilder,
   type MeasureProvenance,
   type Operator,
@@ -510,12 +511,18 @@ function resolveRefSelection(selection: any, resolveToken: TokenResolver): any {
 function mapMarkChildren(
   specs: MarkSpec[],
   deriveServerUrl: string | undefined,
-  resolveToken: TokenResolver
+  resolveToken: TokenResolver,
+  inputRefs?: any[]
 ): any[] {
   const out: any[] = [];
   for (const child of specs as any[]) {
     if (child && child.type === "cut") {
-      const sourceMark = mapMark(child.source, deriveServerUrl, resolveToken);
+      const sourceMark = mapMark(
+        child.source,
+        deriveServerUrl,
+        resolveToken,
+        inputRefs
+      );
       const slices = cutSlices(sourceMark as any, {
         dir: child.dir,
         size: unwrapMarkOpts(child.size, deriveServerUrl),
@@ -523,29 +530,79 @@ function mapMarkChildren(
       });
       out.push(...slices);
     } else {
-      out.push(mapMark(child as MarkSpec, deriveServerUrl, resolveToken));
+      out.push(
+        mapMark(child as MarkSpec, deriveServerUrl, resolveToken, inputRefs)
+      );
     }
   }
   return out;
 }
 
+/**
+ * Serialize a mark-fn's input array for the RPC bridge (mirrors
+ * `packages/gofish-graphics/src/serialize/fromJSON.ts`'s helper of the same
+ * name). Each `GoFishRef` (the shape `.flow(group(...)).mark((refs) => ...)`
+ * hands the callback) can't cross JSON as a live class instance, so it's
+ * replaced with an `{__inputRef: i, datum}` sentinel carrying just its bound
+ * datum. Plain data rows (the pre-#591 mark-fn contract) pass through
+ * unchanged.
+ */
+function serializeMarkFnInput(data: any): { rows: any[]; inputRefs?: any[] } {
+  const items = Array.isArray(data) ? data : [data];
+  if (!items.some((item) => item instanceof GoFishRef)) {
+    return { rows: items };
+  }
+  const rows = items.map((item, i) =>
+    item instanceof GoFishRef ? { __inputRef: i, datum: item.datum } : item
+  );
+  return { rows, inputRefs: items };
+}
+
 function mapMark(
   spec: MarkSpec,
   deriveServerUrl: string | undefined,
-  resolveToken: TokenResolver
+  resolveToken: TokenResolver,
+  inputRefs?: any[]
 ): Mark<any> {
   const applyTranslate = <T>(mark: T): T =>
     spec.translate && typeof (mark as any).translate === "function"
       ? ((mark as any).translate(spec.translate) as T)
       : mark;
 
-  // Mark-as-function: Python registered a `(data) -> ChartBuilder` lambda
-  // in the derive-server registry. The JS Mark fetches a chart IR per
-  // invocation and rebuilds a ChartBuilder JS-side; `resolveMarkResult`
-  // already accepts ChartBuilders as mark results. We memoize the
-  // ChartBuilder per data-key since the gofish runtime may resolve the
-  // same mark multiple times during a render (measurement + placement)
-  // and each RPC round-trip is expensive over localhost HTTP.
+  // `{__inputRef: i}` sentinel — round-trip back to the real `GoFishRef` a
+  // mark-fn was invoked with (see `serializeMarkFnInput`), instead of
+  // reconstructing a new mark from the spec.
+  if (typeof (spec as any).__inputRef === "number") {
+    if (!inputRefs) {
+      throw new Error(
+        "encountered an { __inputRef } sentinel but no input refs were supplied " +
+          "— this mark tree must be returned from a mark-fn invocation"
+      );
+    }
+    const inputRef = inputRefs[(spec as any).__inputRef];
+    // `.name(...)` on the Python `_InputRef` (issue #556) — `GoFishRef.name()`
+    // mutates in place and returns `this`, so this renames the SAME live ref
+    // the rest of the tree already shares, letting an enclosing
+    // `.layer([...]).constrain(...)` target it by name.
+    if (
+      (spec as any).name != null &&
+      typeof (inputRef as any)?.name === "function"
+    ) {
+      (inputRef as any).name(
+        resolveNameField((spec as any).name, resolveToken)
+      );
+    }
+    return inputRef;
+  }
+
+  // Mark-as-function: Python registered a `(data) -> ChartBuilder | Mark`
+  // lambda in the derive-server registry. The JS Mark fetches a chart (or
+  // raw-mark) IR per invocation and rebuilds it JS-side; `resolveMarkResult`
+  // already accepts ChartBuilders (and function-shaped Marks) as mark
+  // results. We memoize the RPC response per data-key since the gofish
+  // runtime may resolve the same mark multiple times during a render
+  // (measurement + placement) and each RPC round-trip is expensive over
+  // localhost HTTP.
   if (spec.type === "mark-fn") {
     const lambdaId = spec.lambdaId as string;
     if (!deriveServerUrl) {
@@ -555,14 +612,15 @@ function mapMark(
     }
     const cache = new Map<string, Promise<any>>();
     return (async (data: any, _key: any, _layerContext: any) => {
-      const cacheKey = JSON.stringify(data);
+      const { rows, inputRefs: newInputRefs } = serializeMarkFnInput(data);
+      const cacheKey = JSON.stringify(rows);
       let entry = cache.get(cacheKey);
       if (!entry) {
         entry = (async () => {
           const resp = await fetch(`${deriveServerUrl}/derive/${lambdaId}`, {
             method: "POST",
             headers: { "Content-Type": "application/json" },
-            body: JSON.stringify(data),
+            body: JSON.stringify(rows),
           });
           if (!resp.ok) {
             throw new Error(
@@ -570,8 +628,25 @@ function mapMark(
             );
           }
           const result = await resp.json();
-          const chartSpec = Array.isArray(result) ? result[0] : result;
-          return buildChartFromSpec(chartSpec, deriveServerUrl, resolveToken);
+          const resultSpec = Array.isArray(result) ? result[0] : result;
+          // A bare Mark returned by the Python mark-fn (e.g. `spread([...])`)
+          // serializes as `{type: "raw-mark", mark: ...}` (same shape as the
+          // top-level raw-mark IR). Returned un-invoked — `resolveMarkResult`
+          // calls a function-shaped Mark with `(undefined, undefined,
+          // layerContext)`, same as the ChartBuilder branch below.
+          if (
+            resultSpec &&
+            typeof resultSpec === "object" &&
+            resultSpec.type === "raw-mark"
+          ) {
+            return mapMark(
+              resultSpec.mark,
+              deriveServerUrl,
+              resolveToken,
+              newInputRefs
+            );
+          }
+          return buildChartFromSpec(resultSpec, deriveServerUrl, resolveToken);
         })();
         cache.set(cacheKey, entry);
       }
@@ -598,7 +673,8 @@ function mapMark(
     const [childMark] = mapMarkChildren(
       spec.children ?? [],
       deriveServerUrl,
-      resolveToken
+      resolveToken,
+      inputRefs
     );
     return applyTranslate(
       offsetOp({ x: spec.x, y: spec.y }, [
@@ -612,7 +688,12 @@ function mapMark(
   // `cut` used as a combinator CHILD is expanded into its N slice nodes in
   // place by `mapMarkChildren` — extent resolution lives in ONE place, JS.)
   if (spec.type === "cut") {
-    const sourceMark = mapMark(spec.source, deriveServerUrl, resolveToken);
+    const sourceMark = mapMark(
+      spec.source,
+      deriveServerUrl,
+      resolveToken,
+      inputRefs
+    );
     let mark = cutMark({
       source: sourceMark as any,
       dir: spec.dir,
@@ -643,7 +724,8 @@ function mapMark(
     const childMarks = mapMarkChildren(
       spec.children ?? [],
       deriveServerUrl,
-      resolveToken
+      resolveToken,
+      inputRefs
     );
     // Resolve color/coord configs too — e.g. a `layer({coord: polar()})`
     // carries its coord transform in the combinator options (BalloonChart,

--- a/tests/python-stories/forward-syntax-v3/bar/test_with_labels.py
+++ b/tests/python-stories/forward-syntax-v3/bar/test_with_labels.py
@@ -1,18 +1,15 @@
-"""Forward Syntax V3/Bar/With Labels — mirrors BarWithLabels.stories.tsx
+"""Equivalent of BarWithLabels.stories.tsx — Forward Syntax V3/Bar/With Labels.
 
-Only the `Default` export is ported. `SpeciesCountPerLake` uses `pluck()`
-(the un-collapsed sibling of the `by: "field"` homogeneity collapse), which
-has no Python wrapper yet — a separate follow-up from #591's ref/datum
-mark-fn bridge implemented here.
+Only `Default` is ported (`story_default`). `SpeciesCountPerLake` uses
+`pluck()`, which has no Python wrapper yet — a separate follow-up from #591's
+ref/datum mark-fn bridge implemented here.
 """
 
 from gofish import chart, spread, rect, text, group
-from stories.data.seafood import seafood
-
-TITLE = "Forward Syntax V3/Bar/With Labels"
+from python_stories.data import SEAFOOD
 
 
-def default(w=400, h=400):
+def story_default():
     # `.layer()`'s empty scope yields one ref per lake; each ref's datum is
     # that lake's array of species records (an aggregate). `by="lake"`
     # resolves because every row in a lake agrees on `lake` (homogeneity
@@ -27,9 +24,10 @@ def default(w=400, h=400):
             spacing=10,
         )
 
-    return (
-        chart(seafood, axes=True)
+    chart_builder = (
+        chart(SEAFOOD, axes=True)
         .flow(spread(by="lake", dir="x"))
         .mark(rect(h="count"))
         .layer(chart().flow(group(by="lake")).mark(label_mark))
     )
+    return (chart_builder, {"w": 400, "h": 400})

--- a/tests/python-stories/forward-syntax-v3/test_cut.py
+++ b/tests/python-stories/forward-syntax-v3/test_cut.py
@@ -15,16 +15,13 @@ baseline. The SVG (1.5KB, under the threshold) is INLINED by Vite as a
 `data:image/svg+xml,` URI — the normalizer leaves data URIs untouched, so we
 reconstruct the byte-identical data URI here with Vite's exact encoding.
 
-`story_image_cut_with_labels` (JS `ImageCutWithLabels`) is exempt — see
-tests/.python-sync-exempt. JS now overlays the labels via a chained
-`.layer(chart().mark((data) => ...))` empty-scope tier (rather than a second
-`chart(selectAll("part"))` sub-chart) — the wiring changed, but the blocker
-didn't: it builds a per-slice `layer(...)` inside that mark-as-function,
-embedding each JS ref node directly (`d.name("slice")`) and reading its bound
-datum (`d.datum.category`). The Python mark-fn still runs over the RPC bridge
-and receives plain JSON rows, not JS ref nodes, so it cannot embed the slice
-nodes or project `.datum` — a wrapper project, not a port, layer-chaining or
-not.
+`story_image_cut_with_labels` (JS `ImageCutWithLabels`) is now ported (#591 —
+the ref/datum mark-fn bridge). The mark-fn receives one `_InputRef` per slice
+(reconstructed from the `{__inputRef, datum}` sentinel the JS harness/widget
+sends across the RPC in place of the live ref); `.name("slice")` on it
+survives the round trip (#556) via the `_InputRef.name()` override, so the
+per-slice `layer([...]).constrain(...)` can target it by name exactly like
+the JS story's `d.name("slice")`.
 """
 
 import os
@@ -88,6 +85,60 @@ def story_image_cut():
             )
         ),
         {"w": 400, "h": 700, "axes": False},
+    )
+
+
+def story_image_cut_with_labels():
+    """Cut chart with labels added via a chained `.layer()` sub-chart. The cut
+    chart returns just the named slices; the empty-scope `.layer(chart()...)`
+    tier inherits those slices (one ref per slice) and overlays category and
+    amount labels at each slice's position. Each ref exposes the slice's
+    datum via `.datum`.
+
+    The cut ties each slice's image band to data order (slice i = band i,
+    top→bottom). To land Grape juice (the bulk) at the BOTTOM showing the
+    bottle BODY, it must be the LAST data row (bottom band) AND positioned
+    last — so reverse the data and keep `reverse=True` on the spread.
+    """
+
+    def label_mark(data):
+        slices = []
+        for d in data:
+            d.name("slice")
+            category_label = text(
+                fontSize=18,
+                fontWeight="bold",
+                fill="#1c5e20",
+                text=d.datum["category"],
+            ).name("label")
+            amount_label = text(
+                fontSize=36,
+                fontFamily="Impact",
+                fill="#1c5e20",
+                text=str(d.datum["amount"]),
+            ).name("amount")
+
+            def _constrain(slice, label, amount):
+                return [
+                    Constraint.align([slice, label], y="middle"),
+                    Constraint.distribute([slice, label], dir="x", spacing=12),
+                    Constraint.align([slice, amount], x="middle"),
+                    Constraint.align([slice, amount], y="middle"),
+                ]
+
+            slices.append(layer([d, category_label, amount_label]).constrain(_constrain))
+        return layer(slices)
+
+    return (
+        chart(list(reversed(BOTTLE_DATA)))
+        .flow(spread(dir="y", spacing=20, reverse=True))
+        .mark(
+            image(href=BOTTLE_PNG, w=193, h=600).cut(
+                dir="y", size="amount", inset=4
+            )
+        )
+        .layer(chart().mark(label_mark)),
+        {"axes": False},
     )
 
 

--- a/tests/python-stories/low-level-syntax/test_flower_chart.py
+++ b/tests/python-stories/low-level-syntax/test_flower_chart.py
@@ -1,0 +1,77 @@
+"""Equivalent of lowlevel/FlowerChart.stories.tsx — Low Level Syntax/Flower Chart.
+
+The same shape as a labeled bar chart — but the bars are stems and the labels
+are flowers. The stems are a real bar chart (one chart, so their heights
+share a scale, growing with each lake's total catch); each flower is the
+stem's "label", placed on top via the `selectAll` + `group` + mark-fn pattern
+(issue #591): the mark-fn receives one `_InputRef` per lake (its `.datum` is
+that lake's species-row bag) and embeds the ref directly in the combinator
+mark it returns, mirroring JS `spread([d[0], <petal fan>], ...)`.
+"""
+
+from gofish import (
+    chart,
+    scatter,
+    spread,
+    stack,
+    rect,
+    layer,
+    group,
+    petal,
+    polar,
+    datum,
+    selectAll,
+)
+from python_stories.data import SEAFOOD, CATCH_LOCATIONS, COLORS
+
+# Fixed radius of every flower head, in pixels. The petals fan out to this
+# shared length; only their colors and angular widths vary with the data.
+_FLOWER_RADIUS = 40
+
+_GREEN_5 = COLORS["colorGreen5"]
+
+# Each species row tagged with its lake's planting location on x.
+_STEM_DATA = [{**row, "x": CATCH_LOCATIONS[row["lake"]]["x"]} for row in SEAFOOD]
+
+
+def story_default():
+    def label_mark(d):
+        ref = d[0]
+        petals = [
+            petal(w=datum(r["count"]), fill=datum(r["species"]).lighten(0.5))
+            for r in ref.datum
+        ]
+        return spread(
+            [
+                ref,
+                layer(
+                    {"coord": polar()},
+                    [
+                        stack(
+                            petals,
+                            dir="x",
+                            h=_FLOWER_RADIUS,
+                            spacing=0,
+                            alignment="start",
+                            sharedScale=True,
+                        ),
+                    ],
+                ),
+            ],
+            dir="y",
+            alignment="middle",
+            spacing=-_FLOWER_RADIUS,
+        )
+
+    stems = (
+        chart(_STEM_DATA)
+        .flow(scatter(by="lake", x="x"))
+        .mark(rect(w=4, h="count", fill=_GREEN_5).name("stems"))
+    )
+    flowers = (
+        chart(selectAll("stems"))
+        .flow(group(by="lake"))
+        .mark(label_mark)
+    )
+    chart_builder = layer([stems, flowers])
+    return (chart_builder, {"w": 400, "h": 400, "axes": False})

--- a/tests/scripts/derive-server.py
+++ b/tests/scripts/derive-server.py
@@ -170,6 +170,7 @@ class DeriveHandler(BaseHTTPRequestHandler):
                 _RefProxy,
                 _collect_mark_lambdas,
                 _MarkFn,
+                _InputRef,
             )
 
             def serialize_chart(child) -> tuple:
@@ -241,8 +242,28 @@ class DeriveHandler(BaseHTTPRequestHandler):
                     child_derive_ids.append(mark_fn.lambda_id)
 
                     def _mark_fn_wrapped(data, _user_fn=mark_fn.fn):
-                        inner_cb = _user_fn(data)
-                        payload, _inner_ids = serialize_chart(inner_cb)
+                        # The JS harness/widget replaces each live `GoFishRef`
+                        # argument (e.g. `.flow(group(...)).mark((refs) =>
+                        # ...)`'s per-group refs) with an `{"__inputRef": i,
+                        # "datum": ...}` sentinel before the RPC — a ref can't
+                        # cross as JSON. Reconstruct an `_InputRef` per
+                        # sentinel so the user's function sees `d[0].datum`
+                        # exactly like the JS story does (issue #591). Rows
+                        # with no sentinel (the pre-#591 plain-data contract)
+                        # pass through unchanged.
+                        wrapped_data = [
+                            _InputRef(row["__inputRef"], row.get("datum"))
+                            if isinstance(row, dict) and "__inputRef" in row
+                            else row
+                            for row in data
+                        ]
+                        result = _user_fn(wrapped_data)
+                        # A mark-fn may return a ChartBuilder (build a chart
+                        # for the group) or a bare Mark (e.g. a `spread([...])`
+                        # combinator embedding one of the input refs directly,
+                        # mirroring JS `spread({...}, [d[0], text(...)])`).
+                        # `serialize_chart` already dispatches on both.
+                        payload, _inner_ids = serialize_chart(result)
                         # Return as a single-element list to fit the existing
                         # `/derive/<id>` rows-in / rows-out contract.
                         return [payload]


### PR DESCRIPTION
## Summary

Closes #591. Advances #556. Closes #783.

The JS labeled-bar-chart shape — `.layer(chart().flow(group(...)).mark(fn))`, where `fn` receives one ref per group and embeds it directly in the mark tree it returns (`spread([d[0], text(...)])`) — had no Python equivalent: a mark-fn runs over the derive RPC and only ever saw plain JSON rows, so it couldn't embed a ref or read `.datum` off one.

### Mechanism

1. **Refs cross the RPC as sentinels, not live objects.** When a mark-fn's `data` argument is a bag of `GoFishRef`s, each one is serialized as `{__inputRef: i, datum: ref.datum}` right before the RPC call (`serializeMarkFnInput` in `fromJSON.ts`/`main.ts`); the real ref array stays in closure.
2. **Python reconstructs a stand-in.** The derive server (`tests/scripts/derive-server.py`) wraps each sentinel back into an `_InputRef` (`packages/gofish-python/gofish/ast.py`) — a `Mark` subclass exposing `.datum` — before calling the user's function.
3. **A mark-fn may now return a bare `Mark`, not just a `ChartBuilder`.** It's wired as `{type: "raw-mark", mark}` (the same shape `Mark.to_ir()` already used at the top level). `mapMark` resolves any `{__inputRef: i}` sentinel it finds in that returned tree back to `inputRefs[i]` — the **original** live ref from the closure, not a reconstruction — so the ref's identity (and anything already registered against it) survives.
4. **`.name(...)` on `_InputRef` round-trips too (#556).** `GoFishRef.name()` mutates in place, so a name applied through the bridge renames the same ref the rest of the tree shares, letting an enclosing `.layer([...]).constrain(...)` target it.

The production anywidget path (`widget-src/index.ts`) needed no code changes for the deserializer — it already goes through the same shared `fromJSON.ts` deserializer via the `Serialize` namespace. It did, however, need a fix on the encode side to actually get multi-row mark-fn data across the wire — see below.

### Stories un-exempted (byte-identical to JS baseline)

- `forwardsyntax/Bar/BarWithLabels.stories.tsx::Default`
- `lowlevel/FlowerChart.stories.tsx::Default`
- `forwardsyntax/Cut.stories.tsx::ImageCutWithLabels` (also exercises the #556 named-ref round trip)

`BarWithLabels::SpeciesCountPerLake` stays exempt — it needs `pluck()`, which has no Python wrapper yet (unrelated to this bridge).

### Arrow RPC transport fix (#783)

The anywidget production path's Arrow-based RPC transport (`arrayToArrow` in `widget-src/index.ts`) couldn't encode a mark-fn row whose `datum` is a **multi-row bag** — `Arrow.tableFromJSON`'s naive type inference throws `Unable to infer Vector type from input values` on a `list<struct>` column. A single-row struct `datum` encoded fine, which is why this only surfaced for the group-bag case (BarWithLabels/FlowerChart).

Fixed by building the Arrow schema explicitly instead of relying on `tableFromJSON` inference (`packages/gofish-python/widget-src/arrowTransport.ts`, `buildArrowTable`):

- Walks the actual row values and recurses into arrays (→ `List`) and objects (→ `Struct`) to construct an explicit Arrow type per column, then hands that type to `Arrow.vectorFromArray` — which (unlike `tableFromJSON`) accepts an explicit type for arbitrary nested shapes instead of trying to infer one.
- **Homogeneity assumption:** rows within a nested bag (a `group(...)`'d ref's row bag) are assumed to share one schema, since they come from one dataset. Struct keys are unioned across all rows seen; a key missing from some rows becomes `null` for those rows (ragged-but-homogeneous data is fine).
- **Loud error on genuine conflicts:** if the same key holds a string in one row and a number in another, `buildArrowTable` throws, naming the column and the conflicting types, instead of silently coercing.
- **Empty bags** (`datum: []`) round-trip to an empty list, not a crash.
- Used **uniformly** for every RPC row payload — no `tableFromJSON`-first-then-fallback dual path, and no special-casing on `__inputRef`; this is generic transport capability that happens to unblock the `__inputRef` sentinel shape.

On the Python decode side, `gofish/widget.py`'s `derive_request` handler now decodes via a new `arrow_to_records` (`gofish/arrow_utils.py`, built on `pyarrow`'s `to_pylist()`) instead of `arrow_to_dataframe(...).to_dict("records")`: pandas' `to_pandas()` decodes a `list<struct>` column into a numpy `ndarray` of dicts rather than a plain Python `list`, which would have made a mark-fn see a different `datum` shape over the real widget transport than over the parity harness's plain-JSON transport. `to_pylist()` decodes straight to native Python `list`/`dict`/`None`, matching the harness exactly.

## Test plan

- [x] `pnpm --filter gofish-graphics build` — clean
- [x] `pnpm --filter @gofish/tests check-python-sync` / `check-python-sync-all` — pass, 0 missing exports
- [x] Full Python DOM capture (207 stories) — 206 captured, 0 failed, 1 pre-existing skip (ViolinPlot, unrelated)
- [x] Byte-diffed the 3 target stories against fresh JS DOM captures — identical
- [x] `pnpm capture-diff main` — "No layout changes. 303 story(ies) identical." (JS-behavior-neutral, as expected)
- [x] `pytest` in `packages/gofish-python` — passes except 2 pre-existing failures unrelated to this change (`area` not exported from `gofish/__init__.py`, present on `main` too)
- [x] Updated the `Frontend IR` internals essay (`apps/docs/docs/internals/frontend/serialization.md`) since `fromJSON.ts` carries its `@wiki` backlink; `check-backlinks` passes
- [x] Documented the new mark-fn-over-refs capability in `apps/docs/docs/python/api/core/mark.md`
- [x] New JS unit tests for the Arrow transport (`pnpm --filter gofish-python test:arrow-transport`, wired into the `js-unit-tests` CI job): flat table, single-row struct, multi-row bag, ragged keys, empty bag, conflicting-type error — all pass
- [x] New Python tests (`packages/gofish-python/tests/test_arrow_transport.py`): `arrow_to_records` decode contract (plain `list[dict]`, missing keys → `None`, empty bag) plus an end-to-end `widget.py` `derive_request` test confirming a mark-fn receives plain `list[dict]` rows — all pass
- [x] `pnpm --filter gofish-python build:widget` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
