### PR TITLE
Docs: clearly state both packages require the prerelease build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,8 @@ pnpm add gofish-graphics@nightly
 yarn add gofish-graphics@nightly
 ```
 
-For the last stable release, drop the `@nightly` tag:
-
-```bash
-npm install gofish-graphics
-```
+The stable release on npm is far behind and will not match the docs, so do not
+drop the `@nightly` tag.
 
 Using Python? `pip install --pre gofish-graphics` (see the
 [docs](https://gofish.graphics/python/get-started)).

--- a/apps/docs/docs/js/get-started.md
+++ b/apps/docs/docs/js/get-started.md
@@ -15,7 +15,8 @@ adopters install the **nightly** build (shown above) to get the latest features
 and fixes. Nightlies are published whenever `main` changes; pin a specific one
 with `gofish-graphics@<version>` once you find a build you like.
 
-Prefer the stable release? Install it with `npm install gofish-graphics`.
+The stable release on npm is far behind and will not match these docs, so do not
+drop the `@nightly` tag.
 :::
 
 ## 2. Create a chart!
@@ -62,7 +63,7 @@ const alphabet = [
 
 const root = document.createElement("div");
 
-chart(seafood, { axes: true })
+chart(alphabet, { axes: true })
   .flow(spread({ by: "letter", dir: "x" }))
   .mark(rect({ h: "frequency" }))
   .render(root, {

--- a/apps/docs/docs/python/get-started.md
+++ b/apps/docs/docs/python/get-started.md
@@ -18,7 +18,8 @@ adopters install the latest **dev** build with `--pre` (shown above). Dev builds
 are published whenever `main` changes; pin a specific one with
 `gofish-graphics==<version>` once you find a build you like.
 
-Prefer the stable release? Install it with `pip install gofish-graphics`.
+The stable release on PyPI is far behind and will not match these docs, so do not
+drop the `--pre` flag.
 :::
 
 Import it as `gofish`:

--- a/packages/gofish-graphics/README.md
+++ b/packages/gofish-graphics/README.md
@@ -1,0 +1,47 @@
+# GoFish Graphics
+
+A JavaScript library for making bespoke charts and visualizations.
+
+## Installation
+
+```bash
+npm install gofish-graphics@nightly
+```
+
+The latest stable release on npm is old and lags far behind development. The docs at
+[gofish.graphics](https://gofish.graphics/) describe the current nightly builds, which
+are published on every change to `main`. You must include the `@nightly` tag, otherwise
+npm installs the outdated stable release.
+
+## Usage
+
+```ts
+import { chart, spread, rect } from "gofish-graphics";
+
+const alphabet = [
+  { letter: "A", frequency: 28 },
+  { letter: "B", frequency: 55 },
+  { letter: "C", frequency: 43 },
+  { letter: "D", frequency: 91 },
+  { letter: "E", frequency: 81 },
+];
+
+const root = document.getElementById("app");
+
+chart(alphabet, { axes: true })
+  .flow(spread({ by: "letter", dir: "x" }))
+  .mark(rect({ h: "frequency" }))
+  .render(root, {
+    w: 500,
+    h: 300,
+  });
+```
+
+This creates a bar chart: `spread` arranges one group per `letter` along the x
+axis, and `rect` draws a bar per row whose height encodes `frequency`.
+
+## Learn more
+
+- [Getting started](https://gofish.graphics/js/get-started)
+- [Docs](https://gofish.graphics/)
+- [GitHub](https://github.com/gofish-graphics/gofish-graphics)

--- a/packages/gofish-graphics/package.json
+++ b/packages/gofish-graphics/package.json
@@ -23,7 +23,7 @@
     "solid-js",
     "typescript"
   ],
-  "author": "Your Name",
+  "author": "Josh Pollock",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/gofish-python/README.md
+++ b/packages/gofish-python/README.md
@@ -1,33 +1,27 @@
 # gofish-python
 
-A Python wrapper for the GoFish graphics library. Supports the mid-level chart API for now. The
-low-level API is not supported yet. (See [notes/design.md](notes/design.md) and [notes/implementation.md](notes/implementation.md) for more details.)
-
-**Note**: This package uses [uv](https://github.com/astral-sh/uv) for fast package management and testing.
-
-## Prerequisites
-
-- **Python 3.8+**
-- **[uv](https://github.com/astral-sh/uv)** - Fast Python package manager
-- **Node.js** (for building the widget bundle)
-- **pnpm** (for managing Node.js dependencies)
+A Python wrapper for the GoFish graphics library. Both the mid-level chart API and the
+low-level mark/operator API are supported. (See [notes/design.md](notes/design.md) and
+[notes/implementation.md](notes/implementation.md) for more details.)
 
 ## Installation
 
-This package uses [uv](https://github.com/astral-sh/uv) for fast package management.
-
 ```bash
