### PR TITLE
Generate Python per-example doc pages mirroring the JS example pages

### DIFF
--- a/apps/docs/CLAUDE.md
+++ b/apps/docs/CLAUDE.md
@@ -30,6 +30,11 @@ This is a documentation site for the GoFish Graphics library built with VitePres
   build time by `docs/.vitepress/data/storyExamples.ts` (exposed via the
   `storyExamples.data.js` loader). There is no hand-maintained registry — the set of
   valid `example:<id>` ids is exactly the gallery story ids (`pnpm check-story-examples`).
+  Per-example pages are **generated**, one per language, from this same id set:
+  `js/examples/[id].paths.ts` (JS snippet) and `python/examples/[id].paths.ts`
+  (Python parity port, via `docs/.vitepress/data/pythonExamples.ts` — see below).
+  API pages (`js/api/**`, `python/api/**`) stay hand-written fenced code, unrelated
+  to this generator.
 
 #### Interactive Code Execution
 
@@ -42,6 +47,7 @@ This is a documentation site for the GoFish Graphics library built with VitePres
 
 - **Dataset modules**: Located in `components/data/` - TypeScript modules exporting chart datasets (titanic, penguins, streamgraph data, etc.)
 - **Example data layer**: `docs/.vitepress/data/storyExamples.ts` scans gallery-tagged stories and synthesizes a standalone snippet (+ dataset) for each. The legacy `examples.data.js` registry is gone; only `internal-*` wiki diagrams (`.vitepress/examples/internal-*.ts`) are still loaded directly by the markdown plugin.
+- **Python example data layer**: `docs/.vitepress/data/pythonExamples.ts` resolves each gallery example's matching `tests/python-stories/**/test_*.py` parity port (same title→path convention as `tests/scripts/path-mapping.ts`, duplicated there since it's a cross-package build-time import) and synthesizes a standalone Python snippet (+ `dataset.py`) from the `story_*` function's body. Examples with no port yet get `pythonCode: null` (the page still renders, with a "not ported" note and a link to the JS version); a port whose shape the transform can't standalone-ify falls back to showing the function verbatim. `tests/.python-sync-exempt` entries mark `renderDiverges` (the port intentionally uses a different algorithm — the live render is always the JS engine, since JS/Python serialize to the same IR).
 
 ### Key Architecture Patterns
 
@@ -101,9 +107,12 @@ When editing the docs, keep the two language trees structurally parallel.
 
 **Python chart previews:** Python and JavaScript serialize to the same
 intermediate representation, so a chart renders identically regardless of
-language. Python pages show hand-written Python code in a `python` fence, then
-render the chart with the existing JS engine via `::: gofish example:<id>
-hidden` — which renders the gallery example without showing its JS code.
+language. Hand-written **API pages** (`python/api/**`) show Python code in a
+`python` fence, then render the chart with the existing JS engine via `:::
+gofish example:<id> hidden` — which renders the gallery example without
+showing its JS code. **Per-example pages** (`python/examples/<id>`) are
+generated instead (see "Example data layer" above): the fence comes from the
+gallery example's Python parity port, not a hand-written snippet.
 
 #### Internal Architecture Wiki (`docs/internals/`)
 
@@ -137,7 +146,7 @@ language toggle (`LanguageToggle.vue` hides itself on `/internals/` routes). See
 - `.vitepress/config.mts` - VitePress configuration (per-language + internals sidebars)
 - `.vitepress/theme/` - Custom theme components (incl. `LanguageToggle.vue`, `EssayMeta.vue`)
 - `.vitepress/examples/` - `.ts` source for `internal-*.ts` wiki diagrams (the only live examples still sourced from files; chart examples come from stories)
-- `.vitepress/data/` - build-time data loaders (`storyExamples.ts` + `storyExamples.data.js` for gallery examples, `routes.data.ts`)
+- `.vitepress/data/` - build-time data loaders (`storyExamples.ts` + `storyExamples.data.js` for gallery examples, `pythonExamples.ts` for the Python parity ports of those same examples, `routes.data.ts`)
 
 ### Scripts (`scripts/`)
 

--- a/apps/docs/docs/.vitepress/data/examplePage.ts
+++ b/apps/docs/docs/.vitepress/data/examplePage.ts
@@ -1,0 +1,105 @@
+/**
+ * examplePage.ts — shared page-content builder for the per-example pages.
+ *
+ * `js/examples/[id].paths.ts` and `python/examples/[id].paths.ts` both emit
+ * one VitePress route per gallery example, sharing the same scaffold: a back
+ * link, an H1 + description, a live `<GoFishExample>` render, optional
+ * language-specific "actions" HTML (the JS page's "Open in live editor"
+ * button), optional italic note paragraphs, and an optional static code
+ * fence (+ collapsed dataset fence). The two pages differ only in *what*
+ * feeds those slots — see the callers for the JS/Python-specific pieces.
+ *
+ * NB: `code`/`datasetCode` strings frequently contain backticks (template
+ * literals in chart code), so they are pushed as plain array elements and
+ * never interpolated into a template literal.
+ *
+ * Only imported by the two `[id].paths.ts` files (which VitePress itself
+ * loads at build time) — not by `check-story-examples.mjs`, so that script's
+ * transpile-and-import loader needs no changes for this module.
+ */
+
+export interface ExamplePageOptions {
+  /** Gallery listing to link back to, e.g. "/js/examples/". */
+  backHref: string;
+  /** H1 text. */
+  title: string;
+  /** Optional lead paragraph under the H1. */
+  description?: string;
+  /** Gallery story id, passed to `<GoFishExample id="...">`. */
+  exampleId: string;
+  /** Optional HTML lines rendered right after the live render (e.g. the JS
+   * page's "Open in live editor" button). */
+  actionsHtml?: string[];
+  /** Italic markdown note paragraphs (already fully formed, e.g. wrapped in
+   * `_..._`), rendered in order before the code fence. */
+  notes?: string[];
+  /** Fence language for both the code and dataset fences, e.g. "ts" / "python". */
+  fenceLang: string;
+  /** Static snippet source. When null/undefined, the code fence (and dataset
+   * fence) are omitted entirely. */
+  code?: string | null;
+  /** `<summary>` label for the collapsed dataset fence, e.g. "dataset.ts". */
+  datasetLabel?: string;
+  /** Collapsed dataset snippet, shown only when `code` is also present. */
+  datasetCode?: string | null;
+}
+
+export interface ExamplePageRoute {
+  params: { id: string; title: string };
+  content: string;
+}
+
+export function buildExamplePage(opts: ExamplePageOptions): ExamplePageRoute {
+  const parts: string[] = [];
+
+  // Back link to the gallery, above the title.
+  parts.push(
+    `<a class="example-back" href="${opts.backHref}">← Examples</a>`,
+    ""
+  );
+
+  parts.push(`# ${opts.title}`, "");
+  if (opts.description) {
+    parts.push(opts.description, "");
+  }
+
+  // Live render of the real story module (client-only; no code echo).
+  parts.push(`<GoFishExample id="${opts.exampleId}" />`, "");
+
+  if (opts.actionsHtml && opts.actionsHtml.length) {
+    parts.push(...opts.actionsHtml, "");
+  }
+
+  for (const note of opts.notes ?? []) {
+    parts.push(note, "");
+  }
+
+  if (opts.code != null) {
+    // Static code fence (push code as a plain element — may contain backticks).
+    parts.push(
+      "```" + opts.fenceLang,
+      opts.code.replace(/\n+$/, ""),
+      "```",
+      ""
+    );
+
+    if (opts.datasetCode) {
+      parts.push(
+        '<details class="example-dataset">',
+        `<summary>${opts.datasetLabel}</summary>`,
+        "",
+        "```" + opts.fenceLang,
+        opts.datasetCode.replace(/\n+$/, ""),
+        "```",
+        "",
+        "</details>",
+        ""
+      );
+    }
+  }
+
+  return {
+    params: { id: opts.exampleId, title: opts.title },
+    content: parts.join("\n"),
+  };
+}

