### PR TITLE
Fix Porter-Duff composite rendering: pixel-space bbox + masks instead of feImage

### DIFF
--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -252,8 +252,20 @@ three carry structure the flat-absolute fold cannot express on its own:
   list can't fold away.
 - **`composite`** — a Porter-Duff composite of two sub-lists, named with Figma-style
   operators (`over`/`atop`/`in`/`out`/`xor` plus a CSS `mixBlendMode`). The SVG
-  backend reconstructs the `feImage`/`feComposite`/`feBlend` filter graph; a
-  Canvas/WebGPU backend would map the operator to its own blend state.
+  backends reconstruct it as plain SVG masks and `mix-blend-mode`, not an
+  `<feImage>` filter graph: `<feImage>` referencing live SVG content has three
+  independent browser pathologies (Chrome's GPU raster path clips it at
+  fractional page zoom, issue #795; WebKit misaligns its content bbox; WebKit
+  can rasterize before a data-URI `<image>` inside it decodes and never
+  invalidate), so both painters emit the source and destination groups once
+  each and wire them together per-operator: the source is grayscaled with a
+  local `saturate(0)` filter, and each layer is alpha-masked by the other
+  layer's content (or its inverse) depending on the operator — `over` masks
+  neither, `atop`/`in` mask the destination by the source's alpha, `out`/`xor`
+  mask the destination by the source's _inverse_ alpha, and `in`/`xor`
+  additionally mask the source by the destination's alpha or inverse alpha.
+  Only `over`/`atop`/`in` add a `mix-blend-mode` to the destination layer. A
+  Canvas/WebGPU backend would map the operator to its own blend state instead.
 - **`mask`** — clip `content` by the alpha of `mask`.
 
 Each item also carries optional **provenance** — `datum` (the source row(s) the
@@ -290,7 +302,7 @@ test keeps them in lockstep, since they must agree pixel-for-pixel:
 Because items are already in final absolute pixels, painting is verbatim: a `rect`
 item becomes `<rect x y width height …/>`, an `ellipse` becomes `<ellipse cx cy …/>`,
 and so on. The only painter-side cleverness is reconstructing the `composite`/`mask`
-filter graphs and assigning their deterministic def ids.
+mask-and-blend-mode graphs and assigning their deterministic def ids.
 
 ## How the live `render()` wires it together
 

--- a/apps/docs/docs/internals/core/rendering.md
+++ b/apps/docs/docs/internals/core/rendering.md
@@ -12,6 +12,7 @@ covers:
   - packages/gofish-graphics/src/ast/displayList/lowerHelpers.ts
   - packages/gofish-ir/src/display-list/schema.ts
   - packages/gofish-ir/src/display-list/render.ts
+  - packages/gofish-ir/src/display-list/composite.ts
 ---
 
 # Rendering

--- a/packages/gofish-graphics/src/ast/displayList/paintSVG.tsx
+++ b/packages/gofish-graphics/src/ast/displayList/paintSVG.tsx
@@ -171,33 +171,66 @@ export function paintSVG(
       );
     }
     case "composite": {
+      // Porter-Duff composite, lowered to plain SVG masks + `mix-blend-mode`
+      // (no `<feImage>`). `<feImage>` referencing live SVG content has three
+      // independent browser pathologies: Chrome's GPU raster path quantizes
+      // the reference at fractional page zoom and clips the right/bottom of
+      // the composited image (issue #795); WebKit aligns the referenced
+      // element's content bbox to the filter region's origin rather than the
+      // element's own origin (diverging from Chromium's behavior); and WebKit
+      // can rasterize the filter before a data-URI `<image>` inside it has
+      // decoded, then never invalidate to repaint once it has. Masks and
+      // `mix-blend-mode` are the ordinary, well-tested rendering path — no
+      // `<feImage>` anywhere in the graph below.
+      //
+      // Grayscale-then-composite becomes: paint the source once, grayscale it
+      // with a local `saturate(0)` filter, and paint the destination once;
+      // which of the two gets alpha-masked by the other (and whether the
+      // destination gets a `mix-blend-mode`) depends on the operator:
+      //
+      //   over:  gray(src) unmasked           + dest blended, unmasked
+      //   atop:  gray(src) unmasked           + dest blended, masked by alpha(src)
+      //   in:    gray(src) masked by alpha(dest) + dest blended, masked by alpha(src)
+      //   out:   (no source layer)            + dest NOT blended, masked by inverse-alpha(src)
+      //   xor:   gray(src) masked by inverse-alpha(dest) + dest NOT blended, masked by inverse-alpha(src)
+      //
+      // Both layers live in a group translated to the bbox origin (matching
+      // the lowered items' bbox-relative coordinates) and `isolate`d so
+      // `mix-blend-mode` only blends the two layers against each other, not
+      // against whatever is behind the composite on the page.
       const uid = `gf-comp-${compositeIdCounter++}`;
       const sourceId = `${uid}-source`;
       const destinationId = `${uid}-destination`;
-      const filterId = `${uid}-filter`;
+      const grayId = `${uid}-gray`;
+      const maskAlphaSrcId = `${uid}-mask-alpha-src`;
+      const maskAlphaDestId = `${uid}-mask-alpha-dest`;
+      const maskInvAlphaSrcId = `${uid}-mask-invalpha-src`;
+      const maskInvAlphaDestId = `${uid}-mask-invalpha-dest`;
       const { operator } = item;
-      const blendMode = (item.blendMode ?? "color") as "multiply" | "screen";
-      const tail =
-        operator === "in" ? (
-          <>
-            <feBlend
-              in="compositeResult"
-              in2="graySource"
-              mode={blendMode}
-              result="blendedIntersect"
-            />
-            <feComposite
-              in="blendedIntersect"
-              in2="compositeResult"
-              operator="in"
-            />
-          </>
-        ) : operator === "over" || operator === "atop" ? (
-          <feBlend in="compositeResult" in2="graySource" mode={blendMode} />
-        ) : null;
+      const blendMode = item.blendMode ?? "color";
       const { x, y, w, h } = item.bbox;
+
+      const hasSourceLayer = operator !== "out";
+      const hasBlend =
+        operator === "over" || operator === "atop" || operator === "in";
+      const needsAlphaSrcMask = operator === "atop" || operator === "in";
+      const needsAlphaDestMask = operator === "in";
+      const needsInvAlphaSrcMask = operator === "out" || operator === "xor";
+      const needsInvAlphaDestMask = operator === "xor";
+
+      const sourceMaskId = needsAlphaDestMask
+        ? maskAlphaDestId
+        : needsInvAlphaDestMask
+          ? maskInvAlphaDestId
+          : undefined;
+      const destMaskId = needsAlphaSrcMask
+        ? maskAlphaSrcId
+        : needsInvAlphaSrcMask
+          ? maskInvAlphaSrcId
+          : undefined;
+
       return (
-        <>
+        <g transform={`translate(${x} ${y})`} style="isolation:isolate">
           <defs>
             <g id={sourceId}>
               {item.source.map((c) => paintSVG(c, interactive))}
@@ -205,41 +238,65 @@ export function paintSVG(
             <g id={destinationId}>
               {item.dest.map((c) => paintSVG(c, interactive))}
             </g>
-            <filter
-              id={filterId}
-              x={x}
-              y={y}
-              width={w}
-              height={h}
-              filterUnits="userSpaceOnUse"
-              color-interpolation-filters="sRGB"
-            >
-              <feImage href={`#${sourceId}`} result="sourceImage" />
-              <feColorMatrix
-                in="sourceImage"
-                type="saturate"
-                values="0"
-                result="graySource"
-              />
-              <feImage href={`#${destinationId}`} result="destination" />
-              <feComposite
-                in="destination"
-                in2="graySource"
-                operator={operator}
-                result="compositeResult"
-              />
-              {tail}
-            </filter>
+            {hasSourceLayer && (
+              <filter id={grayId} color-interpolation-filters="sRGB">
+                <feColorMatrix type="saturate" values="0" />
+              </filter>
+            )}
+            {needsAlphaSrcMask && (
+              <mask
+                id={maskAlphaSrcId}
+                maskUnits="userSpaceOnUse"
+                maskContentUnits="userSpaceOnUse"
+                style="mask-type:alpha"
+              >
+                <use href={`#${sourceId}`} />
+              </mask>
+            )}
+            {needsAlphaDestMask && (
+              <mask
+                id={maskAlphaDestId}
+                maskUnits="userSpaceOnUse"
+                maskContentUnits="userSpaceOnUse"
+                style="mask-type:alpha"
+              >
+                <use href={`#${destinationId}`} />
+              </mask>
+            )}
+            {needsInvAlphaSrcMask && (
+              <mask
+                id={maskInvAlphaSrcId}
+                maskUnits="userSpaceOnUse"
+                maskContentUnits="userSpaceOnUse"
+              >
+                <rect x={0} y={0} width={w} height={h} fill="#fff" />
+                <use href={`#${sourceId}`} filter="brightness(0)" />
+              </mask>
+            )}
+            {needsInvAlphaDestMask && (
+              <mask
+                id={maskInvAlphaDestId}
+                maskUnits="userSpaceOnUse"
+                maskContentUnits="userSpaceOnUse"
+              >
+                <rect x={0} y={0} width={w} height={h} fill="#fff" />
+                <use href={`#${destinationId}`} filter="brightness(0)" />
+              </mask>
+            )}
           </defs>
-          <rect
-            x={x}
-            y={y}
-            width={w}
-            height={h}
-            fill="transparent"
-            filter={`url(#${filterId})`}
+          {hasSourceLayer && (
+            <use
+              href={`#${sourceId}`}
+              filter={`url(#${grayId})`}
+              mask={sourceMaskId ? `url(#${sourceMaskId})` : undefined}
+            />
+          )}
+          <use
+            href={`#${destinationId}`}
+            style={hasBlend ? `mix-blend-mode:${blendMode}` : undefined}
+            mask={destMaskId ? `url(#${destMaskId})` : undefined}
           />
-        </>
+        </g>
       );
     }
     case "mask": {

--- a/packages/gofish-graphics/src/ast/displayList/paintSVG.tsx
+++ b/packages/gofish-graphics/src/ast/displayList/paintSVG.tsx
@@ -16,7 +16,7 @@
  */
 
 import type { JSX } from "solid-js";
-import type { DisplayList } from "gofish-ir";
+import { DisplayList } from "gofish-ir";
 import { getLiveSlots } from "../../interaction/liveSlots";
 
 type Style = DisplayList.Style | undefined;
@@ -198,6 +198,16 @@ export function paintSVG(
       // the lowered items' bbox-relative coordinates) and `isolate`d so
       // `mix-blend-mode` only blends the two layers against each other, not
       // against whatever is behind the composite on the page.
+      //
+      // Cost: for `atop`/`in`/`xor`, the masked layer's sublist is referenced
+      // twice (once as mask content via `<use>`, once as the visible layer),
+      // so those sublists rasterize twice per composite. That's inherent to
+      // SVG's mask model, not a bug — the accepted price of leaving
+      // `<feImage>` behind.
+      //
+      // Per-operator layer/mask wiring lives in gofish-ir's
+      // `compositeLayerConfig` (the single source of truth both SVG backends
+      // consume); see that table for the over/atop/in/out/xor breakdown.
       const uid = `gf-comp-${compositeIdCounter++}`;
       const sourceId = `${uid}-source`;
       const destinationId = `${uid}-destination`;
@@ -210,24 +220,46 @@ export function paintSVG(
       const blendMode = item.blendMode ?? "color";
       const { x, y, w, h } = item.bbox;
 
-      const hasSourceLayer = operator !== "out";
-      const hasBlend =
-        operator === "over" || operator === "atop" || operator === "in";
-      const needsAlphaSrcMask = operator === "atop" || operator === "in";
-      const needsAlphaDestMask = operator === "in";
-      const needsInvAlphaSrcMask = operator === "out" || operator === "xor";
-      const needsInvAlphaDestMask = operator === "xor";
+      const cfg = DisplayList.compositeLayerConfig[operator];
+      const { hasSourceLayer, hasBlend } = cfg;
 
-      const sourceMaskId = needsAlphaDestMask
-        ? maskAlphaDestId
-        : needsInvAlphaDestMask
-          ? maskInvAlphaDestId
-          : undefined;
-      const destMaskId = needsAlphaSrcMask
-        ? maskAlphaSrcId
-        : needsInvAlphaSrcMask
-          ? maskInvAlphaSrcId
-          : undefined;
+      const sourceMaskId =
+        cfg.sourceMask === "alphaDest"
+          ? maskAlphaDestId
+          : cfg.sourceMask === "invAlphaDest"
+            ? maskInvAlphaDestId
+            : undefined;
+      const destMaskId =
+        cfg.destMask === "alphaSrc"
+          ? maskAlphaSrcId
+          : cfg.destMask === "invAlphaSrc"
+            ? maskInvAlphaSrcId
+            : undefined;
+
+      /** `mask-type:alpha` mask that clips by the referenced layer's alpha. */
+      const alphaMask = (id: string, refId: string): JSX.Element => (
+        <mask
+          id={id}
+          maskUnits="userSpaceOnUse"
+          maskContentUnits="userSpaceOnUse"
+          style="mask-type:alpha"
+        >
+          <use href={`#${refId}`} />
+        </mask>
+      );
+      /** Inverse-alpha mask: white rect (fully opaque) minus the referenced
+       *  layer's shape (blacked out via `brightness(0)`), so the mask clips
+       *  to everywhere the referenced layer is NOT. */
+      const invAlphaMask = (id: string, refId: string): JSX.Element => (
+        <mask
+          id={id}
+          maskUnits="userSpaceOnUse"
+          maskContentUnits="userSpaceOnUse"
+        >
+          <rect x={0} y={0} width={w} height={h} fill="#fff" />
+          <use href={`#${refId}`} filter="brightness(0)" />
+        </mask>
+      );
 
       return (
         <g transform={`translate(${x} ${y})`} style="isolation:isolate">
@@ -243,46 +275,13 @@ export function paintSVG(
                 <feColorMatrix type="saturate" values="0" />
               </filter>
             )}
-            {needsAlphaSrcMask && (
-              <mask
-                id={maskAlphaSrcId}
-                maskUnits="userSpaceOnUse"
-                maskContentUnits="userSpaceOnUse"
-                style="mask-type:alpha"
-              >
-                <use href={`#${sourceId}`} />
-              </mask>
-            )}
-            {needsAlphaDestMask && (
-              <mask
-                id={maskAlphaDestId}
-                maskUnits="userSpaceOnUse"
-                maskContentUnits="userSpaceOnUse"
-                style="mask-type:alpha"
-              >
-                <use href={`#${destinationId}`} />
-              </mask>
-            )}
-            {needsInvAlphaSrcMask && (
-              <mask
-                id={maskInvAlphaSrcId}
-                maskUnits="userSpaceOnUse"
-                maskContentUnits="userSpaceOnUse"
-              >
-                <rect x={0} y={0} width={w} height={h} fill="#fff" />
-                <use href={`#${sourceId}`} filter="brightness(0)" />
-              </mask>
-            )}
-            {needsInvAlphaDestMask && (
-              <mask
-                id={maskInvAlphaDestId}
-                maskUnits="userSpaceOnUse"
-                maskContentUnits="userSpaceOnUse"
-              >
-                <rect x={0} y={0} width={w} height={h} fill="#fff" />
-                <use href={`#${destinationId}`} filter="brightness(0)" />
-              </mask>
-            )}
+            {cfg.destMask === "alphaSrc" && alphaMask(maskAlphaSrcId, sourceId)}
+            {cfg.sourceMask === "alphaDest" &&
+              alphaMask(maskAlphaDestId, destinationId)}
+            {cfg.destMask === "invAlphaSrc" &&
+              invAlphaMask(maskInvAlphaSrcId, sourceId)}
+            {cfg.sourceMask === "invAlphaDest" &&
+              invAlphaMask(maskInvAlphaDestId, destinationId)}
           </defs>
           {hasSourceLayer && (
             <use

--- a/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
@@ -93,8 +93,8 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
           // so its children are NOT pre-lowered: we re-walk the two subtrees
           // ourselves, offset by the node's baked translate (the legacy
           // `<g transform>`), and emit one CompositeItem. source = first child
-          // (`#…-source`), dest = second (`#…-destination`), matching
-          // `renderComposite`'s feImage wiring.
+          // (`#…-source`), dest = second (`#…-destination`), matching the SVG
+          // backends' `composite` source/destination group ids.
           lower: (
             { intrinsicDims, transform, coordinateTransform },
             _children,
@@ -123,13 +123,11 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
             );
 
             // The two layers are lowered RELATIVE to the bbox pixel origin, not
-            // at absolute pixels. The SVG backend places each layer in a
-            // `<feImage>` whose subregion is the filter region (the bbox), and
-            // browsers offset a referenced `<feImage>` element BY that region
-            // origin — so an absolute-positioned child would double-count it.
-            // Legacy `renderComposite` sidestepped this by keeping children in
-            // the compositor's local frame (min ≈ 0) with the filter at that
-            // same min; we reproduce that by subtracting the bbox origin.
+            // at absolute pixels: both SVG backends wrap the composited layers
+            // in a `<g transform="translate(bbox.x bbox.y)">` (see
+            // `paintSVG`'s / `render.ts`'s `composite` case), so child
+            // coordinates must start near the bbox's own origin rather than
+            // the document's. We reproduce that by subtracting the bbox origin.
             const composed: ToPixel = ([cx, cy]) => {
               const [ax, ay] = outer([tx + cx, ty + cy]);
               return [ax - bx, ay - by];

--- a/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
+++ b/packages/gofish-graphics/src/ast/graphicalOperators/porterDuff.tsx
@@ -111,7 +111,12 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
             // Pixel bbox top-left, flip-AGNOSTIC (see `pixelBox`): under the
             // y-up flip the top edge is `gyMax`, in y-down free space it is
             // `gyMin` — the component-wise min picks the right one (issue #143/#16).
-            const { x: bx, y: by } = pixelBox(
+            const {
+              x: bx,
+              y: by,
+              w: bw,
+              h: bh,
+            } = pixelBox(
               [tx + minX, ty + minY],
               [tx + minX + width, ty + minY + height],
               outer
@@ -145,7 +150,7 @@ const createCompositeRelation = (type: string, operator: CompositeOperator) =>
                 kind: "composite",
                 operator,
                 blendMode,
-                bbox: { x: bx, y: by, w: width, h: height },
+                bbox: { x: bx, y: by, w: bw, h: bh },
                 source,
                 dest,
               },
@@ -290,7 +295,12 @@ export const mask = createNodeOperator(
           const width = intrinsicDims?.[0]?.size ?? 0;
           const height = intrinsicDims?.[1]?.size ?? 0;
           // Flip-agnostic bbox top-left — see `pixelBox` / the compositor (#143/#16).
-          const { x: bx, y: by } = pixelBox(
+          const {
+            x: bx,
+            y: by,
+            w: bw,
+            h: bh,
+          } = pixelBox(
             [tx + minX, ty + minY],
             [tx + minX + width, ty + minY + height],
             outer
@@ -299,7 +309,7 @@ export const mask = createNodeOperator(
           return [
             {
               kind: "mask",
-              bbox: { x: bx, y: by, w: width, h: height },
+              bbox: { x: bx, y: by, w: bw, h: bh },
               mask: maskItems,
               content,
             },

--- a/packages/gofish-ir/package.json
+++ b/packages/gofish-ir/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "build": "tsc && tsx scripts/emit-jsonschema.ts",
+    "prepare": "pnpm run build",
     "test": "tsx src/tests/schema.test.ts && tsx src/tests/displayList.test.ts && tsx src/tests/descriptors.test.ts",
     "prepublishOnly": "pnpm run build"
   },

--- a/packages/gofish-ir/src/display-list/composite.ts
+++ b/packages/gofish-ir/src/display-list/composite.ts
@@ -1,0 +1,54 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Rendering — /internals/core/rendering
+// </gofish-wiki>
+
+import type { CompositeItem } from "./schema.js";
+
+/** Per-operator layer/mask wiring for the mask+mix-blend-mode composite
+ *  lowering — the single source of truth both SVG backends consume, so the
+ *  decision logic cannot drift between them. Keys mirror the Porter-Duff
+ *  operator wire names. */
+export const compositeLayerConfig: Record<
+  CompositeItem["operator"],
+  {
+    /** draw the grayscaled source layer at all (false only for `out`) */
+    hasSourceLayer: boolean;
+    /** destination layer carries `mix-blend-mode` */
+    hasBlend: boolean;
+    /** mask applied to the source layer */
+    sourceMask: "alphaDest" | "invAlphaDest" | null;
+    /** mask applied to the destination layer */
+    destMask: "alphaSrc" | "invAlphaSrc" | null;
+  }
+> = {
+  over: {
+    hasSourceLayer: true,
+    hasBlend: true,
+    sourceMask: null,
+    destMask: null,
+  },
+  atop: {
+    hasSourceLayer: true,
+    hasBlend: true,
+    sourceMask: null,
+    destMask: "alphaSrc",
+  },
+  in: {
+    hasSourceLayer: true,
+    hasBlend: true,
+    sourceMask: "alphaDest",
+    destMask: "alphaSrc",
+  },
+  out: {
+    hasSourceLayer: false,
+    hasBlend: false,
+    sourceMask: null,
+    destMask: "invAlphaSrc",
+  },
+  xor: {
+    hasSourceLayer: true,
+    hasBlend: false,
+    sourceMask: "invAlphaDest",
+    destMask: "invAlphaSrc",
+  },
+};

--- a/packages/gofish-ir/src/display-list/index.ts
+++ b/packages/gofish-ir/src/display-list/index.ts
@@ -8,3 +8,4 @@ export {
 export { exampleBars, examplePetal, allExamples } from "./examples.js";
 export { DISPLAY_LIST_JSON_SCHEMA } from "./jsonSchema.js";
 export { displayListToSVG } from "./render.js";
+export { compositeLayerConfig } from "./composite.js";

--- a/packages/gofish-ir/src/display-list/render.ts
+++ b/packages/gofish-ir/src/display-list/render.ts
@@ -21,6 +21,7 @@ import type {
   MaskItem,
   Style,
 } from "./schema.js";
+import { compositeLayerConfig } from "./composite.js";
 
 const esc = (s: string): string =>
   s
@@ -154,44 +155,50 @@ const compositeToSVG = (item: CompositeItem | MaskItem): string => {
   const blendMode = item.blendMode ?? "color";
   const { x, y, w, h } = item.bbox;
 
-  const hasSourceLayer = operator !== "out";
-  const hasBlend =
-    operator === "over" || operator === "atop" || operator === "in";
-  const needsAlphaSrcMask = operator === "atop" || operator === "in";
-  const needsAlphaDestMask = operator === "in";
-  const needsInvAlphaSrcMask = operator === "out" || operator === "xor";
-  const needsInvAlphaDestMask = operator === "xor";
+  const cfg = compositeLayerConfig[operator];
+  const { hasSourceLayer, hasBlend } = cfg;
 
-  const sourceMaskId = needsAlphaDestMask
-    ? maskAlphaDestId
-    : needsInvAlphaDestMask
-      ? maskInvAlphaDestId
-      : undefined;
-  const destMaskId = needsAlphaSrcMask
-    ? maskAlphaSrcId
-    : needsInvAlphaSrcMask
-      ? maskInvAlphaSrcId
-      : undefined;
+  const sourceMaskId =
+    cfg.sourceMask === "alphaDest"
+      ? maskAlphaDestId
+      : cfg.sourceMask === "invAlphaDest"
+        ? maskInvAlphaDestId
+        : undefined;
+  const destMaskId =
+    cfg.destMask === "alphaSrc"
+      ? maskAlphaSrcId
+      : cfg.destMask === "invAlphaSrc"
+        ? maskInvAlphaSrcId
+        : undefined;
+
+  /** `mask-type:alpha` mask that clips by the referenced layer's alpha. */
+  const alphaMask = (id: string, refId: string): string =>
+    `<mask id="${id}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" style="mask-type:alpha"><use href="#${refId}"/></mask>`;
+  /** Inverse-alpha mask: white rect (fully opaque) minus the referenced
+   *  layer's shape (blacked out via `brightness(0)`), so the mask clips to
+   *  everywhere the referenced layer is NOT. */
+  const invAlphaMask = (id: string, refId: string): string =>
+    `<mask id="${id}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">` +
+    `<rect x="0" y="0" width="${w}" height="${h}" fill="#fff"/>` +
+    `<use href="#${refId}" filter="brightness(0)"/></mask>`;
 
   const grayFilterDef = hasSourceLayer
     ? `<filter id="${grayId}" color-interpolation-filters="sRGB"><feColorMatrix type="saturate" values="0"/></filter>`
     : "";
-  const alphaSrcMaskDef = needsAlphaSrcMask
-    ? `<mask id="${maskAlphaSrcId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" style="mask-type:alpha"><use href="#${sourceId}"/></mask>`
-    : "";
-  const alphaDestMaskDef = needsAlphaDestMask
-    ? `<mask id="${maskAlphaDestId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" style="mask-type:alpha"><use href="#${destinationId}"/></mask>`
-    : "";
-  const invAlphaSrcMaskDef = needsInvAlphaSrcMask
-    ? `<mask id="${maskInvAlphaSrcId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">` +
-      `<rect x="0" y="0" width="${w}" height="${h}" fill="#fff"/>` +
-      `<use href="#${sourceId}" filter="brightness(0)"/></mask>`
-    : "";
-  const invAlphaDestMaskDef = needsInvAlphaDestMask
-    ? `<mask id="${maskInvAlphaDestId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">` +
-      `<rect x="0" y="0" width="${w}" height="${h}" fill="#fff"/>` +
-      `<use href="#${destinationId}" filter="brightness(0)"/></mask>`
-    : "";
+  const alphaSrcMaskDef =
+    cfg.destMask === "alphaSrc" ? alphaMask(maskAlphaSrcId, sourceId) : "";
+  const alphaDestMaskDef =
+    cfg.sourceMask === "alphaDest"
+      ? alphaMask(maskAlphaDestId, destinationId)
+      : "";
+  const invAlphaSrcMaskDef =
+    cfg.destMask === "invAlphaSrc"
+      ? invAlphaMask(maskInvAlphaSrcId, sourceId)
+      : "";
+  const invAlphaDestMaskDef =
+    cfg.sourceMask === "invAlphaDest"
+      ? invAlphaMask(maskInvAlphaDestId, destinationId)
+      : "";
 
   const sourceLayer = hasSourceLayer
     ? `<use href="#${sourceId}" filter="url(#${grayId})"${

--- a/packages/gofish-ir/src/display-list/render.ts
+++ b/packages/gofish-ir/src/display-list/render.ts
@@ -118,10 +118,15 @@ const itemToSVG = (item: DisplayItem): string => {
  *  agree on id shape. */
 let compositeIdCounter = 0;
 
-/** Reconstruct the Porter-Duff filter / mask SVG from a structured
- *  composite/mask item — ported verbatim from porterDuff.tsx's `renderComposite`
- *  / mask render. The lower pass folded the legacy outer `<g transform>` into
- *  the items' absolute pixels and the `bbox`, so no wrapper group is emitted. */
+/** Reconstruct the Porter-Duff mask/blend SVG from a structured composite/mask
+ *  item — ported verbatim from `paintSVG.tsx`'s `composite`/`mask` cases,
+ *  which carry the full rationale for the mask/blend lowering (no `<feImage>`
+ *  — see that file for why: Chrome GPU-raster quantization at fractional zoom
+ *  clips `<feImage>` content, issue #795; WebKit has two more `<feImage>`
+ *  pathologies). The lower pass folded the legacy outer `<g transform>` into
+ *  the items' absolute pixels and the `bbox`, so for `mask` no wrapper group
+ *  is emitted; `composite` wraps its layers in a `<g transform="translate(…)">`
+ *  at the bbox origin since its children are lowered bbox-relative. */
 const compositeToSVG = (item: CompositeItem | MaskItem): string => {
   const uid = `gf-comp-${compositeIdCounter++}`;
   const sourceId = `${uid}-source`;
@@ -140,30 +145,79 @@ const compositeToSVG = (item: CompositeItem | MaskItem): string => {
     );
   }
 
-  const filterId = `${uid}-filter`;
+  const grayId = `${uid}-gray`;
+  const maskAlphaSrcId = `${uid}-mask-alpha-src`;
+  const maskAlphaDestId = `${uid}-mask-alpha-dest`;
+  const maskInvAlphaSrcId = `${uid}-mask-invalpha-src`;
+  const maskInvAlphaDestId = `${uid}-mask-invalpha-dest`;
   const { operator } = item;
   const blendMode = item.blendMode ?? "color";
-  const tail =
-    operator === "in"
-      ? `<feBlend in="compositeResult" in2="graySource" mode="${esc(blendMode)}" result="blendedIntersect"/>` +
-        `<feComposite in="blendedIntersect" in2="compositeResult" operator="in"/>`
-      : operator === "over" || operator === "atop"
-        ? `<feBlend in="compositeResult" in2="graySource" mode="${esc(blendMode)}"/>`
-        : "";
   const { x, y, w, h } = item.bbox;
+
+  const hasSourceLayer = operator !== "out";
+  const hasBlend =
+    operator === "over" || operator === "atop" || operator === "in";
+  const needsAlphaSrcMask = operator === "atop" || operator === "in";
+  const needsAlphaDestMask = operator === "in";
+  const needsInvAlphaSrcMask = operator === "out" || operator === "xor";
+  const needsInvAlphaDestMask = operator === "xor";
+
+  const sourceMaskId = needsAlphaDestMask
+    ? maskAlphaDestId
+    : needsInvAlphaDestMask
+      ? maskInvAlphaDestId
+      : undefined;
+  const destMaskId = needsAlphaSrcMask
+    ? maskAlphaSrcId
+    : needsInvAlphaSrcMask
+      ? maskInvAlphaSrcId
+      : undefined;
+
+  const grayFilterDef = hasSourceLayer
+    ? `<filter id="${grayId}" color-interpolation-filters="sRGB"><feColorMatrix type="saturate" values="0"/></filter>`
+    : "";
+  const alphaSrcMaskDef = needsAlphaSrcMask
+    ? `<mask id="${maskAlphaSrcId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" style="mask-type:alpha"><use href="#${sourceId}"/></mask>`
+    : "";
+  const alphaDestMaskDef = needsAlphaDestMask
+    ? `<mask id="${maskAlphaDestId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse" style="mask-type:alpha"><use href="#${destinationId}"/></mask>`
+    : "";
+  const invAlphaSrcMaskDef = needsInvAlphaSrcMask
+    ? `<mask id="${maskInvAlphaSrcId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">` +
+      `<rect x="0" y="0" width="${w}" height="${h}" fill="#fff"/>` +
+      `<use href="#${sourceId}" filter="brightness(0)"/></mask>`
+    : "";
+  const invAlphaDestMaskDef = needsInvAlphaDestMask
+    ? `<mask id="${maskInvAlphaDestId}" maskUnits="userSpaceOnUse" maskContentUnits="userSpaceOnUse">` +
+      `<rect x="0" y="0" width="${w}" height="${h}" fill="#fff"/>` +
+      `<use href="#${destinationId}" filter="brightness(0)"/></mask>`
+    : "";
+
+  const sourceLayer = hasSourceLayer
+    ? `<use href="#${sourceId}" filter="url(#${grayId})"${
+        sourceMaskId ? ` mask="url(#${sourceMaskId})"` : ""
+      }/>`
+    : "";
+  const destLayer =
+    `<use href="#${destinationId}"` +
+    (hasBlend ? ` style="mix-blend-mode:${esc(blendMode)}"` : "") +
+    (destMaskId ? ` mask="url(#${destMaskId})"` : "") +
+    `/>`;
+
   return (
+    `<g transform="translate(${x} ${y})" style="isolation:isolate">` +
     `<defs>` +
     `<g id="${sourceId}">${item.source.map(itemToSVG).join("")}</g>` +
     `<g id="${destinationId}">${item.dest.map(itemToSVG).join("")}</g>` +
-    `<filter id="${filterId}" x="${x}" y="${y}" width="${w}" height="${h}" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">` +
-    `<feImage href="#${sourceId}" result="sourceImage"/>` +
-    `<feColorMatrix in="sourceImage" type="saturate" values="0" result="graySource"/>` +
-    `<feImage href="#${destinationId}" result="destination"/>` +
-    `<feComposite in="destination" in2="graySource" operator="${operator}" result="compositeResult"/>` +
-    tail +
-    `</filter>` +
+    grayFilterDef +
+    alphaSrcMaskDef +
+    alphaDestMaskDef +
+    invAlphaSrcMaskDef +
+    invAlphaDestMaskDef +
     `</defs>` +
-    `<rect x="${x}" y="${y}" width="${w}" height="${h}" fill="transparent" filter="url(#${filterId})"/>`
+    sourceLayer +
+    destLayer +
+    `</g>`
   );
 };
 


### PR DESCRIPTION
Closes #795. Confirmed on-screen by the maintainer: side-by-side in Chrome on macOS under real browser zoom, the old rendering clips the bottle's right edge and this PR's rendering does not.

Two commits, reviewed together (the second depends on the first):

## 1. Emit the composite/mask bbox fully in pixel space

The composite and mask lowerings in `porterDuff.tsx` called `pixelBox()` for the bbox origin but paired it with chart-space width/height. Consumers treat the bbox as pixel-space. Behavior-preserving today — every `toPixel` map in the library is a translation plus optional y-mirror, so pixel extent equals chart extent numerically (verified: all 304 stories byte-identical) — but the mask lowering below consumes `bbox.w/h` for its inverse-mask white rects, which makes the pixel-units contract load-bearing.

## 2. Render composites as masks + mix-blend-mode, not feImage

The composite operators (`paint`/`intersect`/`subtract`/`exclude`, internal `over`) rendered through an `feImage`-based SVG filter graph. `feImage` referencing live SVG content has three independent browser pathologies, all confirmed during the #795 investigation:

1. **Chrome (GPU raster):** at fractional page zoom, the raster scale of `feImage`-referenced content is quantized while the filter region maps continuously — the content draws oversized relative to the region and gets clipped at its right/bottom edge, shifting with zoom. This is the #795 artifact; it is immune to any region geometry (live-padding the region changed nothing) and invisible to screenshot paths (they re-rasterize, bypassing on-screen GPU tiles).
2. **WebKit:** aligns the referenced element's content bbox to the region origin (Chromium offsets child coordinates by it) — the two agree only while the region is exactly flush to content.
3. **WebKit:** can rasterize the filter before a data-URI `<image>` inside it decodes, and never invalidates — the composite renders empty until an unrelated repaint.

Both SVG backends (`paintSVG.tsx` and `gofish-ir`'s `render.ts`, kept in structural lockstep for Python parity) now lower a composite item to two plain layers inside an `isolation: isolate` group translated to the bbox origin — source grayscaled by a local `feColorMatrix` filter (ordinary content-filter path, no feImage), destination optionally carrying `mix-blend-mode`, each layer alpha-masked by the other's content (inverse masks via white-rect luminance):

| op | source layer (gray) | dest layer |
|---|---|---|
| `over` | unmasked | blended, unmasked |
| `atop` (paint) | unmasked | blended, mask α(src) |
| `in` (intersect) | mask α(dest) | blended, mask α(src) |
| `out` (subtract) | omitted | mask 1−α(src) |
| `xor` (exclude) | mask 1−α(dest) | mask 1−α(src) |

IR unchanged; the `mask` item's rendering was already feImage-free and is untouched. The internals essay (`/internals/core/rendering`) is updated in the same change. As a side effect, the composite operators now render in Firefox for the first time — Firefox never supported `feImage` element references.

## Verification

- On-screen (the check that matters for #795): old clips under Chrome browser zoom, new does not — same page, same zoom levels, including the SciPy deck's `zoom: 0.47` tile scaling.
- `capture-diff` blast radius is exactly the six composite stories; all 298 others byte-identical.
- Pixel gate on the six (Chromium, DPR 2): `subtract`/`exclude` pixel-identical (validates the mask math); `paint`/`intersect`/`union`/Bottle differ only on semi-transparent image edges, where the old graph hard-clipped edge alpha and masks preserve it — interiors identical.
- WebKit renders the new markup correctly; `gofish-ir` tests pass (30/30); both packages build clean.
- Normalizer check: attribute sorting, float rounding, and id renumbering all neutral to the new markup; both backends emit ids in the same document order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)