### PR TITLE
Design choice-based layout and cooperating layout theories

### DIFF
--- a/notes/design/automatic-axis-label-angle.md
+++ b/notes/design/automatic-axis-label-angle.md
@@ -1,0 +1,434 @@
+# Automatic axis label angle
+
+**Status:** design note (2026-07-16). Focused first client of the choice-based layout work in
+issue #486. Builds on the manual `labelAngle` implementation from #746 and the boundary-summary
+model in [silhouette-interface](./silhouette-interface.md).
+
+## 1. Decision
+
+Add `labelAngle: "auto"` as an automatic spelling alongside the existing manual number and
+per-tier array forms:
+
+```ts
+chart(data, {
+  axes: { x: { labelAngle: "auto" } },
+});
+```
+
+For one authored `"auto"` ordinal axis, measurement considers exactly three alternative
+layouts:
+
+1. all label tiers at 0°;
+2. all label tiers at 45° clockwise on screen;
+3. all label tiers at 90° clockwise on screen.
+
+The three alternatives are created during abstract measurement, before the enclosing scale
+scope resolves σ. Each alternative carries its own frame claim. The scope solver resolves each
+claim independently, so alternatives may receive different σ values. The realized alternatives
+are then measured for label collisions, ranked by the fixed policy in §5, and reduced to one
+placement plan. Only that selected plan reaches the mutating placement pass.
+
+The first release supports ordinal category-label axes only. Continuous and difference axes keep
+their existing manual `labelAngle` behavior; requesting `"auto"` for one is an explicit unsupported
+configuration error. Those axes will likely need a different candidate-generation and resolution
+strategy, so this design does not prejudge it.
+
+This feature deliberately does **not** introduce a public `choice` operator, a pluggable cost
+factory, arbitrary candidate angles, label thinning, or a general-purpose frontier type in the
+public API. It should, however, use internal shapes that can later be factored into those more
+general mechanisms without changing the semantics specified here.
+
+## 2. Motivation
+
+Manual `labelAngle` solved the immediate grouped-bar-chart problem in #746, but it asks the
+author to choose an angle for one render size. The right angle for ordinal category labels changes
+when the same chart is shown as a full-size figure, a narrow documentation example, or a
+thumbnail:
+
+- 0° is easiest to read when labels fit;
+- 45° preserves a mostly horizontal reading direction while reducing track-axis width;
+- 90° is the compact fallback for very narrow slots.
+
+The choice is geometric rather than syntactic. It depends on measured glyph boxes, category-key
+anchor positions, the proposed frame, and the scale factor that each candidate frame admits.
+Axis elaboration runs before those quantities are final, while placement is too late because it
+must receive one committed geometry. The natural home is therefore the abstract measurement
+stage between elaboration and placement, with σ resolution lifted over the alternatives.
+
+## 3. Existing behavior that must remain unchanged
+
+Today `AxisOptions.labelAngle` accepts:
+
+```ts
+labelAngle?: number | number[];
+```
+
+A number applies to every tier. An array is indexed from the innermost ordinal tier outward.
+Angles are authored clockwise on screen. The axis elaborator converts an authored angle into a
+`LabelRotation` containing:
+
+- the frame-resolved `Text.rotate` value;
+- the track-axis anchor (`"middle"` or `"baseline"`);
+- the text anchor (`"start"` or `"end"`).
+
+The conversion implements the existing hanging-point rule:
+
+| authored angle | track anchor | text anchor |
+| -------------- | ------------ | ----------- |
+| 0°             | middle       | start       |
+| 45°            | baseline     | start       |
+| 90°            | middle       | start       |
+
+Frame flipping may negate the value handed to `Text`, but it must not change the authored
+screen-clockwise result. The auto candidates use this same conversion; they are not a second
+rotation implementation.
+
+Manual values keep exact precedence and behavior:
+
+- `undefined` means the current unrotated behavior, not auto;
+- a number remains an unconditional manual angle;
+- a number array remains an unconditional per-tier specification;
+- `"auto"` is the only spelling that creates alternatives.
+
+The first release does not allow `"auto"` inside a per-tier array. A scalar `"auto"` chooses one
+angle for the whole authored ordinal axis, applying it uniformly to every tier, just as a scalar
+number does. This keeps the first candidate set at exactly three layouts. Per-tier independent
+choice would create `3^n` combinations and should be considered only after the three-layout
+version is understood.
+
+## 4. Candidate semantics
+
+An automatic ordinal axis contributes an axis-local measurement choice. The content subtree is
+shared; the alternatives describe three ways to measure and later place labels attached to the
+same category keys. They do not duplicate the chart data marks.
+
+The implementation should start with a feature-local representation rather than a generic
+framework:
+
+```ts
+type AutoLabelAngle = 0 | 45 | 90;
+
+type AxisLabelPlan = {
+  authoredAngle: AutoLabelAngle;
+  rotationsByTier: LabelRotation[];
+};
+
+type AxisLabelCandidate = {
+  plan: AxisLabelPlan;
+  frameClaims: [
+    Monotonic.Monotonic | undefined,
+    Monotonic.Monotonic | undefined,
+  ];
+  resolve: (scales: Size<AxisScale | undefined>) => ResolvedAxisLabelCandidate;
+};
+
+type ResolvedAxisLabelCandidate = {
+  plan: AxisLabelPlan;
+  scales: Size<AxisScale | undefined>;
+  labelBoxes: MeasuredLabelBox[][]; // tier, then label in track order
+  silhouette: Box;
+  score: AxisLabelScore;
+};
+```
+
+These names are illustrative, not a requirement to publish a new module with exactly these
+types. The important boundaries are:
+
+- the pre-solve candidate contains a frame claim and a placement plan;
+- the scale scope solves each candidate independently;
+- text and collision measurement are pure and use the candidate's solved scales;
+- the selected plan, not the whole frontier, crosses into placement.
+
+The box is sufficient as this feature's silhouette. A later generic choice implementation can
+replace `Box` with a type parameter satisfying the silhouette laws without changing the three
+candidate semantics.
+
+### 4.1 Domain restriction
+
+All three alternatives must expose the same ordinal domain, measure, keys, and reference names.
+They may differ only in geometric claims and the resulting scales, boxes, and placement plan. If
+candidate construction ever produces different semantic domains, that is an internal error.
+
+This restriction keeps axis choice independent of domain inference and category-key discovery.
+It still permits different σ values elsewhere in the enclosing frame: the same ordinal domain
+may be composed with three different geometric frame claims.
+
+### 4.2 Alternative-specific σ
+
+For candidate `a` on one axis, let its frame claim be `f_a(σ)` and the enclosing allocation be
+`W`. Resolution computes:
+
+```text
+σ_a = inverse(f_a, W)
+```
+
+The candidate is infeasible if its required scope equation cannot be solved under the usual
+scope-solver rules. Equal-measure recentering and any other scope-level post-solve adjustment
+must be applied per candidate before collision measurement. There is no shared σ unless the
+three frame claims happen to resolve to the same value.
+
+Under the current axis-chrome accounting, the three label alternatives may initially have the
+same frame claim and therefore the same σ. The implementation must not rely on that coincidence:
+the API between measurement and the scope solver should still carry claims per candidate. A
+solver unit test with candidate-dependent constant padding should demonstrate that distinct
+claims produce distinct σ values and that selection retains the winning candidate's σ.
+
+## 5. Selection policy
+
+Selection uses one fixed lexicographic score. This is intentionally narrower than a public cost
+factory:
+
+```ts
+type AxisLabelScore = readonly [
+  overlapArea: number,
+  collidingPairs: number,
+  angleRank: 0 | 1 | 2,
+  crossExtent: number,
+];
+```
+
+Lower is better. `angleRank` is 0 for 0°, 1 for 45°, and 2 for 90°.
+
+The ordering means:
+
+1. any collision-free layout beats every colliding layout;
+2. if all layouts collide, prefer the one with the least total overlap area, then the fewest
+   colliding adjacent pairs;
+3. among collision-free layouts, prefer the smallest rotation, preserving readability;
+4. use occupied cross-axis extent only as a final geometric tie-break.
+
+This policy always selects a candidate. Collision is not an unsatisfiable hard constraint in the
+first release because all three angles can still collide for extremely dense or long labels.
+Treating collision as the leading zero-or-positive cost preserves the desired hard-constraint
+behavior whenever a valid candidate exists while giving a deterministic least-bad fallback.
+
+### 5.1 Collision measurement
+
+Measure each label as an anchor-relative rotated axis-aligned box using the same font metrics,
+rotation matrix, and hanging point that `Text` placement will use. Translate those boxes to their
+abstract category-key anchors for the candidate. No `GoFishNode` bbox ledger or transform may be
+written during this computation.
+
+Within each tier:
+
+- sort labels in track order;
+- compare adjacent boxes after expanding each by a small fixed clearance
+  `AUTO_LABEL_GAP` (initially 2 px) on the track axis;
+- count pairs whose expanded boxes have positive two-dimensional intersection;
+- sum the unexpanded intersection areas for `overlapArea`.
+
+Only adjacent labels are required because axis anchors are ordered and label boxes are connected
+rectangles along the track. A debug assertion may compare the result with an all-pairs sweep in
+development builds while this assumption is validated.
+
+Collision scores sum across tiers. Boxes from different tiers are not compared with one another:
+the tier layout deliberately separates those rows/columns on the cross axis, and their combined
+cross extent is already represented by the candidate silhouette.
+
+## 6. Pipeline placement
+
+The desired pass ordering is:
+
+```text
+axis ownership and ordinal key discovery
+→ axis elaboration records an unresolved auto-label specification
+→ underlying-space/domain resolution
+→ abstract measurement creates the 0°/45°/90° candidates
+→ enclosing σ-scope solves each candidate's frame claims
+→ each candidate measures concrete label boxes with its own scales
+→ score and select one AxisLabelPlan
+→ placement applies only the selected plan
+→ lowering renders the selected Text rotations
+```
+
+The essential invariant is:
+
+> Measurement may construct, solve, and discard alternatives, but it must not commit node
+> geometry. Placement sees exactly one plan and preserves the current write-once bbox-ledger
+> discipline.
+
+At the root, this requires lifting the existing single frame solve over the three candidates
+before `child.layout`. Nested self-scaled/shared/constraint-budget scopes need the same behavior
+at their existing scope boundary. The first implementation may use a three-element axis-specific
+loop; it need not introduce a repository-wide `Frontier<T>` abstraction merely to remove three
+lines of duplication.
+
+## 7. Ordinal-axis elaboration strategy
+
+Manual ordinal-axis elaboration already represents each category label separately from the key
+node it tracks. Its alignment constraint can assign the label and key different anchors: an
+oblique label uses `"baseline"` while the tracked key remains `"middle"`; 0° and 90° use
+`"middle"` for both. The three auto alternatives therefore share one structural topology. They
+differ only in the label rotation, text anchor, and the label side of the heterogeneous alignment
+constraint.
+
+For auto mode, ordinal-axis elaboration should retain angle-independent key metadata plus an
+unresolved `AxisLabelPlan`. Measurement evaluates the three plans; the winner supplies the
+concrete `rotate`, `textAnchor`, and label alignment anchor before placement. The key node and its
+`"middle"` anchor never vary.
+
+Do not duplicate the content subtree or build three concrete ordinal-axis trees and hide two
+during lowering. Both approaches would make names, refs, and mutable placement state
+alternative-dependent.
+
+Reuse `resolveLabelRotation`; the table in §3 must have one source of truth for manual and
+automatic ordinal angles. Continuous/difference axis elaboration is unchanged and remains
+outside auto resolution.
+
+## 8. Text measurement extraction
+
+`Text.layout` currently performs both pure font/bbox measurement and placement-facing node
+layout. Extract the pure portion so auto-axis measurement and `Text.layout` call the same helper:
+
+```ts
+type MeasuredText = {
+  layout: TextLayout;
+  relativeBox: RelBBox;
+};
+
+function measureText(spec: TextMeasureSpec): MeasuredText;
+```
+
+`TextMeasureSpec` contains text, font properties, text anchor, dominant baseline, and rotation.
+The helper must use the existing DOM canvas metrics when available and the same SSR fallback.
+It returns an anchor-relative box and performs no node writes. `Text.layout` then becomes a
+consumer that converts this result into `intrinsicDims`, `transform`, and `renderData`.
+
+This extraction is part of the feature, not a general measurement-pass rewrite. Other marks keep
+their current layout implementations.
+
+## 9. Public API and serialization
+
+The TypeScript API becomes:
+
+```ts
+labelAngle?: number | number[] | "auto";
+```
+
+The frontend IR serializes the literal string unchanged:
+
+```json
+{ "axes": { "x": { "labelAngle": "auto" } } }
+```
+
+Python accepts the corresponding string:
+
+```py
+gf.chart(data, axes={"x": {"labelAngle": "auto"}})
+```
+
+Because this is a cross-language public option, JS serialization, Python reconstruction, API
+docs, and at least one JS/Python parity story must land in the same change. Manual numeric and
+array round trips remain unchanged.
+
+Invalid strings should fail at the normal API/IR validation boundary. Do not silently interpret
+unknown strings as 0°.
+
+After underlying-space resolution identifies the owned axis kind, `"auto"` on a continuous or
+difference axis must fail with a clear message such as `labelAngle: "auto" is currently supported
+only for ordinal axes`. It must not silently choose 0° or enter the manual continuous-axis path.
+
+## 10. Verification
+
+### 10.1 Pure unit tests
+
+Add unit tests for:
+
+- candidate construction produces exactly `[0, 45, 90]` in that order;
+- score ordering chooses 0° when all candidates fit;
+- score ordering chooses 45° when 0° collides and 45°/90° fit;
+- score ordering chooses 90° when it is the only collision-free candidate;
+- all-colliding input chooses the minimum-overlap candidate deterministically;
+- rotated measurement matches `Text.layout`'s bbox for 0°, 45°, and 90°;
+- y-up/frame-flipped axes still produce the authored clockwise screen angle;
+- three distinct frame claims are independently inverted and the winner retains its own σ;
+- candidate evaluation leaves node bbox ledgers and transforms untouched.
+
+The score tests should use synthetic boxes and anchors, not browser font metrics.
+
+### 10.2 Integration and visual tests
+
+Extend the grouped city/year axis permutation story that motivated #746 with:
+
+- a wide render selecting 0°;
+- a medium render selecting 45°;
+- a narrow render selecting 90°;
+- an extremely narrow render where all candidates collide, pinning the least-bad fallback;
+- a two-tier ordinal axis proving scalar auto applies one shared selected angle;
+- an ordinal y-axis case;
+- a y-up or continuous-y frame-flip case.
+
+Record the selected authored angle in normalized debug output or a test-only inspection hook so
+tests assert the decision directly rather than inferring it only from pixels.
+
+Run the normal verification gates:
+
+```bash
+pnpm --filter gofish-graphics typecheck
+pnpm --filter gofish-graphics test
+pnpm --filter @gofish/tests test:js
+pnpm --filter @gofish/tests test:python
+pnpm --filter docs docs:build
+```
+
+Use `pnpm capture-diff <base-ref> axes` to confirm that charts without `"auto"` are geometrically
+unchanged.
+
+## 11. Staged implementation
+
+1. Extract pure text measurement and prove manual text/rotation output is unchanged.
+2. Add the feature-local candidate and score types with synthetic-box tests.
+3. Teach `AxisOptions`, frontend IR, and Python reconstruction to preserve `"auto"`.
+4. Make auto axis elaboration retain a deferred label plan.
+5. Lift the relevant σ-scope solve over the three candidates and select one plan before
+   placement.
+6. Add visual/parity stories and documentation.
+7. After the implementation has shipped, evaluate whether the feature-local three-candidate
+   loop should be extracted into the generic choice/silhouette machinery from #486.
+
+Steps 1–5 should remain separable commits where practical. In particular, the text-measurement
+extraction should be behavior-preserving and reviewable without the choice policy mixed in.
+
+## 12. Deliberate non-goals and future generalization
+
+The first version does not include:
+
+- arbitrary angle lists;
+- negative-angle candidates;
+- independent per-tier auto selection;
+- automatic angles for continuous or difference axes;
+- label thinning or ellipsis;
+- user-defined cost factories;
+- contour or non-box silhouettes;
+- choices whose alternatives change data domains;
+- a public `choice`/`alt` operator.
+
+The local design leaves clean future seams:
+
+- `AxisLabelCandidate.frameClaims` can become the claim component of a generic measured
+  alternative;
+- `Box` can become a generic silhouette;
+- `AxisLabelScore` can become one lawful cost-algebra instance;
+- the three-element scope loop can become frontier resolution;
+- `AxisLabelPlan` demonstrates the certificate boundary: selection emits an abstract plan and
+  ordinary placement realizes it once.
+
+Label thinning is the most likely next axis-specific extension. It should be added as additional
+plans in the same measurement choice, not as a paint-time omission. Independent per-tier angles
+should wait until there is evidence that the extra combinations improve real charts enough to
+justify a larger frontier.
+
+## 13. Open questions to settle during implementation
+
+1. Do current axis-label boxes participate in the σ-producing frame claim, or do all three
+   candidates initially share σ because labels are accounted as chrome overhang? Either result is
+   acceptable, but the per-candidate solver interface and distinct-claim unit test are required.
+2. Is adjacent-pair collision sufficient for every supported axis ordering, including reversed
+   and nested ordinal axes? Keep the development all-pairs assertion until visual coverage answers
+   this.
+3. Should `AUTO_LABEL_GAP` remain an internal constant or eventually become an axis option? Keep
+   it internal for this feature.
+
+None of these questions changes the public semantics: three whole-axis alternatives, resolved
+during measurement with candidate-specific scales, ranked by collisions first and rotation
+second, with one selected plan entering placement.

