### PR TITLE
Python parity: port NestedMosaicChart via the lambda bridge

### DIFF
--- a/apps/docs/docs/internals/frontend/mark-factory.md
+++ b/apps/docs/docs/internals/frontend/mark-factory.md
@@ -90,6 +90,13 @@ Two are wired up today, both defined at `src/ast/channels.ts`:
 | `"size"`  | `number \| (keyof T & string) \| Value` | string → `inferSize` (sums field across data); number → pass-through |
 | `"color"` | `string \| (keyof T & string) \| Value` | string → `inferColor` (color palette lookup if field, else literal)  |
 
+`inferColor` is `async` (a function accessor is awaited before being wrapped as
+a `Value`) so a plain sync `fill: (d) => ...` and the harness's Python-bridge
+arrow for `fill: { __gofish_lambda: id }` both resolve the same way — the same
+"await is a no-op on non-Promises" trick `inferRaw` uses for `text`'s content
+channel. `createMark`'s channel loop (`withGoFish.ts`) and `createOperator`'s
+`applyChannels`/`runChannel` both `await` it.
+
 If your prop should be a position offset (mean rather than sum), see the
 `inferPos` helper — `createOperator` uses it via channel annotations of its
 own; `createMark` could grow a `"pos"` channel the same way if a future shape
@@ -126,9 +133,11 @@ Walking `withGoFish.ts:431-477`:
    - `Value`-wrapped (`v(...)`) → pass through unchanged. (Already final.)
    - `"size"` channel → `inferSize(markValue, data)`. If `markValue` is a
      string, sum that field across `data`; if a number, use as-is.
-   - `"color"` channel → `inferColor(markValue, data)`. If the string matches
-     a field in the first datum, wrap it as a `Value` so the color scale
-     picks it up; otherwise treat the string as a literal color.
+   - `"color"` channel → `await inferColor(markValue, data)`. If the string
+     matches a field in the first datum, wrap it as a `Value` so the color
+     scale picks it up; otherwise treat the string as a literal color. A
+     function accessor is awaited, so this is also where the Python wrapper's
+     `rect(fill=lambda d: ...)` bridge resolves.
    - **Coordinate-space axis aliases** (`theta`/`r`/`thetaSize`/`rSize`, the
      `KNOWN_ALIAS_KEYS`) aren't declared channels, but carry the same value
      semantics as the canonical dims they resolve to, so `createMark` infers

--- a/apps/docs/docs/internals/frontend/operator-factory.md
+++ b/apps/docs/docs/internals/frontend/operator-factory.md
@@ -159,7 +159,10 @@ Walking `createOperator.ts:391-415`:
    `inferColor` on annotated opts. For an entry-flagged channel
    (`{type, entry: true}`), the inference runs once per split entry,
    producing an array of values (one per child); otherwise it aggregates
-   over all of `d` and produces one value.
+   over all of `d` and produces one value. `applyChannels`/`runChannel`/
+   `buildLayoutOpts` are all `async` because `inferColor` is (see [The Mark
+   Factory](/internals/frontend/mark-factory) — it awaits a function
+   accessor, which is how a Python-bridge `fill` lambda resolves).
 4. **Strip factory keys** — `by` and `debug` never reach the low-level
    layout; remove them from opts.
 5. **Inject the grouping measure** — `by` is stripped, but a grouping operator

--- a/packages/gofish-graphics/src/ast/channels.ts
+++ b/packages/gofish-graphics/src/ast/channels.ts
@@ -240,16 +240,21 @@ export const inferPos = inferNumeric(meanBy);
  * - string matching a field in data[0]: wraps field value as a Value.
  * - string not matching a field: passes through as a literal color.
  * - function: called on data[0] and wraps the result as a Value.
+ *
+ * Async (like `inferRaw`) so a callable accessor may return a Promise —
+ * needed for a rect's `fill: (d) => ...` when the harness has swapped in the
+ * async Python-bridge arrow for a `{ __gofish_lambda }` sentinel. Awaiting a
+ * non-Promise is a no-op, so plain sync accessors are unaffected.
  */