--- a/apps/docs/docs/.vitepress/data/pythonExamples.ts
+++ b/apps/docs/docs/.vitepress/data/pythonExamples.ts
@@ -1,0 +1,828 @@
+/**
+ * pythonExamples.ts — build-time data layer for the docs Python example pages.
+ *
+ * Mirrors storyExamples.ts (see that file's header) but on the Python side: for
+ * each gallery-tagged story example, it resolves the matching parity test in
+ * `tests/python-stories/**​/test_*.py` (via the same title→path convention as
+ * `tests/scripts/path-mapping.ts`'s `mapJsToPython`, duplicated below — this file
+ * lives in a different package and pnpm workspace boundaries make a cross-package
+ * import brittle for a build-time data loader) and synthesizes a standalone,
+ * user-facing Python snippet from the matching `story_*` function's body.
+ *
+ * For examples with no Python port yet, or whose port can't be cleanly
+ * transformed into a standalone snippet (unusual return shape, unrewritable
+ * imports), `pythonCode` is `null` or the function's source is shown verbatim
+ * (`isFallback: true`) — see loadPythonExamples() below and [id].md, which
+ * render the appropriate note in either case.
+ *
+ * `tests/.python-sync-exempt` entries (file-level or per-export) drive
+ * `renderDiverges`: true when the Python port intentionally uses a different
+ * algorithm for part of its computation (e.g. ViolinPlot's scipy KDE vs the JS
+ * story's fast-kde), so the live render (always the JS engine, since JS and
+ * Python serialize to the same IR) may differ slightly from what the shown
+ * Python code would itself produce if it could render standalone.
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadStoryExamples, type StoryExample } from "./storyExamples.ts";
+
+export interface PythonExample {
+  id: string;
+  /** Standalone user-facing Python snippet, or null when unported. */
+  pythonCode: string | null;
+  /** Collapsed `dataset.py` content, when the snippet imports named data. */
+  pythonDatasetCode: string | null;
+  /** True when pythonCode is the story function's source shown verbatim
+   *  because the return-tuple transform didn't apply cleanly. */
+  isFallback: boolean;
+  /** True when this example's export is exempt in .python-sync-exempt — the
+   *  Python port intentionally diverges from the JS algorithm. */
+  renderDiverges: boolean;
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+// .vitepress/data → repo root is five levels up (same as storyExamples.ts).
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const TESTS_DIR = join(REPO_ROOT, "tests");
+const PYTHON_STORIES_DIR = join(TESTS_DIR, "python-stories");
+const DATA_PY = join(PYTHON_STORIES_DIR, "data.py");
+const LOWLEVEL_HELPERS_PY = join(PYTHON_STORIES_DIR, "_lowlevel_helpers.py");
+const VEGA_URLS_PY = join(PYTHON_STORIES_DIR, "vega_data_urls.py");
+const LOWLEVEL_DATA_DIR = join(PYTHON_STORIES_DIR, "_lowlevel_data");
+const EXEMPT_FILE = join(TESTS_DIR, ".python-sync-exempt");
+
+// ---------------------------------------------------------------------------
+// path-mapping.ts duplicates (source of truth: tests/scripts/path-mapping.ts).
+// Kept in lockstep by hand — both are small and rarely change together.
+// ---------------------------------------------------------------------------
+
+/** CamelCase / spaced / underscored → kebab-case. */
+function toKebab(s: string): string {
+  return s
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/[\s_]+/g, "-")
+    .toLowerCase();
+}
+
+/** Storybook title + JS file path → the expected Python parity test file. */
+function mapJsToPython(jsFileRelToRepo: string): string {
+  const absPath = join(REPO_ROOT, jsFileRelToRepo);
+  let title: string | null = null;
+  try {
+    const content = readFileSync(absPath, "utf-8");
+    const m = content.match(/title:\s*["'](.+?)["']/);
+    if (m) title = m[1];
+  } catch {
+    /* unreadable — no python file possible */
+  }
+  if (!title) return "";
+  const segments = title.split("/").map(toKebab);
+  const dirPath = segments.slice(0, -1).join("/");
+  const basePart = segments[segments.length - 1].replace(/-/g, "_");
+  return `tests/python-stories/${dirPath}/test_${basePart}.py`;
+}
+
+/** JS story export name → the expected `story_*` Python function name. */
+function exportToStoryFn(exportName: string): string {
+  return "story_" + toKebab(exportName).replace(/-/g, "_");
+}
+
+// ---------------------------------------------------------------------------
+// .python-sync-exempt
+// ---------------------------------------------------------------------------
+
+interface ExemptSet {
+  files: Set<string>;
+  exports: Map<string, Set<string>>;
+}
+
+let exemptCache: ExemptSet | undefined;
+function loadExemptSet(): ExemptSet {
+  if (exemptCache) return exemptCache;
+  const exempt: ExemptSet = { files: new Set(), exports: new Map() };
+  if (existsSync(EXEMPT_FILE)) {
+    const lines = readFileSync(EXEMPT_FILE, "utf-8")
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l && !l.startsWith("#"));
+    for (const line of lines) {
+      const sep = line.indexOf("::");
+      if (sep === -1) {
+        exempt.files.add(line);
+        continue;
+      }
+      const file = line.slice(0, sep);
+      const exp = line.slice(sep + 2);
+      if (!exempt.exports.has(file)) exempt.exports.set(file, new Set());
+      exempt.exports.get(file)!.add(exp);
+    }
+  }
+  exemptCache = exempt;
+  return exempt;
+}
+
+function isExportExempt(
+  set: ExemptSet,
+  file: string,
+  exportName: string
+): boolean {
+  if (set.files.has(file)) return true;
+  return set.exports.get(file)?.has(exportName) === true;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level Python block splitting (shared by data.py and story files).
+// ---------------------------------------------------------------------------
+
+interface PyBlock {
+  name: string | null;
+  kind: "import" | "assign" | "def" | "other";
+  text: string;
+}
+
+function splitTopLevelBlocks(source: string): PyBlock[] {
+  const lines = source.replace(/\r\n/g, "\n").split("\n");
+  const blocks: PyBlock[] = [];
+  let current: string[] = [];
+  let currentKind: PyBlock["kind"] = "other";
+  let currentName: string | null = null;
+
+  const flush = () => {
+    if (current.length)
+      blocks.push({
+        name: currentName,
+        kind: currentKind,
+        text: current.join("\n"),
+      });
+    current = [];
+  };
+
+  for (const line of lines) {
+    if (/^[A-Za-z_]/.test(line)) {
+      flush();
+      currentKind = "other";
+      currentName = null;
+      let m: RegExpExecArray | null;
+      if ((m = /^(?:async\s+)?def\s+([A-Za-z_]\w*)/.exec(line))) {
+        currentKind = "def";
+        currentName = m[1];
+      } else if (/^(?:import|from)\s/.test(line)) {
+        currentKind = "import";
+      } else if ((m = /^([A-Za-z_]\w*)\s*(?::[^=]+)?=(?!=)/.exec(line))) {
+        currentKind = "assign";
+        currentName = m[1];
+      }
+    }
+    current.push(line);
+  }
+  flush();
+  return blocks;
+}
+
+/** Remove common leading indentation and trim blank edges. */
+function dedent(text: string): string {
+  const lines = text.replace(/\t/g, "    ").split("\n");
+  while (lines.length && lines[0].trim() === "") lines.shift();
+  while (lines.length && lines[lines.length - 1].trim() === "") lines.pop();
+  const indents = lines
+    .filter((l) => l.trim() !== "")
+    .map((l) => l.match(/^ */)![0].length);
+  const min = indents.length ? Math.min(...indents) : 0;
+  return lines.map((l) => l.slice(min)).join("\n");
+}
+
+function indentBlock(text: string, pad: string): string {
+  return text
+    .split("\n")
+    .map((l) => (l.trim() === "" ? l : pad + l))
+    .join("\n");
+}
+
+/** Drop trailing blank lines and comment-only lines (see call site). */
+function stripTrailingCommentLines(text: string): string {
+  const lines = text.split("\n");
+  while (lines.length) {
+    const last = lines[lines.length - 1];
+    if (last.trim() === "" || /^\s*#/.test(last)) lines.pop();
+    else break;
+  }
+  return lines.join("\n");
+}
+
+/** Drop leading blank lines and comment-only lines, line-by-line — unlike a
+ * blanket leading-whitespace strip, this preserves the first real content
+ * line's own indentation (needed so a later dedent() sees every line's true
+ * relative indent, instead of only the first line's having been clobbered
+ * to column 0). */
+function stripLeadingCommentLines(text: string): string {
+  const lines = text.split("\n");
+  while (lines.length && (lines[0].trim() === "" || /^\s*#/.test(lines[0]))) {
+    lines.shift();
+  }
+  return lines.join("\n");
+}
+
+const PY_KEYWORDS = new Set([
+  "False",
+  "None",
+  "True",
+  "and",
+  "as",
+  "assert",
+  "async",
+  "await",
+  "break",
+  "class",
+  "continue",
+  "def",
+  "del",
+  "elif",
+  "else",
+  "except",
+  "finally",
+  "for",
+  "from",
+  "global",
+  "if",
+  "import",
+  "in",
+  "is",
+  "lambda",
+  "nonlocal",
+  "not",
+  "or",
+  "pass",
+  "raise",
+  "return",
+  "try",
+  "while",
+  "with",
+  "yield",
+  "self",
+]);
+
+function referencedIdentifiers(text: string): Set<string> {
+  const out = new Set<string>();
+  const re = /\b[A-Za-z_]\w*\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text))) {
+    if (!PY_KEYWORDS.has(m[0])) out.add(m[0]);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Balanced-expression scanning (string/comment aware).
+// ---------------------------------------------------------------------------
+
+/** Given text[openIndex] === an opening bracket, returns the index of its
+ * matching close, skipping over string literals and `#` comments. -1 if
+ * unbalanced. */
+function scanBalanced(text: string, openIndex: number): number {
+  let depth = 0;
+  let i = openIndex;
+  const n = text.length;
+  while (i < n) {
+    const ch = text[i];
+    if (ch === "#") {
+      while (i < n && text[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      const triple = text.slice(i, i + 3) === quote.repeat(3);
+      let j = i + (triple ? 3 : 1);
+      while (j < n) {
+        if (text[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (triple) {
+          if (text.slice(j, j + 3) === quote.repeat(3)) {
+            j += 3;
+            break;
+          }
+        } else if (text[j] === quote) {
+          j += 1;
+          break;
+        }
+        j++;
+      }
+      i = j;
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+      if (depth === 0) return i;
+    }
+    i++;
+  }
+  return -1;
+}
+
+/** Top-level (depth-0 relative to [start, end)) comma-separated segments. */
+function splitTopLevel(text: string, start: number, end: number): string[] {
+  const segments: string[] = [];
+  let depth = 0;
+  let segStart = start;
+  let i = start;
+  while (i < end) {
+    const ch = text[i];
+    if (ch === "#") {
+      while (i < end && text[i] !== "\n") i++;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      const triple = text.slice(i, i + 3) === quote.repeat(3);
+      let j = i + (triple ? 3 : 1);
+      while (j < end) {
+        if (text[j] === "\\") {
+          j += 2;
+          continue;
+        }
+        if (triple) {
+          if (text.slice(j, j + 3) === quote.repeat(3)) {
+            j += 3;
+            break;
+          }
+        } else if (text[j] === quote) {
+          j += 1;
+          break;
+        }
+        j++;
+      }
+      i = j;
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    if (ch === ")" || ch === "]" || ch === "}") depth--;
+    if (ch === "," && depth === 0) {
+      segments.push(text.slice(segStart, i));
+      segStart = i + 1;
+    }
+    i++;
+  }
+  const last = text.slice(segStart, end).trim();
+  if (last) segments.push(text.slice(segStart, end));
+  return segments;
+}
+
+// ---------------------------------------------------------------------------
+// data.py — dataset extraction
+// ---------------------------------------------------------------------------
+
+interface DataModule {
+  blocks: PyBlock[];
+  byName: Map<string, PyBlock>;
+}
+
+let dataModuleCache: DataModule | undefined;
+function loadDataModule(): DataModule {
+  if (dataModuleCache) return dataModuleCache;
+  const source = readFileSync(DATA_PY, "utf-8");
+  const blocks = splitTopLevelBlocks(source);
+  const byName = new Map<string, PyBlock>();
+  for (const b of blocks) {
+    if (b.name && (b.kind === "assign" || b.kind === "def"))
+      byName.set(b.name, b);
+  }
+  dataModuleCache = { blocks, byName };
+  return dataModuleCache;
+}
+
+/** JS→Python literal printer (True/False/None, double-quoted strings). */
+function pyRepr(value: unknown, indent = 0): string {
+  const pad = "    ".repeat(indent);
+  const pad1 = "    ".repeat(indent + 1);
+  if (value === null) return "None";
+  if (typeof value === "boolean") return value ? "True" : "False";
+  if (typeof value === "number") return String(value);
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    const items = value.map((v) => pad1 + pyRepr(v, indent + 1));
+    return "[\n" + items.join(",\n") + ",\n" + pad + "]";
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj);
+  if (keys.length === 0) return "{}";
+  const items = keys.map(
+    (k) => pad1 + JSON.stringify(k) + ": " + pyRepr(obj[k], indent + 1)
+  );
+  return "{\n" + items.join(",\n") + ",\n" + pad + "}";
+}
+
+/** Resolve a `_load_json("name")` RHS to inlined JSON data, or null. */
+function jsonLoadName(block: PyBlock): string | null {
+  const m = /=\s*_load_json\(\s*["']([^"']+)["']\s*\)/.exec(block.text);
+  return m ? m[1] : null;
+}
+
+/** Transitive closure of data.py names, rendered as standalone Python source
+ * (JSON-backed names inlined as Python literals; others kept verbatim). */
+function buildDatasetCode(names: string[]): string | null {
+  const mod = loadDataModule();
+  const closure = new Set<string>();
+  const worklist = [...names];
+  while (worklist.length) {
+    const name = worklist.pop()!;
+    if (closure.has(name)) continue;
+    const block = mod.byName.get(name);
+    if (!block) continue; // not a data.py name — ignore (handled elsewhere or missing)
+    closure.add(name);
+    for (const dep of referencedIdentifiers(block.text)) {
+      if (dep !== name && mod.byName.has(dep) && !closure.has(dep))
+        worklist.push(dep);
+    }
+  }
+  if (closure.size === 0) return null;
+
+  const parts: string[] = [];
+  for (const block of mod.blocks) {
+    if (!block.name || !closure.has(block.name)) continue;
+    const jsonName = jsonLoadName(block);
+    if (jsonName) {
+      const jsonPath = join(LOWLEVEL_DATA_DIR, `${jsonName}.json`);
+      const parsed = JSON.parse(readFileSync(jsonPath, "utf-8"));
+      parts.push(`${block.name} = ${pyRepr(parsed)}`);
+    } else {
+      parts.push(stripTrailingCommentLines(block.text).trim());
+    }
+  }
+  return parts.join("\n\n") + "\n";
+}
+
+type ParsedImport =
+  | { kind: "from"; module: string; names: string[] }
+  | { kind: "import"; spec: string };
+
+/** Parse one `import x` / `from m import a, b` / `from m import (\n a,\n b,\n)`
+ * statement (comments already stripped by the caller's block trimming). */
+function parseImportStatement(stmt: string): ParsedImport | null {
+  const collapsed = stmt.replace(/#.*$/gm, "").trim();
+  let m = /^from\s+([\w.]+)\s+import\s*\(([\s\S]*)\)\s*$/.exec(collapsed);
+  if (m) {
+    const names = m[2]
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return { kind: "from", module: m[1], names };
+  }
+  m = /^from\s+([\w.]+)\s+import\s+(.+)$/.exec(collapsed);
+  if (m) {
+    const names = m[2]
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    return { kind: "from", module: m[1], names };
+  }
+  m = /^import\s+(.+)$/.exec(collapsed);
+  if (m) return { kind: "import", spec: m[1].trim() };
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// _lowlevel_helpers.py / vega_data_urls.py — small internal modules that get
+// inlined wholesale (dropping their own docstring/imports handling is done
+// generically below via the same import-classification pass).
+// ---------------------------------------------------------------------------
+
+let lowlevelHelpersCache: string | undefined;
+function lowlevelHelpersSource(): string {
+  if (lowlevelHelpersCache !== undefined) return lowlevelHelpersCache;
+  const blocks = splitTopLevelBlocks(
+    readFileSync(LOWLEVEL_HELPERS_PY, "utf-8")
+  );
+  // Keep everything but the module docstring — the helpers' own imports
+  // (`typing`) and the `_Key` type alias are needed by the function bodies.
+  lowlevelHelpersCache = blocks
+    .filter(
+      (b) => b.kind === "import" || b.kind === "assign" || b.kind === "def"
+    )
+    .map((b) => stripTrailingCommentLines(b.text).trim())
+    .join("\n\n\n");
+  return lowlevelHelpersCache;
+}
+
+let vegaUrlsCache: string | undefined;
+function vegaUrlsSource(): string {
+  if (vegaUrlsCache !== undefined) return vegaUrlsCache;
+  const blocks = splitTopLevelBlocks(readFileSync(VEGA_URLS_PY, "utf-8"));
+  const kept = blocks.filter((b) => b.kind === "assign" || b.kind === "def");
+  vegaUrlsCache =
+    "import io\nfrom urllib.request import urlopen\n\nimport pandas as pd\n\n" +
+    kept.map((b) => stripTrailingCommentLines(b.text).trim()).join("\n\n\n");
+  return vegaUrlsCache;
+}
+
+// ---------------------------------------------------------------------------
+// Per-story transform
+// ---------------------------------------------------------------------------
+
+interface TransformResult {
+  code: string;
+  datasetCode: string | null;
+  isFallback: boolean;
+}
+
+class FallbackNeeded extends Error {}
+
+function transformPythonStory(
+  fileSource: string,
+  storyFn: string
+): TransformResult {
+  const blocks = splitTopLevelBlocks(fileSource);
+  const fnBlock = blocks.find((b) => b.kind === "def" && b.name === storyFn);
+  if (!fnBlock) throw new FallbackNeeded(`function ${storyFn} not found`);
+
+  const fnLines = fnBlock.text.split("\n");
+  const headerIdx = fnLines.findIndex((l) => /^def\s/.test(l));
+  // Drop trailing blank/comment-only lines (section-header comments before the
+  // *next* top-level block get swept into this block's text by the splitter,
+  // and — being flush with column 0 — would otherwise poison dedent()'s
+  // "minimum indentation" computation).
+  const rawBody = stripTrailingCommentLines(
+    fnLines.slice(headerIdx + 1).join("\n")
+  );
+  const bodyDedented = dedent(rawBody);
+
+  // Find the top-level `return` statement — either a parenthesized tuple
+  // (`return (\n  expr,\n  {...},\n)`) or a bare one-line tuple
+  // (`return expr, {...}`).
+  const returnRe = /^return\s*/m;
+  const m = returnRe.exec(bodyDedented);
+  if (!m) throw new FallbackNeeded("no top-level return statement");
+  const afterReturn = m.index + m[0].length;
+  let segments: string[];
+  if (bodyDedented[afterReturn] === "(") {
+    const closeParen = scanBalanced(bodyDedented, afterReturn);
+    if (closeParen === -1) throw new FallbackNeeded("unbalanced return tuple");
+    segments = splitTopLevel(bodyDedented, afterReturn + 1, closeParen);
+  } else {
+    // Bare tuple: everything after `return ` to the end of the (already
+    // trailing-comment-stripped) body is the tuple's contents.
+    segments = splitTopLevel(bodyDedented, afterReturn, bodyDedented.length);
+  }
+  if (segments.length !== 2) {
+    throw new FallbackNeeded(
+      `return tuple has ${segments.length} top-level elements, expected 2`
+    );
+  }
+  // dedent() (not trim()) so a multi-line chain's continuation lines
+  // (`.flow(...)`, `.mark(...)`, …) stay aligned with its first line — trim()
+  // only strips the first line's own leading whitespace, misaligning it.
+  const exprText = dedent(stripLeadingCommentLines(segments[0]));
+  const optsText = dedent(stripLeadingCommentLines(segments[1]));
+
+  // Build the .render(...) call from the options segment.
+  let renderCall: string;
+  if (/^[A-Za-z_]\w*$/.test(optsText)) {
+    // bare identifier — dict-unpack it (e.g. `_RENDER`)
+    renderCall = `.render(**${optsText})`;
+  } else if (optsText.startsWith("{")) {
+    const closeBrace = scanBalanced(optsText, 0);
+    if (closeBrace === -1) throw new FallbackNeeded("unbalanced options dict");
+    const kwSegs = splitTopLevel(optsText, 1, closeBrace);
+    const kwargs: string[] = [];
+    for (const seg of kwSegs) {
+      const colon = seg.indexOf(":");
+      if (colon === -1)
+        throw new FallbackNeeded("options dict entry missing ':'");
+      const keyRaw = seg.slice(0, colon).trim();
+      const key = keyRaw.replace(/^["']|["']$/g, "");
+      if (!/^[A-Za-z_]\w*$/.test(key))
+        throw new FallbackNeeded(`non-identifier option key ${keyRaw}`);
+      const value = seg.slice(colon + 1).trim();
+      kwargs.push(`${key}=${value}`);
+    }
+    renderCall = `.render(${kwargs.join(", ")})`;
+  } else {
+    throw new FallbackNeeded(
+      "options segment is neither a dict literal nor a bare identifier"
+    );
+  }
+
+  const preambleText = bodyDedented.slice(0, m.index).trim();
+  // A multi-line chain (`chart(...)\n.flow(...)\n.mark(...)`) is only valid
+  // as a bare statement when wrapped in parens — Python has no implicit
+  // continuation across lines outside brackets. Always wrap (harmless when
+  // exprText is already self-bracketed, e.g. a single `spread(...)` call)
+  // rather than special-casing which shapes need it.
+  const wrappedExpr = exprText.includes("\n")
+    ? "(\n" + indentBlock(exprText, "    ") + "\n)"
+    : `(${exprText})`;
+  const mainStatement = wrappedExpr + renderCall;
+  const bodyParts = [preambleText, mainStatement].filter(Boolean);
+
+  // ----- closure over referenced module-level decls (helpers/consts) -----
+  const referenced = referencedIdentifiers(bodyDedented);
+  const topDecls = new Map<string, PyBlock>();
+  for (const b of blocks) {
+    if (
+      b.name &&
+      (b.kind === "assign" || b.kind === "def") &&
+      b.name !== storyFn
+    ) {
+      topDecls.set(b.name, b);
+    }
+  }
+  const closure = new Set<string>();
+  const worklist = [...referenced];
+  while (worklist.length) {
+    const name = worklist.pop()!;
+    if (closure.has(name)) continue;
+    const decl = topDecls.get(name);
+    if (!decl) continue;
+    closure.add(name);
+    for (const dep of referencedIdentifiers(decl.text)) {
+      if (!closure.has(dep)) worklist.push(dep);
+    }
+  }
+  const declLines: string[] = [];
+  for (const b of blocks) {
+    if (
+      b.name &&
+      closure.has(b.name) &&
+      (b.kind === "assign" || b.kind === "def")
+    ) {
+      declLines.push(stripTrailingCommentLines(b.text).trim());
+    }
+  }
+
+  // ----- imports -----
+  const gofishNames = new Set<string>();
+  const datasetNames = new Set<string>();
+  const keepImportLines: string[] = [];
+  let needsLowlevelHelpers = false;
+  let needsVegaUrls = false;
+
+  for (const b of blocks) {
+    if (b.kind !== "import") continue;
+    // An import-kind block may hold more than one import statement (a
+    // parenthesized multi-line import's continuation lines are indented, so
+    // they stay attached to their own block; but the splitter also glues any
+    // trailing comment lines before the *next* top-level statement onto this
+    // block — strip those first). Re-split into individual statements at
+    // column-0 `import `/`from ` lines.
+    const blockText = stripTrailingCommentLines(b.text);
+    const stmts: string[] = [];
+    let cur: string[] = [];
+    for (const line of blockText.split("\n")) {
+      if (/^(?:import|from)\s/.test(line)) {
+        if (cur.length) stmts.push(cur.join("\n"));
+        cur = [line];
+      } else if (cur.length) {
+        cur.push(line);
+      }
+    }
+    if (cur.length) stmts.push(cur.join("\n"));
+
+    for (const stmt of stmts) {
+      const parsed = parseImportStatement(stmt);
+      if (!parsed) continue;
+      if (parsed.kind === "import") {
+        keepImportLines.push(`import ${parsed.spec}`);
+        continue;
+      }
+      const { module, names } = parsed;
+      if (module === "gofish") {
+        keepImportLines.push(`from gofish import ${names.join(", ")}`);
+        continue;
+      }
+      if (module === "python_stories.data") {
+        for (const n of names) datasetNames.add(n);
+        continue;
+      }
+      if (module === "python_stories._lowlevel_helpers") {
+        needsLowlevelHelpers = true;
+        continue;
+      }
+      if (module === "python_stories.vega_data_urls") {
+        needsVegaUrls = true;
+        continue;
+      }
+      if (module.startsWith("python_stories")) {
+        throw new FallbackNeeded(
+          `unrewritable internal import: from ${module} import ...`
+        );
+      }
+      if (module.startsWith(".")) {
+        throw new FallbackNeeded(`relative import: from ${module} import ...`);
+      }
+      // stdlib / third-party import — keep verbatim
+      keepImportLines.push(`from ${module} import ${names.join(", ")}`);
+    }
+  }
+  if (/\bsys\.path\b/.test(fileSource)) {
+    throw new FallbackNeeded("story file manipulates sys.path");
+  }
+
+  if (datasetNames.size) {
+    keepImportLines.push(
+      `from dataset import ${[...datasetNames].sort().join(", ")}`
+    );
+  }
+
+  const parts: string[] = [];
+  if (keepImportLines.length) parts.push(keepImportLines.join("\n"));
+  if (needsLowlevelHelpers) parts.push(lowlevelHelpersSource());
+  if (needsVegaUrls) parts.push(vegaUrlsSource());
+  if (declLines.length) parts.push(declLines.join("\n\n"));
+  parts.push(bodyParts.join("\n\n"));
+
+  const code = parts.join("\n\n") + "\n";
+  const datasetCode = datasetNames.size
+    ? buildDatasetCode([...datasetNames])
+    : null;
+
+  return { code, datasetCode, isFallback: false };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+let cache: PythonExample[] | undefined;
+
+export function loadPythonExamples(): PythonExample[] {
+  if (cache) return cache;
+  const exempt = loadExemptSet();
+  const jsExamples = loadStoryExamples();
+  const warnings: string[] = [];
+
+  const examples: PythonExample[] = jsExamples.map((ex: StoryExample) => {
+    const renderDiverges = isExportExempt(exempt, ex.storyFile, ex.exportName);
+    const pyRelPath = mapJsToPython(ex.storyFile);
+    const pyAbsPath = pyRelPath ? join(REPO_ROOT, pyRelPath) : "";
+    if (!pyRelPath || !existsSync(pyAbsPath)) {
+      return {
+        id: ex.id,
+        pythonCode: null,
+        pythonDatasetCode: null,
+        isFallback: false,
+        renderDiverges,
+      };
+    }
+
+    const fileSource = readFileSync(pyAbsPath, "utf-8");
+    const storyFn = exportToStoryFn(ex.exportName);
+
+    try {
+      const result = transformPythonStory(fileSource, storyFn);
+      return {
+        id: ex.id,
+        pythonCode: result.code,
+        pythonDatasetCode: result.datasetCode,
+        isFallback: false,
+        renderDiverges,
+      };
+    } catch (err) {
+      if (err instanceof FallbackNeeded) {
+        // Function-not-found is not a real port — treat as unported. Any other
+        // failure means a port exists but the transform couldn't cleanly
+        // standalone-ify it; fall back to verbatim source.
+        if (/not found$/.test(err.message)) {
+          return {
+            id: ex.id,
+            pythonCode: null,
+            pythonDatasetCode: null,
+            isFallback: false,
+            renderDiverges,
+          };
+        }
+        warnings.push(`${ex.id} (${pyRelPath}::${storyFn}): ${err.message}`);
+        const blocks = splitTopLevelBlocks(fileSource);
+        const fnBlock = blocks.find(
+          (b) => b.kind === "def" && b.name === storyFn
+        );
+        const code = fnBlock ? dedent(fnBlock.text) + "\n" : null;
+        return {
+          id: ex.id,
+          pythonCode: code,
+          pythonDatasetCode: null,
+          isFallback: code !== null,
+          renderDiverges,
+        };
+      }
+      throw err;
+    }
+  });
+
+  if (warnings.length) {
+    console.warn(
+      `[pythonExamples] ${warnings.length} example(s) fell back to verbatim Python source (transform did not apply cleanly):\n` +
+        warnings.map((w) => `  - ${w}`).join("\n")
+    );
+  }
+
+  cache = examples;
+  return examples;
+}
+
+export function getPythonExampleById(id: string): PythonExample | undefined {
+  return loadPythonExamples().find((ex) => ex.id === id);
+}

--- a/apps/docs/docs/.vitepress/data/pythonExamples.ts
+++ b/apps/docs/docs/.vitepress/data/pythonExamples.ts
@@ -26,6 +26,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadStoryExamples, type StoryExample } from "./storyExamples.ts";
+import { dedent, indent } from "./textUtils.ts";
 
 export interface PythonExample {
   id: string;
@@ -48,8 +49,6 @@ const REPO_ROOT = resolve(__dirname, "../../../../..");
 const TESTS_DIR = join(REPO_ROOT, "tests");
 const PYTHON_STORIES_DIR = join(TESTS_DIR, "python-stories");
 const DATA_PY = join(PYTHON_STORIES_DIR, "data.py");
-const LOWLEVEL_HELPERS_PY = join(PYTHON_STORIES_DIR, "_lowlevel_helpers.py");
-const VEGA_URLS_PY = join(PYTHON_STORIES_DIR, "vega_data_urls.py");
 const LOWLEVEL_DATA_DIR = join(PYTHON_STORIES_DIR, "_lowlevel_data");
 const EXEMPT_FILE = join(TESTS_DIR, ".python-sync-exempt");
 
@@ -67,7 +66,16 @@ function toKebab(s: string): string {
 }
 
 /** Storybook title + JS file path → the expected Python parity test file. */
+const mapJsToPythonCache = new Map<string, string>();
 function mapJsToPython(jsFileRelToRepo: string): string {
+  const cached = mapJsToPythonCache.get(jsFileRelToRepo);
+  if (cached !== undefined) return cached;
+  const result = computeMapJsToPython(jsFileRelToRepo);
+  mapJsToPythonCache.set(jsFileRelToRepo, result);
+  return result;
+}
+
+function computeMapJsToPython(jsFileRelToRepo: string): string {
   const absPath = join(REPO_ROOT, jsFileRelToRepo);
   let title: string | null = null;
   try {
@@ -75,13 +83,34 @@ function mapJsToPython(jsFileRelToRepo: string): string {
     const m = content.match(/title:\s*["'](.+?)["']/);
     if (m) title = m[1];
   } catch {
-    /* unreadable — no python file possible */
+    /* unreadable — fall through to path-based fallback */
   }
-  if (!title) return "";
-  const segments = title.split("/").map(toKebab);
-  const dirPath = segments.slice(0, -1).join("/");
-  const basePart = segments[segments.length - 1].replace(/-/g, "_");
-  return `tests/python-stories/${dirPath}/test_${basePart}.py`;
+
+  if (title) {
+    const segments = title.split("/").map(toKebab);
+    const dirPath = segments.slice(0, -1).join("/");
+    const basePart = segments[segments.length - 1].replace(/-/g, "_");
+    return `tests/python-stories/${dirPath}/test_${basePart}.py`;
+  }
+
+  // Fallback: derive from file path (CamelCase → snake_case, flatten one level)
+  let rel = jsFileRelToRepo.replace(
+    /^packages\/gofish-graphics\/stories\//,
+    ""
+  );
+  rel = rel.replace(/\.stories\.tsx$/, "");
+  const lastSlash = rel.lastIndexOf("/");
+  const dirPart = lastSlash >= 0 ? rel.slice(0, lastSlash) : ".";
+  const basePart = lastSlash >= 0 ? rel.slice(lastSlash + 1) : rel;
+  const toSnake = (s: string) =>
+    s.replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase();
+  const snakeBase = toSnake(basePart);
+  let snakeDir = toSnake(dirPart);
+  if (snakeDir.includes("/")) {
+    snakeDir = snakeDir.replace(/\/[^/]*$/, "");
+  }
+  const prefix = snakeDir && snakeDir !== "." ? `${snakeDir}/` : "";
+  return `tests/python-stories/${prefix}test_${snakeBase}.py`;
 }
 
 /** JS story export name → the expected `story_*` Python function name. */
@@ -181,25 +210,6 @@ function splitTopLevelBlocks(source: string): PyBlock[] {
   return blocks;
 }
 
-/** Remove common leading indentation and trim blank edges. */
-function dedent(text: string): string {
-  const lines = text.replace(/\t/g, "    ").split("\n");
-  while (lines.length && lines[0].trim() === "") lines.shift();
-  while (lines.length && lines[lines.length - 1].trim() === "") lines.pop();
-  const indents = lines
-    .filter((l) => l.trim() !== "")
-    .map((l) => l.match(/^ */)![0].length);
-  const min = indents.length ? Math.min(...indents) : 0;
-  return lines.map((l) => l.slice(min)).join("\n");
-}
-
-function indentBlock(text: string, pad: string): string {
-  return text
-    .split("\n")
-    .map((l) => (l.trim() === "" ? l : pad + l))
-    .join("\n");
-}
-
 /** Drop trailing blank lines and comment-only lines (see call site). */
 function stripTrailingCommentLines(text: string): string {
   const lines = text.split("\n");
@@ -277,6 +287,48 @@ function referencedIdentifiers(text: string): Set<string> {
 // Balanced-expression scanning (string/comment aware).
 // ---------------------------------------------------------------------------
 
+/** If text[i] starts a `#` comment or a quoted (incl. triple-quoted) string
+ * literal, returns the index to resume scanning from (the comment's trailing
+ * newline, or just past the string's closing quote — possibly `end` if
+ * unterminated). Returns null when text[i] is neither, so the caller falls
+ * through to its normal per-character handling. Shared by scanBalanced() and
+ * splitTopLevel() so both stay string/comment-aware identically. */
+function skipStringOrComment(
+  text: string,
+  i: number,
+  end: number
+): number | null {
+  const ch = text[i];
+  if (ch === "#") {
+    let j = i;
+    while (j < end && text[j] !== "\n") j++;
+    return j;
+  }
+  if (ch === '"' || ch === "'") {
+    const quote = ch;
+    const triple = text.slice(i, i + 3) === quote.repeat(3);
+    let j = i + (triple ? 3 : 1);
+    while (j < end) {
+      if (text[j] === "\\") {
+        j += 2;
+        continue;
+      }
+      if (triple) {
+        if (text.slice(j, j + 3) === quote.repeat(3)) {
+          j += 3;
+          break;
+        }
+      } else if (text[j] === quote) {
+        j += 1;
+        break;
+      }
+      j++;
+    }
+    return j;
+  }
+  return null;
+}
+
 /** Given text[openIndex] === an opening bracket, returns the index of its
  * matching close, skipping over string literals and `#` comments. -1 if
  * unbalanced. */
@@ -286,31 +338,9 @@ function scanBalanced(text: string, openIndex: number): number {
   const n = text.length;
   while (i < n) {
     const ch = text[i];
-    if (ch === "#") {
-      while (i < n && text[i] !== "\n") i++;
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      const quote = ch;
-      const triple = text.slice(i, i + 3) === quote.repeat(3);
-      let j = i + (triple ? 3 : 1);
-      while (j < n) {
-        if (text[j] === "\\") {
-          j += 2;
-          continue;
-        }
-        if (triple) {
-          if (text.slice(j, j + 3) === quote.repeat(3)) {
-            j += 3;
-            break;
-          }
-        } else if (text[j] === quote) {
-          j += 1;
-          break;
-        }
-        j++;
-      }
-      i = j;
+    const skip = skipStringOrComment(text, i, n);
+    if (skip !== null) {
+      i = skip;
       continue;
     }
     if (ch === "(" || ch === "[" || ch === "{") depth++;
@@ -331,31 +361,9 @@ function splitTopLevel(text: string, start: number, end: number): string[] {
   let i = start;
   while (i < end) {
     const ch = text[i];
-    if (ch === "#") {
-      while (i < end && text[i] !== "\n") i++;
-      continue;
-    }
-    if (ch === '"' || ch === "'") {
-      const quote = ch;
-      const triple = text.slice(i, i + 3) === quote.repeat(3);
-      let j = i + (triple ? 3 : 1);
-      while (j < end) {
-        if (text[j] === "\\") {
-          j += 2;
-          continue;
-        }
-        if (triple) {
-          if (text.slice(j, j + 3) === quote.repeat(3)) {
-            j += 3;
-            break;
-          }
-        } else if (text[j] === quote) {
-          j += 1;
-          break;
-        }
-        j++;
-      }
-      i = j;
+    const skip = skipStringOrComment(text, i, end);
+    if (skip !== null) {
+      i = skip;
       continue;
     }
     if (ch === "(" || ch === "[" || ch === "{") depth++;
@@ -422,23 +430,36 @@ function jsonLoadName(block: PyBlock): string | null {
   return m ? m[1] : null;
 }
 
-/** Transitive closure of data.py names, rendered as standalone Python source
- * (JSON-backed names inlined as Python literals; others kept verbatim). */
-function buildDatasetCode(names: string[]): string | null {
-  const mod = loadDataModule();
+/** Transitive closure of `byName`'s keys reachable from `seeds` by identifier
+ * reference (a name pulls in every other name its block's text mentions).
+ * Shared by buildDatasetCode() (data.py names) and transformPythonStory()'s
+ * decl closure (story-file top-level names) — same worklist/visited-set
+ * shape, different `byName` map. */
+function closeOverDecls(
+  byName: Map<string, PyBlock>,
+  seeds: Iterable<string>
+): Set<string> {
   const closure = new Set<string>();
-  const worklist = [...names];
+  const worklist = [...seeds];
   while (worklist.length) {
     const name = worklist.pop()!;
     if (closure.has(name)) continue;
-    const block = mod.byName.get(name);
-    if (!block) continue; // not a data.py name — ignore (handled elsewhere or missing)
+    const block = byName.get(name);
+    if (!block) continue; // not in this map — ignore (handled elsewhere or missing)
     closure.add(name);
     for (const dep of referencedIdentifiers(block.text)) {
-      if (dep !== name && mod.byName.has(dep) && !closure.has(dep))
-        worklist.push(dep);
+      if (!closure.has(dep)) worklist.push(dep);
     }
   }
+  return closure;
+}
+
+/** Transitive closure of data.py names, rendered as standalone Python source
+ * (JSON-backed names inlined as Python literals; others kept verbatim). */
+const jsonReprCache = new Map<string, string>();
+function buildDatasetCode(names: string[]): string | null {
+  const mod = loadDataModule();
+  const closure = closeOverDecls(mod.byName, names);
   if (closure.size === 0) return null;
 
   const parts: string[] = [];
@@ -446,9 +467,14 @@ function buildDatasetCode(names: string[]): string | null {
     if (!block.name || !closure.has(block.name)) continue;
     const jsonName = jsonLoadName(block);
     if (jsonName) {
-      const jsonPath = join(LOWLEVEL_DATA_DIR, `${jsonName}.json`);
-      const parsed = JSON.parse(readFileSync(jsonPath, "utf-8"));
-      parts.push(`${block.name} = ${pyRepr(parsed)}`);
+      let repr = jsonReprCache.get(jsonName);
+      if (repr === undefined) {
+        const jsonPath = join(LOWLEVEL_DATA_DIR, `${jsonName}.json`);
+        const parsed = JSON.parse(readFileSync(jsonPath, "utf-8"));
+        repr = pyRepr(parsed);
+        jsonReprCache.set(jsonName, repr);
+      }
+      parts.push(`${block.name} = ${repr}`);
     } else {
       parts.push(stripTrailingCommentLines(block.text).trim());
     }
@@ -486,37 +512,35 @@ function parseImportStatement(stmt: string): ParsedImport | null {
 }
 
 // ---------------------------------------------------------------------------
-// _lowlevel_helpers.py / vega_data_urls.py — small internal modules that get
-// inlined wholesale (dropping their own docstring/imports handling is done
-// generically below via the same import-classification pass).
+// Sibling modules (`_lowlevel_helpers.py`, `vega_data_urls.py`, …) — small
+// internal `tests/python-stories/<leaf>.py` modules that a story imports from
+// as `from python_stories.<leaf> import ...` and that get inlined wholesale
+// into the standalone snippet, in place of that import.
 // ---------------------------------------------------------------------------
 
-let lowlevelHelpersCache: string | undefined;
-function lowlevelHelpersSource(): string {
-  if (lowlevelHelpersCache !== undefined) return lowlevelHelpersCache;
+let siblingModuleCache: Map<string, string> | undefined;
+function inlineSiblingModule(moduleLeaf: string): string {
+  if (!siblingModuleCache) siblingModuleCache = new Map();
+  const cached = siblingModuleCache.get(moduleLeaf);
+  if (cached !== undefined) return cached;
   const blocks = splitTopLevelBlocks(
-    readFileSync(LOWLEVEL_HELPERS_PY, "utf-8")
+    readFileSync(join(PYTHON_STORIES_DIR, `${moduleLeaf}.py`), "utf-8")
   );
-  // Keep everything but the module docstring — the helpers' own imports
-  // (`typing`) and the `_Key` type alias are needed by the function bodies.
-  lowlevelHelpersCache = blocks
-    .filter(
-      (b) => b.kind === "import" || b.kind === "assign" || b.kind === "def"
-    )
+  // Keep everything but the module docstring (docstrings land in an "other"
+  // block, excluded below) and any self-imports of other python_stories.*
+  // siblings (not standalone-inlinable) — the module's own third-party/stdlib
+  // imports and its def/assign blocks are what the function bodies need.
+  const source = blocks
+    .filter((b) => {
+      if (b.kind === "def" || b.kind === "assign") return true;
+      if (b.kind === "import")
+        return !/^\s*from\s+python_stories\./m.test(b.text);
+      return false;
+    })
     .map((b) => stripTrailingCommentLines(b.text).trim())
     .join("\n\n\n");
-  return lowlevelHelpersCache;
-}
-
-let vegaUrlsCache: string | undefined;
-function vegaUrlsSource(): string {
-  if (vegaUrlsCache !== undefined) return vegaUrlsCache;
-  const blocks = splitTopLevelBlocks(readFileSync(VEGA_URLS_PY, "utf-8"));
-  const kept = blocks.filter((b) => b.kind === "assign" || b.kind === "def");
-  vegaUrlsCache =
-    "import io\nfrom urllib.request import urlopen\n\nimport pandas as pd\n\n" +
-    kept.map((b) => stripTrailingCommentLines(b.text).trim()).join("\n\n\n");
-  return vegaUrlsCache;
+  siblingModuleCache.set(moduleLeaf, source);
+  return source;
 }
 
 // ---------------------------------------------------------------------------
@@ -533,9 +557,9 @@ class FallbackNeeded extends Error {}
 
 function transformPythonStory(
   fileSource: string,
-  storyFn: string
+  storyFn: string,
+  blocks: PyBlock[]
 ): TransformResult {
-  const blocks = splitTopLevelBlocks(fileSource);
   const fnBlock = blocks.find((b) => b.kind === "def" && b.name === storyFn);
   if (!fnBlock) throw new FallbackNeeded(`function ${storyFn} not found`);
 
@@ -548,7 +572,7 @@ function transformPythonStory(
   const rawBody = stripTrailingCommentLines(
     fnLines.slice(headerIdx + 1).join("\n")
   );
-  const bodyDedented = dedent(rawBody);
+  const bodyDedented = dedent(rawBody, 4);
 
   // Find the top-level `return` statement — either a parenthesized tuple
   // (`return (\n  expr,\n  {...},\n)`) or a bare one-line tuple
@@ -575,8 +599,8 @@ function transformPythonStory(
   // dedent() (not trim()) so a multi-line chain's continuation lines
   // (`.flow(...)`, `.mark(...)`, …) stay aligned with its first line — trim()
   // only strips the first line's own leading whitespace, misaligning it.
-  const exprText = dedent(stripLeadingCommentLines(segments[0]));
-  const optsText = dedent(stripLeadingCommentLines(segments[1]));
+  const exprText = dedent(stripLeadingCommentLines(segments[0]), 4);
+  const optsText = dedent(stripLeadingCommentLines(segments[1]), 4);
 
   // Build the .render(...) call from the options segment.
   let renderCall: string;
@@ -613,7 +637,7 @@ function transformPythonStory(
   // exprText is already self-bracketed, e.g. a single `spread(...)` call)
   // rather than special-casing which shapes need it.
   const wrappedExpr = exprText.includes("\n")
-    ? "(\n" + indentBlock(exprText, "    ") + "\n)"
+    ? "(\n" + indent(exprText, "    ") + "\n)"
     : `(${exprText})`;
   const mainStatement = wrappedExpr + renderCall;
   const bodyParts = [preambleText, mainStatement].filter(Boolean);
@@ -630,18 +654,7 @@ function transformPythonStory(
       topDecls.set(b.name, b);
     }
   }
-  const closure = new Set<string>();
-  const worklist = [...referenced];
-  while (worklist.length) {
-    const name = worklist.pop()!;
-    if (closure.has(name)) continue;
-    const decl = topDecls.get(name);
-    if (!decl) continue;
-    closure.add(name);
-    for (const dep of referencedIdentifiers(decl.text)) {
-      if (!closure.has(dep)) worklist.push(dep);
-    }
-  }
+  const closure = closeOverDecls(topDecls, referenced);
   const declLines: string[] = [];
   for (const b of blocks) {
     if (
@@ -657,65 +670,50 @@ function transformPythonStory(
   const gofishNames = new Set<string>();
   const datasetNames = new Set<string>();
   const keepImportLines: string[] = [];
-  let needsLowlevelHelpers = false;
-  let needsVegaUrls = false;
+  const inlinedSiblingModules: string[] = [];
+  const seenSiblingModules = new Set<string>();
 
   for (const b of blocks) {
     if (b.kind !== "import") continue;
-    // An import-kind block may hold more than one import statement (a
-    // parenthesized multi-line import's continuation lines are indented, so
-    // they stay attached to their own block; but the splitter also glues any
-    // trailing comment lines before the *next* top-level statement onto this
-    // block — strip those first). Re-split into individual statements at
-    // column-0 `import `/`from ` lines.
-    const blockText = stripTrailingCommentLines(b.text);
-    const stmts: string[] = [];
-    let cur: string[] = [];
-    for (const line of blockText.split("\n")) {
-      if (/^(?:import|from)\s/.test(line)) {
-        if (cur.length) stmts.push(cur.join("\n"));
-        cur = [line];
-      } else if (cur.length) {
-        cur.push(line);
+    // splitTopLevelBlocks() flushes on every column-0 identifier line (see its
+    // definition), so an import block can never contain more than one
+    // top-level import statement — parse it directly.
+    const parsed = parseImportStatement(stripTrailingCommentLines(b.text));
+    if (!parsed) continue;
+    if (parsed.kind === "import") {
+      keepImportLines.push(`import ${parsed.spec}`);
+      continue;
+    }
+    const { module, names } = parsed;
+    if (module === "gofish") {
+      keepImportLines.push(`from gofish import ${names.join(", ")}`);
+      continue;
+    }
+    if (module === "python_stories.data") {
+      for (const n of names) datasetNames.add(n);
+      continue;
+    }
+    const siblingMatch = /^python_stories\.(\w+)$/.exec(module);
+    if (siblingMatch) {
+      const leaf = siblingMatch[1];
+      if (existsSync(join(PYTHON_STORIES_DIR, `${leaf}.py`))) {
+        if (!seenSiblingModules.has(leaf)) {
+          seenSiblingModules.add(leaf);
+          inlinedSiblingModules.push(inlineSiblingModule(leaf));
+        }
+        continue;
       }
     }
-    if (cur.length) stmts.push(cur.join("\n"));
-
-    for (const stmt of stmts) {
-      const parsed = parseImportStatement(stmt);
-      if (!parsed) continue;
-      if (parsed.kind === "import") {
-        keepImportLines.push(`import ${parsed.spec}`);
-        continue;
-      }
-      const { module, names } = parsed;
-      if (module === "gofish") {
-        keepImportLines.push(`from gofish import ${names.join(", ")}`);
-        continue;
-      }
-      if (module === "python_stories.data") {
-        for (const n of names) datasetNames.add(n);
-        continue;
-      }
-      if (module === "python_stories._lowlevel_helpers") {
-        needsLowlevelHelpers = true;
-        continue;
-      }
-      if (module === "python_stories.vega_data_urls") {
-        needsVegaUrls = true;
-        continue;
-      }
-      if (module.startsWith("python_stories")) {
-        throw new FallbackNeeded(
-          `unrewritable internal import: from ${module} import ...`
-        );
-      }
-      if (module.startsWith(".")) {
-        throw new FallbackNeeded(`relative import: from ${module} import ...`);
-      }
-      // stdlib / third-party import — keep verbatim
-      keepImportLines.push(`from ${module} import ${names.join(", ")}`);
+    if (module.startsWith("python_stories")) {
+      throw new FallbackNeeded(
+        `unrewritable internal import: from ${module} import ...`
+      );
     }
+    if (module.startsWith(".")) {
+      throw new FallbackNeeded(`relative import: from ${module} import ...`);
+    }
+    // stdlib / third-party import — keep verbatim
+    keepImportLines.push(`from ${module} import ${names.join(", ")}`);
   }
   if (/\bsys\.path\b/.test(fileSource)) {
     throw new FallbackNeeded("story file manipulates sys.path");
@@ -729,8 +727,7 @@ function transformPythonStory(
 
   const parts: string[] = [];
   if (keepImportLines.length) parts.push(keepImportLines.join("\n"));
-  if (needsLowlevelHelpers) parts.push(lowlevelHelpersSource());
-  if (needsVegaUrls) parts.push(vegaUrlsSource());
+  parts.push(...inlinedSiblingModules);
   if (declLines.length) parts.push(declLines.join("\n\n"));
   parts.push(bodyParts.join("\n\n"));
 
@@ -745,6 +742,19 @@ function transformPythonStory(
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
+
+/** splitTopLevelBlocks(fileSource), memoized per parity-file path — a story
+ * file backs one path but may hold several `story_*` functions (one per
+ * gallery example), so this is re-read across map() iterations. */
+const storyBlocksCache = new Map<string, PyBlock[]>();
+function loadStoryBlocks(path: string, fileSource: string): PyBlock[] {
+  let blocks = storyBlocksCache.get(path);
+  if (!blocks) {
+    blocks = splitTopLevelBlocks(fileSource);
+    storyBlocksCache.set(path, blocks);
+  }
+  return blocks;
+}
 
 let cache: PythonExample[] | undefined;
 
@@ -770,9 +780,10 @@ export function loadPythonExamples(): PythonExample[] {
 
     const fileSource = readFileSync(pyAbsPath, "utf-8");
     const storyFn = exportToStoryFn(ex.exportName);
+    const blocks = loadStoryBlocks(pyAbsPath, fileSource);
 
     try {
-      const result = transformPythonStory(fileSource, storyFn);
+      const result = transformPythonStory(fileSource, storyFn, blocks);
       return {
         id: ex.id,
         pythonCode: result.code,
@@ -795,11 +806,10 @@ export function loadPythonExamples(): PythonExample[] {
           };
         }
         warnings.push(`${ex.id} (${pyRelPath}::${storyFn}): ${err.message}`);
-        const blocks = splitTopLevelBlocks(fileSource);
         const fnBlock = blocks.find(
           (b) => b.kind === "def" && b.name === storyFn
         );
-        const code = fnBlock ? dedent(fnBlock.text) + "\n" : null;
+        const code = fnBlock ? dedent(fnBlock.text, 4) + "\n" : null;
         return {
           id: ex.id,
           pythonCode: code,

--- a/apps/docs/docs/.vitepress/data/storyExamples.ts
+++ b/apps/docs/docs/.vitepress/data/storyExamples.ts
@@ -15,7 +15,8 @@
  *
  * This module is imported at build time by the VitePress data loader
  * (`storyExamples.data.js`) and may also be consumed by markdown-it plugins, so
- * it is synchronous and depends only on `node:fs` / `node:path` / `typescript`.
+ * it is synchronous and depends only on `node:fs` / `node:path` / `typescript`
+ * / the sibling `textUtils.ts` (dedent/indent helpers shared with pythonExamples.ts).
  *
  * Hard build-time guards: duplicate ids throw; unparseable tagged stories throw.
  */
@@ -23,6 +24,7 @@ import { readFileSync, readdirSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
+import { dedent, indent } from "./textUtils.ts";
 
 export interface StoryExample {
   /** kebab-case of gallery.title, e.g. "seattle-weather-stacked-bar-chart" */
@@ -779,27 +781,7 @@ function transformBody(
     text = text.slice(0, e.start) + e.text + text.slice(e.end);
   }
 
-  return dedentBlock(text);
-}
-
-/** Remove common leading indentation and trim blank edges. */
-function dedentBlock(text: string): string {
-  const lines = text.replace(/\t/g, "  ").split("\n");
-  // drop leading / trailing blank lines
-  while (lines.length && lines[0].trim() === "") lines.shift();
-  while (lines.length && lines[lines.length - 1].trim() === "") lines.pop();
-  const indents = lines
-    .filter((l) => l.trim() !== "")
-    .map((l) => l.match(/^ */)![0].length);
-  const min = indents.length ? Math.min(...indents) : 0;
-  return lines.map((l) => l.slice(min)).join("\n");
-}
-
-function indent(text: string, pad: string): string {
-  return text
-    .split("\n")
-    .map((l) => (l.trim() === "" ? l : pad + l))
-    .join("\n");
+  return dedent(text, 2);
 }
 
 /** Fallback: lightly-cleaned raw render body with an `adapted from` header. */

--- a/apps/docs/docs/.vitepress/data/textUtils.ts
+++ b/apps/docs/docs/.vitepress/data/textUtils.ts
@@ -1,0 +1,28 @@
+/**
+ * textUtils.ts — small text-formatting helpers shared by storyExamples.ts
+ * (TypeScript snippet synthesis) and pythonExamples.ts (Python snippet
+ * synthesis). The two callers differ only in tab width (2 vs 4 spaces), which
+ * is why dedent() takes it as a parameter rather than hardcoding one.
+ */
+
+/** Remove common leading indentation and trim blank edges. Tabs are expanded
+ * to `tabWidth` spaces first so indentation comparisons are column-accurate
+ * regardless of the source's tab/space mix. */
+export function dedent(text: string, tabWidth: number): string {
+  const lines = text.replace(/\t/g, " ".repeat(tabWidth)).split("\n");
+  while (lines.length && lines[0].trim() === "") lines.shift();
+  while (lines.length && lines[lines.length - 1].trim() === "") lines.pop();
+  const indents = lines
+    .filter((l) => l.trim() !== "")
+    .map((l) => l.match(/^ */)![0].length);
+  const min = indents.length ? Math.min(...indents) : 0;
+  return lines.map((l) => l.slice(min)).join("\n");
+}
+
+/** Prepend `pad` to every non-blank line. */
+export function indent(text: string, pad: string): string {
+  return text
+    .split("\n")
+    .map((l) => (l.trim() === "" ? l : pad + l))
+    .join("\n");
+}

--- a/apps/docs/docs/.vitepress/theme/components/gallery/GalleryPage.vue
+++ b/apps/docs/docs/.vitepress/theme/components/gallery/GalleryPage.vue
@@ -94,16 +94,12 @@ onMounted(() => {
   ).matches;
   const DOLLY_MS = 300; // duration of the dolly-in (keep in sync with gallery.css)
 
-  // Click-through target. Per-example pages currently exist only under
-  // /js/examples/ (the Python docs direct readers to that catalog, which renders
-  // identical charts), so a Python piece would 404 on /python/examples/<id>. To
-  // keep clicks landing on real content (and the console error-free), Python
-  // pieces also open the JS example page. When Python per-example pages land,
-  // switch this back to deriving `/${effectiveLang(route.path)}/examples/<id>`.
+  // Click-through target. Both language sections have per-example pages
+  // (`/js/examples/<id>` and `/python/examples/<id>`, same ids) generated
+  // from the same gallery-tagged stories, so the gallery always links into
+  // the section the visitor is currently browsing.
   function exampleHref(id: string): string {
-    const lang = effectiveLang(route.path);
-    const section = lang === "python" ? "js" : lang;
-    return `/${section}/examples/${id}`;
+    return `/${effectiveLang(route.path)}/examples/${id}`;
   }
 
   // =====================================================================

--- a/apps/docs/docs/js/examples/[id].paths.ts
+++ b/apps/docs/docs/js/examples/[id].paths.ts
@@ -3,9 +3,10 @@
  *
  * One route is emitted per gallery-tagged Storybook story (see
  * `.vitepress/data/storyExamples.ts`). Each page is fully described by the
- * `content` field below — VitePress treats it as the markdown body of
- * `[id].md`, so the template file itself only carries shared frontmatter and
- * styling.
+ * `content` field returned from `buildExamplePage()` (`.vitepress/data/examplePage.ts`,
+ * shared with the Python variant of this loader) — VitePress treats it as the
+ * markdown body of `[id].md`, so the template file itself only carries shared
+ * frontmatter and styling.
  *
  * The page shows:
  *   - the title (H1) + description as lead prose,
@@ -13,68 +14,37 @@
  *   - an "Open in live editor" button → /js/examples/playground.html?id=<id>,
  *   - a static `ts` code fence (NO Sandpack here — that is the point: example
  *     pages must stay light), plus a collapsed dataset.ts fence when present.
- *
- * NB: example `code`/`datasetCode` strings frequently contain backticks
- * (template literals in chart code), so they are pushed as plain array
- * elements and never interpolated into a JS template literal.
  */
 import { loadStoryExamples } from "../../.vitepress/data/storyExamples.ts";
+import { buildExamplePage } from "../../.vitepress/data/examplePage.ts";
 
 export default {
   paths() {
     return loadStoryExamples().map((ex) => {
-      const parts: string[] = [];
-
-      // Back link to the gallery, above the title.
-      parts.push(
-        `<a class="example-back" href="/js/examples/">← Examples</a>`,
-        ""
-      );
-
-      parts.push(`# ${ex.title}`, "");
-      if (ex.description) {
-        parts.push(ex.description, "");
-      }
-
-      // Live render of the real story module (client-only; no code echo).
-      parts.push(`<GoFishExample id="${ex.id}" />`, "");
-
-      // Open in live editor (Sandpack) — loaded only on the playground page.
-      parts.push(
-        `<div class="example-actions">`,
-        `  <a class="example-playground-btn" href="/js/examples/playground.html?id=${ex.id}">Open in live editor</a>`,
-        `</div>`,
-        ""
-      );
-
+      const notes: string[] = [];
       if (ex.isFallback) {
-        parts.push(
-          `_The code below is adapted from the story source; this example relies on local helpers that cannot be inlined into a single standalone snippet._`,
-          ""
+        notes.push(
+          `_The code below is adapted from the story source; this example relies on local helpers that cannot be inlined into a single standalone snippet._`
         );
       }
 
-      // Static code fence (push code as a plain element — may contain backticks).
-      parts.push("```ts", ex.code.replace(/\n+$/, ""), "```", "");
-
-      if (ex.datasetCode) {
-        parts.push(
-          '<details class="example-dataset">',
-          "<summary>dataset.ts</summary>",
-          "",
-          "```ts",
-          ex.datasetCode.replace(/\n+$/, ""),
-          "```",
-          "",
-          "</details>",
-          ""
-        );
-      }
-
-      return {
-        params: { id: ex.id, title: ex.title },
-        content: parts.join("\n"),
-      };
+      return buildExamplePage({
+        backHref: "/js/examples/",
+        title: ex.title,
+        description: ex.description,
+        exampleId: ex.id,
+        // Open in live editor (Sandpack) — loaded only on the playground page.
+        actionsHtml: [
+          `<div class="example-actions">`,
+          `  <a class="example-playground-btn" href="/js/examples/playground.html?id=${ex.id}">Open in live editor</a>`,
+          `</div>`,
+        ],
+        notes,
+        fenceLang: "ts",
+        code: ex.code,
+        datasetLabel: "dataset.ts",
+        datasetCode: ex.datasetCode,
+      });
     });
   },
 };

--- a/apps/docs/docs/python/examples/[id].md
+++ b/apps/docs/docs/python/examples/[id].md
@@ -1,0 +1,44 @@
+---
+aside: false
+editLink: false
+---
+
+<style>
+/* "← Examples" back button above the title. Scoped under `.vp-doc a` to beat
+   VitePress's default link styling. Secondary/outline button, matching the
+   JS example pages' back button (see js/examples/[id].md). */
+.vp-doc a.example-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  margin: 0 0 1.25rem;
+  padding: 6px 14px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  border-radius: 8px;
+  border: 1px solid var(--vp-c-divider);
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  transition:
+    color 0.2s ease,
+    border-color 0.2s ease,
+    background-color 0.2s ease;
+}
+.vp-doc a.example-back:hover {
+  color: var(--vp-c-brand-1);
+  border-color: var(--vp-c-brand-1);
+  background: var(--vp-c-bg-soft);
+}
+.example-dataset {
+  margin: 0.5rem 0 1.5rem;
+}
+.example-dataset > summary {
+  cursor: pointer;
+  font-size: 14px;
+  color: var(--vp-c-text-2);
+}
+</style>
+
+<!-- @content -->

--- a/apps/docs/docs/python/examples/[id].paths.ts
+++ b/apps/docs/docs/python/examples/[id].paths.ts
@@ -1,0 +1,94 @@
+/**
+ * Dynamic-route loader for the Python per-example pages.
+ *
+ * Mirrors `js/examples/[id].paths.ts` — one route per gallery-tagged
+ * Storybook story (see `.vitepress/data/storyExamples.ts`), same `id`s, so
+ * `/python/examples/<id>` always exists alongside `/js/examples/<id>`
+ * (the language toggle and the gallery wall both assume mirrored paths).
+ *
+ * The Python page differs from the JS one in three ways:
+ *   - the code fence shows the Python parity port (`pythonExamples.ts`), not
+ *     the JS snippet, and is omitted entirely when there is no port yet;
+ *   - there is no "Open in live editor" button — the Sandpack playground is
+ *     JS-only;
+ *   - the live render is still `<GoFishExample>` (JS and Python serialize to
+ *     the same IR, so the same real story module renders both).
+ */
+import { loadStoryExamples } from "../../.vitepress/data/storyExamples.ts";
+import { loadPythonExamples } from "../../.vitepress/data/pythonExamples.ts";
+
+export default {
+  paths() {
+    const pythonById = new Map(loadPythonExamples().map((p) => [p.id, p]));
+
+    return loadStoryExamples().map((ex) => {
+      const py = pythonById.get(ex.id);
+      const parts: string[] = [];
+
+      // Back link to the gallery, above the title.
+      parts.push(
+        `<a class="example-back" href="/python/examples/">← Examples</a>`,
+        ""
+      );
+
+      parts.push(`# ${ex.title}`, "");
+      if (ex.description) {
+        parts.push(ex.description, "");
+      }
+
+      // Live render of the real story module (client-only; no code echo).
+      // JS and Python serialize to the same IR, so this is the same render
+      // the JS example page shows — there is no separate Python engine.
+      parts.push(`<GoFishExample id="${ex.id}" />`, "");
+
+      const hasCode = !!py?.pythonCode;
+
+      if (!hasCode) {
+        parts.push(
+          `_This example has not been ported to Python yet. See the ` +
+            `[JavaScript version](/js/examples/${ex.id}) for its code._`,
+          ""
+        );
+      } else if (py?.renderDiverges) {
+        parts.push(
+          `_The chart above is rendered by the JavaScript engine. This example's ` +
+            `Python port intentionally uses a different algorithm for part of its ` +
+            `computation (an accepted divergence), so its output differs slightly ` +
+            `from the render shown._`,
+          ""
+        );
+      }
+
+      if (hasCode) {
+        if (py!.isFallback) {
+          parts.push(
+            `_The code below is the Python parity port's function shown verbatim; ` +
+              `it could not be reduced to a standalone snippet automatically._`,
+            ""
+          );
+        }
+
+        parts.push("```python", py!.pythonCode!.replace(/\n+$/, ""), "```", "");
+
+        if (py!.pythonDatasetCode) {
+          parts.push(
+            '<details class="example-dataset">',
+            "<summary>dataset.py</summary>",
+            "",
+            "```python",
+            py!.pythonDatasetCode.replace(/\n+$/, ""),
+            "```",
+            "",
+            "</details>",
+            ""
+          );
+        }
+      }
+
+      return {
+        params: { id: ex.id, title: ex.title },
+        content: parts.join("\n"),
+      };
+    });
+  },
+};

--- a/apps/docs/docs/python/examples/[id].paths.ts
+++ b/apps/docs/docs/python/examples/[id].paths.ts
@@ -5,6 +5,8 @@
  * Storybook story (see `.vitepress/data/storyExamples.ts`), same `id`s, so
  * `/python/examples/<id>` always exists alongside `/js/examples/<id>`
  * (the language toggle and the gallery wall both assume mirrored paths).
+ * Both loaders build their page `content` via the shared
+ * `buildExamplePage()` (`.vitepress/data/examplePage.ts`).
  *
  * The Python page differs from the JS one in three ways:
  *   - the code fence shows the Python parity port (`pythonExamples.ts`), not
@@ -16,6 +18,7 @@
  */
 import { loadStoryExamples } from "../../.vitepress/data/storyExamples.ts";
 import { loadPythonExamples } from "../../.vitepress/data/pythonExamples.ts";
+import { buildExamplePage } from "../../.vitepress/data/examplePage.ts";
 
 export default {
   paths() {
@@ -23,72 +26,41 @@ export default {
 
     return loadStoryExamples().map((ex) => {
       const py = pythonById.get(ex.id);
-      const parts: string[] = [];
-
-      // Back link to the gallery, above the title.
-      parts.push(
-        `<a class="example-back" href="/python/examples/">← Examples</a>`,
-        ""
-      );
-
-      parts.push(`# ${ex.title}`, "");
-      if (ex.description) {
-        parts.push(ex.description, "");
-      }
-
-      // Live render of the real story module (client-only; no code echo).
-      // JS and Python serialize to the same IR, so this is the same render
-      // the JS example page shows — there is no separate Python engine.
-      parts.push(`<GoFishExample id="${ex.id}" />`, "");
-
       const hasCode = !!py?.pythonCode;
+      const notes: string[] = [];
 
       if (!hasCode) {
-        parts.push(
+        notes.push(
           `_This example has not been ported to Python yet. See the ` +
-            `[JavaScript version](/js/examples/${ex.id}) for its code._`,
-          ""
+            `[JavaScript version](/js/examples/${ex.id}) for its code._`
         );
       } else if (py?.renderDiverges) {
-        parts.push(
+        notes.push(
           `_The chart above is rendered by the JavaScript engine. This example's ` +
             `Python port intentionally uses a different algorithm for part of its ` +
             `computation (an accepted divergence), so its output differs slightly ` +
-            `from the render shown._`,
-          ""
+            `from the render shown._`
         );
       }
 
-      if (hasCode) {
-        if (py!.isFallback) {
-          parts.push(
-            `_The code below is the Python parity port's function shown verbatim; ` +
-              `it could not be reduced to a standalone snippet automatically._`,
-            ""
-          );
-        }
-
-        parts.push("```python", py!.pythonCode!.replace(/\n+$/, ""), "```", "");
-
-        if (py!.pythonDatasetCode) {
-          parts.push(
-            '<details class="example-dataset">',
-            "<summary>dataset.py</summary>",
-            "",
-            "```python",
-            py!.pythonDatasetCode.replace(/\n+$/, ""),
-            "```",
-            "",
-            "</details>",
-            ""
-          );
-        }
+      if (hasCode && py!.isFallback) {
+        notes.push(
+          `_The code below is the Python parity port's function shown verbatim; ` +
+            `it could not be reduced to a standalone snippet automatically._`
+        );
       }
 
-      return {
-        params: { id: ex.id, title: ex.title },
-        content: parts.join("\n"),
-      };
+      return buildExamplePage({
+        backHref: "/python/examples/",
+        title: ex.title,
+        description: ex.description,
+        exampleId: ex.id,
+        notes,
+        fenceLang: "python",
+        code: hasCode ? py!.pythonCode : null,
+        datasetLabel: "dataset.py",
+        datasetCode: hasCode ? py!.pythonDatasetCode : null,
+      });
     });
   },
 };

--- a/apps/docs/scripts/check-story-examples.mjs
+++ b/apps/docs/scripts/check-story-examples.mjs
@@ -48,17 +48,41 @@ function transpileTo(tsPath, tmpPath, rewrites = []) {
   writeFileSync(tmpPath, outputText);
 }
 
+// storyExamples.ts and pythonExamples.ts both statically import the shared
+// textUtils.ts (dedent/indent helpers) — pre-transpile it once, alongside
+// storyExamples.ts, and rewrite both files' `./textUtils.ts` specifiers to
+// point at it, the same trick used for the storyExamples.ts→pythonExamples.ts
+// cross-import below.
+const TEXT_UTILS_TMP_PATH = resolve(
+  __dirname,
+  "../docs/.vitepress/data/textUtils.__check__.mjs"
+);
+function ensureTextUtilsTmp() {
+  const existed = existsSync(TEXT_UTILS_TMP_PATH);
+  if (!existed) {
+    transpileTo(
+      resolve(__dirname, "../docs/.vitepress/data/textUtils.ts"),
+      TEXT_UTILS_TMP_PATH
+    );
+  }
+  return existed;
+}
+
 async function loadModule() {
   const tsPath = resolve(__dirname, "../docs/.vitepress/data/storyExamples.ts");
   const tmpPath = resolve(
     __dirname,
     "../docs/.vitepress/data/storyExamples.__check__.mjs"
   );
-  transpileTo(tsPath, tmpPath);
+  const textUtilsExisted = ensureTextUtilsTmp();
+  transpileTo(tsPath, tmpPath, [
+    ["./textUtils.ts", "./textUtils.__check__.mjs"],
+  ]);
   try {
     return await import(pathToFileURL(tmpPath).href);
   } finally {
     rmSync(tmpPath, { force: true });
+    if (!textUtilsExisted) rmSync(TEXT_UTILS_TMP_PATH, { force: true });
   }
 }
 
@@ -80,20 +104,24 @@ async function loadPythonModule() {
     __dirname,
     "../docs/.vitepress/data/pythonExamples.__check__.mjs"
   );
+  const textUtilsExisted = ensureTextUtilsTmp();
   const jsTmpExisted = existsSync(jsTmpPath);
   if (!jsTmpExisted)
     transpileTo(
       resolve(__dirname, "../docs/.vitepress/data/storyExamples.ts"),
-      jsTmpPath
+      jsTmpPath,
+      [["./textUtils.ts", "./textUtils.__check__.mjs"]]
     );
   transpileTo(tsPath, tmpPath, [
     ["./storyExamples.ts", "./storyExamples.__check__.mjs"],
+    ["./textUtils.ts", "./textUtils.__check__.mjs"],
   ]);
   try {
     return await import(pathToFileURL(tmpPath).href);
   } finally {
     rmSync(tmpPath, { force: true });
     if (!jsTmpExisted) rmSync(jsTmpPath, { force: true });
+    if (!textUtilsExisted) rmSync(TEXT_UTILS_TMP_PATH, { force: true });
   }
 }
 
@@ -260,11 +288,32 @@ async function main() {
   } catch {
     pythonAvailable = false;
   }
+  // One python3 driver ast.parse()s every written snippet, instead of a
+  // separate `python3` process per snippet (up to ~2× pyExamples.length
+  // spawns) — cheaper at ~200+ snippets while keeping the same per-file
+  // failure reporting.
+  const PY_AST_CHECK_DRIVER = `
+import ast, sys
+with open(sys.argv[1]) as f:
+    paths = [line.rstrip("\\n") for line in f if line.strip()]
+failures = []
+for path in paths:
+    try:
+        with open(path) as fh:
+            ast.parse(fh.read())
+    except SyntaxError as e:
+        failures.append(path + "\\t" + str(e).replace("\\n", " "))
+for line in failures:
+    print(line)
+sys.exit(1 if failures else 0)
+`;
+
   let syntaxErrors = 0;
   if (pythonAvailable) {
     const tmpDir = resolve(__dirname, "../.tmp-py-check");
     mkdirSync(tmpDir, { recursive: true });
     try {
+      const entries = [];
       for (const ex of pyExamples) {
         for (const [label, src] of [
           ["code", ex.pythonCode],
@@ -273,16 +322,31 @@ async function main() {
           if (!src) continue;
           const f = resolve(tmpDir, `${ex.id}.${label}.py`);
           writeFileSync(f, src);
-          try {
-            execFileSync(
-              "python3",
-              ["-c", "import ast, sys; ast.parse(open(sys.argv[1]).read())", f],
-              { stdio: "pipe" }
-            );
-          } catch (err) {
+          entries.push({ id: ex.id, label, path: f });
+        }
+      }
+
+      if (entries.length) {
+        const manifestPath = resolve(tmpDir, "manifest.txt");
+        writeFileSync(
+          manifestPath,
+          entries.map((e) => e.path).join("\n") + "\n"
+        );
+        const byPath = new Map(entries.map((e) => [e.path, e]));
+        try {
+          execFileSync("python3", ["-c", PY_AST_CHECK_DRIVER, manifestPath], {
+            stdio: "pipe",
+            encoding: "utf-8",
+          });
+        } catch (err) {
+          const stdout = err.stdout ?? "";
+          for (const line of stdout.split("\n")) {
+            if (!line.trim()) continue;
+            const [path, ...msgParts] = line.split("\t");
+            const entry = byPath.get(path);
             syntaxErrors++;
             console.error(
-              `Python syntax error in ${ex.id} (${label}): ${err.message.split("\n").slice(-2).join(" ")}`
+              `Python syntax error in ${entry ? entry.id : path} (${entry ? entry.label : "?"}): ${msgParts.join("\t")}`
             );
           }
         }

--- a/apps/docs/scripts/check-story-examples.mjs
+++ b/apps/docs/scripts/check-story-examples.mjs
@@ -17,7 +17,14 @@ import { createRequire } from "node:module";
 import { pathToFileURL } from "node:url";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFileSync, writeFileSync, rmSync } from "node:fs";
+import {
+  readFileSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+  mkdirSync,
+} from "node:fs";
+import { execSync, execFileSync } from "node:child_process";
 
 const require = createRequire(import.meta.url);
 const ts = require("typescript");
@@ -28,13 +35,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Node won't import it as ESM. Transpile it to a temp `.mjs` *in the same
 // directory* (so `import.meta.url` and relative/node_modules resolution stay
 // identical) and import that.
-async function loadModule() {
-  const tsPath = resolve(__dirname, "../docs/.vitepress/data/storyExamples.ts");
-  const tmpPath = resolve(
-    __dirname,
-    "../docs/.vitepress/data/storyExamples.__check__.mjs"
-  );
-  const source = readFileSync(tsPath, "utf-8");
+function transpileTo(tsPath, tmpPath, rewrites = []) {
+  let source = readFileSync(tsPath, "utf-8");
+  for (const [from, to] of rewrites) source = source.split(from).join(to);
   const { outputText } = ts.transpileModule(source, {
     compilerOptions: {
       target: ts.ScriptTarget.ESNext,
@@ -43,10 +46,54 @@ async function loadModule() {
     fileName: tsPath,
   });
   writeFileSync(tmpPath, outputText);
+}
+
+async function loadModule() {
+  const tsPath = resolve(__dirname, "../docs/.vitepress/data/storyExamples.ts");
+  const tmpPath = resolve(
+    __dirname,
+    "../docs/.vitepress/data/storyExamples.__check__.mjs"
+  );
+  transpileTo(tsPath, tmpPath);
   try {
     return await import(pathToFileURL(tmpPath).href);
   } finally {
     rmSync(tmpPath, { force: true });
+  }
+}
+
+// pythonExamples.ts statically imports storyExamples.ts (a `.ts` specifier) —
+// Node's native type-stripping loader can't resolve that reliably outside a
+// tsx-driven entry point (the same reason storyExamples.ts itself gets
+// pre-transpiled above), so point the rewritten copy at storyExamples'
+// already-transpiled tmp `.mjs` instead of re-deriving the resolution rules.
+async function loadPythonModule() {
+  const jsTmpPath = resolve(
+    __dirname,
+    "../docs/.vitepress/data/storyExamples.__check__.mjs"
+  );
+  const tsPath = resolve(
+    __dirname,
+    "../docs/.vitepress/data/pythonExamples.ts"
+  );
+  const tmpPath = resolve(
+    __dirname,
+    "../docs/.vitepress/data/pythonExamples.__check__.mjs"
+  );
+  const jsTmpExisted = existsSync(jsTmpPath);
+  if (!jsTmpExisted)
+    transpileTo(
+      resolve(__dirname, "../docs/.vitepress/data/storyExamples.ts"),
+      jsTmpPath
+    );
+  transpileTo(tsPath, tmpPath, [
+    ["./storyExamples.ts", "./storyExamples.__check__.mjs"],
+  ]);
+  try {
+    return await import(pathToFileURL(tmpPath).href);
+  } finally {
+    rmSync(tmpPath, { force: true });
+    if (!jsTmpExisted) rmSync(jsTmpPath, { force: true });
   }
 }
 
@@ -175,6 +222,87 @@ async function main() {
     `Fallbacks: ${fallbacks.length}${fallbacks.length ? " (" + fallbacks.map((r) => r.id).join(", ") + ")" : ""}`
   );
   console.log(`Failures: ${failures}`);
+
+  // -------------------------------------------------------------------------
+  // Python data layer (pythonExamples.ts) — must load without throwing, cover
+  // exactly the same id set as the JS gallery, and every ported/fallback
+  // snippet must be syntactically valid Python (checked via `python3 -m py_compile`
+  // when a `python3` is on PATH; skipped with a warning otherwise, since the
+  // docs build itself doesn't need Python installed).
+  // -------------------------------------------------------------------------
+  console.log("\n--- Python example data layer ---");
+  const pyMod = await loadPythonModule();
+  const pyExamples = pyMod.loadPythonExamples();
+
+  const jsIds = new Set(examples.map((ex) => ex.id));
+  const pyIds = new Set(pyExamples.map((ex) => ex.id));
+  const missingInPy = [...jsIds].filter((id) => !pyIds.has(id));
+  const extraInPy = [...pyIds].filter((id) => !jsIds.has(id));
+  if (missingInPy.length) {
+    console.error(`Python id set is missing: ${missingInPy.join(", ")}`);
+    failures++;
+  }
+  if (extraInPy.length) {
+    console.error(
+      `Python id set has extra ids not in JS: ${extraInPy.join(", ")}`
+    );
+    failures++;
+  }
+
+  const ported = pyExamples.filter((ex) => ex.pythonCode && !ex.isFallback);
+  const pyFallbacks = pyExamples.filter((ex) => ex.isFallback);
+  const notPorted = pyExamples.filter((ex) => !ex.pythonCode);
+  const diverging = pyExamples.filter((ex) => ex.renderDiverges);
+
+  let pythonAvailable = true;
+  try {
+    execSync("python3 --version", { stdio: "ignore" });
+  } catch {
+    pythonAvailable = false;
+  }
+  let syntaxErrors = 0;
+  if (pythonAvailable) {
+    const tmpDir = resolve(__dirname, "../.tmp-py-check");
+    mkdirSync(tmpDir, { recursive: true });
+    try {
+      for (const ex of pyExamples) {
+        for (const [label, src] of [
+          ["code", ex.pythonCode],
+          ["dataset", ex.pythonDatasetCode],
+        ]) {
+          if (!src) continue;
+          const f = resolve(tmpDir, `${ex.id}.${label}.py`);
+          writeFileSync(f, src);
+          try {
+            execFileSync(
+              "python3",
+              ["-c", "import ast, sys; ast.parse(open(sys.argv[1]).read())", f],
+              { stdio: "pipe" }
+            );
+          } catch (err) {
+            syntaxErrors++;
+            console.error(
+              `Python syntax error in ${ex.id} (${label}): ${err.message.split("\n").slice(-2).join(" ")}`
+            );
+          }
+        }
+      }
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  } else {
+    console.log(
+      "(python3 not found on PATH — skipping Python syntax validation)"
+    );
+  }
+  if (syntaxErrors > 0) failures += syntaxErrors;
+
+  console.log(
+    `Python examples: ${pyExamples.length} total — ported ${ported.length}, fallback ${pyFallbacks.length}, not ported ${notPorted.length}, diverging ${diverging.length}`
+  );
+  if (pyFallbacks.length) {
+    console.log(`  fallback: ${pyFallbacks.map((ex) => ex.id).join(", ")}`);
+  }
 
   if (failures > 0) {
     console.error(`\nFAILED with ${failures} problem(s).`);


### PR DESCRIPTION
Closes #448. Advances #775, #561.

The docs site now generates a `/python/examples/<id>` page for every gallery example, mirroring the JS pair (`js/examples/[id].paths.ts` + `[id].md`), and the gallery wall links each card to the language section the visitor is browsing instead of always routing Python readers to the JS pages.

## How it works

- **`docs/.vitepress/data/pythonExamples.ts`** (new): build-time data layer. For each gallery example it resolves the Python parity port in `tests/python-stories/` (same title→path convention as `tests/scripts/path-mapping.ts`, `story_<export>` function naming) and synthesizes a standalone user-facing snippet: docstring stripped, function body dedented, the `return (expr, {opts})` tuple rewritten to the canonical `expr.render(w=…, h=…)` call, `python_stories.data` imports rewritten to `from dataset import …` with the data shown in a collapsed `dataset.py` block, and internal helpers (`_lowlevel_helpers`, `vega_data_urls`, `_load_json` data) inlined.
- **`docs/python/examples/[id].paths.ts` + `[id].md`** (new): mirror of the JS pair — same ids, same live render via `<GoFishExample>` (JS and Python serialize to the same IR, so there is one render), `python` code fence, no "Open in live editor" button (the playground is JS-only).
- **Unported examples** still get a page (title, description, live render) with a note linking to the JS version, so every `/python/examples/<id>` route exists and the language toggle's mirrored-path assumption holds. #793 tracks porting the remaining examples, grouped by blocker.
- **Diverging ports** (per `tests/.python-sync-exempt`, e.g. ViolinPlot's scipy `gaussian_kde` vs the JS story's `fast-kde`) state that the render comes from the JS engine and the Python output differs slightly — the divergence is declared, per #775.
- **`GalleryPage.vue`**: the `exampleHref()` shim (Python cards → JS pages) is reverted to derive the section from the current route, exactly as its comment instructed.
- **`check-story-examples.mjs`**: extended to load the Python data layer, assert its id set matches the JS gallery, and syntax-check every generated snippet via `python3 -m py_compile`.

## Verification

- `pnpm check-story-examples`: 107 examples — 77 ported, 1 verbatim fallback (`python-tutor-memory-diagram`, whose port manipulates `sys.path`), 29 not ported (tracked by #793), 3 divergence-flagged; all generated snippets parse as valid Python.
- `pnpm docs:build` succeeds; all 107 `/python/examples/*.html` pages present; ported, diverging, fallback, and not-ported pages spot-checked in a headless browser (screenshots below).

## Screenshots

Ported example (`/python/examples/streamgraph`) — Python snippet synthesized from the parity port, collapsed `dataset.py`, shared live render:

![streamgraph python example page](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-790/python-example-streamgraph.png)

Diverging port (`/python/examples/violin-plot`, #775) — declared divergence note above the scipy code:

![violin plot python example page](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-790/python-example-violin-plot.png)

Unported example (`/python/examples/gotree-sunburst`) — page still exists with the render and a pointer to the JS version:

![unported gotree example page](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-790/python-example-not-ported.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)