-cd packages/gofish-python
-uv pip install -e .
+pip install --pre gofish-graphics
 ```
 
-### Installing Node.js Dependencies
+The latest stable release on PyPI is old and lags far behind development. These docs
+describe the current dev builds, which are published on every change to `main`. You
+must include the `--pre` flag, otherwise pip installs the outdated stable release.
 
-If you need to build the widget bundle, install Node.js dependencies:
+The package is imported as `gofish`:
 
-```bash
-pnpm install
+```python
+from gofish import chart
 ```
+
+See the [getting started docs](https://gofish.graphics/python/get-started) for a full
+introduction.
 
 ## Usage
 
@@ -76,7 +70,32 @@ The JSON IR has the following structure:
 }
 ```
 
-## Building
+## Development
+
+**Note**: This package uses [uv](https://github.com/astral-sh/uv) for fast package
+management and testing.
+
+### Prerequisites
+
+- **Python 3.10+**
+- **[uv](https://github.com/astral-sh/uv)** - Fast Python package manager
+- **Node.js** (for building the widget bundle)
+- **pnpm** (for managing Node.js dependencies)
+
+### Development Install
+
+```bash
+cd packages/gofish-python
+uv pip install -e .
+```
+
+#### Installing Node.js Dependencies
+
+If you need to build the widget bundle, install Node.js dependencies:
+
+```bash
+pnpm install
+```
 
 ### Building the Widget Bundle
 
@@ -98,9 +117,9 @@ This will:
 
 **Note**: The build process will automatically use `gofish-graphics/dist/index.js` if available, otherwise it falls back to the package import. Make sure `gofish-graphics` is built first if you're developing locally.
 
-## Running Tests
+### Running Tests
 
-### Python Unit Tests
+#### Python Unit Tests
 
 ```bash
 # Install with test dependencies
@@ -119,7 +138,7 @@ pytest tests/test_ast.py
 pytest -v
 ```
 
-### Jupyter Notebook Tests
+#### Jupyter Notebook Tests
 
 The package includes Jupyter notebooks for interactive testing:
 
@@ -136,7 +155,7 @@ jupyter notebook
 ./run_notebook.sh
 ```
 
-## Development Workflow
+### Development Workflow
 
 1. **Install dependencies**:
 

--- a/packages/gofish-python/README.md
+++ b/packages/gofish-python/README.md
@@ -10,9 +10,10 @@ low-level mark/operator API are supported. (See [notes/design.md](notes/design.m
 pip install --pre gofish-graphics
 ```
 
-The latest stable release on PyPI is old and lags far behind development. These docs
-describe the current dev builds, which are published on every change to `main`. You
-must include the `--pre` flag, otherwise pip installs the outdated stable release.
+The latest stable release on PyPI is old and lags far behind development. The docs at
+[gofish.graphics](https://gofish.graphics/python/get-started) describe the current dev
+builds, which are published on every change to `main`. You must include the `--pre`
+flag, otherwise pip installs the outdated stable release.
 
 The package is imported as `gofish`:
 


### PR DESCRIPTION
## Summary

Both registries have a stale `0.1.0` stable release while current builds ship as prereleases on every change to `main` (PyPI: `0.1.1.devYYYYMMDD`; npm: `0.1.0-nightly.YYYYMMDD`, published 2026-04-21 vs. daily nightlies). Plain `pip install gofish-graphics` / `npm install gofish-graphics` silently installs the stale build, which does not match the docs.

### Python (#797)
- **`packages/gofish-python/README.md`** (the PyPI landing page via `readme = "README.md"`): previously showed only contributor `uv pip install -e .` instructions. Now leads with an Installation section: `pip install --pre gofish-graphics`, an explicit warning that dropping `--pre` installs the outdated stable release, the `gofish` import name, and a link to the getting-started docs. Contributor setup moved under a Development section. Also updated the stale "low-level API is not supported yet" claim (bridged in #777) and fixed the Python floor to 3.10+ (matching `requires-python`).
- **`apps/docs/docs/python/get-started.md`**: the install tip previously ended with "Prefer the stable release? Install it with `pip install gofish-graphics`." — an invitation into the stale-release trap. Replaced with a warning not to drop `--pre`.

### npm
- **`packages/gofish-graphics/README.md`** (new): the published npm package had **no README at all** (`files` already listed `README.md`, but the file didn't exist), so npmjs.com shows a blank page. Adds a short landing page: `npm install gofish-graphics@nightly`, the stale-stable warning, a real v3 fluent-API usage snippet (adapted from get-started), and links to docs/repo. Ships automatically with the next nightly.
- **Root `README.md`**: replaced "For the last stable release, drop the `@nightly` tag" (plus its install block) with the warning not to drop `@nightly`.
- **`apps/docs/docs/js/get-started.md`**: same trap-line replacement as the Python page; also fixed a pre-existing typo in the first snippet (`chart(seafood, ...)` → `chart(alphabet, ...)` — the data variable is `alphabet`).

Notes:
- Registry descriptions for **already-published** versions can't be fixed retroactively; the new READMEs take effect with the next dev/nightly builds.
- Also sets the npm package `author` to Josh Pollock (was the `"Your Name"` placeholder, shown on npmjs.com).

Closes #797

🤖 Generated with [Claude Code](https://claude.com/claude-code)
