### PR TITLE
Emit composite/mask filter bbox fully in pixel space

### DIFF
--- a/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
@@ -111,7 +111,12 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
             // Pixel bbox top-left, flip-AGNOSTIC (see `pixelBox`): under the
             // y-up flip the top edge is `gyMax`, in y-down free space it is
             // `gyMin` — the component-wise min picks the right one (issue #143/#16).
-            const { x: bx, y: by } = pixelBox(
+            const {
+              x: bx,
+              y: by,
+              w: bw,
+              h: bh,
+            } = pixelBox(
               [tx + minX, ty + minY],
               [tx + minX + width, ty + minY + height],
               outer
@@ -145,7 +150,7 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
                 kind: "composite",
                 operator,
                 blendMode,
-                bbox: { x: bx, y: by, w: width, h: height },
+                bbox: { x: bx, y: by, w: bw, h: bh },
                 source,
                 dest,
               },
@@ -290,7 +295,12 @@ export const mask = createNodeOperator(
           const width = intrinsicDims?.[0]?.size ?? 0;
           const height = intrinsicDims?.[1]?.size ?? 0;
           // Flip-agnostic bbox top-left — see `pixelBox` / the compositor (#143/#16).
-          const { x: bx, y: by } = pixelBox(
+          const {
+            x: bx,
+            y: by,
+            w: bw,
+            h: bh,
+          } = pixelBox(
             [tx + minX, ty + minY],
             [tx + minX + width, ty + minY + height],
             outer
@@ -299,7 +309,7 @@ export const mask = createNodeOperator(
           return [
             {
               kind: "mask",
-              bbox: { x: bx, y: by, w: width, h: height },
+              bbox: { x: bx, y: by, w: bw, h: bh },
               mask: maskItems,
               content,
             },


### PR DESCRIPTION
Advances #795 (lands its proposed fix; the reported clipping did not reproduce and appears to have a different cause — see Investigation).

## What changed

`porterDuff.tsx`'s composite **and** mask lowerings called `pixelBox()` for the filter-region origin but paired it with chart-space `width`/`height`. Both SVG backends (`paintSVG.tsx` and `gofish-ir`'s `render.ts`) consume that bbox as a `filterUnits="userSpaceOnUse"` region, so origin and size must share units. The fix carries the whole `pixelBox()` result into the display item, exactly as #795 proposes — applied to both the `composite` and the `mask` item (the issue only named the composite, but the mask lowering had the identical mix).

## Verification

- `pnpm --filter gofish-graphics build` passes.
- `pnpm capture-diff HEAD` over all 304 stories: byte-identical normalized DOM (filter-region attributes are captured in the normalized DOM, so this is a meaningful no-op check).

The no-op is expected: every `toPixel` map in the library today is a translation plus optional y-mirror (root `gofish.tsx`, coord `contentToPixel`, composite child offset), so pixel extent always equals chart extent numerically. The mismatch was latent, and this closes it before any scaling `toPixel` lands.

## Investigation: the reported clipping has a different cause

Because the fix is provably behavior-preserving today, it cannot explain the zoom-dependent right-edge clipping reported in #795. I tried to reproduce that clipping with the in-repo `Piccl/Bottle` story (Playwright, Chromium + WebKit, CSS `zoom` / `transform: scale` / CSS-width embeddings, scales 0.5–1.37, DPR 1–2), measuring the rightmost rendered bottle pixel against the analytic image edge. Result: no clipping anywhere — within ±1px (antialiasing) in every configuration, even though the bottle PNG touches its box edge-to-edge and the filter region is exactly flush.

Two real findings came out of the sweep:

1. **WebKit first-paint dropout.** With the composited image as a data URI, WebKit's first rasterization of the filter can run before the image decodes, and the empty filter result is never invalidated — all four bottles render as nothing (labels only) until a repaint. Reproduced deterministically on first paint at one zoom, self-corrects on re-render. If the talk-time artifact was intermittent bottle damage in Safari, this family of WebKit filter-invalidation bugs is the likelier culprit.

2. **The flush filter region is load-bearing cross-engine.** Chromium positions `feImage`-referenced content by offsetting child coordinates by the region origin (as the code comment says); WebKit instead aligns the referenced element's *bounding box* to the region origin. The two agree only while the lowered children's bbox min sits at (0,0) relative to the region — i.e. region flush to content. A padding experiment (region −8px origin, children +8px) rendered pixel-identically in Chromium but shifted content 8px in WebKit. So if edge clipping is ever confirmed, the safe remedy is padding the region on the **right/bottom only** (origin untouched); padding all sides breaks WebKit.

Recommending #795 stay open until the original repro is captured (exact browser + zoom), since the symptom as described is not explained by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)