--- a/notes/design/essence-of-gofish.md
+++ b/notes/design/essence-of-gofish.md
@@ -1,0 +1,618 @@
+# The essence of GoFish
+
+**Status:** running design note (2026-07-16). This is a record of the architecture as we
+currently understand it, not a frozen specification. It is expected to change as the automatic
+axis-label choice experiment, richer silhouettes, and algorithm-node work produce evidence.
+
+Companion notes:
+
+- [Composition, Not
+  Enumeration](../../apps/docs/docs/internals/design/composition-not-enumeration.md)
+  explains why GoFish wants a recursive language rather than a catalog of chart forms.
+- [A Synthesis of UI, Diagram, and Chart
+  Layout](../../apps/docs/docs/internals/design/layout-synthesis.md)
+  develops the current bbox/claim/constraint model.
+- [Modular Layout Algorithms](./modular-layout-algorithms.md) separates layout spec, policy,
+  and schedule.
+- [The Silhouette Interface](./silhouette-interface.md) generalizes the boundary summary passed
+  between composed layouts.
+- [Automatic Axis Label Angle](./automatic-axis-label-angle.md) is the first deliberately narrow
+  experiment with alternatives measured before placement.
+
+## 1. The question
+
+GoFish has often described its layout core concretely:
+
+- a recursive tree of marks and operators;
+- one `UnderlyingSpace` per axis;
+- monotone size claims, usually affine in a scale factor σ;
+- per-axis bbox ledgers;
+- max-plus folds for extents;
+- difference constraints for placement;
+- one inversion per scale scope.
+
+That description has been productive because it names the actual implementation. It is becoming
+too specific to name the system's essence. Paragraph wrapping needs a last-row summary and a set
+of alternatives. Tidy trees need contours. Tables need column vectors. A treemap may synthesize
+an operator plan. An automatic axis label angle carries three frame claims and selects one plan.
+None of those naturally reduces to “propagate one bbox,” yet all feel like GoFish rather than
+foreign features bolted onto it.
+
+The question is therefore:
+
+> What remains invariant when the propagated data structure, claim algebra, and local solver are
+> allowed to vary?
+
+## 2. Current answer, compressed
+
+GoFish is a **compositional visual compiler whose layout phase is cooperation among scoped
+abstract domains**.
+
+A subtree does not immediately produce pixels. It synthesizes a lawful abstract description of
+its possible layouts. Its parent supplies inherited context—a budget, scale environment,
+coordinate frame, or policy input. At a scope boundary, a domain-specific resolver combines the
+two, selects or solves a plan, and projects the result into the smaller interface understood by
+the surrounding system. A deterministic realization pass commits the selected plan once.
+
+In one line:
+
+> Children describe possibilities; parents provide context; scopes resolve a plan; the kernel
+> realizes its certificate.
+
+The bbox-plus-affine engine is one particularly useful layout theory in this architecture, not
+the definition of the architecture.
+
+## 3. The shift: from universal data structure to universal protocol
+
+The early unification question was “what is the one representation every layout can use?”
+Bboxes, linear constraints, and monotone claims were candidates for that universal
+representation. The newer answer is that there probably is no single maximally useful
+representation.
+
+A bbox forgets exactly the information wrapping and contour composition need. A contour is too
+expensive and too specialized to attach to every bar and text node. A Pareto frontier is wasted
+overhead in a deterministic stack. A general nonlinear constraint system could encode many of
+these cases, but it would discard the predictable schedule, diagnostics, and complexity that the
+restricted domains currently buy.
+
+The universal object is therefore not a carrier such as `BBox`. It is a protocol with places for
+different carriers:
+
+```text
+elaborate
+→ synthesize an abstract measurement
+→ combine measurements with domain-specific joins
+→ meet inherited context at a scope
+→ solve/filter/rank alternatives
+→ select a plan
+→ project to the parent boundary
+→ realize the selected plan deterministically
+```
+
+This is a shift from **data-structure universalism** to **architectural universalism**. GoFish
+does not require every graphic to speak the same internal geometry at every point. It requires
+each local geometry to participate in the same staged composition discipline.
+
+## 4. The two things being generalized
+
+Two independent structures have sometimes both been called “the layout IR.” They should remain
+separate.
+
+### 4.1 The visual language
+
+The frontend's generative core is the recursive type:
+
+```text
+Node = Mark(...) | Operator(..., children: Node[])
+```
+
+This is the lambda-calculus/relational-algebra side of the ambition. A combinator consumes visual
+nodes and produces a visual node, so composition is closed and unbounded. New chart families can
+be libraries expressed in the language rather than new top-level grammar slots or runtime forks.
+
+The visual language answers:
+
+- what is being composed;
+- which data and semantic measures it denotes;
+- where scopes and coordinate boundaries occur;
+- which local layout theory an operator requests.
+
+### 4.2 The interpretation domains
+
+The layout interpreter is generic over the abstract information used to interpret those nodes.
+Different scopes may use different domains:
+
+- intervals and bboxes;
+- monotone σ-claims;
+- paragraph summaries;
+- vectors of track widths;
+- contours;
+- finite frontiers of alternatives;
+- a foreign algorithm's plan and certificate.
+
+This layer answers:
+
+- what information crosses a child boundary;
+- which joins are valid;
+- how inherited allocation resolves unknowns;
+- when alternatives may be pruned;
+- what plan is handed to realization.
+
+The recursive visual language should remain small and uniform even as its interpretations become
+generic. Otherwise “generic domains” merely recreates a federation of unrelated sub-DSLs.
+
+## 5. A layout theory module
+
+The following is a mathematical inventory, not a proposed TypeScript interface. For one local
+layout theory `T`, identify:
+
+```text
+T = (S, Q, J, ⊑, π, R, P)
+```
+
+where:
+
+- `S` is the **summary domain**: box, paragraph silhouette, contour, column vector, and so on;
+- `Q` is the **claim language** presented to an enclosing scope: a monotone σ-function, a fixed
+  extent, a cross-axis measurement function, or a finite family of claims;
+- `J` is the set of **joins** the theory understands: overlay, hard sequence, soft sequence,
+  contour merge, row merge, etc.;
+- `⊑` is a **domination preorder** used to discard alternatives safely;
+- `π` is a **projection** to a boundary theory understood by the parent;
+- `R` is a **resolution strategy** that meets claims with inherited context and returns feasible
+  resolved alternatives;
+- `P` is the **plan/certificate language** consumed by deterministic realization.
+
+A candidate measurement has roughly this shape:
+
+```ts
+type Candidate<S, Q, P, C> = {
+  summary: S;
+  claim: Q;
+  plan: P;
+  cost: C;
+};
+```
+
+The type is intentionally schematic. Some costs are known symbolically; some are evaluated only
+after a candidate receives its own solved σ. Some summaries contain claims rather than sitting
+beside them. A deterministic theory has one candidate and no meaningful cost. The purpose of the
+inventory is to expose the extension points and laws, not to force every theory into one object
+layout.
+
+### 5.1 Examples
+
+| theory | summary `S` | claim `Q` | plan `P` | resolution |
+| --- | --- | --- | --- | --- |
+| current box layout | per-axis intervals/bbox facets | monotone extent in σ | bbox equations + placement relations | invert once, solve difference graph |
+| ordinal auto-label angle | three measured box candidates | one frame claim per angle | selected angle + anchor policy | solve each claim, score collisions |
+| paragraph wrap | `(rows, maxWidth, lastWidth)` frontier | width/height behavior | break positions | Pareto dynamic program |
+| table | vector of column/row widths | sum of track claims | track allocation | pointwise max then sum |
+| fixed-order tidy tree | left/right contour | contour extent | subtree offsets/threads | deterministic contour merge |
+| treemap plan synthesis | child weights + proposed rect | fixed frame | nested partition/operator tree | selected tiling algorithm |
+| heuristic packing | skyline plus search state | fixed container | placements/order certificate | heuristic search, then validation |
+
+The table is evidence against one universal carrier and for one universal protocol.
+
+## 6. Cooperation between theories
+
+Generic local domains are useful only if independently authored operators can still compose.
+The architecture therefore needs an explicit account of cooperation.
+
+### 6.1 Shared facts
+
+Specialized theories should exchange a deliberately small vocabulary of facts rather than reach
+into one another's internal representations. Current candidates include:
+
+- semantic measure and data domain;
+- scope identity;
+- allocated frame;
+- scale map or unresolved scale claim;
+- boundary box projection;
+- named anchors and reference identity;
+- feasibility/conflict information;
+- a selected realization certificate.
+
+These are the layout analogue of an interface theory. They are not meant to encode every local
+detail. A paragraph theory need not expose its line-break dynamic program to an enclosing layer;
+it exposes the selected box, relevant claims, and anchors. A contour theory need not make every
+ancestor contour-aware; it projects when leaving the scope that understands contours.
+
+### 6.2 Purification at boundaries
+
+When a node mixes theories, elaboration should isolate theory-specific subterms and name their
+shared boundary values. For example:
+
+```text
+wrap-specific subtree
+  exports: selected width, height, baseline, named anchors
+
+ordinary surrounding layer
+  imports: those exported facts as box/constraint participants
+```
+
+This resembles purification in combined decision procedures: a mixed expression is decomposed
+into pieces owned by specialist procedures, connected through shared variables. In GoFish the
+operation is a compiler elaboration and scope boundary rather than a logical formula rewrite,
+but the architectural move is the same: keep specialist internals private and make cooperation
+explicit.
+
+### 6.3 Projection is lossy on purpose
+
+The parent generally receives less information than the child scope used internally:
+
+```text
+paragraph frontier ──select──▶ paragraph silhouette ──π──▶ box
+contour + offsets  ──merge───▶ subtree contour      ──π──▶ box
+tiling search      ──choose──▶ partition plan       ──π──▶ child boxes
+```
+
+This loss is the tractability boundary. Rich information should travel only as far as an
+operator can use it lawfully. If every detail escaped upward, every ancestor would be forced into
+the most expensive domain present anywhere below it.
+
+### 6.4 Certificates preserve a small kernel
+
+A theory that performs search or arbitrary computation should not acquire unrestricted authority
+to mutate the scene graph. It returns a plan or certificate. The realization kernel checks and
+commits that certificate using ordinary ownership rules.
+
+Examples include:
+
+- line-break positions;
+- a chosen angle and anchor policy;
+- a permutation;
+- a partition tree;
+- contour offsets;
+- fixed placements from a heuristic packer.
+
+The trusted core can therefore remain smaller than the set of layout algorithms. This is the
+same reason proof-producing solvers and compiler lowering passes are easier to compose than
+arbitrary procedures sharing mutable state.
+
+## 7. The Nelson–Oppen analogy
+
+Nelson and Oppen's combination method addresses formulas containing terms from multiple logical
+theories. Rather than build a new monolithic decision procedure for every union, it purifies the
+formula into theory-specific pieces and lets specialist procedures cooperate by communicating
+facts about shared variables. The original line of work is described in
+[_Simplification by Cooperating Decision
+Procedures_](https://doi.org/10.1145/357073.357079)
+and the related congruence-closure procedure in
+[_Fast Decision Procedures Based on Congruence Closure_](https://doi.org/10.1145/322186.322198).
+
+The overlap with GoFish is architectural:
+
+| Nelson–Oppen family | possible GoFish analogue |
+| --- | --- |
+| union of specialized theories | one visual tree containing several layout domains |
+| purification of mixed terms | elaboration into domain-owned scopes with named boundaries |
+| shared variables | boxes, anchors, measures, scales, and allocations at scope boundaries |
+| theory decision procedure | domain-specific measurement/resolution strategy |
+| exchange of implied equalities | exchange of shared boundary facts and conflicts |
+| combined satisfiability result | one feasible selected layout plan |
+
+The analogy suggests a direction: GoFish's extensibility may depend less on finding the final
+layout algebra and more on defining a disciplined **combination protocol for layout theories**.
+
+It also suggests that restrictions are part of the design, not inconveniences. Nelson–Oppen
+combination theorems rely on conditions such as signature separation and properties of the
+component theories; arbitrary procedures do not automatically combine soundly or efficiently.
+Likewise, a GoFish layout theory should have explicit obligations governing projection,
+monotonicity, ownership, and certificates. “Implements the interface” is weaker than “composes
+lawfully.”
+
+### 7.1 Where the analogy stops
+
+GoFish is not an SMT solver, and treating the correspondence literally would misdesign it.
+
+- Nelson–Oppen decides conjunctions; GoFish performs staged synthesis, allocation, selection,
+  and realization.
+- Logical theories communicate equalities to a fixed point; GoFish strongly prefers a statically
+  ordered schedule with no general fixpoint.
+- GoFish theories may share semantic operations intentionally (`+`, `max`, anchors, boxes) rather
+  than having disjoint signatures.
+- Layout is allowed to be underdetermined and resolved by policy or cost. Satisfiability alone is
+  not a complete visual result.
+- Some layout problems are NP-hard. GoFish may accept a heuristic certificate while preserving a
+  deterministic checker; that is not a complete decision procedure.
+- Information flow is hierarchical and scoped, not an unrestricted peer-to-peer broadcast among
+  solvers.
+
+The useful lesson is **cooperation through a small shared theory**, not the specific
+Nelson–Oppen algorithm.
+
+## 8. The universal-language ambition
+
+GoFish's long-term ambition is sometimes described by analogy to lambda calculus or relational
+algebra: not merely another chart grammar, but a small substrate in which many visualization
+grammars can be expressed as libraries.
+
+The analogy should be made precisely.
+
+### 8.1 Lambda calculus: generative syntax
+
+Lambda calculus is powerful not because it enumerates many program forms, but because abstraction
+and application are closed and recursively composable. The corresponding GoFish bet is:
+
+```text
+visual node + visual combinator → visual node
+```
+
+Marks, operators, coordinate transforms, and derived constructs should elaborate into this
+recursive shape. A unit-chart grammar, tree grammar, animation grammar, or diagram component
+should be definable in user space rather than installed as another privileged chart family.
+
+This is a claim about the **shape of the language**, not about making GoFish Turing-complete.
+Indeed, unrestricted computation in the semantic core would weaken the laws that make
+composition analyzable.
+
+### 8.2 Relational algebra: closure plus laws
+
+Relational algebra is a small closed vocabulary whose expressions denote relations again. Its
+laws permit normalization, optimization, and substitution without knowing the storage strategy.
+The GoFish analogue needs both parts:
+
+- closure: operators consume and return visual nodes;
+- laws: elaboration, measurement joins, projections, and plans have semantics that support
+  rewriting and independent implementation.
+
+Closure without laws produces a generic scene-graph toolkit. Laws without recursive closure
+produce another fixed-shape Grammar of Graphics. The pursuit is the combination.
+
+### 8.3 What “universal” should mean
+
+The plausible goal is not “one solver can directly express every graphic.” It is:
+
+> One recursive visual language and one cooperation architecture can host many restricted layout
+> theories, with explicit translations and shared boundary semantics.
+
+Universality lives at three levels:
+
+1. **syntactic universality:** new visual constructs elaborate from the same recursive node
+   language;
+2. **semantic interoperability:** local layout theories can exchange shared facts and nest;
+3. **implementation extensibility:** new policies and schedules can emit plans checked by the
+   same realization kernel.
+
+Failure at any level recreates the current ecosystem's parallel grammars inside one repository.
+
+## 9. What is likely the fixed kernel
+
+The exact boundary remains open, but the following pieces look more stable than any one layout
+carrier.
+
+### 9.1 Elaboration
+
+High-level chart constructs become a small recursive core. Provenance is retained so errors and
+readback can name the source construct. Elaborators may introduce scopes, theory-owned nodes,
+shared variables, and deferred plans, but should not commit viewport geometry.
+
+### 9.2 Semantic spaces and measures
+
+Before geometric theories cooperate, they must agree on what quantities mean. Data domains,
+ordinal keys, units of measure, and coordinate aliases are type-level facts. Two pixel extents
+with incompatible semantic measures must not be silently combined merely because both are
+numbers.
+
+### 9.3 Scope scheduling
+
+A scope is where synthesized descriptions meet inherited context and local unknowns become
+resolved. The AST may be large, but the operational structure is the coarser tree of scopes.
+Different theories may have different local schedules, while the nesting of scopes supplies the
+global schedule.
+
+### 9.4 Choice discipline
+
+Hard constraints filter. Policy or cost chooses among feasible alternatives. Choice remains an
+explicit construct in measurement rather than an accidental consequence of traversal order or
+last-writer-wins mutation.
+
+### 9.5 Deterministic realization and ownership
+
+One selected plan enters realization. Geometry writes are owned, checked for conflict, and
+committed once. Search, measurement, and candidate comparison remain pure with respect to node
+geometry.
+
+### 9.6 Projection and lowering
+
+Each theory projects to shared boundary facts; the selected realized tree lowers to a backend-
+independent display list. Rendering backends should not need to understand the theory that chose
+the geometry.
+
+## 10. Obligations of a cooperating layout theory
+
+A future extension should answer these questions before it is treated as a first-class layout
+theory.
+
+### 10.1 Denotation
+
+- What layouts does a term denote?
+- Which distinctions in the summary are semantically meaningful?
+- Which parts are policy rather than feasibility?
+
+### 10.2 Composition
+
+- What are the joins?
+- Are they associative, and what is their identity?
+- Is child order semantically fixed or a policy variable?
+- What happens when this theory is nested under an ordinary box parent?
+
+### 10.3 Projection
+
+- Which facts cross the theory boundary?
+- Is projection conservative for joins the parent also understands?
+- Which information is deliberately forgotten, and at what scope?
+
+### 10.4 Resolution
+
+- Which inherited values does resolution require?
+- Which unknowns are solved per candidate?
+- Is resolution exact, bounded, or heuristic?
+- What is the visible complexity bound or frontier-width risk?
+
+### 10.5 Choice
+
+- What is the domination relation?
+- Are joins monotone under it, making pruning sound?
+- Is the cost order total and its combination associative/monotone?
+- What deterministic tie-break makes output stable?
+
+### 10.6 Realization
+
+- What certificate does the theory emit?
+- Which existing constraints can realize it?
+- What must the kernel validate before committing geometry?
+- Can failures name the source operator and conflicting owners?
+
+This checklist is the analogue of combination conditions. It is more important than whether all
+implementations literally share one generic interface.
+
+## 11. Consequences for architecture
+
+Several design consequences follow if this account is right.
+
+### 11.1 `BBox` becomes a boundary theory
+
+Bboxes remain ubiquitous because raster/vector backends, hit testing, parent allocation, and
+ordinary alignment need them. Their role changes from “the complete intermediate representation”
+to “the common coarse projection most scopes can export.”
+
+### 11.2 `Monotonic` is one claim language
+
+The monotone σ-function algebra remains the ideal language for proportional sizes, scales,
+padding, stacks, overlays, and grids. It need not absorb contours, line-break state, permutations,
+or every cross-axis dependency. A theory may carry those internally and export a monotone claim
+when crossing into a σ scope.
+
+### 11.3 Constraints are a realization calculus
+
+Align, distribute, position, nest, grid, and bbox equations remain a compact deterministic
+calculus for realizing many selected plans. They need not be the language in which every policy
+decision is expressed. “Choose an order” and “realize this order” are different jobs.
+
+### 11.4 Algorithm nodes become theory adapters
+
+An algorithm node is not merely an escape hatch. Properly designed, it is an adapter from a
+specialized planning domain into shared claims and realization certificates. Treemap, tidy-tree,
+Sankey ordering, and packing can each expose different internal strategies while presenting a
+lawful face to the rest of the compiler.
+
+### 11.5 The measurement pass becomes plural
+
+“Measurement” no longer means only “compute one intrinsic bbox.” It means abstract evaluation
+in the current theory. Its result may be one claim, a frontier, a contour, or a plan-producing
+function. What unifies these is that measurement is non-committing and precedes realization.
+
+### 11.6 Genericity should follow evidence
+
+The automatic ordinal-label experiment should use feature-local candidate types. Wrap should use
+a paragraph-specific summary. Only after two or three implementations exhibit the same
+operations should the common frontier/theory interfaces be extracted. The architecture should be
+generic; the first code should not be generic merely in anticipation.
+
+## 12. What this account rejects
+
+### 12.1 One global optimizer
+
+Encoding all layout as simultaneous soft constraints would make theories superficially uniform
+while hiding their schedules and complexity. GoFish instead combines restricted exact domains
+and explicit policy, with heuristic search fenced behind certificates where necessary.
+
+### 12.2 One maximal summary
+
+Attaching contours, alternatives, baselines, row state, and every future fact to every node would
+turn the boundary type into an ever-growing product. Scoped domains and lossy projection are the
+answer to that accretion.
+
+### 12.3 Unchecked plugin solvers
+
+An arbitrary callback that mutates child geometry is extensible but not compositional. Extensions
+should return claims, shared facts, and plans whose effects can be checked and owned.
+
+### 12.4 A collection of sealed sub-grammars
+
+If “generic over domains” means a switch among unrelated engines that cannot nest or exchange
+facts, the universal-language goal has failed. The hard problem is combination, not registration.
+
+### 12.5 Turing completeness as the finish line
+
+The host language already supplies arbitrary computation. The visual core earns its value by
+being more restricted: denotationally clear, optimizable, diagnosable, and closed under the
+compositions visualization needs.
+
+## 13. Open research questions
+
+This note is intentionally a running account because the following questions are unresolved.
+
+### 13.1 What is the shared boundary theory?
+
+Is `{semantic space, frame claim, box, anchors, plan}` sufficient? Are baselines ordinary named
+anchors? Do cross-axis dependencies need a standard representation, or should they always remain
+inside a theory scope?
+
+### 13.2 How are multiple theories present at one node?
+
+Does each operator own exactly one theory and project before its parent sees it? Can a node carry
+a product of independent theories? Is there a principled coproduct/adapter mechanism, or will
+elaboration always introduce explicit nested scopes?
+
+### 13.3 What are the combination conditions?
+
+The silhouette laws cover associative joins, conservative projection, and monotone domination.
+They may be the beginning of a broader set of sufficient conditions. We do not yet have a theorem
+stating when two independently implemented GoFish layout theories compose soundly, terminate, or
+preserve complexity.
+
+### 13.4 Where does σ live in a frontier?
+
+Automatic label angle shows that alternatives may carry different frame claims and therefore
+different solved σ values. Which symbolic dominance tests are valid before σ resolution? When
+must pruning wait until candidates are realized? Does a bounded-width frontier survive when its
+measure components are monotone functions rather than constants?
+
+### 13.5 What is the right certificate kernel?
+
+Can most algorithms lower to operator trees plus current constraints? Which require direct
+placement certificates? What checker is strong enough to preserve ownership and hard constraints
+without reimplementing the algorithm?
+
+### 13.6 What does completeness mean?
+
+There are at least three possible claims:
+
+- the visual combinators can encode a broad class of graphics;
+- the cooperating-theory protocol can host the required layout domains;
+- the built-in theory set covers common visualization practice without plugins.
+
+These should not be conflated. Lambda calculus and relational algebra analogies concern the first
+two, not a promise that the standard library already contains every chart.
+
+### 13.7 Can laws support optimization?
+
+Relational algebra's practical power comes not only from expression but from equivalence laws and
+query optimization. Which GoFish rewrites are semantics-preserving across theories? Can
+elaboration select representations or schedules from declared laws? Can a cost model choose
+between equivalent realization plans without changing visual semantics?
+
+## 14. Working thesis
+
+The current working thesis is:
+
+> A universal visualization grammar is possible not because every visualization shares one
+> geometric representation, but because visual programs share a recursive composition language
+> and their specialized layout theories can cooperate through scoped, lawful boundaries.
+
+The immediate research program follows:
+
+1. keep the recursive `Node = Mark | Operator(Node[])` language small and closed;
+2. make abstract measurement distinct from mutating realization;
+3. validate choice on the three-layout ordinal-axis experiment;
+4. validate a genuinely richer summary on paragraph wrap or contour composition;
+5. compare the two implementations and extract only the cooperation machinery they actually
+   share;
+6. state stronger combination laws once there is enough evidence to know what they are.
+
+If that program succeeds, bbox constraints, pretty-printing frontiers, contours, and algorithm
+nodes are not competing proposals for the core. They are cooperating theories hosted by the same
+visual calculus.


### PR DESCRIPTION
## Summary

- specify `labelAngle: "auto"` for ordinal category-label axes using exactly three whole-axis alternatives: 0°, 45°, and 90°
- place alternative construction in abstract measurement before per-candidate σ resolution
- define a collision-first selection policy and selected-plan boundary before placement
- describe GoFish more broadly as a recursive visual calculus hosting cooperating, scoped layout theories
- connect bbox claims, paragraph frontiers, contours, and algorithm certificates through a shared architectural protocol
- bound the Nelson–Oppen, lambda-calculus, and relational-algebra analogies and record the open research questions

## Why

The ordinal auto-label proposal is a deliberately narrow first test of choice-based layout. The companion running note captures the broader architectural hypothesis it exercises: GoFish may generalize through a cooperation protocol among lawful local layout domains rather than through one universal geometry carrier.

Together, the notes preserve the concrete feature design while making its relationship to the project’s universal-grammar ambition explicit.

## Impact

This is a design-only change. It does not alter runtime behavior or the public API yet. Continuous and difference axis labels remain explicitly outside the first automatic-angle experiment.

## Validation

- inspected both complete Markdown diffs
- `git diff --check` passed for both commits
- no runtime tests were run because this PR adds documentation only

## Related

- #486
- #746