### PR TITLE
field(name).map(mapping, {default}): partial discrete mappings; zOrder accepts field expressions

### DIFF
--- a/apps/docs/docs/internals/core/underlying-space.md
+++ b/apps/docs/docs/internals/core/underlying-space.md
@@ -1342,6 +1342,21 @@ own tag, `shareMeasure(base, byName)` — see
 above for why a share is a distinct unit (0–1, not the base measure's own
 units) that must never silently union with it.
 
+**A third family: `.map(mapping, {default?})`, elementwise rather than
+folding.** `.map()` doesn't belong to either slot above — it's a VALUE op
+(valid wherever an aggregate is, since it's a serializable alternative to a
+function accessor on a label or `.zOrder()`, not just a value channel), but
+it doesn't fold rows to a singleton. It's a partial discrete mapping keyed by
+the field's own (stringified) values: an own-property lookup in `mapping`
+(so `{}`'s inherited members never match), falling back to `opts.default`
+when the option is present — even `default: null` counts as present — else
+to `undefined`. `evalFieldValues`'s pipeline loop applies it in place before
+any aggregate runs, so `field("site").map({...}).sum()` maps first and folds
+second, and `getFieldOps`/the domain-vs-aggregate split (`isDomainOp`,
+`isAggregateOp`) both treat `map` as neither, dispatching it through its own
+branch. `splitEntries` (`datumProjection.ts`) rejects `map` on a `by` slot
+with the same "value op, not a domain op" error as an aggregate.
+
 ## Axis inference
 
 Conceptually, axis inference splits into two independent questions:

--- a/apps/docs/docs/internals/frontend/operator-factory.md
+++ b/apps/docs/docs/internals/frontend/operator-factory.md
@@ -371,14 +371,23 @@ A modifier's `apply(node, layerContext, datum, ...args)` receives the
 factory saw — so a modifier can produce a _data-driven_ value rather than a
 constant. `nameModifier` / `labelModifier` / `constrainModifier` ignore it, but
 `zOrderModifier` uses it: `.zOrder(value)` takes a `ZOrderValue<T> = number |
-((datum: T) => number)` and, when handed a callback, evaluates it against this
-datum to set each produced node's paint-order hint. That is what lets paint
-order be data-driven (e.g. raise one category over the rest) without splitting a
-mark into separately-named layers — the callback runs once per replicated
-instance, and the [bake pass](/internals/layout/coord-flattening) already orders
-each layer's children by `(zOrder, index)`. A constant hint round-trips through
-the IR; a callback can't be serialized, so its `tag` hook drops it from the
-emitted IR (the same as a function `.label` accessor).
+((datum: T) => number) | FieldExpr | FieldExprWire` and, when handed a
+callback, evaluates it against this datum to set each produced node's
+paint-order hint. That is what lets paint order be data-driven (e.g. raise
+one category over the rest) without splitting a mark into separately-named
+layers — the callback runs once per replicated instance, and the [bake
+pass](/internals/layout/coord-flattening) already orders each layer's
+children by `(zOrder, index)`. A constant hint round-trips through the IR; a
+callback can't be serialized, so its `tag` hook drops it from the emitted IR
+(the same as a function `.label` accessor). A `field(...)` accessor sits
+between the two: like a callback it's resolved per-instance
+(`resolveZOrderValue` projects the same scalar off the datum that
+`projectPath` would, runs it through the field's own op pipeline via
+`evalFieldValues` — so `.map(...)` applies identically to zOrder as to a
+value channel — and coerces the result to a number), but like a constant
+it's serializable, so `tag` round-trips it (`value.toJSON()` for a live
+`FieldExpr`, the wire form verbatim for an already-deserialized one) instead
+of dropping it.
 
 The **export terminals** — `render`, `toSVG`, `toSVGElement`, `save`,
 `toDisplayList` — are the dual of modifiers: where a modifier mutates the

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -428,6 +428,22 @@ for the API.
               "const": "distinct"
             }
           }
+        },
+        {
+          "type": "object",
+          "required": ["op", "mapping"],
+          "properties": {
+            "op": {
+              "const": "map"
+            },
+            "mapping": {
+              "type": "object",
+              "description": "Partial discrete mapping, keyed by the field's (stringified) values."
+            },
+            "default": {
+              "description": "Value for an unmapped key. Presence on the wire (vs. omission) is itself meaningful: an explicit `default: null` still applies, while an omitted default falls through to undefined."
+            }
+          }
         }
       ]
     },

--- a/apps/docs/docs/js/api/core/mark.md
+++ b/apps/docs/docs/js/api/core/mark.md
@@ -86,29 +86,36 @@ options list, including `fontFamily`/`fontWeight`/`fontStyle`.
 ### `.zOrder(value)` — paint order {#zorder}
 
 `.zOrder(value)` sets the mark's paint-order hint: higher values paint **later**
-(on top). `value` is either a constant or a **callback** resolved per-instance
-against the datum the mark is bound to, so paint order can be data-driven without
-splitting the mark into separately-named layers:
+(on top). `value` is a constant, a
+[`field(...)`](/js/api/operators/spread#field-expression-pipeline) accessor,
+or a **callback** — the latter two are resolved per-instance against the datum
+the mark is bound to, so paint order can be data-driven without splitting the
+mark into separately-named layers:
 
 ```ts
 // Constant: raise this whole mark above its siblings.
 rect({ h: "count" }).zOrder(1);
 
-// Data-driven: raise the emphasized category over the rest. `d` is the bag the
-// mark is bound to, so read the field with `project` (see ref / selection).
-const isEmphasized = (site: unknown) =>
-  site === "Morris" || site === "Grand Rapids";
-
-area({ opacity: 0.7 }).zOrder((d) =>
-  isEmphasized(project(d, "site")) ? 1 : 0
+// Data-driven: raise the emphasized categories over the rest. `.map()` is a
+// partial mapping — unmapped sites get the `default`.
+ribbon({ opacity: 0.7 }).zOrder(
+  field("site").map({ Morris: 1, "Grand Rapids": 1 }, { default: 0 })
 );
+
+// Callback escape hatch — arbitrary logic, but not serializable. `d` is the
+// bag the mark is bound to, so read the field with `project` (see ref /
+// selection).
+area({ opacity: 0.7 }).zOrder((d) => (project(d, "site") === "Morris" ? 1 : 0));
 ```
 
 Within a layer, children are painted in `(zOrder, document order)` order, so a
-higher `zOrder` lifts a mark in front of its lower siblings. The constant form
-round-trips through the [IR](/internals/python/bridge); a callback can't be
-serialized, so it is applied at render time and omitted from the emitted IR (the
-same as a function [`.label`](#modifiers) accessor).
+higher `zOrder` lifts a mark in front of its lower siblings. The constant and
+`field(...)` forms round-trip through the [IR](/internals/python/bridge); a
+callback can't be serialized, so it is applied at render time and omitted from
+the emitted IR (the same as a function [`.label`](#modifiers) accessor). A
+`field(...)` zOrder whose `.map()` misses (no `default` given) evaluates to
+`undefined`, which falls back to the base paint order — the same as not calling
+`.zOrder()` on that instance.
 
 ### `.translate({ x?, y? })` — pixel offset
 

--- a/apps/docs/docs/js/api/operators/spread.md
+++ b/apps/docs/docs/js/api/operators/spread.md
@@ -149,7 +149,9 @@ appends one op to an ordered pipeline. It works in two disjoint places:
 - As a mark or `size` channel value (a **value** slot): `.sum()`, `.mean()`,
   `.count()`, and `.distinct()` **fold a group's rows to one number**,
   overriding the channel's own default aggregation (sum for size, mean for
-  position).
+  position). `.map(mapping, { default? })` **replaces each value through a
+  partial mapping** — it is elementwise, not a fold, and also works in
+  [`.label()`](../../guides/labels.md) and `.zOrder()` accessors.
 
 Mixing the two — an aggregate op on `by`, or a domain op on a value channel —
 throws.
@@ -207,6 +209,40 @@ Empty bins are dropped, like an ordinary `groupBy`. Pass
 `.count()` and `.distinct()` report measure `"count"` (they're counts, not the
 source field's own units) unless you annotate the accessor explicitly:
 `field("id", "my-measure").distinct()`.
+
+**Map values through a partial discrete mapping** —
+`.map(mapping, { default? })` is a keyed projection into a NEW domain
+(semantics of polars' `replace_strict`, named after pandas' `Series.map`).
+Each value is looked up in `mapping`; a miss becomes `default` when given,
+else `undefined` — and each consuming surface applies its own fallback for
+`undefined`: a `.label()` **skips** that group, `.zOrder()` falls back to
+base paint order. `mapping` must be a plain object (a function throws —
+use `derive()` for arbitrary transforms); unlike a function, `.map()`
+serializes, so it round-trips through IR and works from Python.
+
+```ts
+// Data-driven paint order: raise the two emphasized sites' areas above
+// the rest — no per-datum callback, so the spec stays serializable
+.mark(
+  ribbon({ opacity: 0.7 }).zOrder(
+    field("site").map({ Morris: 1, "Grand Rapids": 1 }, { default: 0 })
+  )
+)
+```
+
+```ts
+// Conditional group callout: only "Lake B" maps to a text; every other
+// group's label evaluates to undefined and is skipped
+.flow(
+  spread({ by: "lake", dir: "x" }).label(
+    field("lake").map({ "Lake B": "Best catch!" }),
+    { position: "outset-top" }
+  )
+)
+```
+
+An explicit `default: null` is a real default (misses become `null`), distinct
+from omitting the option (misses stay `undefined`).
 
 ## Space-filling spines (mosaic / marimekko)
 

--- a/apps/docs/docs/js/guides/labels.md
+++ b/apps/docs/docs/js/guides/labels.md
@@ -198,6 +198,29 @@ on what you're labeling:
 See [`.label()` on operators](/js/api/core/mark#operator-label) for the full
 semantics.
 
+### Conditional labels (label only some groups)
+
+To call out **one** group and leave the rest unlabeled, map the `by` field
+through a partial mapping with
+[`field(...).map()`](/js/api/operators/spread#field-expression-pipeline):
+only keys with an entry produce text, and a group whose accessor evaluates to
+`undefined` is skipped entirely — no empty text node, no placeholder:
+
+```ts
+chart(seafood)
+  .flow(
+    spread({ by: "lake", dir: "x", spacing: 50 }).label(
+      field("lake").map({ "Lake B": "Best catch!" }),
+      { position: "outset-top", fontSize: 13, color: "#c0392b" }
+    ),
+    stack({ by: "species", dir: "x" })
+  )
+  .mark(rect({ h: "count", fill: "species" }));
+```
+
+Unlike a function accessor that returns `""` for the other groups, `.map()`
+serializes — the spec round-trips through IR and works from Python.
+
 ## Custom label text
 
 Pass a function instead of a field name for computed labels.

--- a/apps/docs/docs/python/api/core/mark.md
+++ b/apps/docs/docs/python/api/core/mark.md
@@ -167,6 +167,21 @@ group's rows) produces gets stamped with that leaf's own subdata, and
   ).mark(rect(h="count"))
   ```
 
+- **A `field(...).map()` partial mapping** labels only some groups: keys
+  with an entry produce text, and a group whose accessor evaluates to
+  `None` is skipped entirely — no empty text node. See the
+  [field-expression pipeline](/python/api/operators/spread#field-expression-pipeline):
+
+  ```python
+  chart(seafood).flow(
+      spread(by="lake", dir="x").label(
+          field("lake").map({"Lake B": "Best catch!"}),
+          position="outset-top",
+      ),
+      stack(by="species", dir="x"),
+  ).mark(rect(h="count", fill="species"))
+  ```
+
 ```python
 chart(data).flow(
     stack(by="class", dir="y").label("class", position="center")
@@ -179,3 +194,30 @@ chart(data).flow(
 stack(by="class", dir="y").translate(y=8).label("class")
 stack(by="class", dir="y").label("class").translate(y=8)
 ```
+
+## Paint order — `.z_order(value)` {#z-order}
+
+`.z_order(value)` sets the mark's paint-order hint: higher values paint
+**later** (on top). Within a layer, children are painted in `(z_order,
+document order)` order. `value` is a constant or a
+[`field(...)`](/python/api/operators/spread#field-expression-pipeline)
+accessor resolved per-instance against the datum the mark is bound to —
+data-driven paint order with no per-datum callback (Python has no callback
+form here; a `field(...).map()` covers the discrete cases):
+
+```python
+# Constant: raise this whole mark above its siblings.
+rect(h="count").z_order(1)
+
+# Data-driven: raise the emphasized sites' areas over the rest. `.map()` is
+# a partial mapping — unmapped sites get the `default`.
+ribbon(opacity=0.7).z_order(
+    field("site").map({"Morris": 1, "Grand Rapids": 1}, default=0)
+)
+```
+
+A `field(...)` z-order whose `.map()` misses (no `default` given) evaluates
+to `None`, which falls back to the base paint order — the same as not calling
+`.z_order()` on that instance. For _relational_ paint order ("this above
+that"), use `Constraint.z_above(a, b)` / `Constraint.z_below(a, b)` inside
+the enclosing layer's `.constrain(...)` instead.

--- a/apps/docs/docs/python/api/operators/spread.md
+++ b/apps/docs/docs/python/api/operators/spread.md
@@ -126,7 +126,9 @@ appends one op to an ordered pipeline. It works in two disjoint places:
 - As a mark or `size` channel value (a **value** slot): `.sum()`, `.mean()`,
   `.count()`, and `.distinct()` **fold a group's rows to one number**,
   overriding the channel's own default aggregation (sum for size, mean for
-  position).
+  position). `.map(mapping, default=...)` **replaces each value through a
+  partial mapping** — it is elementwise, not a fold, and also works in
+  `.label()` and `.z_order()` accessors.
 
 Mixing the two — an aggregate op on `by`, or a domain op on a value channel —
 raises.
@@ -191,6 +193,42 @@ chart(data).flow(
 `.count()` and `.distinct()` report measure `"count"` (they're counts, not the
 source field's own units) unless you annotate the accessor explicitly:
 `field("id", measure="my-measure").distinct()`.
+
+**Map values through a partial discrete mapping** —
+`.map(mapping, default=...)` is a keyed projection into a NEW domain
+(semantics of polars' `replace_strict`, named after pandas' `Series.map`).
+Each value is looked up in `mapping`; a miss becomes `default` when given,
+else `None` — and each consuming surface applies its own fallback for `None`:
+a `.label()` **skips** that group, `.z_order()` falls back to base paint
+order. `mapping` must be a plain dict (a callable raises `TypeError` — use
+`derive()` for arbitrary transforms).
+
+```python
+# Data-driven paint order: raise the two emphasized sites' areas above
+# the rest — no per-datum callback needed
+chart(selectAll("bars")).flow(group(by="variety"), group(by="site")).mark(
+    ribbon(opacity=0.7).z_order(
+        field("site").map({"Morris": 1, "Grand Rapids": 1}, default=0)
+    )
+)
+```
+
+```python
+# Conditional group callout: only "Lake B" maps to a text; every other
+# group's label evaluates to None and is skipped
+chart(seafood).flow(
+    spread(by="lake", dir="x").label(
+        field("lake").map({"Lake B": "Best catch!"}),
+        position="outset-top",
+    ),
+    stack(by="species", dir="x"),
+).mark(rect(h="count", fill="species"))
+```
+
+An explicit `default=None` is a real default (misses become `None` on the
+wire, `"default": null`), distinct from omitting the argument entirely (no
+`default` key on the wire; misses fall through to each surface's own
+fallback).
 
 ## Space-filling spines (mosaic / marimekko) {#space-filling-spines-mosaic-marimekko}
 

--- a/packages/gofish-graphics/src/ast/datumProjection.ts
+++ b/packages/gofish-graphics/src/ast/datumProjection.ts
@@ -257,6 +257,12 @@ export function splitEntries<T extends Record<string, any>>(
           `field(...).${op.op}() is an aggregate op — valid on a value channel ` +
             `(e.g. rect({ h: field(...).${op.op}() })), not on \`by\`.`
         );
+      case "map":
+        throw new Error(
+          "field(...).map() is a value op — valid on a value channel " +
+            "(e.g. rect({ h: field(...).map({...}) })) or a .label()/.zOrder() " +
+            "accessor, not on `by`."
+        );
       case "normalize":
         throw new Error(
           "field(...).normalize() is only supported on an operator's size channel"

--- a/packages/gofish-graphics/src/ast/fieldExpr.ts
+++ b/packages/gofish-graphics/src/ast/fieldExpr.ts
@@ -310,6 +310,16 @@ export function evalFieldValues<T>(
     }
     if (op.op === "normalize") throw normalizeNotSupportedError();
     if (op.op === "map") {
+      // `map` is elementwise, so it can only run over the pre-aggregate
+      // per-row values. Applying it silently here after an aggregate was
+      // already recorded would reorder the pipeline (map-then-fold when the
+      // user wrote fold-then-map) — make that loud instead.
+      if (agg !== undefined) {
+        throw new Error(
+          `field(...).map() must precede aggregation — write ` +
+            `field(x).map({...}).${agg.op}(), not field(x).${agg.op}().map({...}).`
+        );
+      }
       values = applyMapOp(values, op);
       continue;
     }

--- a/packages/gofish-graphics/src/ast/fieldExpr.ts
+++ b/packages/gofish-graphics/src/ast/fieldExpr.ts
@@ -49,7 +49,17 @@ export type FieldOp =
   | { op: "sum" }
   | { op: "mean" }
   | { op: "count" }
-  | { op: "distinct" };
+  | { op: "distinct" }
+  | {
+      op: "map";
+      /** Partial discrete mapping, keyed by the field's (stringified) values. */
+      mapping: Record<string, unknown>;
+      /** Value for an unmapped key. Presence on the wire (vs. omission) is
+       *  itself meaningful: an explicit `default: null` still applies, while
+       *  an omitted `default` means "fall through to undefined" — see
+       *  `map()`'s doc below. */
+      default?: unknown;
+    };
 
 /** The field-expression wire shape — what `FieldExpr#toJSON` emits and what
  *  the Python bridge/deserializer produces directly (no class involved). */
@@ -161,6 +171,46 @@ export class FieldExpr {
     return this._withOp({ op: "distinct" });
   }
 
+  /**
+   * A partial discrete mapping, keyed by this field's own values — a keyed
+   * projection into a NEW domain, e.g.
+   * `field("site").map({ Morris: 1, "Grand Rapids": 1 }, { default: 0 })`.
+   * Elementwise, like `sort`'s `values` form but for values rather than
+   * order: each row's value at this field is looked up in `mapping` (an own-
+   * property check, so `{}`'s inherited members never match); a miss becomes
+   * `opts.default` when given, else `undefined` (each consuming surface then
+   * applies its own default — a label skips an undefined result, `zOrder`
+   * falls back to base paint order). `opts.default` may itself be `null` —
+   * that's a real, present default, distinct from omitting the option
+   * entirely (which leaves misses as `undefined`).
+   *
+   * `mapping` must be a plain record, not a function: this construct exists
+   * specifically because function accessors have no IR spelling and can't
+   * cross the Python bridge. For an arbitrary computed transform, use
+   * `derive()` instead.
+   *
+   * Semantics mirror polars' `replace_strict(mapping, default=...)`; named
+   * after pandas' `Series.map(dict)`.
+   */
+  map(
+    mapping: Record<string, unknown>,
+    opts?: { default?: unknown }
+  ): FieldExpr {
+    if (typeof mapping === "function") {
+      throw new Error(
+        "field(...).map() takes a plain mapping object, not a function — " +
+          "use derive() for arbitrary transforms."
+      );
+    }
+    return this._withOp({
+      op: "map",
+      mapping,
+      ...(opts && Object.prototype.hasOwnProperty.call(opts, "default")
+        ? { default: opts.default }
+        : {}),
+    });
+  }
+
   toJSON(): FieldExprWire {
     return {
       type: this.type,
@@ -196,6 +246,28 @@ export function getFieldOps(accessor: unknown): FieldOp[] {
 const AGGREGATE_OPS = new Set(["sum", "mean", "count", "distinct"]);
 /** Domain op names — valid only on a `by` (grouping) slot. */
 const DOMAIN_OPS = new Set(["sort", "reverse", "bin", "dropNulls"]);
+// `map` is neither: a VALUE op (valid in a value/label/zOrder slot, like the
+// aggregates) but elementwise rather than folding (like neither `normalize`
+// nor an aggregate) — see `evalFieldValues`'s pipeline loop below.
+
+/** Apply one `map` op elementwise: look up each value's (stringified) key in
+ *  `mapping` via an own-property check (so `{}`'s inherited members never
+ *  match); a miss becomes `op.default` when the op carries one, else
+ *  `undefined`. Shared so every evaluation site applies the identical
+ *  lookup rule. */
+function applyMapOp(
+  values: unknown[],
+  op: Extract<FieldOp, { op: "map" }>
+): unknown[] {
+  const hasDefault = Object.prototype.hasOwnProperty.call(op, "default");
+  return values.map((v) => {
+    const key = String(v);
+    if (Object.prototype.hasOwnProperty.call(op.mapping, key)) {
+      return op.mapping[key];
+    }
+    return hasDefault ? op.default : undefined;
+  });
+}
 
 export const isAggregateOp = (op: FieldOp): boolean => AGGREGATE_OPS.has(op.op);
 export const isDomainOp = (op: FieldOp): boolean => DOMAIN_OPS.has(op.op);
@@ -227,6 +299,7 @@ export function evalFieldValues<T>(
       ? accessor
       : (r: any) =>
           r?.[typeof accessor === "string" ? accessor : accessor.name];
+  let values: unknown[] = rows.map(key);
   let agg: FieldOp | undefined;
   for (const op of getFieldOps(accessor)) {
     if (isDomainOp(op)) {
@@ -236,6 +309,10 @@ export function evalFieldValues<T>(
       );
     }
     if (op.op === "normalize") throw normalizeNotSupportedError();
+    if (op.op === "map") {
+      values = applyMapOp(values, op);
+      continue;
+    }
     if (agg !== undefined) {
       throw new Error(
         `field(...) can only carry one aggregate op; found ${agg.op}, ${op.op}.`
@@ -243,7 +320,7 @@ export function evalFieldValues<T>(
     }
     agg = op;
   }
-  if (agg === undefined) return { values: rows.map(key) };
+  if (agg === undefined) return { values };
   const annotation =
     typeof accessor === "object" && accessor !== null
       ? accessor.measure
@@ -253,13 +330,13 @@ export function evalFieldValues<T>(
       return { values: [rows.length], measure: annotation ?? "count" };
     case "distinct":
       return {
-        values: [new Set(rows.map(key)).size],
+        values: [new Set(values).size],
         measure: annotation ?? "count",
       };
     case "mean":
-      return { values: [meanBy(rows.map(key) as any[])] };
+      return { values: [meanBy(values as any[])] };
     default: // "sum"
-      return { values: [sumBy(rows.map(key) as any[])] };
+      return { values: [sumBy(values as any[])] };
   }
 }
 

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -199,14 +199,25 @@ const isFieldExprValue = (v: unknown): v is FieldExpr | FieldExprWire =>
  * a plain row or a homogeneous bag of refs (e.g. a `group()`-bound ribbon) —
  * then run through the field's own op pipeline (`evalFieldValues`, so
  * `.map(...)` applies identically to the label/value-channel paths).
+ *
+ * Returns `undefined` when the field-expr yields no usable number — a
+ * `.map()` miss with no default (`null`/`undefined`), or a mapping value
+ * that isn't numeric (`Number(...)` → NaN). An `undefined` hint means "don't
+ * set a z hint at all": the mark keeps BASE paint order, per `.map()`'s
+ * documented fall-through semantics.
  */
-function resolveZOrderValue(value: ZOrderValue, datum: unknown): number {
+function resolveZOrderValue(
+  value: ZOrderValue,
+  datum: unknown
+): number | undefined {
   if (typeof value === "function") return value(datum);
   if (isFieldExprValue(value)) {
     const name = value.name;
     const scalar = projectPath(datum, name);
     const { values } = evalFieldValues(value, [{ [name]: scalar }]);
-    return Number(values[0]);
+    if (values[0] === undefined || values[0] === null) return undefined;
+    const n = Number(values[0]);
+    return Number.isNaN(n) ? undefined : n;
   }
   return value;
 }
@@ -445,7 +456,11 @@ export const labelModifier = createModifier<
 export const zOrderModifier = createModifier<[value: ZOrderValue]>({
   name: "zOrder",
   apply: (node, _layerContext, datum, value) => {
-    node.zOrder(resolveZOrderValue(value, datum));
+    // An undefined resolution (field-expr `.map()` miss with no default, or a
+    // non-numeric mapping value) means "no z hint": leave the node on base
+    // paint order rather than stamping NaN.
+    const resolved = resolveZOrderValue(value, datum);
+    if (resolved !== undefined) node.zOrder(resolved);
   },
   tag: (wrapped, base, value) => {
     // A constant or field-expr hint round-trips; a callback can't be

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -46,8 +46,11 @@ import {
   hasNormalizeOp,
   splitAtNormalize,
   applyEntryNormalize,
+  evalFieldValues,
   FieldExpr,
+  type FieldExprWire,
 } from "../fieldExpr";
+import { projectPath } from "../datumProjection";
 import type { LabelAccessor, LabelOptions } from "../labels/labelPlacement";
 import type { NameableMark } from "../withGoFish";
 import {
@@ -172,9 +175,41 @@ export type ModifierConfig<Args extends any[] = any[]> = {
   tag?: (wrapped: Mark<any>, base: Mark<any>, ...args: Args) => void;
 };
 
-/** A paint-order hint: a constant, or a callback resolved per-instance against
- *  the datum the mark is bound to. */
-export type ZOrderValue<T = any> = number | ((datum: T) => number);
+/** A paint-order hint: a constant, a callback resolved per-instance against
+ *  the datum the mark is bound to, or a `field(...)` accessor (e.g.
+ *  `field("site").map({...}, { default: 0 })`) resolved the same way a
+ *  callback is — but, unlike a callback, serializable, so it round-trips
+ *  through IR (see `zOrderModifier`'s `tag`). */
+export type ZOrderValue<T = any> =
+  | number
+  | ((datum: T) => number)
+  | FieldExpr
+  | FieldExprWire;
+
+/** Is this a `field(...)` accessor (class instance or deserialized wire
+ *  form)? Mirrors the identical duck-typed check in `labelPlacement.ts`. */
+const isFieldExprValue = (v: unknown): v is FieldExpr | FieldExprWire =>
+  v instanceof FieldExpr ||
+  (v !== null && typeof v === "object" && (v as any).type === "field");
+
+/**
+ * Resolve a `.zOrder(value)` hint against the mark's bound datum. A field-
+ * expr accessor is evaluated against the SAME projected scalar `project(d,
+ * name)` (`projectPath`) would read off `d` — so it works whether `datum` is
+ * a plain row or a homogeneous bag of refs (e.g. a `group()`-bound ribbon) —
+ * then run through the field's own op pipeline (`evalFieldValues`, so
+ * `.map(...)` applies identically to the label/value-channel paths).
+ */
+function resolveZOrderValue(value: ZOrderValue, datum: unknown): number {
+  if (typeof value === "function") return value(datum);
+  if (isFieldExprValue(value)) {
+    const name = value.name;
+    const scalar = projectPath(datum, name);
+    const { values } = evalFieldValues(value, [{ [name]: scalar }]);
+    return Number(values[0]);
+  }
+  return value;
+}
 
 /** Register a modifier. Identity at runtime; the value is the typed config. */
 export function createModifier<Args extends any[]>(
@@ -410,14 +445,17 @@ export const labelModifier = createModifier<
 export const zOrderModifier = createModifier<[value: ZOrderValue]>({
   name: "zOrder",
   apply: (node, _layerContext, datum, value) => {
-    node.zOrder(typeof value === "function" ? value(datum) : value);
+    node.zOrder(resolveZOrderValue(value, datum));
   },
   tag: (wrapped, base, value) => {
-    // A constant hint round-trips; a callback can't be JSON-serialized, so it
-    // is dropped from the emitted IR (the rest of the tag still propagates),
-    // mirroring `.label(fn)`.
+    // A constant or field-expr hint round-trips; a callback can't be
+    // JSON-serialized, so it is dropped from the emitted IR (the rest of the
+    // tag still propagates), mirroring `.label(fn)`.
     propagateSerialize(base, wrapped, (tag) => {
       if (typeof value === "number") tag.zOrder = value;
+      else if (isFieldExprValue(value)) {
+        tag.zOrder = value instanceof FieldExpr ? value.toJSON() : value;
+      }
     });
   },
 });

--- a/packages/gofish-graphics/src/serialize/fromJSON.ts
+++ b/packages/gofish-graphics/src/serialize/fromJSON.ts
@@ -82,6 +82,28 @@ export function isTokenSentinel(v: any): v is TokenSentinel {
   );
 }
 
+/** Is `v` a reconstructable `.zOrder(...)` value from the wire: a constant,
+ *  or a `field(...)` wire object (a callback never round-trips — see
+ *  `zOrderModifier`'s `tag` in createOperator.ts). Shared by the three
+ *  reapplication sites below (cut, combinator, plain mark). */
+function isZOrderSpec(v: unknown): boolean {
+  return (
+    typeof v === "number" ||
+    (v !== null && typeof v === "object" && (v as any).type === "field")
+  );
+}
+
+/** Reapply a reconstructed `.zOrder(...)` spec onto `mark`, when present and
+ *  the mark supports it. A field-expr wire is passed straight through — the
+ *  mark's own `.zOrder()` (`zOrderModifier`) evaluates it against the bound
+ *  datum per-instance, the same as a live `FieldExpr`. */
+function applyZOrderSpec(mark: any, spec: { zOrder?: unknown }): any {
+  if (isZOrderSpec(spec.zOrder) && typeof mark.zOrder === "function") {
+    return mark.zOrder(spec.zOrder);
+  }
+  return mark;
+}
+
 // ---------------------------------------------------------------------------
 // Bridge-sentinel unwrapping
 // ---------------------------------------------------------------------------
@@ -502,12 +524,7 @@ export function mapMark(
     if (nameVal != null && typeof (mark as any).name === "function") {
       mark = (mark as any).name(nameVal);
     }
-    if (
-      typeof spec.zOrder === "number" &&
-      typeof (mark as any).zOrder === "function"
-    ) {
-      mark = (mark as any).zOrder(spec.zOrder);
-    }
+    mark = applyZOrderSpec(mark, spec);
     return mark;
   }
 
@@ -552,12 +569,7 @@ export function mapMark(
     if (nameVal != null && typeof (mark as any).name === "function") {
       mark = (mark as any).name(nameVal);
     }
-    if (
-      typeof spec.zOrder === "number" &&
-      typeof (mark as any).zOrder === "function"
-    ) {
-      mark = (mark as any).zOrder(spec.zOrder);
-    }
+    mark = applyZOrderSpec(mark, spec);
     return mark;
   }
 
@@ -601,12 +613,7 @@ export function mapMark(
   if (nameVal != null && typeof (mark as any).name === "function") {
     mark = (mark as any).name(nameVal);
   }
-  if (
-    typeof spec.zOrder === "number" &&
-    typeof (mark as any).zOrder === "function"
-  ) {
-    mark = (mark as any).zOrder(spec.zOrder);
-  }
+  mark = applyZOrderSpec(mark, spec);
   if ("__datum" in spec) {
     const boundDatum = spec.__datum;
     const boundKey = spec.__key ?? undefined;

--- a/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
+++ b/packages/gofish-graphics/stories/forwardsyntax/Labels.stories.tsx
@@ -298,6 +298,40 @@ export const LabelOnSpread: StoryObj<Args> = {
   }
 };
 
+// ─── Conditional group callout (field(...).map(), #796) ───────────────────────
+// `.label(field("lake").map({...}), options)` chained on the `spread`
+// operator: `map()` is a partial mapping — only "Lake B" has an entry, so
+// only its group gets a callout text ("Best catch!"); every other group's
+// accessor evaluates to `undefined` (no `default` given), and the label
+// elaborator skips a group whose text is empty. This is the same mechanism
+// LayeredBarsAndArea's `.zOrder(field("site").map(...))` uses for data-driven
+// paint order, applied to labels instead: a partial discrete mapping is a
+// keyed projection into a NEW domain (here, callout text) that a bare field
+// name or an aggregate can't express.
+
+export const LabelOnSpreadConditional: StoryObj<Args> = {
+  name: "Label on Spread (conditional, field.map())",
+  args: { w: 500, h: 300 },
+  render: (args) => {
+    const container = initializeContainer();
+    chart(seafood, { axes: false })
+      .flow(
+        spread({ by: "lake", dir: "x", spacing: 50 }).label(
+          field("lake").map({ "Lake B": "Best catch!" }),
+          {
+            position: "outset-top",
+            fontSize: 13,
+            color: "#c0392b",
+          }
+        ),
+        stack({ by: "species", dir: "x" })
+      )
+      .mark(rect({ h: "count", fill: "species" }))
+      .render(container, { w: args.w, h: args.h });
+    return container;
+  }
+};
+
 // ─── Label on stack (per-group label, #702) ───────────────────────────────────
 // `.label(accessor)` chained directly on a `stack({by, dir})` operator: each
 // class's leaf produces one rect, stamped with that leaf's own rows and a

--- a/packages/gofish-graphics/stories/vega-lite/Bar/LayeredBarsAndArea.stories.tsx
+++ b/packages/gofish-graphics/stories/vega-lite/Bar/LayeredBarsAndArea.stories.tsx
@@ -10,7 +10,6 @@ import {
   layer,
   selectAll,
   palette,
-  project,
   field,
 } from "../../../src/lib";
 import data from "vega-datasets";
@@ -29,6 +28,16 @@ type Args = { w: number; h: number };
 
 const isEmphasized = (site: unknown) =>
   site === "Morris" || site === "Grand Rapids";
+
+// Data-driven paint order (#796): the two emphasized sites' areas (z = 1)
+// paint on top of the gray ones (z = 0). This is `field("site").map(...)`
+// rather than the `(d) => isEmphasized(project(d, "site")) ? 1 : 0` callback
+// it replaces — a callback can't be serialized (has no IR spelling), so it
+// never round-trips through Python; `.map()` does.
+const emphasisZOrder = field("site").map(
+  { Morris: 1, "Grand Rapids": 1 },
+  { default: 0 }
+);
 
 export const Default: StoryObj<Args> = {
   args: { w: 400, h: 400 },
@@ -49,14 +58,7 @@ export const Default: StoryObj<Args> = {
         .mark(rect({ h: "yield", fill: "site" }).name("bars")),
       chart(selectAll("bars"))
         .flow(group({ by: "variety" }), group({ by: "site" }))
-        // Data-driven paint order: the emphasized sites' areas (z = 1) paint on
-        // top of the gray ones (z = 0). `project` reads the site off the bag of
-        // refs the area is bound to (homogeneous, since we grouped by site).
-        .mark(
-          ribbon({ opacity: 0.7 }).zOrder((d) =>
-            isEmphasized(project(d, "site")) ? 1 : 0
-          )
-        ),
+        .mark(ribbon({ opacity: 0.7 }).zOrder(emphasisZOrder)),
     ]).render(container, { w: args.w, h: args.h, axes: true });
 
     return container;
@@ -132,11 +134,7 @@ export const HoistedVarietySpread: StoryObj<Args> = {
             .mark(rect({ h: "yield", fill: "site" }).name("bars")),
           chart(selectAll("bars"))
             .flow(group({ by: "site" }))
-            .mark(
-              ribbon({ opacity: 0.7 }).zOrder((a) =>
-                isEmphasized(project(a, "site")) ? 1 : 0
-              )
-            ),
+            .mark(ribbon({ opacity: 0.7 }).zOrder(emphasisZOrder)),
         ])
       )
       .render(container, { w: args.w, h: args.h });

--- a/packages/gofish-ir/src/frontend/descriptors.ts
+++ b/packages/gofish-ir/src/frontend/descriptors.ts
@@ -172,7 +172,11 @@ export const MARK_BASE_FIELDS: FieldGroup = group({
   name: { type: t.string, doc: 'Layer name, from `.name("...")`.' },
   label: { type: t.ref("LabelIR") },
   constraints: { type: t.array(t.ref("ConstraintIR")) },
-  zOrder: { type: t.number },
+  // Widened to a full channel slot (constant OR a `field(...)` accessor,
+  // e.g. `field("site").map({...}, {default: 0})`, resolved per-instance
+  // against the mark's bound datum) — a callback never round-trips, so it
+  // never reaches the wire. See `expectZOrder` in validate.ts.
+  zOrder: { type: t.channel("number") },
   translate: { type: t.ref("TranslateIR") },
   debug: {
     type: t.boolean,

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -447,6 +447,22 @@ export const FRONTEND_IR_JSON_SCHEMA = {
           required: ["op"],
           properties: { op: { const: "distinct" } },
         },
+        {
+          type: "object",
+          required: ["op", "mapping"],
+          properties: {
+            op: { const: "map" },
+            mapping: {
+              type: "object",
+              description:
+                "Partial discrete mapping, keyed by the field's (stringified) values.",
+            },
+            default: {
+              description:
+                "Value for an unmapped key. Presence on the wire (vs. omission) is itself meaningful: an explicit `default: null` still applies, while an omitted default falls through to undefined.",
+            },
+          },
+        },
       ],
     },
     MarkIR: {

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -597,7 +597,15 @@ export type FieldOpIR =
   | { op: "sum" }
   | { op: "mean" }
   | { op: "count" }
-  | { op: "distinct" };
+  | { op: "distinct" }
+  | {
+      op: "map";
+      /** Partial discrete mapping, keyed by the field's (stringified) values. */
+      mapping: Record<string, unknown>;
+      /** Value for an unmapped key. Presence on the wire (vs. omission) is
+       *  itself meaningful — see gofish-graphics' `fieldExpr.ts` `map()`. */
+      default?: unknown;
+    };
 
 /** A post-scale color transform carried by a datum value, applied AFTER the
  *  datum maps through its color scale — the color analog of {@link

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -676,6 +676,7 @@ const FIELD_OP_NAMES = [
   "mean",
   "count",
   "distinct",
+  "map",
 ] as const;
 
 /** One op in a `field(...)` pipeline. Rejects an unrecognized op name
@@ -743,6 +744,17 @@ function walkFieldOp(value: unknown, path: string, ctx: Context): void {
             'bin "thresholds" must be a number or an array of numbers when present',
         });
       }
+      return;
+    case "map":
+      if (!isObject(value.mapping)) {
+        ctx.errors.push({
+          path: `${path}.mapping`,
+          message: `map "mapping" must be an object, got ${typeNameOf(value.mapping)}`,
+        });
+      }
+      // `default` may be any value, including `null` — its mere PRESENCE on
+      // the wire is meaningful (see fieldExpr.ts's `map()`), so it is
+      // intentionally not checked here beyond being an object member.
       return;
     default:
       // reverse/dropNulls/normalize/sum/mean/count/distinct carry no extra fields.
@@ -847,7 +859,7 @@ function walkRefMark(
   });
   optionalField(node, "name", path, ctx, expectNameOrToken);
   optionalField(node, "label", path, ctx, walkLabel);
-  optionalField(node, "zOrder", path, ctx, expectNumber);
+  optionalField(node, "zOrder", path, ctx, expectZOrder);
   optionalField(node, "translate", path, ctx, walkTranslate);
   if (ctx.strict) {
     rejectUnknown(
@@ -953,7 +965,7 @@ function walkCutMark(
   optionalField(node, "size", path, ctx, walkCutSize);
   optionalField(node, "inset", path, ctx, expectNumber);
   optionalField(node, "name", path, ctx, expectNameOrToken);
-  optionalField(node, "zOrder", path, ctx, expectNumber);
+  optionalField(node, "zOrder", path, ctx, expectZOrder);
   optionalField(node, "translate", path, ctx, walkTranslate);
   if (ctx.strict) {
     rejectUnknown(
@@ -999,7 +1011,7 @@ function walkCombinatorMark(
   optionalField(node, "constraints", path, ctx, (v, p) =>
     walkArray(v, p, ctx, walkConstraint)
   );
-  optionalField(node, "zOrder", path, ctx, expectNumber);
+  optionalField(node, "zOrder", path, ctx, expectZOrder);
   optionalField(node, "translate", path, ctx, walkTranslate);
   if (ctx.strict) {
     rejectUnknown(
@@ -1034,7 +1046,7 @@ function walkLeafMark(
   optionalField(node, "constraints", path, ctx, (v, p) =>
     walkArray(v, p, ctx, walkConstraint)
   );
-  optionalField(node, "zOrder", path, ctx, expectNumber);
+  optionalField(node, "zOrder", path, ctx, expectZOrder);
   optionalField(node, "translate", path, ctx, walkTranslate);
   // Channel-valued props are unrestricted in v0 (mirrors widget IR).
   // Strict mode does NOT reject unknown fields on leaf marks, because the
@@ -1315,6 +1327,26 @@ function expectNumber(value: unknown, path: string, ctx: Context): void {
       message: `expected number, got ${typeNameOf(value)}`,
     });
   }
+}
+
+/**
+ * A mark-level `.zOrder(...)` value: a constant, or a `field(...)` accessor
+ * (e.g. `field("site").map({...}, {default: 0})`) resolved per-instance
+ * against the mark's bound datum (`resolveZOrderValue` in
+ * gofish-graphics' createOperator.ts) — a callback never round-trips, so it
+ * never reaches the wire. Not used for the CHART-level `zOrder` (`walkChart`
+ * above), which stays a plain constant.
+ */
+function expectZOrder(value: unknown, path: string, ctx: Context): void {
+  if (typeof value === "number") return;
+  if (isObject(value) && value.type === "field") {
+    walkFieldAccessor(value, path, ctx);
+    return;
+  }
+  ctx.errors.push({
+    path,
+    message: `expected number or field(...) accessor, got ${typeNameOf(value)}`,
+  });
 }
 
 function expectStringOrNumber(

--- a/packages/gofish-python/gofish/ast.py
+++ b/packages/gofish-python/gofish/ast.py
@@ -6,6 +6,20 @@ import uuid
 T = TypeVar("T")
 
 
+class _NoDefault:
+    """Sentinel distinguishing an omitted `default=` from an explicit
+    `default=None` — mirrors polars' `no_default` (`replace_strict`). See
+    `FieldAccessor.map()`: on the wire, omitting `default` means the
+    `"default"` key is absent entirely; passing `default=None` still emits
+    `"default": None`, a real (present) fallback distinct from omission."""
+
+    def __repr__(self) -> str:
+        return "no_default"
+
+
+no_default = _NoDefault()
+
+
 class Operator:
     """Base class for chart operators."""
 
@@ -318,8 +332,10 @@ class Mark:
         self._datum_set: bool = False
         self._key: Optional[str] = None
         # Default z-order hint (sorted within siblings inside `layer`'s
-        # render). Mirrors JS `node._zOrder` (`.zOrder(n)`).
-        self._z_order: Optional[float] = None
+        # render). Mirrors JS `node._zOrder` (`.zOrder(n)`). A `field(...)`
+        # accessor is resolved per-instance at reconstruction/render time;
+        # this container itself doesn't evaluate it.
+        self._z_order: Optional[Union[float, "FieldAccessor"]] = None
         self._translate: Optional[dict] = None
 
     def _copy_meta(self, target: "Mark") -> "Mark":
@@ -372,12 +388,17 @@ class Mark:
         new_mark._name = name_or_token
         return new_mark
 
-    def z_order(self, value: float) -> "Mark":
+    def z_order(self, value: Union[float, "FieldAccessor"]) -> "Mark":
         """Set the default z-order hint for this mark.
 
         Within a single layer's render, marks are sorted by `(z_order, index)`
         before painting. Lower values paint first (further back). Mirrors
         JS `node.zOrder(n)`.
+
+        `value` may also be a `field(...)` accessor (e.g.
+        `field("site").map({...}, default=0)`), resolved per-instance
+        against the mark's bound datum — data-driven paint order that, unlike
+        a raw callable, is serializable and round-trips through IR.
 
         For *relational* paint order ("this above that"), use
         `Constraint.z_above(a, b)` / `Constraint.z_below(a, b)` inside the
@@ -2544,6 +2565,42 @@ class FieldAccessor(dict):
         """Fold the group's rows to the number of distinct values of this
         field. Valid only in a value (size/pos) slot."""
         return self._with_op({"op": "distinct"})
+
+    def map(
+        self,
+        mapping: Dict[Any, Any],
+        default: Any = no_default,
+    ) -> "FieldAccessor":
+        """A partial discrete mapping, keyed by this field's own values — a
+        keyed projection into a NEW domain, e.g.
+        ``field("site").map({"Morris": 1, "Grand Rapids": 1}, default=0)``.
+
+        Elementwise: each row's value at this field is looked up in
+        `mapping`; a miss becomes `default` when given, else `None` (each
+        consuming surface then applies its own default — a label skips a
+        `None` result, `z_order` falls back to base paint order). `default`
+        may itself be `None` — a real, present default, distinct from
+        omitting the argument entirely (which leaves misses as `None`). Use
+        the module-level sentinel `no_default` (the parameter's own default)
+        to detect "omitted" if you're wrapping this method.
+
+        `mapping` must be a plain dict, not a callable: this construct
+        exists specifically because function accessors have no IR spelling
+        and can't cross the Python bridge. For an arbitrary computed
+        transform, use `derive()` instead.
+
+        Semantics mirror polars' `replace_strict(mapping, default=...)`;
+        named after pandas' `Series.map(dict)`.
+        """
+        if callable(mapping):
+            raise TypeError(
+                "field(...).map() takes a plain mapping dict, not a "
+                "callable — use derive() for arbitrary transforms."
+            )
+        op: dict = {"op": "map", "mapping": mapping}
+        if default is not no_default:
+            op["default"] = default
+        return self._with_op(op)
 
 
 def field(name: str, measure: Optional[str] = None) -> FieldAccessor:

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -103,6 +103,23 @@ packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_Rever
 # structure, data, options); only the pixel-for-pixel DOM diff is skipped.
 packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx::Default
 
+# Per-export exemption — LayeredBarsAndArea::HoistedVarietySpread nests
+# `layer([chart(...), chart(...)])` INSIDE another chart's `.mark(...)`
+# (a chart-tier layer used as an embedded mark). Default and TwoSites (same
+# file) ARE ported and byte-parity-validated — #796's
+# `field(...).map(mapping, default=...)` gave the emphasis `.zOrder(...)`
+# call a serializable spelling, which is why this file is no longer exempt
+# wholesale. This one export hits a separate, pre-existing gap: Python's
+# `layer([...])` only implements the LayerIR chart-tiers wire shape
+# (`{type: "layer", charts: [...]}`, reconstructed as a ROOT chart), not the
+# mark-combinator shape JS's single `layer()` also produces when nested
+# inside a `.mark(...)` call (`{type: "layer", __combinator: true, children:
+# [...]}` — a different wire type, reconstructed via COMBINATOR_FACTORIES).
+# Closing this needs new Python-wrapper dispatch design (when do ChartBuilder
+# children serialize as chart-tiers vs. as an embeddable mark?), not a
+# field(...).map() follow-up — tracked as a to-do, not fixed here.
+packages/gofish-graphics/stories/vega-lite/Bar/LayeredBarsAndArea.stories.tsx::HoistedVarietySpread
+
 # ---------------------------------------------------------------------------
 # gofish-gotree (the GoTree tree-DSL package) — exempt from Python parity.
 #
@@ -116,15 +133,6 @@ packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx::Default
 # (see walkJsStories + the gitDiff filters in check-python-sync.ts), so it
 # never walks the gofish-gotree package. If parity coverage is ever extended
 # to gofish-gotree, list its stories here.
-
-# LayeredBarsAndArea stays exempt: it drives a data-driven paint order with
-# `area(...).zOrder(d => …)` and reorders the area selection with a `derive`
-# callback. Both are JS functions that can't cross the derive RPC, and the
-# `.zOrder(fn)` form is omitted from the IR (like a function `.label`), so a
-# Python port can't reproduce — let alone byte-match — the paint ordering that
-# raises the emphasized sites above the gray ones. Revisit once the highlight /
-# `emphasize` API (#641) gives this a serializable, declarative spelling.
-packages/gofish-graphics/stories/vega-lite/Bar/LayeredBarsAndArea.stories.tsx
 
 # ---------------------------------------------------------------------------
 # Interaction/reactivity stories — exempt from Python parity (JS-only feature).

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -296,6 +296,28 @@ function isTokenSentinel(v: any): v is TokenSentinel {
   );
 }
 
+/** Is `v` a reconstructable `.zOrder(...)` value from the wire: a constant,
+ *  or a `field(...)` wire object (a callback never round-trips). Mirrors the
+ *  identical helper in `packages/gofish-graphics/src/serialize/fromJSON.ts` —
+ *  this harness rebuilds a `ChartBuilder` through its OWN switch rather than
+ *  calling the registry, so both need the same reapplication logic. */
+function isZOrderSpec(v: unknown): boolean {
+  return (
+    typeof v === "number" ||
+    (v !== null && typeof v === "object" && (v as any).type === "field")
+  );
+}
+
+/** Reapply a reconstructed mark-level `.zOrder(...)` spec, when present and
+ *  the mark supports it. A field-expr wire is passed straight through — the
+ *  mark's own `.zOrder()` evaluates it against the bound datum per-instance. */
+function applyZOrderSpec(mark: any, spec: { zOrder?: unknown }): any {
+  if (isZOrderSpec(spec.zOrder) && typeof mark.zOrder === "function") {
+    return mark.zOrder(spec.zOrder);
+  }
+  return mark;
+}
+
 /**
  * Wrap a Mark so its resolved GoFishNode gets `.scope()` called on it —
  * matches what JS `createMark` does for any component-defined mark. The
@@ -714,12 +736,7 @@ function mapMark(
     if (nameVal != null && typeof (mark as any).name === "function") {
       mark = (mark as any).name(nameVal);
     }
-    if (
-      typeof spec.zOrder === "number" &&
-      typeof (mark as any).zOrder === "function"
-    ) {
-      mark = (mark as any).zOrder(spec.zOrder);
-    }
+    mark = applyZOrderSpec(mark, spec);
     return mark;
   }
 
@@ -782,12 +799,7 @@ function mapMark(
     if (nameVal != null && typeof (mark as any).name === "function") {
       mark = (mark as any).name(nameVal);
     }
-    if (
-      typeof spec.zOrder === "number" &&
-      typeof (mark as any).zOrder === "function"
-    ) {
-      mark = (mark as any).zOrder(spec.zOrder);
-    }
+    mark = applyZOrderSpec(mark, spec);
     return mark;
   }
 
@@ -831,12 +843,7 @@ function mapMark(
   if (nameVal != null && typeof (mark as any).name === "function") {
     mark = (mark as any).name(nameVal);
   }
-  if (
-    typeof spec.zOrder === "number" &&
-    typeof (mark as any).zOrder === "function"
-  ) {
-    mark = (mark as any).zOrder(spec.zOrder);
-  }
+  mark = applyZOrderSpec(mark, spec);
   // `bind_data(d, key)` (Treemap-style) pre-binds a datum so the JS-side
   // mark factory is invoked as `mark(d, key)`. Wrap last so name/label
   // chains take effect on the underlying mark first.

--- a/tests/python-stories/forward-syntax-v3/test_labels.py
+++ b/tests/python-stories/forward-syntax-v3/test_labels.py
@@ -178,6 +178,28 @@ def story_heatmap_with_labels():
     )
 
 
+# ─── conditional group callout (field(...).map(), #796) ─────────────────────
+# `map()` is a partial mapping — only "Lake B" has an entry, so only its
+# group gets the callout text; every other group's accessor evaluates to
+# None (no default given) and the label elaborator skips it.
+
+def story_label_on_spread_conditional():
+    return (
+        chart(SEAFOOD)
+        .flow(
+            spread(by="lake", dir="x", spacing=50).label(
+                field("lake").map({"Lake B": "Best catch!"}),
+                position="outset-top",
+                fontSize=13,
+                color="#c0392b",
+            ),
+            stack(by="species", dir="x"),
+        )
+        .mark(rect(h="count", fill="species")),
+        {"w": 500, "h": 300, "axes": False},
+    )
+
+
 # ─── label on stack operator (per-group, #702) ──────────────────────────────
 
 def story_label_on_stack_operator():

--- a/tests/python-stories/vega-lite/test_layered_bars_and_area.py
+++ b/tests/python-stories/vega-lite/test_layered_bars_and_area.py
@@ -1,0 +1,77 @@
+"""Equivalent of Bar/LayeredBarsAndArea.stories.tsx — Vega-Lite/Layered Bars
+and Area.
+
+Was exempt from Python parity (see the removed file-level
+`.python-sync-exempt` entry): the JS story used to raise the emphasized
+sites' areas with a `.zOrder((d) => isEmphasized(project(d, "site")) ? 1 :
+0)` callback, which has no IR spelling and can't cross the derive RPC. #796's
+`field(...).map(mapping, default=...)` gives that data-driven paint order a
+serializable, declarative spelling — `EMPHASIS_Z_ORDER` below — so Default
+and TwoSites now port byte-for-byte.
+
+HoistedVarietySpread stays exempt (see the per-export entry in
+`.python-sync-exempt`): it nests `layer([chart(...), chart(...)])` INSIDE
+another chart's `.mark(...)`, and Python's `layer([...])` doesn't yet support
+producing the mark-combinator wire shape for ChartBuilder children (only the
+root LayerIR chart-tiers shape) — a separate, pre-existing gap.
+"""
+
+from gofish import chart, field, group, layer, palette, rect, ribbon, selectAll, spread, stack
+from python_stories.vega_data_urls import read_json
+
+# Data-driven paint order: the two emphasized sites' areas (z = 1) paint on
+# top of the gray ones (z = 0). Mirrors the JS story's `emphasisZOrder`.
+EMPHASIS_Z_ORDER = field("site").map({"Morris": 1, "Grand Rapids": 1}, default=0)
+
+
+def _is_emphasized(site) -> bool:
+    return site == "Morris" or site == "Grand Rapids"
+
+
+def story_default():
+    barley = read_json("barley.json").to_dict("records")
+    return (
+        layer([
+            chart(
+                barley,
+                color=palette({"Morris": "#e15759", "Grand Rapids": "#4e79a7"}),
+            )
+            .flow(
+                spread(by="variety", dir="x", spacing=20),
+                spread(by="year", dir="x", spacing=40),
+                stack(by=field("site").sort("yield"), dir="y"),
+            )
+            .mark(rect(h="yield", fill="site").name("bars")),
+            chart(selectAll("bars"))
+            .flow(group(by="variety"), group(by="site"))
+            .mark(ribbon(opacity=0.7).z_order(EMPHASIS_Z_ORDER)),
+        ]),
+        {"w": 400, "h": 400, "axes": True},
+    )
+
+
+def story_two_sites():
+    barley = read_json("barley.json").to_dict("records")
+    barley = [row for row in barley if _is_emphasized(row["site"])]
+    return (
+        layer([
+            chart(
+                barley,
+                color=palette({"Morris": "#e15759", "Grand Rapids": "#4e79a7"}),
+            )
+            .flow(
+                spread(by="variety", dir="x", spacing=20),
+                spread(by="year", dir="x", spacing=40),
+                stack(by=field("site").sort("yield"), dir="y"),
+            )
+            .mark(rect(h="yield", fill="site").name("bars")),
+            chart(selectAll("bars"))
+            .flow(group(by="variety"), group(by="site"))
+            .mark(ribbon(opacity=0.7)),
+        ]),
+        {"w": 400, "h": 400, "axes": True},
+    )
+
+
+# HoistedVarietySpread is intentionally not ported here — see the module
+# docstring and the per-export entry in tests/.python-sync-exempt.


### PR DESCRIPTION
## What

Adds `field(name).map(mapping, { default? })`, a partial discrete mapping on the field-expression pipeline, and widens mark `.zOrder()` to accept field expressions so data-driven paint order has a serializable spelling.

```ts
// conditional group label (previously needed a raw function accessor)
spread({ by: "site", dir: "x" }).label(
  field("site").map({ Morris: "Morris: every variety rose" }),
  { position: "outset-top", fontSize: 14, color: "#e08214" }
)

// data-driven paint order (previously .zOrder((d) => project(d, "site") === "Morris" ? 1 : 0))
ribbon({ opacity: 0.7 }).zOrder(
  field("site").map({ Morris: 1, "Grand Rapids": 1 }, { default: 0 })
)
```

Python spelling, same wire shape:

```python
field("site").map({"Morris": 1, "Grand Rapids": 1}, default=0)
```

## Semantics

- `map` is a value op. It applies elementwise in pipeline order, so it composes with aggregates when it comes first (`field(x).map({...}).sum()`), and it throws a clear error when written after an aggregate instead of silently reordering.
- A key lookup uses an own-property check. A miss becomes `default` when the option is given, else `undefined`, and each consuming surface then applies its own default. A label with an `undefined` result is skipped. A `zOrder` that resolves to `undefined` (or to a non-number) sets no hint at all, so the mark keeps base paint order.
- `default: null` is a real, present default, distinct from omitting the option. On the wire an omitted default is an absent key. The Python mirror uses a `no_default` sentinel so `default=None` still serializes as `"default": null`. Semantics match polars `replace_strict(mapping, default=...)`, and the name is pandas `Series.map(dict)`.
- `map` in a `by` slot is rejected with a pointed error, and so is a function argument (`derive()` is the spelling for arbitrary transforms). This construct exists specifically because function accessors have no IR spelling.

## Surfaces touched

- JS: `FieldOp` variant + `FieldExpr.map()` + evaluation (`fieldExpr.ts`, `datumProjection.ts`), `ZOrderValue` widened with per-instance resolution and IR round-trip (`createOperator.ts`, `serialize/fromJSON.ts`).
- IR: descriptor/schema/validate/jsonSchema entries for the widened `zOrder` slot, schema synced.
- Parity harness (`tests/harness/main.ts`): reconstructs field-expression `zOrder` values.
- Python: hand-written `FieldAccessor.map(mapping, default=no_default)`, `Mark.z_order` accepts a field accessor.
- Stories: `LayeredBarsAndArea` converted off its unserializable `zOrder` callback (capture-diff against main reports the story identical), new `LabelOnSpreadConditional` story for the conditional group callout, both ported to `tests/python-stories/` with the `layered-bars-and-area` exemption removed from `tests/.python-sync-exempt`.
- Docs: field-expression pipeline section and labels guide on the JS side, mirrored on the Python pages, plus the covered internals essays.

## Verification

- `validate-python-ir`: 217 passed, 0 failed, 1 skipped (unrelated missing narwhals dependency).
- `capture-python`: both ported stories captured clean (2/2 and 14/14).
- `capture-diff origin/main "Layered Bars and Area"`: no layout changes, 3 stories identical.
- `capture-one LabelOnSpreadConditional`: only the mapped group carries the callout.

Advances #641 (this is the serializable primitive the emphasize design needs), #776 and #793 (removes the `zOrder` callback blocker on the layered-bars-and-area Python port). Groundwork for #804 (the record label sugar desugars to this). Context: #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