-export const inferColor = <T extends Record<string, any>>(
+export const inferColor = async <T extends Record<string, any>>(
   accessor:
     | string
-    | ((d: T) => string)
+    | ((d: T) => string | Promise<string>)
     | FieldAccessor
     | LiteralValue
     | undefined,
   data: T[]
-): MaybeValue<string> | undefined => {
+): Promise<MaybeValue<string> | undefined> => {
   if (accessor === undefined) return undefined;
   if (isLiteral(accessor)) return accessor.value as string;
   if (isField(accessor)) {
@@ -259,7 +264,7 @@ export const inferColor = <T extends Record<string, any>>(
   }
   if (typeof accessor === "function") {
     return data.length > 0 && data[0] != null
-      ? value(accessor(data[0]))
+      ? value(await accessor(data[0]))
       : undefined;
   }
   if (data.length > 0 && data[0] != null && accessor in data[0]) {

--- a/packages/gofish-graphics/src/ast/marks/chart.ts
+++ b/packages/gofish-graphics/src/ast/marks/chart.ts
@@ -500,11 +500,11 @@ function tagRelationalFusable(
  */
 const PAINT_KEYS = ["fill", "stroke"] as const;
 
-function resolveGroupFill<O extends RelationalMarkOptions>(
+async function resolveGroupFill<O extends RelationalMarkOptions>(
   type: string,
   opts: O,
   groupRefs: GoFishRef[]
-): O {
+): Promise<O> {
   const rows = groupRefs.flatMap((r) =>
     Array.isArray(r.datum) ? r.datum : [r.datum]
   );
@@ -532,7 +532,7 @@ function resolveGroupFill<O extends RelationalMarkOptions>(
           `explicit color.`
       );
     }
-    const resolved = inferColor(raw, rows);
+    const resolved = await inferColor(raw, rows);
     if (resolved !== undefined) {
       resolvedOpts = { ...resolvedOpts, [key]: resolved } as O;
     }
@@ -631,7 +631,7 @@ export function createRelationalMark<O extends RelationalMarkOptions>(
             const groupRefs = (
               Array.isArray(group) ? group : [group]
             ) as GoFishRef[];
-            const groupOpts = resolveGroupFill(type, baseOpts, groupRefs);
+            const groupOpts = await resolveGroupFill(type, baseOpts, groupRefs);
             return tagRelationalOperands(
               (await produce(groupOpts, groupRefs)) as GoFishNode,
               groupRefs
@@ -643,7 +643,7 @@ export function createRelationalMark<O extends RelationalMarkOptions>(
 
       // Unsplit: one connector through the whole bag, treated as a single
       // group for `resolveGroupFill` (see its doc comment for the paint fix).
-      const groupOpts = resolveGroupFill(type, baseOpts, d);
+      const groupOpts = await resolveGroupFill(type, baseOpts, d);
       return tagRelationalOperands(
         (await produce(groupOpts, d)) as GoFishNode,
         d

--- a/packages/gofish-graphics/src/ast/marks/createOperator.ts
+++ b/packages/gofish-graphics/src/ast/marks/createOperator.ts
@@ -705,14 +705,16 @@ function translateOperator<T, U>(
  * per-entry slice that does not) and passed down so `inferSize`/`inferPos` don't
  * recompute it per split entry.
  */
-function runChannel(
+async function runChannel(
   type: ChannelType,
   val: any,
   data: any[],
   measure: Measure | undefined
-): any {
+): Promise<any> {
   if (type === "size") return inferSize(val, data, measure);
   if (type === "pos") return inferPos(val, data, measure);
+  // `inferColor` is async (like `inferRaw`) so a callable accessor may
+  // return a Promise — the Python-bridge lambda path.
   if (type === "color") return inferColor(val, data);
   return val;
 }
@@ -741,12 +743,12 @@ function isNonNumericEntryField(
  * - If the opts value is already an array, channels pass it through unchanged
  *   (user supplied the final form directly).
  */
-function applyChannels<Options extends Record<string, any>>(
+async function applyChannels<Options extends Record<string, any>>(
   opts: Options,
   channels: ChannelAnnotations<Options> | undefined,
   d: any,
   entries: Map<string | number, any> | undefined
-): Options {
+): Promise<Options> {
   if (!channels) return opts;
   const wholeData = Array.isArray(d) ? d : [d];
   const out: any = { ...opts };
@@ -792,8 +794,10 @@ function applyChannels<Options extends Record<string, any>>(
       // knowledge from this.
       if (type === "size" && hasNormalizeOp(val)) {
         const { pre } = splitAtNormalize(val);
-        const rawEntryValues = [...entries.values()].map((items) =>
-          runChannel(type, pre, items, measure)
+        const rawEntryValues = await Promise.all(
+          [...entries.values()].map((items) =>
+            runChannel(type, pre, items, measure)
+          )
         );
         const byOpt = (opts as any).by;
         const byName =
@@ -808,11 +812,13 @@ function applyChannels<Options extends Record<string, any>>(
       // Value aggregation uses each entry's items; the measure comes from
       // `wholeData` (the binned array still carries the symbol — each per-entry
       // slice does not).
-      out[key] = [...entries.values()].map((items) =>
-        runChannel(type, val, items, measure)
+      out[key] = await Promise.all(
+        [...entries.values()].map((items) =>
+          runChannel(type, val, items, measure)
+        )
       );
     } else {
-      out[key] = runChannel(type, val, wholeData, measure);
+      out[key] = await runChannel(type, val, wholeData, measure);
     }
   }
   return out as Options;
@@ -837,14 +843,14 @@ function stripFactoryKeys<Options extends Record<string, any>>(
 }
 
 /** Build the low-level opts passed to `layout`. */
-function buildLayoutOpts<Datum, Options extends Record<string, any>>(
+async function buildLayoutOpts<Datum, Options extends Record<string, any>>(
   channels: ChannelAnnotations<Options> | undefined,
   opts: Options,
   d: Datum | Datum[],
   entries: Map<string | number, Datum | Datum[]> | undefined,
   keys: Record<string, string[]> | undefined
-): Options {
-  const withChannels = applyChannels(opts, channels, d, entries);
+): Promise<Options> {
+  const withChannels = await applyChannels(opts, channels, d, entries);
   const stripped = stripFactoryKeys(withChannels);
   // Merge split's axis keys (e.g. colKeys, rowKeys for table) into opts.
   return keys !== undefined ? ({ ...stripped, ...keys } as Options) : stripped;
@@ -896,7 +902,7 @@ export function createOperator<Datum, Options extends Record<string, any>>(
             return resolveMarkResult(result, layerContext);
           })
         );
-        const lowOpts = buildLayoutOpts(
+        const lowOpts = await buildLayoutOpts(
           cfg.channels,
           opts,
           d,
@@ -1047,7 +1053,13 @@ export function createOperator<Datum, Options extends Record<string, any>>(
           })
         );
         const nodes = nodesPerLeaf.flat();
-        const lowOpts = buildLayoutOpts(cfg.channels, opts, d, entries, keys);
+        const lowOpts = await buildLayoutOpts(
+          cfg.channels,
+          opts,
+          d,
+          entries,
+          keys
+        );
         // Carry the grouping field (e.g. spread's `by`) into the node operator
         // so it can stamp the ORDINAL space it builds with a `measure` — the
         // discrete axis names itself off its own space, mirroring how a

--- a/packages/gofish-graphics/src/ast/withGoFish.ts
+++ b/packages/gofish-graphics/src/ast/withGoFish.ts
@@ -622,7 +622,11 @@ function buildCreatedMark(
       } else if (channelType === "pos") {
         shapeProps[propName] = inferPos(markValue, data);
       } else if (channelType === "color") {
-        shapeProps[propName] = inferColor(markValue, data);
+        // `inferColor` is async so that callable accessors may return a
+        // Promise — used by the Python wrapper to bridge `rect(fill=
+        // lambda d: ...)` through the derive-server RPC, the same way
+        // `inferRaw` bridges `text`'s "raw" channel.
+        shapeProps[propName] = await inferColor(markValue, data);
       } else if (channelType === "raw") {
         // `inferRaw` is async so that callable accessors may return a
         // Promise — used by the Python wrapper to bridge `text(text=

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -11,14 +11,6 @@
 # frame→layer, and add the polar/wavy coord transforms to the Python wrapper +
 # IR bridge.
 #
-# NestedMosaicChart was ported under #433, but the story was rewritten (#675,
-# then #700) to the fluent `chart().flow(stack(size: field("count").normalize()))`
-# pipeline with a 2-D function fill (`survived == "No" ? gray : classColor[class]`).
-# A function channel can't cross the derive RPC, so it is now exempt — the
-# pure-spec mosaics (atom/Mosaic and Forward Syntax Mosaic Chart) ARE ported
-# and byte-parity-validated.
-packages/gofish-graphics/stories/lowlevel/NestedMosaicChart.stories.tsx
-
 # Per-export exemption — PolarText constructs a raw custom coordinate
 # transform inline ({ type, transform: ([r, theta]) => ..., domain }), an
 # arbitrary JS closure rather than one of the IR's named coord transforms

--- a/tests/python-stories/low-level-syntax/test_nested_mosaic_chart.py
+++ b/tests/python-stories/low-level-syntax/test_nested_mosaic_chart.py
@@ -1,0 +1,78 @@
+"""Equivalent of lowlevel/NestedMosaicChart.stories.tsx — Low Level Syntax/Nested Mosaic Chart.
+
+Three nested `stack(...)` flows (class -> sex -> survived), each with
+`size: field("count").normalize()`, mirror the JS spec exactly.
+
+The only unportable fragment in the JS story is the fill channel, a function
+of two fields:
+
+    fill: (d) => (d.survived === "No" ? gray : classColor[d.class])
+
+This crosses via the EXISTING lambda bridge (the same one `text(text=lambda
+d: ...)` already uses, see `piccl/test_bottle.py`): a bare Python callable
+passed as a mark kwarg is wrapped by `_channel()` in `gofish/ast.py` into a
+`_PendingAccessor`, registered with the derive server under a UUID, and
+serialized as `{"__gofish_lambda": id}`. The JS harness (`fromJSON.ts`)
+swaps in an `async (d) => fetch /derive/<id>` arrow at render time. Until
+this port, `rect`'s `fill` channel (`inferColor` in `src/ast/channels.ts`)
+did not await a function accessor's return value the way `text`'s `raw`
+channel (`inferRaw`) did, so an async lambda fill would have resolved to an
+unresolved Promise instead of a color string. `inferColor` was made async
+(and its callers updated to await it) to close that gap — see
+`/internals/frontend/mark-factory`.
+
+`gray` (`#D1D9E2`) and `color6[0..3]` (`#4190c5`, `#f2cf57`, `#a181c8`,
+`#ff9666`) are inlined from `packages/gofish-graphics/src/color.ts`; the
+Python package does not (yet) expose the JS color palette.
+"""
+
+from gofish import chart, stack, rect, field
+
+# packages/gofish-graphics/src/color.ts: gray
+GRAY = "#D1D9E2"
+
+# packages/gofish-graphics/src/color.ts: color6[0..3]
+CLASS_COLOR = {
+    "First": "#4190c5",
+    "Second": "#f2cf57",
+    "Third": "#a181c8",
+    "Crew": "#ff9666",
+}
+
+TITANIC = [
+    {"class": "First", "sex": "Female", "survived": "Yes", "count": 141},
+    {"class": "First", "sex": "Male", "survived": "Yes", "count": 62},
+    {"class": "Second", "sex": "Female", "survived": "Yes", "count": 93},
+    {"class": "Second", "sex": "Male", "survived": "Yes", "count": 25},
+    {"class": "Third", "sex": "Female", "survived": "Yes", "count": 90},
+    {"class": "Third", "sex": "Male", "survived": "Yes", "count": 88},
+    {"class": "Crew", "sex": "Female", "survived": "Yes", "count": 20},
+    {"class": "Crew", "sex": "Male", "survived": "Yes", "count": 192},
+    {"class": "First", "sex": "Female", "survived": "No", "count": 4},
+    {"class": "First", "sex": "Male", "survived": "No", "count": 118},
+    {"class": "Second", "sex": "Female", "survived": "No", "count": 13},
+    {"class": "Second", "sex": "Male", "survived": "No", "count": 154},
+    {"class": "Third", "sex": "Female", "survived": "No", "count": 106},
+    {"class": "Third", "sex": "Male", "survived": "No", "count": 422},
+    {"class": "Crew", "sex": "Female", "survived": "No", "count": 3},
+    {"class": "Crew", "sex": "Male", "survived": "No", "count": 670},
+]
+
+
+def story_default():
+    return (
+        chart(TITANIC, axes=True)
+        .flow(
+            stack(by="class", dir="y", size=field("count").normalize()),
+            stack(by="sex", dir="x", size=field("count").normalize()),
+            stack(by="survived", dir="y", size=field("count").normalize()),
+        )
+        .mark(
+            rect(
+                fill=lambda d: GRAY if d["survived"] == "No" else CLASS_COLOR[d["class"]],
+                stroke="white",
+                strokeWidth=1,
+            )
+        ),
+        {"w": 500, "h": 500},
+    )

--- a/tests/scripts/capture-python-dom.ts
+++ b/tests/scripts/capture-python-dom.ts
@@ -105,13 +105,13 @@ function discoverPythonStories(): PythonStory[] {
 /**
  * Python files (relative to TESTS_DIR) whose JS source story is **file-level
  * exempt** in `.python-sync-exempt`. A Python port may still exist and be
- * committed (e.g. NestedMosaicChart's fluent-pipeline port, which can't
- * cross the derive RPC because of its function fill), but an exempt story is
- * excluded from the byte-parity gate — so we skip capturing it rather than
- * emit a snapshot that `compare-python` would (correctly) flag as a
- * mismatch. Stories that only need the byte-diff skipped (the algorithm
- * genuinely diverges but the port IS captured/IR-validated, e.g. ViolinPlot's
- * scipy vs. fast-kde KDE) use the per-export `file::Export` tier instead —
+ * committed (e.g. a story whose JS uses a v1/v2-only feature the Python
+ * wrapper doesn't yet expose), but an exempt story is excluded from the
+ * byte-parity gate — so we skip capturing it rather than emit a snapshot
+ * that `compare-python` would (correctly) flag as a mismatch. Stories that
+ * only need the byte-diff skipped (the algorithm genuinely diverges but the
+ * port IS captured/IR-validated, e.g. ViolinPlot's scipy vs. fast-kde KDE)
+ * use the per-export `file::Export` tier instead —
  * see `loadExportExemptParityPaths` in compare-python.ts, which skips only
  * the byte diff for those.
  */
@@ -524,7 +524,7 @@ async function main() {
       );
 
       // Skip stories whose JS source is file-level parity-exempt — the port
-      // isn't expressible at all (e.g. NestedMosaicChart's function fill).
+      // isn't expressible at all (e.g. a v1/v2-only feature).
       if (exemptPythonFiles.has(story.file)) {
         console.log("SKIP (JS story is parity-exempt)");
         skipped++;


### PR DESCRIPTION
## Summary

- Ports the `lowlevel/NestedMosaicChart` Storybook story to Python:
  `tests/python-stories/low-level-syntax/test_nested_mosaic_chart.py`.
  Mirrors the JS spec exactly (three nested `stack(...)` flows over
  `field("count").normalize()` sizes, `rect(fill=..., stroke="white",
  strokeWidth=1)`, 500x500 render).
- The JS story's only unportable fragment was a 2-D function fill:

  ```ts
  fill: (d: any) => (d.survived === "No" ? gray : classColor[d.class])
  ```

  This crosses via the **existing** lambda bridge — the same mechanism
  `text(text=lambda d: ...)` already uses (see `piccl/test_bottle.py`): a
  bare Python callable passed as a mark kwarg gets wrapped as
  `_PendingAccessor` (`gofish/ast.py`), serialized as `{"__gofish_lambda":
  id}`, registered with the derive server, and swapped for an async
  `(d) => fetch /derive/<id>` arrow by the JS harness at render time. No new
  serialization mechanism, no precomputed fill column, no JS story changes.
- `gray` (`#D1D9E2`) and `color6[0..3]` are inlined from
  `packages/gofish-graphics/src/color.ts` with a comment pointing at the
  source, since the Python package doesn't expose the JS color palette yet.
- Removes the now-stale NestedMosaicChart entry (and its explanatory
  comment) from `tests/.python-sync-exempt`.

## JS-side change (mechanical gap, not a new mechanism)

Wiring the lambda through exposed a real gap: `inferColor`
(`packages/gofish-graphics/src/ast/channels.ts`) was **sync** and never
awaited a function accessor's return value, unlike `inferRaw` (the sibling
helper `text`'s content channel already uses for its own lambda-bridge
path). An async Python-bridge fill would have resolved to an unresolved
`Promise` instead of a color string.

Fixed by making `inferColor` `async` (mirroring `inferRaw` — "await is a
no-op on a non-Promise" so plain sync fills are unaffected) and updating its
three call sites to await it:
- `withGoFish.ts`'s per-mark channel loop (`createMark`)
- `chart.ts`'s `resolveGroupFill` (relational-mark paint resolution)
- `createOperator.ts`'s `runChannel` / `applyChannels` / `buildLayoutOpts`
  (operator-level channel annotations)

Also updated the two internals essays these files are tagged to
(`mark-factory`, `operator-factory`) in the same change, per the wiki-sync
convention.

## Parity result

Byte-identical. `diff` between a live JS capture of the story
(`capture-one`) and the Python IR capture (`capture-python-dom`) is empty.
Also visually sanity-checked the captured PNG: a mosaic of Titanic class ×
sex × survived, gray "No" cells and colored class cells, matching the JS
design.

Ran a full 304-story JS DOM capture with the `inferColor` change in place —
0 failures. A `capture-diff` run against a local `main` ref initially
flagged 9 unrelated stories (ribbon/porter-duff/piccl), but that `main` ref
turned out to be 8 commits stale; a direct A/B capture (this branch vs.
unmodified HEAD, holding everything else constant) showed **zero**
difference, confirming the `inferColor` async change is behavior-preserving
for all non-lambda fills.

## Deviations from the brief

None of substance. One thing worth flagging: `tests/.python-sync-exempt`'s
removed comment also referenced the exemption as an example in two other
doc comments (`capture-python-dom.ts`); those were generalized rather than
left pointing at a story that's no longer exempt.

Advances #793
Advances #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)