### PR TITLE
gotree Python bridge: gofish.gotree module, 40-story parity, docs

### DIFF
--- a/apps/docs/docs/.vitepress/config.mts
+++ b/apps/docs/docs/.vitepress/config.mts
@@ -661,6 +661,10 @@ export default defineConfig({
             },
           ],
         },
+        {
+          text: "GoTree",
+          items: [{ text: "tree (separate package)", link: "/python/gotree" }],
+        },
       ],
       "/internals/": collectInternalsSidebar(),
     },

--- a/apps/docs/docs/.vitepress/data/pythonExamples.ts
+++ b/apps/docs/docs/.vitepress/data/pythonExamples.ts
@@ -57,8 +57,18 @@ const EXEMPT_FILE = join(TESTS_DIR, ".python-sync-exempt");
 // Kept in lockstep by hand — both are small and rarely change together.
 // ---------------------------------------------------------------------------
 
-/** CamelCase / spaced / underscored → kebab-case. */
+/** CamelCase / spaced / underscored → kebab-case.
+ *
+ * "GoTree" (the gofish-gotree package's title segment on every one of its
+ * story titles, e.g. "GoTree / Gallery / arc-tree") is a single proper-noun
+ * token, not two English words — the general CamelCase-split rule below
+ * would otherwise mangle it to "go-tree", diverging from the package's own
+ * "gotree" name (and from the tests/python-stories/gotree/ convention).
+ * Declared exception, not a generalizable rule: no other title segment
+ * needs this. Kept in lockstep with tests/scripts/path-mapping.ts's toKebab
+ * (this file's header explains why that one isn't imported directly). */
 function toKebab(s: string): string {
+  if (s.trim() === "GoTree") return "gotree";
   return s
     .replace(/([a-z])([A-Z])/g, "$1-$2")
     .replace(/[\s_]+/g, "-")
@@ -87,7 +97,11 @@ function computeMapJsToPython(jsFileRelToRepo: string): string {
   }
 
   if (title) {
-    const segments = title.split("/").map(toKebab);
+    // Trim each segment before kebab-casing — gofish-gotree's story titles
+    // put spaces around "/" ("GoTree / Gallery / arc-tree"), which without
+    // trimming leaves stray leading/trailing dashes (" Gallery " → "-gallery-")
+    // and breaks the resulting path. Mirrors path-mapping.ts's titleToStoryId.
+    const segments = title.split("/").map((seg) => toKebab(seg.trim()));
     const dirPath = segments.slice(0, -1).join("/");
     const basePart = segments[segments.length - 1].replace(/-/g, "_");
     return `tests/python-stories/${dirPath}/test_${basePart}.py`;

--- a/apps/docs/docs/internals/frontend/schema-json.md
+++ b/apps/docs/docs/internals/frontend/schema-json.md
@@ -447,6 +447,112 @@ for the API.
         },
         {
           "$ref": "#/$defs/CutMarkIR"
+        },
+        {
+          "$ref": "#/$defs/GotreeTreeIR"
+        }
+      ]
+    },
+    "GotreeTreeIR": {
+      "description": "gotree-tree (issue #792): a serialized gotree hierarchy visualization. Reconstructed via an injected markBridges entry (gofish-graphics never statically imports gofish-gotree). Row shape for field/lambda resolution at each hierarchy node: {...d.data (children key omitted), depth, height, width, value} — depth/height/width/value come from gotree's HierarchyDatum and OVERRIDE same-named data fields.",
+      "type": "object",
+      "required": ["type", "data"],
+      "properties": {
+        "type": {
+          "const": "gotree-tree"
+        },
+        "data": {
+          "type": "object"
+        },
+        "node": {
+          "$ref": "#/$defs/MarkIR"
+        },
+        "link": {
+          "$ref": "#/$defs/GotreeLinkSpec"
+        },
+        "parentChild": {
+          "$ref": "#/$defs/GotreeCombinerIR"
+        },
+        "sibling": {
+          "$ref": "#/$defs/GotreeCombinerIR"
+        },
+        "coord": {
+          "type": "object"
+        },
+        "origin": {
+          "$ref": "#/$defs/Origin"
+        },
+        "meta": {
+          "$ref": "#/$defs/Meta"
+        }
+      }
+    },
+    "GotreeLinkOptionsIR": {
+      "type": "object",
+      "properties": {
+        "curve": {
+          "enum": ["straight", "bezier", "orthogonal", "arc"]
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeWidth": {
+          "type": "number"
+        },
+        "opacity": {
+          "type": "number"
+        }
+      }
+    },
+    "GotreeLinkSpec": {
+      "description": "\"none\", a link-options object, or a {__gofish_lambda} sentinel — the lambda receives (srcRow, tgtRow) and returns a link-options dict, resolved eagerly at deserialize time.",
+      "oneOf": [
+        {
+          "const": "none"
+        },
+        {
+          "$ref": "#/$defs/GotreeLinkOptionsIR"
+        },
+        {
+          "type": "object",
+          "required": ["__gofish_lambda"],
+          "properties": {
+            "__gofish_lambda": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "GotreeCombinerIR": {
+      "description": "Mirrors gofish-gotree's SpreadOptions/DistributeOptions/NestOptions/CombineOptions (helpers.ts) and its depth-indexed alternate(...). `options` bags are unvalidated here (the real helpers own their own opts), like other combinator options elsewhere in this schema.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["kind", "options"],
+          "properties": {
+            "kind": {
+              "enum": ["spread", "distribute", "nest", "combine"]
+            },
+            "options": {
+              "type": "object"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["kind", "combiners"],
+          "properties": {
+            "kind": {
+              "const": "alternate"
+            },
+            "combiners": {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/GotreeCombinerIR"
+              }
+            }
+          }
         }
       ]
     },

--- a/apps/docs/docs/internals/frontend/serialization.md
+++ b/apps/docs/docs/internals/frontend/serialization.md
@@ -13,6 +13,8 @@ covers:
   - packages/gofish-graphics/src/serialize/fromJSON.ts
   - packages/gofish-graphics/src/serialize/registry.ts
   - packages/gofish-python/scripts/generate.ts
+  - packages/gofish-gotree/src/serialize.ts
+  - packages/gofish-gotree/src/spec.ts
 ---
 
 # The Frontend IR
@@ -136,7 +138,8 @@ without a bridge. Marks are a tree — leaves
 `image`, `polygon`, plus the Python-bridge `mark-fn`), combinators (with
 `__combinator: true` and a `children` array — `layer`, `spread`, `stack`,
 `arrow`, `position`, `line`, `ribbon`, `treemap`, and the Porter-Duff family),
-refs, or the two self-discriminating wrapper marks `offset` and `cut` (below).
+refs, or one of the self-discriminating wrapper marks `offset`, `cut`, and
+`gotree-tree` (below).
 `position` is `enclose`'s undecorated sibling: it sets a single child's
 min-corner `(x, y)` in the parent's coordinates and draws nothing of its own
 (no hull, no styling) — a workaround for `enclose`'s convex-bbox-hull-only
@@ -164,6 +167,57 @@ absolute-vs-weight mixing, measure-unit checks) lives in ONE place, JS-side:
   deserializer expands it in place into its N slice nodes — the pure
   `cut(source, opts)` returns a `Promise<GoFishNode>[]` that combinators accept
   directly as children (see `mapMarkChildren` in `fromJSON.ts`).
+
+`gotree-tree` (#792) — `{ type: "gotree-tree", data, node?, link?, parentChild?,
+sibling?, coord? }` — a serialized gotree hierarchy visualization (the
+`gofish-gotree` package's tree grammar). `data` is the nested tree; `node` is a
+per-node mark template (channels may be `FieldAccessor`s, `DatumValue`s, or
+`{__gofish_lambda}` sentinels — omitted means gotree's `DEFAULT_NODE`); `link`
+is `"none"`, a static `{curve?, stroke?, strokeWidth?, opacity?}` object, or a
+lambda sentinel; `parentChild`/`sibling` are `GotreeCombinerIR`s — `{kind:
+"spread"|"distribute"|"nest"|"combine", options}` calling the matching
+gofish-gotree helper, or `{kind: "alternate", combiners}` for the depth-cycling
+combiner. The row seen by every field/lambda resolution at a hierarchy node is
+`{...data (children key omitted), depth, height, width, value}` —
+`depth`/`height`/`width`/`value` come from gotree's `HierarchyDatum` and
+**override** same-named fields already on the raw tree data.
+
+Unlike every other mark type, `gotree-tree` isn't reconstructed inside
+gofish-graphics at all: gofish-graphics must not depend on `gofish-gotree`
+(that package already depends on gofish-graphics, so the reverse edge would be
+a workspace cycle). Instead the deserializer accepts an optional `markBridges:
+Record<string, (spec) => Promise<Mark<any>> | Mark<any>>` map — consulted in
+`mapMark` before the `mark-fn`/`MARK_MAP` dispatch, keyed by the IR's `type`
+tag — and the caller (the Python widget, the parity harness) supplies `{
+"gotree-tree": (spec) => reconstructGotreeTree(spec, ctx) }`, where
+`reconstructGotreeTree` (`packages/gofish-gotree/src/serialize.ts`) rebuilds
+the real `GoTreeSpec` and calls gotree's own `tree()`. This is the same
+injection shape as `DeriveBridge`, generalized from "resolve a lambda" to
+"reconstruct an entire mark subtree gofish-graphics doesn't know about."
+
+`reconstructGotreeTree`'s `ctx` is `{ mapMark, applyLambda? }` — `mapMark`
+recurses back into the caller's own `Serialize.mapMark` (so a node template can
+itself contain any other mark IR, including a nested `gotree-tree`);
+`applyLambda(id, args)` resolves one lambda call to one value. That's a
+narrower contract than `DeriveBridge.applyLambda(id, rows)` (batched rows-in/
+rows-out over Arrow) — gotree needs single calls with 1 or 2 positional
+arguments (one node's row, or a link's `(srcRow, tgtRow)` pair), which doesn't
+fit the row-batching shape at all. Both the widget and the harness adapt the
+two by wrapping the positional args as the payload of a one-row batch call
+(`{__gofish_args: args}`); this is a deliberate shortcut, not a new bridge
+protocol — see `makeGotreeApplyLambda` in `widget-src/index.ts` for the exact
+wire shape a Python-side lambda dispatcher for gotree callables must unwrap.
+
+Because gotree's node factory and link callback are called _synchronously_
+during `tree()`'s hierarchy walk, `reconstructGotreeTree` cannot resolve
+lambda-backed channels or link options lazily — it pre-walks the hierarchy,
+resolves every node's `Mark` and every edge's link options up front (keyed by
+each node's stable `nodePath`), and only then calls `tree()` with plain
+synchronous lookup functions. This required a small internal change to
+`gofish-gotree` itself: `NodeFactory` and the function form of `LinkSpec` both
+gained an optional trailing `path`/`sourcePath, targetPath` argument so the
+pre-computed lookup can key by position (existing single-argument callers are
+unaffected).
 
 **`mark-fn` over refs** (#591) — a Python `.mark(fn)` callback isn't limited
 to receiving plain data rows: when the callback's `data` is a bag of
@@ -550,6 +604,11 @@ directly — no bridge sentinel needed.
 Olli and other pure-JS consumers don't see these — they're a
 `FrontendIRWithBridge` extension declared in the Python widget code
 (see [The Jupyter Bridge & RPC](/internals/python/bridge)).
+
+The `gotree-tree` mark (above) reuses the RPC transport but not the schema
+extension mechanism: instead of a new sentinel, it's an optional
+`markBridges` map passed alongside `bridge` into `mapMark`/`buildChart`, so
+gofish-graphics stays unaware of `gofish-gotree`'s existence.
 
 ## Prior art
 

--- a/apps/docs/docs/python/gotree.md
+++ b/apps/docs/docs/python/gotree.md
@@ -1,0 +1,284 @@
+# GoTree
+
+`gofish.gotree` is a declarative grammar for tree visualizations — node-link
+diagrams, dendrograms, nested-box trees, icicle plots, sunbursts, and treemap
+slices — built on top of GoFish. It is a pure snake_case mirror of the
+JavaScript `gofish-gotree` package's API, kept as a separate submodule (not
+re-exported from the top-level `gofish` namespace, the same way `derive` and
+`field` live outside it):
+
+```python
+from gofish.gotree import tree, spread, distribute, nest, combine, alternate
+```
+
+or, if you prefer to keep the namespace explicit:
+
+```python
+from gofish import gotree
+
+gotree.tree(...)
+```
+
+A single function, `tree(data, **spec)`, builds a tree visualization. The
+**combiners** — `spread`, `distribute`, `nest`, `combine`, `alternate` — control
+how a tree's layout is assembled; varying them turns the same data into a
+node-link diagram, a dendrogram, or a nested-box tree. The grammar follows the
+structure of [GoTree (Li et al., CHI 2020)](https://dl.acm.org/doi/10.1145/3313831.3376297)
+but renames concepts to match GoFish conventions. See the
+[JavaScript version](/js/gotree) for the underlying design in full detail —
+this page covers the Python spelling and its few deliberate omissions.
+
+## Quick example — node-link tree with orthogonal links
+
+::: gofish example:gotree-orthogonal-tree hidden
+:::
+
+```python
+from gofish import circle
+from gofish.gotree import combine, tree
+
+sample_tree = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {"name": "C", "children": [{"name": "C1", "value": 3}, {"name": "C2", "value": 2}]},
+    ],
+}
+
+# Node color depends on hierarchy depth, not on a data field, so `node=` is a
+# callable rather than a plain mark — see "node" below.
+depth_blues = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def by_depth(depth):
+    return depth_blues[min(depth, len(depth_blues) - 1)]
+
+
+def node(d):
+    return circle(r=7, fill=by_depth(d["depth"]), stroke="#08306b", strokeWidth=1)
+
+
+tree(
+    sample_tree,
+    node=node,
+    link={"curve": "orthogonal", "stroke": "#90a4ae", "stroke_width": 1.5},
+    # every relationship distributes on both axes, so parent and siblings both
+    # cascade diagonally — the classic orthogonal "staircase" grid
+    parent_child=combine(
+        x={"kind": "distribute", "spacing": 18},
+        y={"kind": "distribute", "spacing": 18},
+    ),
+    sibling=combine(
+        x={"kind": "distribute", "spacing": 18},
+        y={"kind": "distribute", "spacing": 18},
+    ),
+).render(w=640, h=420)
+```
+
+## `tree(data, ...)`
+
+```python
+tree(
+    data,
+    node=None,
+    link=None,
+    parent_child=None,
+    sibling=None,
+    coord=None,
+) -> Tree
+```
+
+Returns a `Tree`, which has `.render(w=800, h=600)` and `.save(path, w=800,
+h=600)` — the same rendering surface as a `Mark`, but standalone: a GoTree
+tree is always a top-level visualization, not a layer you compose into a
+chart.
+
+| Argument       | Type                                                                            | Description                                                                                                                           |
+| -------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `data`         | `dict`                                                                          | A nested tree: `{"name": ..., "value": ..., "children": [...], ...extra}`. `children` is optional (a leaf omits it).                  |
+| `node`         | `Mark` \| `(row) -> Mark`                                                       | Drawn once per tree node. Defaults to `rect(w=12, h=12, fill="#4682b4")`. See [`node`](#node-the-per-node-mark) below.                |
+| `link`         | `"none"` \| `dict` \| `(source, target) -> dict`                                | Edge styling. See [`link`](#link-the-edge-encoding) below.                                                                            |
+| `parent_child` | combiner (`spread()` / `distribute()` / `nest()` / `combine()` / `alternate()`) | How a parent and its children-group are assembled. Defaults to `distribute(dir="y", spacing=32, alignment="middle")`.                 |
+| `sibling`      | combiner                                                                        | How one node's children are assembled into a group. Defaults to `distribute(dir="x", spacing=16, alignment="start")`.                 |
+| `coord`        | a `gofish` coord transform                                                      | `polar()`, `clock()`, `wavy()` — renders the whole tree under that transform, e.g. for a radial layout. Defaults to linear Cartesian. |
+
+### `node` — the per-node mark
+
+`node` is either a plain GoFish mark (used as a template for every node) or a
+callable `(row) -> Mark` for styling that depends on the node's position in
+the hierarchy rather than a data field on it — for example, color keyed off
+depth.
+
+Each `row` is the node's flattened data fields (`name`, and any other keys you
+put in `data`) plus three synthesized fields: `depth` (root is `0`), `height`
+(distance to the furthest leaf below), and `width` (the leaf count below).
+`value` is included only when the hierarchy defines it (i.e., when some node
+in the data carries a `"value"` key).
+
+```python
+def node(d):
+    return circle(r=4 + d["height"] * 2, fill=by_depth(d["depth"]))
+```
+
+### `link` — the edge encoding
+
+- `"none"` — omit all edges (nested-box, icicle, and treemap variants have no
+  edges).
+- A dict of link options — applied uniformly to every edge:
+
+  ```python
+  link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 1.5}
+  ```
+
+  `curve` accepts `"straight"` (default), `"bezier"`, `"orthogonal"`
+  (right-angle elbows), and `"arc"`. `stroke_width` is the one gotree option
+  that isn't already a single word in JS (`strokeWidth`); every other key
+  (`curve`, `stroke`, `opacity`) is spelled the same in both languages.
+
+- A callable `(source, target) -> dict` for per-edge styling, where `source`
+  and `target` are the two nodes' rows (same shape as `node`'s `row`):
+
+  ```python
+  def link(source, target):
+      return {"stroke_width": 1 + source["value"] / 4}
+
+
+  tree(data, link=link)
+  ```
+
+### `parent_child` and `sibling` — the layout combiners
+
+Every combiner builder returns a plain options dict that `tree()` consumes;
+you never call a combiner yourself. The five builders:
+
+#### `spread(*, dir, spacing=None, alignment=None, anchor=None)`
+
+Distributes children along `dir` (`"x"` or `"y"`). `anchor` is `"edge"`
+(default — sums bounding-box extents) or a fixed-pitch point (`"start"` /
+`"middle"` / `"end"` / `"baseline"`); use `"middle"` under `coord=polar()`.
+
+```python
+parent_child=spread(dir="y", spacing=48, alignment="middle"),
+sibling=spread(dir="x", spacing=24, alignment="start"),
+```
+
+#### `distribute(*, dir, spacing=None, anchor=None, order=None, alignment=None)`
+
+Like `spread`, but built on GoFish's lower-level `distribute` constraint
+(pairing an `align` on the orthogonal axis via `alignment`).
+
+#### `nest(*, x=None, y=None)`
+
+Wraps `[outer, inner]` so a parent box grows to contain its children, padded
+by `x` / `y` on each constrained axis. At least one of `x` / `y` is required.
+
+```python
+parent_child=nest(x=10, y=10),  # box-in-box (nested-box tree)
+```
+
+#### `combine(*, x=None, y=None)`
+
+The general per-axis primitive: one choice — `"align"`, `"distribute"`, or
+`"nest"` — per axis, independently. `spread`/`distribute`/`nest` above are
+shorthands for common shapes; `combine` is GoTree's own `Layout(x, y)` model.
+Each axis takes a bare string or the object form with knobs:
+
+```python
+parent_child=combine(
+    x="nest",                                    # outer wraps inner on x
+    y={"kind": "distribute", "spacing": 40},      # parent/group stacked on y
+),
+sibling=combine(x="distribute", y="align"),
+```
+
+`"nest"` is only valid for `parent_child` (a 2-child relationship) — a sibling
+group of arbitrary size may only `"align"` or `"distribute"`.
+
+#### `alternate(combiners)`
+
+A depth-indexed combiner: cycles through `combiners` by `depth % len(combiners)`.
+Used where a layout's template changes by level — an H-tree that swaps its
+spread axis every level, or a slice-and-dice treemap that alternates dicing
+and slicing:
+
+::: gofish example:gotree-treemap hidden
+:::
+
+```python
+from gofish import rect
+from gofish.gotree import alternate, combine, tree
+
+# every parent box wraps its subtree on both axes; only the sibling
+# subdivision alternates slice <-> dice level by level
+dice = combine(x={"kind": "distribute", "spacing": 9}, y={"kind": "align", "alignment": "middle"})
+slice_ = combine(x={"kind": "align", "alignment": "middle"}, y={"kind": "distribute", "spacing": 9})
+
+
+def node(d):
+    if d["height"] == 0:
+        return rect(w=92, h=14 * d["value"], fill=by_depth(d["depth"]))
+    return rect(fill=by_depth(d["depth"]), stroke="#08306b", strokeWidth=1)
+
+
+tree(
+    sample_tree,
+    node=node,
+    link="none",
+    parent_child=combine(x="nest", y="nest"),
+    sibling=alternate([dice, slice_]),
+).render(w=640, h=420)
+```
+
+::: tip Not exposed: `per_depth`
+The JS API also has `perDepth(fn)`, the general form of `alternate` that takes
+a raw `depth -> Combiner` function. It is deliberately not exposed in Python:
+a raw function can't cross the wire as JSON, and `alternate` already covers
+every real gallery use (H-tree axis swap, slice-and-dice treemap levels). If
+you find a layout that genuinely needs per-depth branching `alternate` can't
+express, open an issue rather than reaching for a workaround.
+:::
+
+### `coord` — coordinate transform
+
+Pass any `gofish` coord transform (e.g. `polar()`) to render the whole tree
+radially:
+
+```python
+from gofish import polar
+
+tree(data, coord=polar(), ...)
+```
+
+Under `coord=polar()`, nodes render as points — only their center sweeps
+through the transform, not their bounding box — so set `anchor="middle"` on
+`sibling` (and typically `parent_child` too). See the
+[JavaScript GoTree guide](/js/gotree#coord-—-coordinate-transform) for the full
+polar authoring rules, including the 2π content budget; they apply identically
+in Python since both languages serialize to the same IR.
+
+## See also
+
+- [JavaScript GoTree guide](/js/gotree) — the same grammar, in more depth,
+  including the GoTree paper translation table and the polar 2π budget.
+- [Examples](/python/examples/) — filter by "GoTree" for every ported gallery
+  example.

--- a/packages/gofish-gotree/src/index.ts
+++ b/packages/gofish-gotree/src/index.ts
@@ -26,3 +26,7 @@ export type {
   Alignment,
   TreeData,
 } from "./spec";
+// Python-bridge reconstruction (issue #792) — injected into gofish-graphics'
+// deserializer as a `markBridges["gotree-tree"]` entry; see serialize.ts.
+export { reconstructGotreeTree } from "./serialize";
+export type { GotreeReconstructCtx } from "./serialize";

--- a/packages/gofish-gotree/src/links.ts
+++ b/packages/gofish-gotree/src/links.ts
@@ -31,12 +31,19 @@ const CURVE_FOR: Record<NonNullable<LinkOptions["curve"]>, () => Curve> = {
 function resolveLinkOptions(
   link: LinkSpec | undefined,
   sourceNode: HierarchyNode<any>,
-  targetNode: HierarchyNode<any>
+  targetNode: HierarchyNode<any>,
+  sourcePath: string,
+  targetPath: string
 ): LinkOptions | null {
   if (link === "none") return null;
   if (!link) return {};
   if (typeof link === "function") {
-    return link(toDatum(sourceNode), toDatum(targetNode));
+    return link(
+      toDatum(sourceNode),
+      toDatum(targetNode),
+      sourcePath,
+      targetPath
+    );
   }
   return link;
 }
@@ -88,10 +95,18 @@ export function collectEdges(
     // The parent↔child combiner (and thus the growth axis) is resolved at the
     // parent's depth — matching how `renderSubtree` assembles that level.
     const growthDir = growthDirAtDepth(spec, node.depth);
+    const sourcePath = nodePath(node);
     for (const child of node.children) {
-      const opts = resolveLinkOptions(link, node, child);
+      const targetPath = nodePath(child);
+      const opts = resolveLinkOptions(
+        link,
+        node,
+        child,
+        sourcePath,
+        targetPath
+      );
       if (opts === null) continue;
-      edges.push(linkMark(opts, nodePath(node), nodePath(child), growthDir));
+      edges.push(linkMark(opts, sourcePath, targetPath, growthDir));
     }
   });
   return edges;

--- a/packages/gofish-gotree/src/recursion.ts
+++ b/packages/gofish-gotree/src/recursion.ts
@@ -46,7 +46,7 @@ const nameMark = (mark: any, pathName: string) => {
 export function renderSubtree(node: HierarchyNode<any>, spec: GoTreeSpec): any {
   const datum = toDatum(node);
   const pathName = nodePath(node);
-  const nodeMark = nameMark(spec.node!(datum), pathName);
+  const nodeMark = nameMark(spec.node!(datum, pathName), pathName);
 
   if (!node.children?.length) return nodeMark;
 

--- a/packages/gofish-gotree/src/serialize.ts
+++ b/packages/gofish-gotree/src/serialize.ts
@@ -60,19 +60,26 @@ function isLambdaSentinel(v: any): v is { __gofish_lambda: string } {
  * order below (`rest` first, then the HierarchyDatum fields) is what
  * enforces that collision rule. Both the Python emitter and this
  * reconstructor must agree on it.
+ *
+ * Exception: `datum.value` is only populated when the hierarchy was built
+ * with d3's `.sum()`/`.count()`, which gotree's own `normalize()` never
+ * calls — so an unconditional `value: datum.value` would stomp a raw data
+ * field named `value` (the field most gallery specs actually read) with
+ * `undefined`. The synthesized key therefore only overrides when it exists.
  */
 function buildRow(datum: HierarchyDatum): Record<string, any> {
   const { children: _children, ...rest } = (datum.data ?? {}) as Record<
     string,
     any
   >;
-  return {
+  const row: Record<string, any> = {
     ...rest,
     depth: datum.depth,
     height: datum.height,
     width: datum.width,
-    value: datum.value,
   };
+  if (datum.value !== undefined) row.value = datum.value;
+  return row;
 }
 
 /**

--- a/packages/gofish-gotree/src/serialize.ts
+++ b/packages/gofish-gotree/src/serialize.ts
@@ -1,0 +1,299 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Frontend IR — /internals/frontend/serialization
+// </gofish-wiki>
+
+/**
+ * Python-bridge reconstruction for the `gotree-tree` frontend-IR mark
+ * (issue #792). Python builds a `GoTreeSpec` shape and serializes it as a
+ * `{type: "gotree-tree", ...}` `MarkIR` node (see `gofish-ir`'s
+ * `GotreeTreeIR`); this module turns that IR back into a live gofish-gotree
+ * `Mark` by rebuilding the combiners and calling the real `tree()`.
+ *
+ * This logic lives HERE (not in gofish-graphics) because gofish-graphics
+ * must not depend on gofish-gotree — that would be a workspace cycle
+ * (gofish-gotree already depends on gofish-graphics). The deserializer
+ * instead INJECTS this function via an optional `markBridges` map, keyed by
+ * IR type tag, exactly like the existing `DeriveBridge` precedent in
+ * gofish-graphics' `serialize/registry.ts`.
+ */
+import type { HierarchyNode } from "d3-hierarchy";
+import { Serialize, type Mark } from "gofish-graphics";
+import type {
+  Combiner,
+  CombinerSpec,
+  GoTreeSpec,
+  HierarchyDatum,
+  LinkOptions,
+  LinkSpec,
+  NodeFactory,
+} from "./spec";
+import { normalize, nodePath, toDatum } from "./data";
+import { spread, distribute, nest, combine, alternate } from "./helpers";
+import { tree, DEFAULT_NODE } from "./tree";
+
+/**
+ * The bridge the deserializer supplies. `mapMark` turns a (possibly
+ * already-resolved) mark IR into a live `Mark` — the caller's own
+ * `Serialize.mapMark` bound to its bridge/token-resolver. `applyLambda`
+ * calls a single Python-registered lambda by id with positional args and
+ * returns its single resolved result (already unwrapped) — a narrower
+ * contract than gofish-graphics' `DeriveBridge.applyLambda` (which is
+ * rows-in/rows-out over an Arrow transport); the caller adapts between the
+ * two so this package stays transport-agnostic.
+ */
+export interface GotreeReconstructCtx {
+  mapMark: (markIR: any) => Promise<Mark<any>> | Mark<any>;
+  applyLambda?: (id: string, args: any[]) => Promise<any>;
+}
+
+function isLambdaSentinel(v: any): v is { __gofish_lambda: string } {
+  return (
+    v !== null && typeof v === "object" && typeof v.__gofish_lambda === "string"
+  );
+}
+
+/**
+ * Row for field/lambda resolution at one hierarchy node:
+ * `{ ...d.data (children key omitted), depth, height, width, value }`.
+ * `depth`/`height`/`width`/`value` come from gotree's `HierarchyDatum` and
+ * OVERRIDE same-named fields already on the raw tree data — the spread
+ * order below (`rest` first, then the HierarchyDatum fields) is what
+ * enforces that collision rule. Both the Python emitter and this
+ * reconstructor must agree on it.
+ */
+function buildRow(datum: HierarchyDatum): Record<string, any> {
+  const { children: _children, ...rest } = (datum.data ?? {}) as Record<
+    string,
+    any
+  >;
+  return {
+    ...rest,
+    depth: datum.depth,
+    height: datum.height,
+    width: datum.width,
+    value: datum.value,
+  };
+}
+
+/**
+ * Deep-walk a node-template `MarkIR`, resolving each channel value against
+ * `row`: a `FieldAccessor` becomes a bare `row[name]` lookup (the sort/
+ * aggregate `ops` a `FieldAccessor` may carry in other IR positions don't
+ * apply to a single already-materialized row), a `{__gofish_lambda}`
+ * sentinel issues one RPC for this node, a `DatumValue` passes through
+ * untouched (its scale mapping happens later, during layout), and every
+ * other value (plain objects/arrays/literals, including the mark's own
+ * `type` discriminator) recurses or passes through unchanged.
+ */
+async function resolveTemplateValue(
+  value: any,
+  row: Record<string, any>,
+  ctx: GotreeReconstructCtx
+): Promise<any> {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) {
+    return Promise.all(value.map((v) => resolveTemplateValue(v, row, ctx)));
+  }
+  if (isLambdaSentinel(value)) {
+    if (!ctx.applyLambda) {
+      throw new Error(
+        "gotree-tree IR: node template has a lambda-backed channel but no applyLambda was supplied on the reconstruction ctx"
+      );
+    }
+    return ctx.applyLambda(value.__gofish_lambda, [row]);
+  }
+  if (value.type === "field" && typeof value.name === "string") {
+    return row[value.name];
+  }
+  if (value.type === "datum") {
+    return value;
+  }
+  const out: Record<string, any> = {};
+  for (const [k, v] of Object.entries(value)) {
+    out[k] = await resolveTemplateValue(v, row, ctx);
+  }
+  return out;
+}
+
+/**
+ * Build the Mark for one hierarchy node from the wire's `node` template
+ * (undefined → gotree's `DEFAULT_NODE`; `{type:"mark-fn"}` → the
+ * whole-factory RPC fallback; otherwise the per-channel template walk).
+ */
+async function buildNodeMark(
+  nodeIR: any,
+  datum: HierarchyDatum,
+  ctx: GotreeReconstructCtx
+): Promise<Mark<any>> {
+  if (nodeIR === undefined) {
+    return DEFAULT_NODE(datum);
+  }
+  const row = buildRow(datum);
+  if (nodeIR.type === "mark-fn") {
+    if (!ctx.applyLambda) {
+      throw new Error(
+        "gotree-tree IR: node is a mark-fn lambda but no applyLambda was supplied on the reconstruction ctx"
+      );
+    }
+    const resultIR = await ctx.applyLambda(nodeIR.lambdaId, [row]);
+    return ctx.mapMark(resultIR);
+  }
+  const resolved = await resolveTemplateValue(nodeIR, row, ctx);
+  return ctx.mapMark(resolved);
+}
+
+/** Rebuild a `GotreeCombinerIR` into a real `CombinerSpec` by calling the
+ *  real helpers (`spread`/`distribute`/`nest`/`combine`/`alternate`) —
+ *  never reimplemented here, so the layout semantics stay in ONE place. */
+function rebuildCombiner(ir: any): CombinerSpec {
+  switch (ir.kind) {
+    case "spread":
+      return spread(ir.options);
+    case "distribute":
+      return distribute(ir.options);
+    case "nest":
+      return nest(ir.options);
+    case "combine":
+      return combine(ir.options);
+    case "alternate": {
+      const combiners = (ir.combiners as any[]).map((c) => {
+        const rebuilt = rebuildCombiner(c);
+        if (typeof rebuilt !== "function") {
+          // gotree's own alternate(combiners: Combiner[]) only accepts
+          // concrete Combiners — a depth-indexed combiner (alternate/
+          // perDepth) nested inside another alternate isn't a meaningful
+          // shape (CombinerSpec = Combiner | DepthCombiner, and alternate
+          // IS the DepthCombiner), so the wire IR never emits it.
+          throw new Error(
+            "gotree-tree IR: alternate() combiners must themselves resolve to concrete combiners, not nested alternate/perDepth"
+          );
+        }
+        return rebuilt as Combiner;
+      });
+      return alternate(combiners);
+    }
+    default:
+      throw new Error(
+        `gotree-tree IR: unknown combiner kind ${JSON.stringify((ir as any).kind)}`
+      );
+  }
+}
+
+/**
+ * Pre-resolve a lambda-backed `link` into a synchronous lookup function,
+ * keyed by `(sourcePath, targetPath)`. gotree's `collectEdges` (src/links.ts)
+ * walks the hierarchy and calls the link function SYNCHRONOUSLY — an RPC
+ * can't run inside that walk — so every edge's link options are awaited
+ * here, before `tree()` runs, over the exact same hierarchy walk order
+ * `collectEdges` uses (root.each, then each node's children in order).
+ */
+async function buildLinkFn(
+  lambdaId: string,
+  root: HierarchyNode<any>,
+  ctx: GotreeReconstructCtx
+): Promise<LinkSpec> {
+  if (!ctx.applyLambda) {
+    throw new Error(
+      "gotree-tree IR: link is a lambda but no applyLambda was supplied on the reconstruction ctx"
+    );
+  }
+  const applyLambda = ctx.applyLambda;
+  const edgeKeys: { sourcePath: string; targetPath: string }[] = [];
+  const pending: Promise<[string, LinkOptions]>[] = [];
+  root.each((node: HierarchyNode<any>) => {
+    if (!node.children) return;
+    const sourcePath = nodePath(node);
+    const srcRow = buildRow(toDatum(node));
+    for (const child of node.children) {
+      const targetPath = nodePath(child);
+      const tgtRow = buildRow(toDatum(child));
+      const key = `${sourcePath}->${targetPath}`;
+      edgeKeys.push({ sourcePath, targetPath });
+      pending.push(
+        applyLambda(lambdaId, [srcRow, tgtRow]).then((opts) => [
+          key,
+          opts as LinkOptions,
+        ])
+      );
+    }
+  });
+  const resolved = await Promise.all(pending);
+  const edgeMap = new Map<string, LinkOptions>(resolved);
+  return (
+    _source: HierarchyDatum,
+    _target: HierarchyDatum,
+    sourcePath?: string,
+    targetPath?: string
+  ): LinkOptions => {
+    const key = `${sourcePath}->${targetPath}`;
+    const opts = edgeMap.get(key);
+    if (!opts) {
+      // Should not happen: this walk visits the exact same edges
+      // collectEdges will, over the same (shared) hierarchy object.
+      throw new Error(
+        `gotree-tree IR: no pre-computed link options for edge ${key}`
+      );
+    }
+    return opts;
+  };
+}
+
+/**
+ * Reconstruct a `gotree-tree` wire-IR node into a live gofish-gotree `Mark`.
+ * Registered by consumers (the Python widget, the parity harness) under
+ * `markBridges["gotree-tree"]` on gofish-graphics' deserializer.
+ */
+export async function reconstructGotreeTree(
+  ir: any,
+  ctx: GotreeReconstructCtx
+): Promise<Mark<any>> {
+  // `normalize` is idempotent on an already-built HierarchyNode, so passing
+  // this same `root` to `tree()` below (rather than the raw `ir.data`)
+  // guarantees the pre-expansion walk here and tree()'s internal walk see
+  // the exact same node/child structure — required for `nodePath` to line
+  // up between the two passes.
+  const root = normalize(ir.data);
+
+  // Pre-expand every node's Mark (see buildNodeMark's doc comment on the
+  // sync-vs-async split: tree()'s node factory is called synchronously from
+  // renderSubtree, but resolving a lambda-backed channel is an RPC).
+  const nodeEntries: { path: string; datum: HierarchyDatum }[] = [];
+  root.each((node: HierarchyNode<any>) => {
+    nodeEntries.push({ path: nodePath(node), datum: toDatum(node) });
+  });
+  const nodeMarks = new Map<string, Mark<any>>();
+  await Promise.all(
+    nodeEntries.map(async ({ path, datum }) => {
+      nodeMarks.set(path, await buildNodeMark(ir.node, datum, ctx));
+    })
+  );
+  const nodeFactory: NodeFactory = (_datum, path) => {
+    const mark = nodeMarks.get(path!);
+    if (!mark) {
+      throw new Error(
+        `gotree-tree IR: no pre-built mark for node path ${path}`
+      );
+    }
+    return mark;
+  };
+
+  const link: LinkSpec | undefined =
+    ir.link === undefined || ir.link === "none" || !isLambdaSentinel(ir.link)
+      ? ir.link
+      : await buildLinkFn(ir.link.__gofish_lambda, root, ctx);
+
+  const spec: GoTreeSpec = {
+    node: nodeFactory,
+    link,
+    parentChild: ir.parentChild ? rebuildCombiner(ir.parentChild) : undefined,
+    sibling: ir.sibling ? rebuildCombiner(ir.sibling) : undefined,
+    // Reuses gofish-graphics' existing coord deserialization (polar/clock/
+    // wavy) via the same `resolveOptions` the chart/combinator `options.coord`
+    // path uses — no separate coord-mapping contract needed on `ctx`.
+    coord: ir.coord
+      ? Serialize.resolveOptions({ coord: ir.coord }).coord
+      : undefined,
+  };
+
+  return tree(spec, root as any) as Mark<any>;
+}

--- a/packages/gofish-gotree/src/spec.ts
+++ b/packages/gofish-gotree/src/spec.ts
@@ -1,3 +1,7 @@
+// <gofish-wiki> AUTO-GENERATED — see covers: in the essay; run `pnpm --filter docs sync-backlinks`
+// @wiki Frontend IR — /internals/frontend/serialization
+// </gofish-wiki>
+
 import type { Mark } from "gofish-graphics";
 import type { HierarchyNode } from "d3-hierarchy";
 
@@ -40,7 +44,16 @@ export type HierarchyDatum = {
   width: number;
 };
 
-export type NodeFactory = (datum: HierarchyDatum) => Mark<any>;
+/**
+ * `path` is the node's stable position key (`nodePath` in data.ts — index
+ * chain from the root, e.g. `"root/0/1"`). It's an optional 2nd argument so
+ * existing single-arg factories are unaffected; the Python-bridge
+ * reconstruction (`gofish-gotree/src/serialize.ts`) needs it to key its
+ * pre-expanded per-node Mark map (RPC-backed node templates must resolve
+ * their lambdas before `tree()` runs, since this factory is called
+ * synchronously from `renderSubtree`).
+ */
+export type NodeFactory = (datum: HierarchyDatum, path?: string) => Mark<any>;
 
 export type LinkOptions = {
   // Screen-space path shape for the link (GoTree's `Link` element). Maps to a
@@ -52,10 +65,22 @@ export type LinkOptions = {
   opacity?: number;
 };
 
+/**
+ * `sourcePath`/`targetPath` are the endpoints' stable position keys
+ * (`nodePath`) — optional trailing arguments for the same reason as
+ * `NodeFactory`'s `path`: the Python-bridge reconstruction pre-resolves
+ * lambda-backed link options per edge (keyed by these paths) before
+ * `tree()`'s synchronous `collectEdges` walk runs.
+ */
 export type LinkSpec =
   | "none"
   | LinkOptions
-  | ((source: HierarchyDatum, target: HierarchyDatum) => LinkOptions);
+  | ((
+      source: HierarchyDatum,
+      target: HierarchyDatum,
+      sourcePath?: string,
+      targetPath?: string
+    ) => LinkOptions);
 
 export type GoTreeSpec = {
   node?: NodeFactory;

--- a/packages/gofish-gotree/src/tree.tsx
+++ b/packages/gofish-gotree/src/tree.tsx
@@ -8,7 +8,10 @@ import { normalize } from "./data";
 import { renderSubtree } from "./recursion";
 import { collectEdges } from "./links";
 
-const DEFAULT_NODE: NodeFactory = () => rect({ w: 12, h: 12, fill: "#4682b4" });
+// Exported so the Python-bridge reconstruction (serialize.ts) can fall back
+// to the same default when the wire IR omits `node`.
+export const DEFAULT_NODE: NodeFactory = () =>
+  rect({ w: 12, h: 12, fill: "#4682b4" });
 
 export function tree(spec: GoTreeSpec, data: TreeData): any {
   const root = normalize(data);

--- a/packages/gofish-graphics/src/serialize/fromJSON.ts
+++ b/packages/gofish-graphics/src/serialize/fromJSON.ts
@@ -33,6 +33,7 @@ import {
   type ChartBuilder,
   type DeriveBridge,
   type Mark,
+  type MarkBridges,
   type Operator,
 } from "./registry";
 
@@ -312,12 +313,19 @@ export function mapMarkChildren(
   specs: MarkSpec[],
   bridge: DeriveBridge | undefined,
   resolveToken: TokenResolver,
-  inputRefs?: any[]
+  inputRefs?: any[],
+  markBridges?: MarkBridges
 ): any[] {
   const out: any[] = [];
   for (const child of specs as any[]) {
     if (child && child.type === "cut") {
-      const sourceMark = mapMark(child.source, bridge, resolveToken, inputRefs);
+      const sourceMark = mapMark(
+        child.source,
+        bridge,
+        resolveToken,
+        inputRefs,
+        markBridges
+      );
       // Pure cut requires an array `size`; the field-name-string sugar is only
       // valid in the chart `.mark(cut(...))` (data-bound expand) form.
       const slices = cutSlices(sourceMark as any, {
@@ -327,7 +335,9 @@ export function mapMarkChildren(
       });
       out.push(...slices);
     } else {
-      out.push(mapMark(child as MarkSpec, bridge, resolveToken, inputRefs));
+      out.push(
+        mapMark(child as MarkSpec, bridge, resolveToken, inputRefs, markBridges)
+      );
     }
   }
   return out;
@@ -368,7 +378,8 @@ export function mapMark(
   markSpec: MarkSpec,
   bridge: DeriveBridge | undefined,
   resolveToken: TokenResolver,
-  inputRefs?: any[]
+  inputRefs?: any[],
+  markBridges?: MarkBridges
 ): Mark<any> {
   const spec = markSpec as any;
   const applyTranslate = <T>(mark: T): T =>
@@ -396,6 +407,35 @@ export function mapMark(
       (inputRef as any).name(resolveNameField(spec.name, resolveToken));
     }
     return inputRef;
+  }
+
+  // Injected reconstruction (e.g. gotree-tree, #792): a mark IR type this
+  // package doesn't itself know how to build. The factory is async (it may
+  // RPC through the bridge before it can return a Mark), so — like the
+  // mark-fn branch just below — defer resolution into an async Mark
+  // wrapper; `resolveMarkResult` (chartBuilder.ts) awaits/recurses through
+  // whatever comes back regardless of sync/async.
+  const inject = markBridges?.[spec.type];
+  if (inject) {
+    const nameVal = resolveNameField(spec.name, resolveToken);
+    return (async (data: any, key: any, layerContext: any) => {
+      let innerMark: any = await inject(spec);
+      if (spec.translate && typeof innerMark?.translate === "function") {
+        innerMark = innerMark.translate(spec.translate);
+      }
+      if (nameVal != null && typeof innerMark?.name === "function") {
+        innerMark = innerMark.name(nameVal);
+      }
+      if (
+        typeof spec.zOrder === "number" &&
+        typeof innerMark?.zOrder === "function"
+      ) {
+        innerMark = innerMark.zOrder(spec.zOrder);
+      }
+      return typeof innerMark === "function"
+        ? innerMark(data, key, layerContext)
+        : innerMark;
+    }) as unknown as Mark<any>;
   }
 
   // Mark-as-function: Python registered a `(data) -> ChartBuilder | Mark`
@@ -438,14 +478,15 @@ export function mapMark(
           (resultSpec as any).mark as MarkSpec,
           bridge,
           resolveToken,
-          newInputRefs
+          newInputRefs,
+          markBridges
         );
       }
       const cs = resultSpec as ChartSpec;
       const data2 = Array.isArray((cs as any).data)
         ? ((cs as any).data as Record<string, any>[])
         : [];
-      return buildChart(cs, data2, bridge, resolveToken);
+      return buildChart(cs, data2, bridge, resolveToken, markBridges);
     }) as unknown as Mark<any>;
   }
 
@@ -470,7 +511,8 @@ export function mapMark(
       childSpecs,
       bridge,
       resolveToken,
-      inputRefs
+      inputRefs,
+      markBridges
     );
     return applyTranslate(
       offsetOp({ x: spec.x, y: spec.y }, [
@@ -489,7 +531,8 @@ export function mapMark(
       spec.source as MarkSpec,
       bridge,
       resolveToken,
-      inputRefs
+      inputRefs,
+      markBridges
     );
     let mark = cutMark({
       source: sourceMark as any,
@@ -518,7 +561,8 @@ export function mapMark(
       (spec.children ?? []) as MarkSpec[],
       bridge,
       resolveToken,
-      inputRefs
+      inputRefs,
+      markBridges
     );
     // Resolve color/coord configs (e.g. a `layer({coord: polar()})` carries
     // its coord transform in the combinator options, not chart options).
@@ -627,7 +671,8 @@ export function buildChart(
   chartSpec: ChartSpec,
   data: Record<string, any>[],
   bridge: DeriveBridge | undefined,
-  resolveToken: TokenResolver
+  resolveToken: TokenResolver,
+  markBridges?: MarkBridges
 ): ChartBuilder<any> {
   const operators: Operator<any, any>[] = [];
   for (const opSpec of (chartSpec.operators ?? []) as OperatorSpec[]) {
@@ -635,7 +680,7 @@ export function buildChart(
     if (op) operators.push(op);
   }
   const markSpec = (chartSpec.mark ?? { type: "rect" }) as MarkSpec;
-  const mark = mapMark(markSpec, bridge, resolveToken);
+  const mark = mapMark(markSpec, bridge, resolveToken, undefined, markBridges);
   const resolvedOptions = resolveOptions(
     ((chartSpec as any).options ?? {}) as Record<string, any>
   );

--- a/packages/gofish-graphics/src/serialize/index.ts
+++ b/packages/gofish-graphics/src/serialize/index.ts
@@ -11,6 +11,7 @@ export {
   MARK_MAP,
   OPERATOR_MAP,
   type DeriveBridge,
+  type MarkBridges,
 } from "./registry";
 
 export {

--- a/packages/gofish-graphics/src/serialize/registry.ts
+++ b/packages/gofish-graphics/src/serialize/registry.ts
@@ -93,6 +93,22 @@ export interface DeriveBridge {
 }
 
 /**
+ * Injected reconstruction for a mark-IR `type` that gofish-graphics doesn't
+ * itself know how to build — e.g. `"gotree-tree"` (issue #792), whose
+ * reconstruction logic lives in `gofish-gotree` and can't be statically
+ * imported here (gofish-graphics must not depend on gofish-gotree — that
+ * would be a workspace cycle, since gofish-gotree already depends on
+ * gofish-graphics). Consulted by `mapMark` BEFORE the `MARK_MAP` lookup,
+ * alongside the existing `mark-fn` special case. Keyed by the mark IR's
+ * `type` discriminator; the factory receives the raw mark spec and returns
+ * (a promise of) a live `Mark`.
+ */
+export type MarkBridges = Record<
+  string,
+  (spec: Record<string, any>) => Promise<Mark<any>> | Mark<any>
+>;
+
+/**
  * Combinator-form factories: operator-like factories that, when called with
  * marks as the second argument, return a combined mark. Keyed by the
  * lowercase `type` discriminator.

--- a/packages/gofish-ir/src/frontend/jsonSchema.ts
+++ b/packages/gofish-ir/src/frontend/jsonSchema.ts
@@ -456,6 +456,71 @@ export const FRONTEND_IR_JSON_SCHEMA = {
         { $ref: "#/$defs/RefMarkIR" },
         { $ref: "#/$defs/OffsetMarkIR" },
         { $ref: "#/$defs/CutMarkIR" },
+        { $ref: "#/$defs/GotreeTreeIR" },
+      ],
+    },
+    GotreeTreeIR: {
+      description:
+        "gotree-tree (issue #792): a serialized gotree hierarchy visualization. Reconstructed via an injected markBridges entry (gofish-graphics never statically imports gofish-gotree). Row shape for field/lambda resolution at each hierarchy node: {...d.data (children key omitted), depth, height, width, value} — depth/height/width/value come from gotree's HierarchyDatum and OVERRIDE same-named data fields.",
+      type: "object",
+      required: ["type", "data"],
+      properties: {
+        type: { const: "gotree-tree" },
+        data: { type: "object" },
+        node: { $ref: "#/$defs/MarkIR" },
+        link: { $ref: "#/$defs/GotreeLinkSpec" },
+        parentChild: { $ref: "#/$defs/GotreeCombinerIR" },
+        sibling: { $ref: "#/$defs/GotreeCombinerIR" },
+        coord: { type: "object" },
+        origin: { $ref: "#/$defs/Origin" },
+        meta: { $ref: "#/$defs/Meta" },
+      },
+    },
+    GotreeLinkOptionsIR: {
+      type: "object",
+      properties: {
+        curve: { enum: ["straight", "bezier", "orthogonal", "arc"] },
+        stroke: { type: "string" },
+        strokeWidth: { type: "number" },
+        opacity: { type: "number" },
+      },
+    },
+    GotreeLinkSpec: {
+      description:
+        '"none", a link-options object, or a {__gofish_lambda} sentinel — the lambda receives (srcRow, tgtRow) and returns a link-options dict, resolved eagerly at deserialize time.',
+      oneOf: [
+        { const: "none" },
+        { $ref: "#/$defs/GotreeLinkOptionsIR" },
+        {
+          type: "object",
+          required: ["__gofish_lambda"],
+          properties: { __gofish_lambda: { type: "string" } },
+        },
+      ],
+    },
+    GotreeCombinerIR: {
+      description:
+        "Mirrors gofish-gotree's SpreadOptions/DistributeOptions/NestOptions/CombineOptions (helpers.ts) and its depth-indexed alternate(...). `options` bags are unvalidated here (the real helpers own their own opts), like other combinator options elsewhere in this schema.",
+      oneOf: [
+        {
+          type: "object",
+          required: ["kind", "options"],
+          properties: {
+            kind: { enum: ["spread", "distribute", "nest", "combine"] },
+            options: { type: "object" },
+          },
+        },
+        {
+          type: "object",
+          required: ["kind", "combiners"],
+          properties: {
+            kind: { const: "alternate" },
+            combiners: {
+              type: "array",
+              items: { $ref: "#/$defs/GotreeCombinerIR" },
+            },
+          },
+        },
       ],
     },
     OffsetMarkIR: {

--- a/packages/gofish-ir/src/frontend/schema.ts
+++ b/packages/gofish-ir/src/frontend/schema.ts
@@ -410,7 +410,8 @@ export type MarkIR =
   | CombinatorMarkIR
   | RefMarkIR
   | OffsetMarkIR
-  | CutMarkIR;
+  | CutMarkIR
+  | GotreeTreeIR;
 
 export type LeafMarkType =
   | "rect"
@@ -533,6 +534,76 @@ export interface CutMarkIR extends BaseIRNode {
   zOrder?: number;
   translate?: TranslateIR;
 }
+
+/**
+ * `gotree-tree` mark (issue #792) — a serialized gotree hierarchy
+ * visualization. Python builds a `GoTreeSpec` and calls gotree's `tree()`;
+ * on the JS side the reconstruction logic lives in `gofish-gotree` (not
+ * here or in gofish-graphics — that dependency would create a workspace
+ * cycle) and is INJECTED into the deserializer as a `markBridges` entry
+ * keyed `"gotree-tree"` (mirrors the existing `DeriveBridge` precedent in
+ * gofish-graphics' `serialize/registry.ts`).
+ *
+ * Row shape for field/lambda resolution at each hierarchy node:
+ * `{ ...d.data (children key omitted), depth, height, width, value }` —
+ * `depth`/`height`/`width`/`value` come from gotree's `HierarchyDatum` and
+ * OVERRIDE same-named fields already present on the raw tree data. Both the
+ * Python emitter and the JS reconstructor must honor this collision rule.
+ */
+export interface GotreeTreeIR extends BaseIRNode {
+  type: "gotree-tree";
+  /** The nested tree data: `{ name?, value?, children?: [...], ...extra }`. */
+  data: Record<string, unknown>;
+  /**
+   * Per-node mark template — channels may be literals, `FieldAccessor`s,
+   * `DatumValue`s, or `{__gofish_lambda}` sentinels, resolved per row at
+   * deserialize time. Omitted → gotree's `DEFAULT_NODE`. The whole-factory
+   * fallback (`{type: "mark-fn", lambdaId}`) is already a `MarkIR` leaf
+   * variant, so no separate union arm is needed for it here.
+   */
+  node?: MarkIR;
+  /**
+   * Per-edge link styling. `"none"` suppresses links; a lambda sentinel
+   * receives `(srcRow, tgtRow)` and returns a `GotreeLinkOptionsIR` dict —
+   * resolved eagerly at deserialize time (gotree's edge-collection callback
+   * is synchronous, so lambda RPCs can't run inside it; see gofish-gotree's
+   * `serialize.ts`).
+   */
+  link?: "none" | GotreeLinkOptionsIR | BridgeLambdaSentinel;
+  /** Combiner for parent ↔ children-group. */
+  parentChild?: GotreeCombinerIR;
+  /** Combiner for the sibling group. */
+  sibling?: GotreeCombinerIR;
+  /** Reuses the existing coord IR shape (e.g. `{type: "polar", ...}`) — see
+   *  `resolveCoordConfig`/`resolveOptions` in gofish-graphics' fromJSON.ts. */
+  coord?: Record<string, unknown>;
+}
+
+/** `GoTreeSpec.link`'s object form — mirrors gofish-gotree's `LinkOptions`
+ *  (`packages/gofish-gotree/src/spec.ts`). */
+export interface GotreeLinkOptionsIR {
+  curve?: "straight" | "bezier" | "orthogonal" | "arc";
+  stroke?: string;
+  strokeWidth?: number;
+  opacity?: number;
+}
+
+/**
+ * A gotree parent-child/sibling combiner. Mirrors gofish-gotree's
+ * `SpreadOptions` / `DistributeOptions` / `NestOptions` / `CombineOptions`
+ * (`packages/gofish-gotree/src/helpers.ts`) and its depth-indexed
+ * `alternate(...)` (depth % length indexing over a fixed combiner list).
+ * `options` stays a loosely-typed bag here — like other combinator
+ * `options` in this schema — rather than re-deriving each helper's full
+ * field set; the real helper functions validate their own opts at
+ * reconstruction time.
+ */
+export type GotreeCombinerIR =
+  | { kind: "spread"; options: Record<string, unknown> }
+  | { kind: "distribute"; options: Record<string, unknown> }
+  | { kind: "nest"; options: Record<string, unknown> }
+  | { kind: "combine"; options: Record<string, unknown> }
+  | { kind: "alternate"; combiners: GotreeCombinerIR[] };
 
 // ---------------------------------------------------------------------------
 // Channel values
@@ -711,12 +782,16 @@ export function isOffsetMarkIR(mark: MarkIR): mark is OffsetMarkIR {
 export function isCutMarkIR(mark: MarkIR): mark is CutMarkIR {
   return mark.type === "cut";
 }
+export function isGotreeTreeIR(mark: MarkIR): mark is GotreeTreeIR {
+  return mark.type === "gotree-tree";
+}
 export function isLeafMarkIR(mark: MarkIR): mark is LeafMarkIR {
   return (
     !isCombinatorMarkIR(mark) &&
     !isRefMarkIR(mark) &&
     !isOffsetMarkIR(mark) &&
-    !isCutMarkIR(mark)
+    !isCutMarkIR(mark) &&
+    !isGotreeTreeIR(mark)
   );
 }
 

--- a/packages/gofish-ir/src/frontend/validate.ts
+++ b/packages/gofish-ir/src/frontend/validate.ts
@@ -20,6 +20,9 @@ import {
   type CutMarkIR,
   type DataIR,
   type FrontendIRDocument,
+  type GotreeCombinerIR,
+  type GotreeLinkOptionsIR,
+  type GotreeTreeIR,
   type LabelIR,
   type LeafMarkIR,
   type MarkIR,
@@ -817,6 +820,10 @@ function walkMark(node: unknown, path: string, ctx: Context): void {
     walkCutMark(node, path, ctx);
     return;
   }
+  if (t === "gotree-tree") {
+    walkGotreeTreeMark(node, path, ctx);
+    return;
+  }
   if (node.__combinator === true) {
     walkCombinatorMark(node, path, ctx);
     return;
@@ -967,6 +974,132 @@ function walkCutMark(
         "name",
         "zOrder",
         "translate",
+        "origin",
+        "meta",
+      ],
+      path,
+      ctx
+    );
+  }
+}
+
+/** `gotree-tree.link`'s object form — see {@link GotreeLinkOptionsIR}. */
+function walkGotreeLinkOptions(
+  value: Record<string, unknown>,
+  path: string,
+  ctx: Context
+): void {
+  if (
+    value.curve !== undefined &&
+    !["straight", "bezier", "orthogonal", "arc"].includes(value.curve as string)
+  ) {
+    ctx.errors.push({
+      path: `${path}.curve`,
+      message: `link.curve must be one of "straight" | "bezier" | "orthogonal" | "arc", got ${JSON.stringify(value.curve)}`,
+    });
+  }
+  optionalField(value, "stroke", path, ctx, expectString);
+  optionalField(value, "strokeWidth", path, ctx, expectNumber);
+  optionalField(value, "opacity", path, ctx, expectNumber);
+  if (ctx.strict) {
+    rejectUnknown(
+      value,
+      ["curve", "stroke", "strokeWidth", "opacity"],
+      path,
+      ctx
+    );
+  }
+}
+
+/** `gotree-tree.link` — `"none"`, a `GotreeLinkOptionsIR` object, or a
+ *  `{__gofish_lambda}` sentinel (the lambda receives `(srcRow, tgtRow)` and
+ *  returns a link-options dict, resolved eagerly at deserialize time). */
+function walkGotreeLink(value: unknown, path: string, ctx: Context): void {
+  if (value === "none") return;
+  if (!isObject(value)) {
+    ctx.errors.push({
+      path,
+      message: `link must be "none", a link-options object, or a lambda sentinel, got ${typeNameOf(value)}`,
+    });
+    return;
+  }
+  if ("__gofish_lambda" in value) {
+    if (typeof value.__gofish_lambda !== "string") {
+      ctx.errors.push({
+        path: `${path}.__gofish_lambda`,
+        message: "__gofish_lambda must be a string",
+      });
+    }
+    return;
+  }
+  walkGotreeLinkOptions(value, path, ctx);
+}
+
+const GOTREE_COMBINER_KINDS = [
+  "spread",
+  "distribute",
+  "nest",
+  "combine",
+  "alternate",
+] as const;
+
+/** `gotree-tree.parentChild` / `.sibling` — see {@link GotreeCombinerIR}.
+ *  `options` bags are validated only for shape (object), not deeply —
+ *  mirrors how combinator-mark/operator `options` are treated elsewhere in
+ *  this file; the real gofish-gotree helpers own their own opts. */
+function walkGotreeCombiner(value: unknown, path: string, ctx: Context): void {
+  if (!isObject(value)) {
+    ctx.errors.push({ path, message: "expected object" });
+    return;
+  }
+  const kind = value.kind;
+  if (!(GOTREE_COMBINER_KINDS as readonly string[]).includes(kind as string)) {
+    ctx.errors.push({
+      path: `${path}.kind`,
+      message: `gotree combiner "kind" must be one of ${GOTREE_COMBINER_KINDS.join(", ")}, got ${JSON.stringify(kind)}`,
+    });
+    return;
+  }
+  if (kind === "alternate") {
+    expectField(value, "combiners", path, ctx, (v, p) =>
+      walkArray(v, p, ctx, walkGotreeCombiner)
+    );
+    if (ctx.strict) rejectUnknown(value, ["kind", "combiners"], path, ctx);
+    return;
+  }
+  expectField(value, "options", path, ctx, expectObject);
+  if (ctx.strict) rejectUnknown(value, ["kind", "options"], path, ctx);
+}
+
+/**
+ * `gotree-tree` mark (issue #792) — see {@link GotreeTreeIR}. `node` (if
+ * present) recurses through the ordinary `walkMark` — a valid `MarkIR`, or
+ * the `{type:"mark-fn", lambdaId}` whole-factory fallback, which is already
+ * a `LeafMarkIR` variant.
+ */
+function walkGotreeTreeMark(
+  node: Record<string, unknown>,
+  path: string,
+  ctx: Context
+): void {
+  walkBaseFields(node, path, ctx);
+  expectField(node, "data", path, ctx, expectObject);
+  optionalField(node, "node", path, ctx, walkMark);
+  optionalField(node, "link", path, ctx, walkGotreeLink);
+  optionalField(node, "parentChild", path, ctx, walkGotreeCombiner);
+  optionalField(node, "sibling", path, ctx, walkGotreeCombiner);
+  optionalField(node, "coord", path, ctx, expectObject);
+  if (ctx.strict) {
+    rejectUnknown(
+      node,
+      [
+        "type",
+        "data",
+        "node",
+        "link",
+        "parentChild",
+        "sibling",
+        "coord",
         "origin",
         "meta",
       ],
@@ -1388,6 +1521,9 @@ export type {
   CutMarkIR,
   DataIR,
   FrontendIRDocument,
+  GotreeCombinerIR,
+  GotreeLinkOptionsIR,
+  GotreeTreeIR,
   LabelIR,
   LeafMarkIR,
   MarkIR,

--- a/packages/gofish-python/gofish/gotree/__init__.py
+++ b/packages/gofish-python/gofish/gotree/__init__.py
@@ -1,0 +1,442 @@
+"""Python bridge for `gofish-gotree` (issue #792).
+
+`gofish-gotree` (packages/gofish-gotree/src/) implements the GoTree grammar
+(Li et al., CHI 2020) on top of GoFish. This submodule is a pure snake_case
+mirror of its JS API — `tree`, `combine`, `spread`, `distribute`, `nest`,
+`alternate` — that builds the `{"type": "gotree-tree", ...}` mark-level IR
+node the JS harness reconstructs by calling the real `tree(spec, data)`.
+
+Deliberately NOT re-exported from the top-level `gofish` namespace (same
+category as `derive`/`field`/`ref`, which also live outside the generated
+descriptor table) — users write::
+
+    from gofish.gotree import tree, combine, spread, distribute, nest, alternate
+
+or::
+
+    from gofish import gotree
+    gotree.tree(...)
+
+Validation here is intentionally cheap and structural (unknown combiner
+kind, unknown link option, wrong arg count) — the canonical `gofish-ir` JSON
+Schema is the source of truth for the wire shape; see `gotree-tree` there.
+"""
+
+from typing import Any, Callable, Dict, List, Optional, Union
+
+from ..ast import Mark, _MarkFn, _PendingAccessor
+
+__all__ = [
+    "tree",
+    "combine",
+    "spread",
+    "distribute",
+    "nest",
+    "alternate",
+    "Tree",
+]
+
+
+# ---------------------------------------------------------------------------
+# Combiners — each builder returns a plain CombinerIR wire dict directly
+# (no wrapper class needed: the dict *is* the wire shape, matching
+# packages/gofish-gotree/src/helpers.ts's SpreadOptions / DistributeOptions /
+# NestOptions / CombineOptions). None of these fields are camelCase in JS
+# (dir/spacing/alignment/anchor/order/kind/pad are all single words), so no
+# snake_case -> camelCase rename table is needed here (unlike `link`, below).
+# ---------------------------------------------------------------------------
+
+_AXIS_KINDS = {"align", "distribute", "nest"}
+
+
+def spread(
+    *,
+    dir: str,
+    spacing: Optional[float] = None,
+    alignment: Optional[str] = None,
+    anchor: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Combiner: distribute children along `dir` via the `spread` operator.
+
+    Mirrors JS `spread({dir, spacing?, alignment?, anchor?})`
+    (helpers.ts `SpreadOptions`). `anchor` is `"edge"` (default, sums bbox
+    extents) or a fixed-pitch point (`"start"`/`"middle"`/`"end"`/
+    `"baseline"`) — use `"middle"` under a `coord=polar()` tree.
+    """
+    options: Dict[str, Any] = {"dir": dir}
+    if spacing is not None:
+        options["spacing"] = spacing
+    if alignment is not None:
+        options["alignment"] = alignment
+    if anchor is not None:
+        options["anchor"] = anchor
+    return {"kind": "spread", "options": options}
+
+
+def distribute(
+    *,
+    dir: str,
+    spacing: Optional[float] = None,
+    anchor: Optional[str] = None,
+    order: Optional[str] = None,
+    alignment: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Combiner: place children along `dir` via `Constraint.distribute`,
+    optionally pairing a `Constraint.align` on the orthogonal axis.
+
+    Mirrors JS `distribute({dir, spacing?, anchor?, order?, alignment?})`
+    (helpers.ts `DistributeOptions`).
+    """
+    options: Dict[str, Any] = {"dir": dir}
+    if spacing is not None:
+        options["spacing"] = spacing
+    if anchor is not None:
+        options["anchor"] = anchor
+    if order is not None:
+        options["order"] = order
+    if alignment is not None:
+        options["alignment"] = alignment
+    return {"kind": "distribute", "options": options}
+
+
+def nest(*, x: Optional[float] = None, y: Optional[float] = None) -> Dict[str, Any]:
+    """Combiner: wrap `[outer, inner]` via `Constraint.nest({x?, y?}, ...)`.
+
+    Mirrors JS `nest({x?, y?})` (helpers.ts `NestOptions`). At least one of
+    `x` / `y` is required.
+    """
+    if x is None and y is None:
+        raise ValueError("gotree.nest() requires at least one of x, y")
+    options: Dict[str, Any] = {}
+    if x is not None:
+        options["x"] = x
+    if y is not None:
+        options["y"] = y
+    return {"kind": "nest", "options": options}
+
+
+def _normalize_axis(axis: Union[str, dict], axis_name: str) -> dict:
+    if isinstance(axis, str):
+        if axis not in _AXIS_KINDS:
+            raise ValueError(
+                f"gotree.combine(): unknown {axis_name} axis kind {axis!r}; "
+                f"expected one of {sorted(_AXIS_KINDS)}"
+            )
+        return {"kind": axis}
+    if isinstance(axis, dict):
+        kind = axis.get("kind")
+        if kind not in _AXIS_KINDS:
+            raise ValueError(
+                f"gotree.combine(): unknown {axis_name} axis kind {kind!r}; "
+                f"expected one of {sorted(_AXIS_KINDS)}"
+            )
+        return dict(axis)
+    raise TypeError(
+        f"gotree.combine(): {axis_name} must be a string or dict CombineAxis, "
+        f"got {type(axis).__name__}"
+    )
+
+
+def combine(
+    *,
+    x: Optional[Union[str, dict]] = None,
+    y: Optional[Union[str, dict]] = None,
+) -> Dict[str, Any]:
+    """Combiner: the general per-axis primitive — one `"align"` /
+    `"distribute"` / `"nest"` choice per axis (GoTree's `Layout(x, y)`
+    model).
+
+    Each of `x` / `y` accepts the same shorthands as JS `CombineAxis`
+    (helpers.ts:122-135): a bare string (`"align"` / `"distribute"` /
+    `"nest"`) or the object form with knobs (e.g.
+    `{"kind": "distribute", "spacing": 18}`, `{"kind": "nest", "pad": 10}`).
+    `nest` is only valid on a 2-child relationship. At least one of `x` /
+    `y` is required.
+    """
+    if x is None and y is None:
+        raise ValueError("gotree.combine() requires at least one of x, y")
+    options: Dict[str, Any] = {}
+    if x is not None:
+        options["x"] = _normalize_axis(x, "x")
+    if y is not None:
+        options["y"] = _normalize_axis(y, "y")
+    return {"kind": "combine", "options": options}
+
+
+def alternate(combiners: List[dict]) -> Dict[str, Any]:
+    """Depth-indexed combiner: cycles through `combiners` by `depth %
+    len(combiners)`. Mirrors JS `alternate([...])` (helpers.ts).
+
+    `perDepth(fn)` (the raw-function depth-indexed form) is not exposed
+    here — it can't cross the wire as JSON, and `alternate` covers every
+    real gallery use (H-tree axis swap, slice-and-dice treemap levels).
+    """
+    combiners = list(combiners)
+    if not combiners:
+        raise ValueError("gotree.alternate() requires at least one combiner")
+    for c in combiners:
+        if not isinstance(c, dict) or "kind" not in c:
+            raise ValueError(
+                "gotree.alternate(): every entry must be a combiner built "
+                "with spread()/distribute()/nest()/combine(), got "
+                f"{c!r}"
+            )
+    return {"kind": "alternate", "combiners": combiners}
+
+
+_COMBINER_KINDS = {"spread", "distribute", "nest", "combine", "alternate"}
+
+
+def _validate_combiner(value: Optional[dict], argname: str) -> Optional[dict]:
+    if value is None:
+        return None
+    if not isinstance(value, dict) or value.get("kind") not in _COMBINER_KINDS:
+        raise ValueError(
+            f"gotree.tree(): {argname}= must be built with spread()/"
+            f"distribute()/nest()/combine()/alternate(), got {value!r}"
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# link — "none" | LinkOptions dict | callable (source, target) -> LinkOptions
+# ---------------------------------------------------------------------------
+
+# snake_case Python kwarg -> camelCase wire key (LinkOptions is the one
+# gotree shape that actually has a multi-word field — strokeWidth).
+_LINK_KEY_MAP = {
+    "curve": "curve",
+    "stroke": "stroke",
+    "stroke_width": "strokeWidth",
+    "opacity": "opacity",
+}
+
+
+def _normalize_link_dict(link: dict) -> dict:
+    out: Dict[str, Any] = {}
+    for k, v in link.items():
+        if k not in _LINK_KEY_MAP:
+            raise ValueError(
+                f"gotree.tree(): unknown link option {k!r}; expected one of "
+                f"{sorted(_LINK_KEY_MAP)}"
+            )
+        out[_LINK_KEY_MAP[k]] = v
+    return out
+
+
+def _prepare_link(link: Any) -> Any:
+    """Normalize the `link=` argument to one of: `None`, `"none"`, a
+    normalized (camelCase-keyed) options dict, or a `_PendingAccessor`
+    wrapping a `(source, target) -> LinkOptions` callable.
+    """
+    if link is None:
+        return None
+    if isinstance(link, str):
+        if link != "none":
+            raise ValueError(
+                f'gotree.tree(): link string form must be "none", got {link!r}'
+            )
+        return "none"
+    if callable(link):
+        # Reuses the existing lambda-sentinel machinery (`_PendingAccessor`)
+        # rather than a bespoke registry — the wire shape
+        # (`{"__gofish_lambda": id}`) and the derive-RPC lambda_id
+        # convention are identical regardless of the wrapped callable's
+        # arity; only the caller-side adapter (rows -> args) differs, and
+        # that lives with whatever drives the RPC, not with the sentinel.
+        return _PendingAccessor(link)
+    if isinstance(link, dict):
+        return _normalize_link_dict(link)
+    raise TypeError(
+        "gotree.tree(): link= must be \"none\", a dict of link options, or "
+        f"a callable (source, target) -> dict, got {type(link).__name__}"
+    )
+
+
+def _link_wire(link: Any) -> Any:
+    if link is None:
+        return None
+    if link == "none":
+        return "none"
+    if isinstance(link, _PendingAccessor):
+        return {"__gofish_lambda": link.lambda_id}
+    return link
+
+
+# ---------------------------------------------------------------------------
+# node — a Mark template, or a callable (row) -> Mark
+# ---------------------------------------------------------------------------
+
+def _default_node() -> Mark:
+    from ..ast import rect
+
+    return rect(w=12, h=12, fill="#4682b4")
+
+
+def _prepare_node(node: Any) -> Any:
+    if node is None:
+        return _default_node()
+    if isinstance(node, Mark):
+        return node
+    if callable(node):
+        # Whole-mark callable — mirrors `ChartBuilder.mark(fn)` / JS
+        # "mark-as-function": wraps the callable in `_MarkFn` so the IR
+        # carries a stable lambda_id the derive-server can register.
+        return _MarkFn(node)
+    raise TypeError(
+        "gotree.tree(): node= must be a Mark (e.g. circle(...)) or a "
+        f"callable (row) -> Mark, got {type(node).__name__}"
+    )
+
+
+def _node_wire(node: Any) -> Any:
+    if isinstance(node, _MarkFn):
+        return {"type": "mark-fn", "lambdaId": node.lambda_id}
+    return node.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Tree — the `{"type": "gotree-tree", ...}` mark-level IR node
+# ---------------------------------------------------------------------------
+
+
+class Tree:
+    """The object returned by `tree(...)`. Not a `Mark` subclass — a
+    gotree tree is always a standalone top-level render (like a raw-mark
+    story), so it only needs `.to_dict()` / `.to_ir()` / `.render()` /
+    `.save()`, mirroring `Mark`'s own implementations of those rather than
+    inheriting them (`Mark`'s `.name()`/`.z_order()`/`.label()` clone-via-
+    `type(self)(mark_type, **kwargs)`, which doesn't match this
+    constructor's shape).
+    """
+
+    def __init__(
+        self,
+        data: Any,
+        *,
+        node: Any = None,
+        link: Any = None,
+        parent_child: Optional[dict] = None,
+        sibling: Optional[dict] = None,
+        coord: Optional[dict] = None,
+    ):
+        if not isinstance(data, dict):
+            raise TypeError(
+                "gotree.tree(): data must be a nested tree dict "
+                '(e.g. {"name": ..., "children": [...]})'
+            )
+        self.data = data
+        self._node = _prepare_node(node)
+        self._link = _prepare_link(link)
+        self._parent_child = _validate_combiner(parent_child, "parent_child")
+        self._sibling = _validate_combiner(sibling, "sibling")
+        self.coord = coord
+
+    def to_dict(self) -> dict:
+        d: Dict[str, Any] = {"type": "gotree-tree", "data": self.data}
+        d["node"] = _node_wire(self._node)
+        link_wire = _link_wire(self._link)
+        if link_wire is not None:
+            d["link"] = link_wire
+        if self._parent_child is not None:
+            d["parentChild"] = self._parent_child
+        if self._sibling is not None:
+            d["sibling"] = self._sibling
+        if self.coord is not None:
+            d["coord"] = self.coord
+        return d
+
+    def to_ir(self) -> dict:
+        """Top-level IR shape for a standalone render — mirrors `Mark.to_ir()`
+        (the same envelope the low-level Bluefish diagram stories use)."""
+        return {"type": "raw-mark", "mark": self.to_dict()}
+
+    def render(
+        self,
+        w: int = 800,
+        h: int = 600,
+        axes: bool = False,
+        debug: bool = False,
+    ):
+        """Render this tree directly (no Chart wrapper) — mirrors
+        `Mark.render()`. Returns a `GoFishChartWidget`; in a notebook this
+        auto-displays.
+        """
+        from ..widget import GoFishChartWidget
+        from ..arrow_utils import empty_placeholder_arrow_bytes
+
+        widget = GoFishChartWidget(
+            spec=self.to_ir(),
+            arrow_data=empty_placeholder_arrow_bytes(),
+            derive_functions={},
+            width=w,
+            height=h,
+            axes=axes,
+            debug=debug,
+        )
+        return widget
+
+    def save(
+        self,
+        path,
+        w: int = 800,
+        h: int = 600,
+        axes: bool = False,
+        debug: bool = False,
+    ):
+        """Save this tree's render to `path` (see `Mark.save`)."""
+        widget = self.render(w=w, h=h, axes=axes, debug=debug)
+        widget.save(path)
+        return widget
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        """Auto-display in notebooks (see `Mark._repr_mimebundle_`)."""
+        return self.render()._repr_mimebundle_(include=include, exclude=exclude)
+
+
+def tree(
+    data: Any,
+    *,
+    node: Any = None,
+    link: Any = None,
+    parent_child: Optional[dict] = None,
+    sibling: Optional[dict] = None,
+    coord: Optional[dict] = None,
+) -> Tree:
+    """Build a GoTree tree visualization — a pure snake_case mirror of JS
+    `tree(spec, data)` (packages/gofish-gotree/src/tree.tsx).
+
+    Args:
+        data: A nested tree dict (`{name?, value?, children?: [...],
+            ...extra}`).
+        node: A GoFish mark (e.g. `rect(w=12, h=12, fill="#4682b4")`,
+            the default) drawn once per tree node, or a callable
+            `(row) -> Mark` for per-node styling that isn't expressible as
+            plain channel accessors (e.g. color keyed off hierarchy depth
+            rather than a data field).
+        link: `"none"` to omit edges (default is drawn with GoFish
+            defaults — straight, gray, width 1), a dict of
+            `curve`/`stroke`/`stroke_width`/`opacity`, or a callable
+            `(source, target) -> dict` for per-edge styling.
+        parent_child: Combiner for parent <-> children-group, built with
+            `spread()`/`distribute()`/`nest()`/`combine()`/`alternate()`.
+            Omit to use GoTree's own default (`distribute(dir="y",
+            spacing=32, alignment="middle")`).
+        sibling: Combiner for the sibling group, same builders. Omit for
+            the default (`distribute(dir="x", spacing=16,
+            alignment="start")`).
+        coord: A coord transform from `gofish` (`polar()`, `clock()`,
+            `wavy()`) to render the whole tree under, e.g. for a radial
+            layout.
+
+    Returns:
+        A `Tree` — call `.render(w=..., h=...)` to display it.
+    """
+    return Tree(
+        data,
+        node=node,
+        link=link,
+        parent_child=parent_child,
+        sibling=sibling,
+        coord=coord,
+    )

--- a/packages/gofish-python/package.json
+++ b/packages/gofish-python/package.json
@@ -13,6 +13,7 @@
     "apache-arrow": "^14.0.0",
     "solid-js": "^1.9.5",
     "gofish-graphics": "workspace:*",
+    "gofish-gotree": "workspace:*",
     "gofish-ir": "workspace:*"
   },
   "devDependencies": {

--- a/packages/gofish-python/tests/test_gotree.py
+++ b/packages/gofish-python/tests/test_gotree.py
@@ -1,0 +1,241 @@
+"""Tests for the `gofish.gotree` bridge (issue #792).
+
+Covers wire-shape parity with the pinned `gotree-tree` IR contract:
+`{type, data, node, link?, parentChild?, sibling?, coord?}`. `gotree` is
+deliberately NOT re-exported from top-level `gofish` (same category as
+`derive`/`field`/`ref`), so every import here goes through
+`gofish.gotree` / `from gofish.gotree import ...`.
+"""
+
+import pytest
+
+from gofish import circle, rect
+from gofish.ast import _MarkFn, _PendingAccessor
+from gofish.gotree import alternate, combine, distribute, nest, spread, tree
+
+TREE_DATA = {
+    "name": "root",
+    "children": [{"name": "A"}, {"name": "B"}],
+}
+
+
+class TestPureSpec:
+    """A pure (no-callable) spec serializes to exactly the pinned wire shape."""
+
+    def test_full_spec_golden_dict(self):
+        t = tree(
+            TREE_DATA,
+            node=circle(r=7, fill="#08306b"),
+            link={"curve": "orthogonal", "stroke": "#90a4ae", "stroke_width": 1.5},
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 18},
+                y={"kind": "distribute", "spacing": 18},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 18},
+                y={"kind": "distribute", "spacing": 18},
+            ),
+        )
+        assert t.to_dict() == {
+            "type": "gotree-tree",
+            "data": TREE_DATA,
+            "node": {"type": "circle", "r": 7, "fill": "#08306b"},
+            "link": {
+                "curve": "orthogonal",
+                "stroke": "#90a4ae",
+                "strokeWidth": 1.5,
+            },
+            "parentChild": {
+                "kind": "combine",
+                "options": {
+                    "x": {"kind": "distribute", "spacing": 18},
+                    "y": {"kind": "distribute", "spacing": 18},
+                },
+            },
+            "sibling": {
+                "kind": "combine",
+                "options": {
+                    "x": {"kind": "distribute", "spacing": 18},
+                    "y": {"kind": "distribute", "spacing": 18},
+                },
+            },
+        }
+
+    def test_to_ir_wraps_in_raw_mark_envelope(self):
+        t = tree(TREE_DATA, node=rect(w=12, h=12))
+        assert t.to_ir() == {"type": "raw-mark", "mark": t.to_dict()}
+
+
+class TestOmittedOptionals:
+    """Optional keys are absent entirely when unset, not null."""
+
+    def test_minimal_tree_omits_optionals(self):
+        t = tree(TREE_DATA)
+        d = t.to_dict()
+        assert d["type"] == "gotree-tree"
+        assert d["data"] == TREE_DATA
+        # Default node mirrors JS's DEFAULT_NODE.
+        assert d["node"] == {"type": "rect", "w": 12, "h": 12, "fill": "#4682b4"}
+        for key in ("link", "parentChild", "sibling", "coord"):
+            assert key not in d
+
+    def test_explicit_node_only(self):
+        t = tree(TREE_DATA, node=circle(r=4))
+        d = t.to_dict()
+        assert d["node"] == {"type": "circle", "r": 4}
+        assert "link" not in d
+
+    def test_link_none_is_emitted_as_string(self):
+        t = tree(TREE_DATA, link="none")
+        assert t.to_dict()["link"] == "none"
+
+
+class TestNodeCallable:
+    """node=callable emits a mark-fn sentinel with a registered lambda."""
+
+    def test_node_callable_emits_mark_fn(self):
+        def node_factory(row):
+            return circle(r=7)
+
+        t = tree(TREE_DATA, node=node_factory)
+        assert isinstance(t._node, _MarkFn)
+        assert t._node.fn is node_factory
+        d = t.to_dict()
+        assert d["node"]["type"] == "mark-fn"
+        assert d["node"]["lambdaId"] == t._node.lambda_id
+
+    def test_node_callable_lambda_id_stable_across_calls(self):
+        t = tree(TREE_DATA, node=lambda row: circle(r=1))
+        assert t.to_dict()["node"]["lambdaId"] == t.to_dict()["node"]["lambdaId"]
+
+
+class TestChannelCallableInsideNode:
+    """A channel-level callable inside a static node mark template already
+    works via the existing `_PendingAccessor` machinery (`_channel` in
+    ast.py) — verified here in the gotree context.
+    """
+
+    def test_channel_callable_emits_lambda_sentinel(self):
+        node_mark = circle(r=7, fill=lambda d: "#ff0000")
+        t = tree(TREE_DATA, node=node_mark)
+        d = t.to_dict()
+        assert isinstance(d["node"]["fill"], dict)
+        assert "__gofish_lambda" in d["node"]["fill"]
+
+
+class TestLinkCallable:
+    """link=callable emits a lambda sentinel."""
+
+    def test_link_callable_emits_sentinel(self):
+        def link_fn(source, target):
+            return {"stroke": "red"}
+
+        t = tree(TREE_DATA, link=link_fn)
+        assert isinstance(t._link, _PendingAccessor)
+        d = t.to_dict()
+        assert d["link"] == {"__gofish_lambda": t._link.lambda_id}
+
+    def test_link_dict_maps_stroke_width(self):
+        t = tree(TREE_DATA, link={"stroke_width": 2})
+        assert t.to_dict()["link"] == {"strokeWidth": 2}
+
+    def test_link_dict_unknown_key_raises(self):
+        with pytest.raises(ValueError, match="unknown link option"):
+            tree(TREE_DATA, link={"bogus": 1})
+
+    def test_link_bad_string_raises(self):
+        with pytest.raises(ValueError, match='must be "none"'):
+            tree(TREE_DATA, link="dotted")
+
+
+class TestAlternate:
+    """alternate() nests its combiners correctly."""
+
+    def test_alternate_nests_combiners(self):
+        c = alternate([spread(dir="x", spacing=10), spread(dir="y", spacing=20)])
+        assert c == {
+            "kind": "alternate",
+            "combiners": [
+                {"kind": "spread", "options": {"dir": "x", "spacing": 10}},
+                {"kind": "spread", "options": {"dir": "y", "spacing": 20}},
+            ],
+        }
+
+    def test_alternate_as_parent_child(self):
+        t = tree(
+            TREE_DATA,
+            parent_child=alternate(
+                [distribute(dir="y", spacing=10), distribute(dir="x", spacing=10)]
+            ),
+        )
+        assert t.to_dict()["parentChild"]["kind"] == "alternate"
+        assert len(t.to_dict()["parentChild"]["combiners"]) == 2
+
+    def test_alternate_empty_raises(self):
+        with pytest.raises(ValueError, match="at least one combiner"):
+            alternate([])
+
+    def test_alternate_rejects_non_combiner_entries(self):
+        with pytest.raises(ValueError, match="must be a combiner"):
+            alternate([{"not": "a combiner"}])
+
+
+class TestCombinerBuilders:
+    def test_spread_requires_dir(self):
+        with pytest.raises(TypeError):
+            spread()
+
+    def test_distribute_shape(self):
+        assert distribute(dir="x", spacing=8, order="reverse") == {
+            "kind": "distribute",
+            "options": {"dir": "x", "spacing": 8, "order": "reverse"},
+        }
+
+    def test_nest_requires_an_axis(self):
+        with pytest.raises(ValueError, match="at least one of x, y"):
+            nest()
+
+    def test_nest_shape(self):
+        assert nest(x=10, y=10) == {"kind": "nest", "options": {"x": 10, "y": 10}}
+
+    def test_combine_requires_an_axis(self):
+        with pytest.raises(ValueError, match="at least one of x, y"):
+            combine()
+
+    def test_combine_string_shorthand(self):
+        assert combine(x="nest", y="align") == {
+            "kind": "combine",
+            "options": {"x": {"kind": "nest"}, "y": {"kind": "align"}},
+        }
+
+    def test_combine_unknown_kind_raises(self):
+        with pytest.raises(ValueError, match="unknown x axis kind"):
+            combine(x="bogus")
+
+    def test_combine_dict_unknown_kind_raises(self):
+        with pytest.raises(ValueError, match="unknown y axis kind"):
+            combine(y={"kind": "bogus"})
+
+
+class TestTreeValidation:
+    def test_data_must_be_dict(self):
+        with pytest.raises(TypeError, match="data must be a nested tree dict"):
+            tree([1, 2, 3])
+
+    def test_parent_child_must_be_a_combiner(self):
+        with pytest.raises(ValueError, match="parent_child="):
+            tree(TREE_DATA, parent_child={"not": "a combiner"})
+
+    def test_sibling_must_be_a_combiner(self):
+        with pytest.raises(ValueError, match="sibling="):
+            tree(TREE_DATA, sibling="bogus")
+
+    def test_node_wrong_type_raises(self):
+        with pytest.raises(TypeError, match="node="):
+            tree(TREE_DATA, node=42)
+
+    def test_coord_passthrough(self):
+        from gofish import polar
+
+        t = tree(TREE_DATA, coord=polar())
+        assert t.to_dict()["coord"] == polar()

--- a/packages/gofish-python/widget-src/index.ts
+++ b/packages/gofish-python/widget-src/index.ts
@@ -22,6 +22,7 @@ import {
   serializeSVG,
   type ChartBuilder,
 } from "gofish-graphics";
+import { reconstructGotreeTree } from "gofish-gotree";
 import type { Frontend } from "gofish-ir";
 import { buildArrowTable } from "./arrowTransport";
 
@@ -248,6 +249,65 @@ function makeDeriveBridge(model: WidgetModel): Serialize.DeriveBridge {
 }
 
 // ---------------------------------------------------------------------------
+// gotree-tree mark bridge (#792)
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapt gofish-gotree's `applyLambda(id, args)` (one lambda call, arbitrary
+ * positional args, one resolved result) onto the widget's
+ * `Serialize.DeriveBridge.applyLambda(id, rows)` (rows-in/rows-out over an
+ * Arrow transport — each row independently mapped to its own result).
+ *
+ * A gotree lambda call — resolving one node-template channel (`args = [row]`)
+ * or one link's options (`args = [srcRow, tgtRow]`) — is a SINGLE Python call
+ * with those args positional, not a batch of independent per-row calls. The
+ * two conventions don't line up, so this wraps `args` as the payload of one
+ * single-row batch call: `{ __gofish_args: args }`. This is a deliberate
+ * shortcut (see repo CLAUDE.md's "declared shortcut" allowance) — the
+ * Python-side lambda dispatcher for gotree-registered callables must
+ * recognize `row.__gofish_args` and invoke the user's callable with those
+ * values positionally (`fn(*row["__gofish_args"])`); ordinary derive/channel
+ * lambdas elsewhere are unaffected, since they never send this wrapper.
+ */
+function makeGotreeApplyLambda(
+  bridge: Serialize.DeriveBridge
+): (id: string, args: any[]) => Promise<any> {
+  return async (id: string, args: any[]) => {
+    const [result] = await bridge.applyLambda(id, [{ __gofish_args: args }]);
+    if (result && typeof result === "object") {
+      const keys = Object.keys(result);
+      if (keys.length === 1) return result[keys[0]];
+    }
+    return result;
+  };
+}
+
+/**
+ * The `markBridges` map passed to every `Serialize.mapMark`/`buildChart`
+ * call — currently just `"gotree-tree"` (#792). `ctx.mapMark` recurses back
+ * into this same widget's `Serialize.mapMark` (bound to this render's
+ * bridge/token-resolver), so a gotree node template can itself contain any
+ * other mark IR, including a nested gotree-tree.
+ */
+function makeMarkBridges(
+  bridge: Serialize.DeriveBridge,
+  resolveToken: Serialize.TokenResolver
+): Serialize.MarkBridges {
+  // `bridges` closes over itself (via the `mapMark` callback below) so a
+  // gotree node template that itself nests another gotree-tree resolves
+  // through the SAME bridge map, arbitrarily deep — no duplicated wiring.
+  const bridges: Serialize.MarkBridges = {
+    "gotree-tree": (spec: any) =>
+      reconstructGotreeTree(spec, {
+        mapMark: (markIR: any) =>
+          Serialize.mapMark(markIR, bridge, resolveToken, undefined, bridges),
+        applyLambda: makeGotreeApplyLambda(bridge),
+      }),
+  };
+  return bridges;
+}
+
+// ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
 
@@ -290,13 +350,20 @@ function renderLayer(
   }
 
   const resolveToken = Serialize.makeTokenResolver();
+  const markBridges = makeMarkBridges(bridge, resolveToken);
   // A tier is a chart (ChartBuilder) or a component-level annotation
   // (raw-mark → a Mark). Build each accordingly; the builder chain stacks
   // them via `.layer()`, which accepts either.
   const childTiers = spec.charts.map((childSpec: any, i: number) => {
     if (childSpec && childSpec.type === "raw-mark") {
       log(`Building raw-mark tier ${i}`);
-      return Serialize.mapMark(childSpec.mark, bridge, resolveToken) as any;
+      return Serialize.mapMark(
+        childSpec.mark,
+        bridge,
+        resolveToken,
+        undefined,
+        markBridges
+      ) as any;
     }
     const b64 = arrowDict[String(i)] || "";
     const data = decodeArrowB64(b64);
@@ -305,7 +372,8 @@ function renderLayer(
       childSpec as ChartSpec,
       data,
       bridge,
-      resolveToken
+      resolveToken,
+      markBridges
     );
   });
 
@@ -354,7 +422,14 @@ function renderRawMark(
 
   log("Building raw mark...");
   const resolveToken = Serialize.makeTokenResolver();
-  const mark = Serialize.mapMark(spec.mark, bridge, resolveToken) as any;
+  const markBridges = makeMarkBridges(bridge, resolveToken);
+  const mark = Serialize.mapMark(
+    spec.mark,
+    bridge,
+    resolveToken,
+    undefined,
+    markBridges
+  ) as any;
   const renderOptions: RenderOptions = {
     w: model.get("width"),
     h: model.get("height"),
@@ -397,7 +472,14 @@ function renderChart(
 
   log("Building chart...");
   const resolveToken = Serialize.makeTokenResolver();
-  const node = Serialize.buildChart(chartSpec, data, bridge, resolveToken);
+  const markBridges = makeMarkBridges(bridge, resolveToken);
+  const node = Serialize.buildChart(
+    chartSpec,
+    data,
+    bridge,
+    resolveToken,
+    markBridges
+  );
 
   const renderOptions: RenderOptions = {
     w: model.get("width"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,6 +288,9 @@ importers:
       apache-arrow:
         specifier: ^14.0.0
         version: 14.0.2
+      gofish-gotree:
+        specifier: workspace:*
+        version: link:../gofish-gotree
       gofish-graphics:
         specifier: workspace:*
         version: link:../gofish-graphics

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -111,9 +111,9 @@ packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx::Default
 # under tests/python-stories/gotree/... (same title-derived mapping as
 # gofish-graphics — see mapJsToPython in tests/scripts/path-mapping.ts).
 #
-# The gofish-gotree Python bridge landed with #792, but the ports themselves
-# haven't been written yet, so every current gotree story is listed below to
-# keep the checker green today. This list is a punch list, not a permanent
+# The gofish-gotree Python bridge and the ports of all 40 DSL-based gallery
+# stories landed with #792; the remaining entries below are the stories that
+# still need bespoke work. This list is a punch list, not a permanent
 # exemption: remove a line as soon as its Python port exists (mirroring the
 # workflow used for the gofish-graphics entries above). These stories ARE
 # already captured by the JS visual-diff harness (tests/harness/
@@ -121,44 +121,6 @@ packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx::Default
 # visual regressions independent of this list.
 packages/gofish-gotree/stories/Matrix.stories.tsx
 packages/gofish-gotree/stories/Tree.stories.tsx
-packages/gofish-gotree/stories/gallery/ArcTree.stories.tsx
-packages/gofish-gotree/stories/gallery/BarcodeTree.stories.tsx
-packages/gofish-gotree/stories/gallery/BeamTree.stories.tsx
-packages/gofish-gotree/stories/gallery/CartesianDeepTree.stories.tsx
-packages/gofish-gotree/stories/gallery/CascadedTreemap.stories.tsx
-packages/gofish-gotree/stories/gallery/Cheops.stories.tsx
-packages/gofish-gotree/stories/gallery/ClockTree.stories.tsx
-packages/gofish-gotree/stories/gallery/ClockTreeWithLink.stories.tsx
-packages/gofish-gotree/stories/gallery/DeepTree.stories.tsx
-packages/gofish-gotree/stories/gallery/Dendrogram.stories.tsx
-packages/gofish-gotree/stories/gallery/ElasticHierarchy.stories.tsx
-packages/gofish-gotree/stories/gallery/FlowerTree.stories.tsx
-packages/gofish-gotree/stories/gallery/GardenLayout.stories.tsx
-packages/gofish-gotree/stories/gallery/HTreeLayout.stories.tsx
-packages/gofish-gotree/stories/gallery/HVDrawing.stories.tsx
-packages/gofish-gotree/stories/gallery/HierarchicalSectorChart.stories.tsx
-packages/gofish-gotree/stories/gallery/IciclePlotPolar.stories.tsx
-packages/gofish-gotree/stories/gallery/IndentedTree.stories.tsx
-packages/gofish-gotree/stories/gallery/Iptp.stories.tsx
-packages/gofish-gotree/stories/gallery/Jewelry.stories.tsx
-packages/gofish-gotree/stories/gallery/NestedPieTree.stories.tsx
-packages/gofish-gotree/stories/gallery/NodeLinkTree.stories.tsx
-packages/gofish-gotree/stories/gallery/OakTreeVis.stories.tsx
-packages/gofish-gotree/stories/gallery/OrthogonalGridEmbedding.stories.tsx
-packages/gofish-gotree/stories/gallery/SectorTree.stories.tsx
-packages/gofish-gotree/stories/gallery/SectorTree2.stories.tsx
-packages/gofish-gotree/stories/gallery/SideTree.stories.tsx
-packages/gofish-gotree/stories/gallery/SpiralLayout.stories.tsx
-packages/gofish-gotree/stories/gallery/StairTree.stories.tsx
-packages/gofish-gotree/stories/gallery/Sunburst.stories.tsx
-packages/gofish-gotree/stories/gallery/TornadoTree.stories.tsx
-packages/gofish-gotree/stories/gallery/TornadoTree2.stories.tsx
-packages/gofish-gotree/stories/gallery/Treemap.stories.tsx
-packages/gofish-gotree/stories/gallery/TreemapOval.stories.tsx
-packages/gofish-gotree/stories/gallery/TreemapSlice.stories.tsx
-packages/gofish-gotree/stories/gallery/TyreTree.stories.tsx
-packages/gofish-gotree/stories/gallery/ViolinTree.stories.tsx
-packages/gofish-gotree/stories/gallery/WeaveTree.stories.tsx
 
 # The following seven gotree gallery stories are hand-rolled, non-DSL
 # layouts (they don't go through the tree()/combine() grammar the other
@@ -168,7 +130,6 @@ packages/gofish-gotree/stories/gallery/WeaveTree.stories.tsx
 packages/gofish-gotree/stories/gallery/MultilevelSilhouetteTree.stories.tsx
 packages/gofish-gotree/stories/gallery/OutsideInTree.stories.tsx
 packages/gofish-gotree/stories/gallery/RadialDeep.stories.tsx
-packages/gofish-gotree/stories/gallery/ReadableTreeLayout.stories.tsx
 packages/gofish-gotree/stories/gallery/RadialPhylogeneticTree.stories.tsx
 packages/gofish-gotree/stories/gallery/RadialTree.stories.tsx
 packages/gofish-gotree/stories/gallery/RadialTreeIncline.stories.tsx

--- a/tests/.python-sync-exempt
+++ b/tests/.python-sync-exempt
@@ -104,18 +104,75 @@ packages/gofish-graphics/stories/lowlevel/Constraints.stories.tsx::SpreadY_Rever
 packages/gofish-graphics/stories/lowlevel/ViolinPlot.stories.tsx::Default
 
 # ---------------------------------------------------------------------------
-# gofish-gotree (the GoTree tree-DSL package) — exempt from Python parity.
+# gofish-gotree (the GoTree tree-DSL package) — per-file exemptions (#792).
 #
-# These stories ARE captured by the JS visual-diff harness (tests/harness/
-# stories-runner.ts globs gofish-gotree/stories too), so they are tracked for
-# visual regressions. They are NOT mirrored to Python: gofish-gotree is a
-# JS-only package with no Python wrapper, so there is nothing to byte-match.
+# `walkJsStories()` now walks packages/gofish-gotree/stories/ alongside
+# gofish-graphics, so every gotree story is checked for a Python parity port
+# under tests/python-stories/gotree/... (same title-derived mapping as
+# gofish-graphics — see mapJsToPython in tests/scripts/path-mapping.ts).
 #
-# No per-file entries are needed below: this checker (both delta mode and
-# `--all`) hard-filters JS stories to `packages/gofish-graphics/stories/`
-# (see walkJsStories + the gitDiff filters in check-python-sync.ts), so it
-# never walks the gofish-gotree package. If parity coverage is ever extended
-# to gofish-gotree, list its stories here.
+# The gofish-gotree Python bridge landed with #792, but the ports themselves
+# haven't been written yet, so every current gotree story is listed below to
+# keep the checker green today. This list is a punch list, not a permanent
+# exemption: remove a line as soon as its Python port exists (mirroring the
+# workflow used for the gofish-graphics entries above). These stories ARE
+# already captured by the JS visual-diff harness (tests/harness/
+# stories-runner.ts globs gofish-gotree/stories too), so they're tracked for
+# visual regressions independent of this list.
+packages/gofish-gotree/stories/Matrix.stories.tsx
+packages/gofish-gotree/stories/Tree.stories.tsx
+packages/gofish-gotree/stories/gallery/ArcTree.stories.tsx
+packages/gofish-gotree/stories/gallery/BarcodeTree.stories.tsx
+packages/gofish-gotree/stories/gallery/BeamTree.stories.tsx
+packages/gofish-gotree/stories/gallery/CartesianDeepTree.stories.tsx
+packages/gofish-gotree/stories/gallery/CascadedTreemap.stories.tsx
+packages/gofish-gotree/stories/gallery/Cheops.stories.tsx
+packages/gofish-gotree/stories/gallery/ClockTree.stories.tsx
+packages/gofish-gotree/stories/gallery/ClockTreeWithLink.stories.tsx
+packages/gofish-gotree/stories/gallery/DeepTree.stories.tsx
+packages/gofish-gotree/stories/gallery/Dendrogram.stories.tsx
+packages/gofish-gotree/stories/gallery/ElasticHierarchy.stories.tsx
+packages/gofish-gotree/stories/gallery/FlowerTree.stories.tsx
+packages/gofish-gotree/stories/gallery/GardenLayout.stories.tsx
+packages/gofish-gotree/stories/gallery/HTreeLayout.stories.tsx
+packages/gofish-gotree/stories/gallery/HVDrawing.stories.tsx
+packages/gofish-gotree/stories/gallery/HierarchicalSectorChart.stories.tsx
+packages/gofish-gotree/stories/gallery/IciclePlotPolar.stories.tsx
+packages/gofish-gotree/stories/gallery/IndentedTree.stories.tsx
+packages/gofish-gotree/stories/gallery/Iptp.stories.tsx
+packages/gofish-gotree/stories/gallery/Jewelry.stories.tsx
+packages/gofish-gotree/stories/gallery/NestedPieTree.stories.tsx
+packages/gofish-gotree/stories/gallery/NodeLinkTree.stories.tsx
+packages/gofish-gotree/stories/gallery/OakTreeVis.stories.tsx
+packages/gofish-gotree/stories/gallery/OrthogonalGridEmbedding.stories.tsx
+packages/gofish-gotree/stories/gallery/SectorTree.stories.tsx
+packages/gofish-gotree/stories/gallery/SectorTree2.stories.tsx
+packages/gofish-gotree/stories/gallery/SideTree.stories.tsx
+packages/gofish-gotree/stories/gallery/SpiralLayout.stories.tsx
+packages/gofish-gotree/stories/gallery/StairTree.stories.tsx
+packages/gofish-gotree/stories/gallery/Sunburst.stories.tsx
+packages/gofish-gotree/stories/gallery/TornadoTree.stories.tsx
+packages/gofish-gotree/stories/gallery/TornadoTree2.stories.tsx
+packages/gofish-gotree/stories/gallery/Treemap.stories.tsx
+packages/gofish-gotree/stories/gallery/TreemapOval.stories.tsx
+packages/gofish-gotree/stories/gallery/TreemapSlice.stories.tsx
+packages/gofish-gotree/stories/gallery/TyreTree.stories.tsx
+packages/gofish-gotree/stories/gallery/ViolinTree.stories.tsx
+packages/gofish-gotree/stories/gallery/WeaveTree.stories.tsx
+
+# The following seven gotree gallery stories are hand-rolled, non-DSL
+# layouts (they don't go through the tree()/combine() grammar the other
+# gotree ports use), so they need bespoke Python ports rather than a
+# mechanical translation — flagged separately as a heads-up for whoever
+# picks them up.
+packages/gofish-gotree/stories/gallery/MultilevelSilhouetteTree.stories.tsx
+packages/gofish-gotree/stories/gallery/OutsideInTree.stories.tsx
+packages/gofish-gotree/stories/gallery/RadialDeep.stories.tsx
+packages/gofish-gotree/stories/gallery/ReadableTreeLayout.stories.tsx
+packages/gofish-gotree/stories/gallery/RadialPhylogeneticTree.stories.tsx
+packages/gofish-gotree/stories/gallery/RadialTree.stories.tsx
+packages/gofish-gotree/stories/gallery/RadialTreeIncline.stories.tsx
+packages/gofish-gotree/stories/gallery/RotationTree.stories.tsx
 
 # LayeredBarsAndArea stays exempt: it drives a data-driven paint order with
 # `area(...).zOrder(d => …)` and reorders the area selection with a `derive`

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -76,6 +76,7 @@ import {
   type Mark,
   type Token,
 } from "gofish-graphics";
+import { reconstructGotreeTree } from "gofish-gotree";
 import { Frontend } from "gofish-ir";
 
 // Combinator-form factory map. Each entry takes (opts, marks) and returns
@@ -263,6 +264,63 @@ function unwrapMarkOpts(value: any, deriveServerUrl: string | undefined): any {
  * `unwrapMarkOpts` directly. */
 function unwrapValues(value: any): any {
   return unwrapMarkOpts(value, undefined);
+}
+
+// ---------------------------------------------------------------------------
+// gotree-tree mark bridge (#792)
+// ---------------------------------------------------------------------------
+
+/**
+ * Adapt gofish-gotree's `applyLambda(id, args)` (one lambda call, arbitrary
+ * positional args, one resolved result) onto this harness's rows-in/rows-out
+ * `/derive/<id>` endpoint. A gotree lambda call — one node-template channel
+ * (`args = [row]`) or one link's options (`args = [srcRow, tgtRow]`) — is a
+ * SINGLE Python call with those args positional, not a batch of independent
+ * per-row calls, so `args` rides as the payload of one single-row batch call:
+ * `{ __gofish_args: args }`. Mirrors the same shortcut in
+ * `packages/gofish-python/widget-src/index.ts`'s `makeGotreeApplyLambda` —
+ * see its doc comment for the Python-side dispatch contract this requires.
+ */
+async function applyGotreeLambda(
+  id: string,
+  args: any[],
+  deriveServerUrl: string | undefined
+): Promise<any> {
+  if (!deriveServerUrl) {
+    throw new Error(`gotree lambda ${id} requires deriveServerUrl on the spec`);
+  }
+  const resp = await fetch(`${deriveServerUrl}/derive/${id}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify([{ __gofish_args: args }]),
+  });
+  if (!resp.ok) {
+    throw new Error(
+      `gotree lambda ${id} failed: ${resp.status} ${await resp.text()}`
+    );
+  }
+  const result = await resp.json();
+  return Array.isArray(result) ? result[0] : result;
+}
+
+/** The `markBridges` map passed to `mapMark`/`buildChartFromSpec` — mirrors
+ *  `packages/gofish-python/widget-src/index.ts`'s `makeMarkBridges`. `bridges`
+ *  closes over itself via `mapMark` so a nested gotree-tree (a node template
+ *  containing another gotree-tree) resolves through the same map. */
+function makeMarkBridges(
+  deriveServerUrl: string | undefined,
+  resolveToken: TokenResolver
+): Record<string, (spec: any) => Promise<Mark<any>> | Mark<any>> {
+  const bridges: Record<string, (spec: any) => Promise<Mark<any>>> = {
+    "gotree-tree": (spec: any) =>
+      reconstructGotreeTree(spec, {
+        mapMark: (markIR: any) =>
+          mapMark(markIR, deriveServerUrl, resolveToken, undefined, bridges),
+        applyLambda: (id: string, args: any[]) =>
+          applyGotreeLambda(id, args, deriveServerUrl),
+      }),
+  };
+  return bridges;
 }
 
 /**
@@ -517,7 +575,8 @@ function mapMarkChildren(
   specs: MarkSpec[],
   deriveServerUrl: string | undefined,
   resolveToken: TokenResolver,
-  inputRefs?: any[]
+  inputRefs?: any[],
+  markBridges?: Record<string, (spec: any) => Promise<Mark<any>> | Mark<any>>
 ): any[] {
   const out: any[] = [];
   for (const child of specs as any[]) {
@@ -526,7 +585,8 @@ function mapMarkChildren(
         child.source,
         deriveServerUrl,
         resolveToken,
-        inputRefs
+        inputRefs,
+        markBridges
       );
       const slices = cutSlices(sourceMark as any, {
         dir: child.dir,
@@ -536,7 +596,13 @@ function mapMarkChildren(
       out.push(...slices);
     } else {
       out.push(
-        mapMark(child as MarkSpec, deriveServerUrl, resolveToken, inputRefs)
+        mapMark(
+          child as MarkSpec,
+          deriveServerUrl,
+          resolveToken,
+          inputRefs,
+          markBridges
+        )
       );
     }
   }
@@ -567,7 +633,8 @@ function mapMark(
   spec: MarkSpec,
   deriveServerUrl: string | undefined,
   resolveToken: TokenResolver,
-  inputRefs?: any[]
+  inputRefs?: any[],
+  markBridges?: Record<string, (spec: any) => Promise<Mark<any>> | Mark<any>>
 ): Mark<any> {
   const applyTranslate = <T>(mark: T): T =>
     spec.translate && typeof (mark as any).translate === "function"
@@ -598,6 +665,33 @@ function mapMark(
       );
     }
     return inputRef;
+  }
+
+  // Injected reconstruction (e.g. gotree-tree, #792) — mirrors
+  // packages/gofish-graphics/src/serialize/fromJSON.ts's markBridges check.
+  // The factory is async, so defer resolution into an async Mark wrapper;
+  // `resolveMarkResult` awaits/recurses through whatever comes back.
+  const inject = markBridges?.[spec.type];
+  if (inject) {
+    const nameVal = resolveNameField((spec as any).name, resolveToken);
+    return (async (data: any, key: any, layerContext: any) => {
+      let innerMark: any = await inject(spec);
+      if (spec.translate && typeof innerMark?.translate === "function") {
+        innerMark = innerMark.translate(spec.translate);
+      }
+      if (nameVal != null && typeof innerMark?.name === "function") {
+        innerMark = innerMark.name(nameVal);
+      }
+      if (
+        typeof (spec as any).zOrder === "number" &&
+        typeof innerMark?.zOrder === "function"
+      ) {
+        innerMark = innerMark.zOrder((spec as any).zOrder);
+      }
+      return typeof innerMark === "function"
+        ? innerMark(data, key, layerContext)
+        : innerMark;
+    }) as unknown as Mark<any>;
   }
 
   // Mark-as-function: Python registered a `(data) -> ChartBuilder | Mark`
@@ -648,10 +742,16 @@ function mapMark(
               resultSpec.mark,
               deriveServerUrl,
               resolveToken,
-              newInputRefs
+              newInputRefs,
+              markBridges
             );
           }
-          return buildChartFromSpec(resultSpec, deriveServerUrl, resolveToken);
+          return buildChartFromSpec(
+            resultSpec,
+            deriveServerUrl,
+            resolveToken,
+            markBridges
+          );
         })();
         cache.set(cacheKey, entry);
       }
@@ -683,7 +783,8 @@ function mapMark(
       spec.children ?? [],
       deriveServerUrl,
       resolveToken,
-      inputRefs
+      inputRefs,
+      markBridges
     );
     return applyTranslate(
       offsetOp({ x: spec.x, y: spec.y }, [
@@ -701,7 +802,8 @@ function mapMark(
       spec.source,
       deriveServerUrl,
       resolveToken,
-      inputRefs
+      inputRefs,
+      markBridges
     );
     let mark = cutMark({
       source: sourceMark as any,
@@ -734,7 +836,8 @@ function mapMark(
       spec.children ?? [],
       deriveServerUrl,
       resolveToken,
-      inputRefs
+      inputRefs,
+      markBridges
     );
     // Resolve color/coord configs too — e.g. a `layer({coord: polar()})`
     // carries its coord transform in the combinator options (BalloonChart,
@@ -900,14 +1003,21 @@ function resolveOptions(
 function buildChartFromSpec(
   chartSpec: ChartHarnessSpec,
   deriveServerUrl: string | undefined,
-  resolveToken: TokenResolver
+  resolveToken: TokenResolver,
+  markBridges?: Record<string, (spec: any) => Promise<Mark<any>> | Mark<any>>
 ): ChartBuilder<any, any> {
   const operators: Operator<any, any>[] = [];
   for (const opSpec of chartSpec.operators || []) {
     const op = mapOperator(opSpec, deriveServerUrl);
     if (op) operators.push(op);
   }
-  const mark = mapMark(chartSpec.mark, deriveServerUrl, resolveToken);
+  const mark = mapMark(
+    chartSpec.mark,
+    deriveServerUrl,
+    resolveToken,
+    undefined,
+    markBridges
+  );
   const chartOpts = resolveOptions(chartSpec.options || {});
 
   // Unwrap the canonical DataIR shapes. The wire formats are:
@@ -950,6 +1060,7 @@ function renderChart(spec: HarnessSpec) {
   // Fresh per-render Token cache so Python's `createName(...)` UUIDs map
   // to the same JS Token everywhere they appear in this spec.
   const resolveToken = makeTokenResolver();
+  const markBridges = makeMarkBridges(spec.deriveServerUrl, resolveToken);
 
   // Wrap the render path in an async IIFE so we can `await` each path's
   // gofish `.render()` (Promise-returning since `inferRaw` went async and
@@ -967,7 +1078,9 @@ function renderChart(spec: HarnessSpec) {
         const mark = mapMark(
           spec.mark,
           spec.deriveServerUrl,
-          resolveToken
+          resolveToken,
+          undefined,
+          markBridges
         ) as any;
         await mark.render(container, {
           w,
@@ -991,8 +1104,19 @@ function renderChart(spec: HarnessSpec) {
         // them via `.layer()`, which accepts either.
         const childCharts = spec.charts.map((c: any) =>
           c && c.type === "raw-mark"
-            ? mapMark(c.mark, spec.deriveServerUrl, resolveToken)
-            : buildChartFromSpec(c, spec.deriveServerUrl, resolveToken)
+            ? mapMark(
+                c.mark,
+                spec.deriveServerUrl,
+                resolveToken,
+                undefined,
+                markBridges
+              )
+            : buildChartFromSpec(
+                c,
+                spec.deriveServerUrl,
+                resolveToken,
+                markBridges
+              )
         );
 
         if (spec.constraints && spec.constraints.length > 0) {
@@ -1085,7 +1209,8 @@ function renderChart(spec: HarnessSpec) {
             zOrder: spec.zOrder ?? null,
           },
           spec.deriveServerUrl,
-          resolveToken
+          resolveToken,
+          markBridges
         );
 
         await node.render(container, {

--- a/tests/harness/main.ts
+++ b/tests/harness/main.ts
@@ -1075,13 +1075,33 @@ function renderChart(spec: HarnessSpec) {
       if (spec.type === "raw-mark") {
         const allOpts = spec.options || {};
         const { w, h, axes, debug } = allOpts;
-        const mark = mapMark(
-          spec.mark,
-          spec.deriveServerUrl,
-          resolveToken,
-          undefined,
-          markBridges
-        ) as any;
+        // A top-level bridge-reconstructed mark (e.g. gotree-tree, #792)
+        // resolves to a REAL renderable Mark (`.render()` attached).
+        // `mapMark`'s generic injection branch instead defers resolution
+        // behind an anonymous `Mark<T>` callable meant to be called by a
+        // parent chart's own evaluation (`mark(data, key, layerContext)`)
+        // when nested — there's no such parent at the top level, so
+        // resolve the bridge directly here instead of going through
+        // `mapMark`.
+        const bridgeInject = markBridges?.[(spec.mark as any).type];
+        let mark: any;
+        if (bridgeInject) {
+          mark = await bridgeInject(spec.mark);
+          if (
+            (spec.mark as any).translate &&
+            typeof mark?.translate === "function"
+          ) {
+            mark = mark.translate((spec.mark as any).translate);
+          }
+        } else {
+          mark = mapMark(
+            spec.mark,
+            spec.deriveServerUrl,
+            resolveToken,
+            undefined,
+            markBridges
+          ) as any;
+        }
         await mark.render(container, {
           w,
           h,

--- a/tests/harness/vite.config.ts
+++ b/tests/harness/vite.config.ts
@@ -18,6 +18,12 @@ const BENCH_PROD = process.env.GOFISH_BENCH_PROD === "1";
 const gofishAlias = BENCH_PROD
   ? resolve(__dirname, "../../packages/gofish-graphics/dist-bench/index.js")
   : resolve(__dirname, "../../packages/gofish-graphics/src/lib.ts");
+// gofish-gotree has no dist-bench build; always resolve to source, even in
+// prod-bench mode (only gofish-graphics itself is instrumented there).
+const gofishGotreeAlias = resolve(
+  __dirname,
+  "../../packages/gofish-gotree/src/index.ts"
+);
 
 export default defineConfig({
   // In prod-bench mode, keep the SolidJS dev export condition from being picked
@@ -43,6 +49,7 @@ export default defineConfig({
       : undefined,
     alias: {
       "gofish-graphics": gofishAlias,
+      "gofish-gotree": gofishGotreeAlias,
     },
   },
 });

--- a/tests/python-stories/gotree/gallery/test_arc_tree.py
+++ b/tests/python-stories/gotree/gallery/test_arc_tree.py
@@ -1,0 +1,88 @@
+"""Equivalent of gofish-gotree/stories/gallery/ArcTree.stories.tsx —
+GoTree / Gallery / arc-tree.
+
+dsl: X.Root juxtapose / X.Subtree flatten ; Y.Root within / Y.Subtree align.
+  parentChild = (distribute x, align y)   sibling = (distribute x, align y)
+Every node -- parent or sibling -- is distributed along x and aligned to a
+shared y baseline, so the whole tree collapses onto a single horizontal
+line. The hierarchy then shows only through the (arc) links connecting each
+node to its relatives.
+
+Links use the `arc` route -- GoTree's `arccurve` (ArcDirection "top"): each
+link is a semicircle through the two nodes, center at their midpoint,
+radius half the chord, so siblings stack as nested semicircular arcs.
+
+Node color depends on hierarchy depth, not a field of the tree data itself,
+so it's ported as a whole `node=` callable rather than a static mark
+template with field-accessor channels (same reasoning as the orthogonal-tree
+port).
+"""
+
+from gofish import circle
+from gofish.gotree import combine, tree
+
+# Same sample tree as gofish-gotree/stories/data.ts::sampleTree.
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+# Sequential blue ramp, dark at the root -> light at the leaves — same as
+# data.ts::depthBlues.
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=6, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_arc_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "arc", "stroke": "#90a4ae", "stroke_width": 1.5},
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 14},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 14},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_barcodetree.py
+++ b/tests/python-stories/gotree/gallery/test_barcodetree.py
@@ -1,0 +1,82 @@
+"""Equivalent of gofish-gotree/stories/gallery/BarcodeTree.stories.tsx —
+GoTree / Gallery / barcodetree.
+
+Thin vertical bars packed left-to-right like a barcode. Each parent bar sits
+left of its subtree (distribute x); nest is on Y ONLY, so internal nodes are
+fixed-narrow-width but UNSIZED on y — the parent bar grows vertically to wrap
+its subtree (include). Siblings flatten along x and align on y. Color =
+depth (dark -> light gray).
+"""
+
+from gofish import rect
+from gofish.gotree import combine, tree
+
+# Same sample tree as gofish-gotree/stories/data.ts::sampleTree.
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+# Dark -> light gray ramp, matching the dsl ColorRange #070707 -> #929598.
+_GRAYS = ["#070707", "#3b3e41", "#6c6f72", "#929598", "#b6b9bc"]
+
+
+def _by_depth(d):
+    return _GRAYS[min(d["depth"], len(_GRAYS) - 1)]
+
+
+# Thin rectangles. Leaves get a fixed narrow width and a tall height (the
+# barcode "bar"); internal nodes keep the same narrow width but are UNSIZED on
+# y (the nest axis) so the parent box grows to wrap its subtree vertically.
+def _node(d):
+    if d["height"] == 0:
+        return rect(w=12, h=80, fill=_by_depth(d))
+    return rect(w=12, fill=_by_depth(d))
+
+
+def story_barcode_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 4},
+                y={"kind": "nest", "pad": 6},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 4},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_beam_tree.py
+++ b/tests/python-stories/gotree/gallery/test_beam_tree.py
@@ -1,0 +1,108 @@
+"""Equivalent of gofish-gotree/stories/gallery/BeamTree.stories.tsx —
+GoTree / Gallery / BeamTree.
+
+Alternating nested beams. parent_child nests on BOTH axes at every level
+(parent rectangle grows to enclose its subtree), so every parent rectangle
+becomes a nested "beam". `alternate([spread_x, spread_y])` swaps the
+sibling-subdivision axis by depth: the root lays children out in a row,
+those children stack their children in a column, and so on. Leaves carry
+the size (proportional to value); internal nodes are unsized so their boxes
+wrap the children plus padding.
+
+NOTE (ported faithfully from the JS story, not fixed here): gotree's
+reference uses asymmetric per-side negative Y.Root padding to make the
+parent band overhang its children. GoFish nest pad is symmetric, so that
+exact overhang nuance isn't expressible here; a small positive pad is used
+for clean nested beams instead (same compromise as the JS story).
+"""
+
+from gofish import rect
+from gofish.gotree import alternate, combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# rectangle nodes, colored by depth (dark root -> light leaves). Leaves are
+# sized by datum — width proportional to value, a fixed tall height — so the
+# beams are proportional. Internal nodes are left UNSIZED on both axes (the
+# nest axes) so each parent box grows to wrap its subtree plus padding.
+_LEAF_W = 14  # px per unit of value
+_LEAF_H = 200  # fixed beam height
+
+
+def _node(d):
+    if d["height"] == 0:
+        w = _LEAF_W * (d["value"] if d["value"] is not None else (d["width"] or 1))
+        return rect(w=w, h=_LEAF_H, fill=_by_depth(d))
+    return rect(fill=_by_depth(d))
+
+
+_G = 8  # sibling gap
+_P = 6  # nest padding (parent box wraps its subtree on both axes)
+
+# parent contains subtree on BOTH axes at every level -> nested beams.
+_PARENT_CHILD = combine(
+    x={"kind": "nest", "pad": _P},
+    y={"kind": "nest", "pad": _P},
+)
+# siblings alternate the spread axis by depth: row, then column, then row...
+_SPREAD_X = combine(
+    x={"kind": "distribute", "spacing": _G},
+    y={"kind": "align", "alignment": "middle"},
+)
+_SPREAD_Y = combine(
+    x={"kind": "align", "alignment": "middle"},
+    y={"kind": "distribute", "spacing": _G},
+)
+_SIBLING = alternate([_SPREAD_X, _SPREAD_Y])
+
+
+def story_beam_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            parent_child=_PARENT_CHILD,
+            sibling=_SIBLING,
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_cartesian_deep_tree.py
+++ b/tests/python-stories/gotree/gallery/test_cartesian_deep_tree.py
@@ -1,0 +1,81 @@
+"""Equivalent of gofish-gotree/stories/gallery/CartesianDeepTree.stories.tsx —
+GoTree / Gallery / cartesian-deep-tree.
+
+dsl: node=circle, color=depth, link=curve, mode=top-down, StaticSize 6.
+  X.Root include / X.Subtree flatten ; Y.Root juxtapose(0r) / Y.Subtree align(bottom).
+Mapped (include->nest, juxtapose/flatten->distribute, align->align):
+  parentChild = combine({ x: nest (parent spans/centers over its subtree),
+                          y: distribute (level stacked vertically) })
+  sibling     = combine({ x: distribute (siblings spread horizontally),
+                          y: align "start" (Alignment "bottom" -> low y in y-up) })
+nest is on X ONLY: the parent is centered horizontally over the whole
+subtree span while levels stack on Y. distribute order is "reverse", so the
+parent (child 0 of [parent, group]) lands at LOW y = bottom and leaves climb
+upward -- matching the reference png (dark root at the bottom center, light
+leaves on top).
+
+COMPROMISES (noted, no hacks):
+ - Nodes are fixed-size circles. A circle can't be "unsized" on the nest
+   axis, so nest-x doesn't grow the parent -- it just CENTERS the parent
+   circle over its subtree span. This matches the reference (all nodes are
+   equal-size dots).
+ - Links: the dsl asks for "curve" links with depth-driven width. We use
+   the `bezier`-equivalent `straight` route mapping from the JS story
+   (which itself notes depth-driven LinkWidth is still a TODO); ported
+   faithfully as `{"curve": "straight"}` per the JS story's actual call.
+"""
+
+from gofish import circle
+from gofish.gotree import combine, tree
+
+# A deep balanced binary tree (4 levels, 16 leaves) — the "deep" in the
+# title. Same recursive construction as the JS story's `deepTree`.
+
+
+def _make_deep(depth, prefix):
+    if depth == 0:
+        return {"name": prefix}
+    return {
+        "name": prefix,
+        "children": [
+            _make_deep(depth - 1, prefix + "a"),
+            _make_deep(depth - 1, prefix + "b"),
+        ],
+    }
+
+
+DEEP_TREE = _make_deep(4, "r")
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# circle nodes, depth-colored (StaticSize 6 -> r 6).
+def _node(d):
+    return circle(r=6, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_cartesian_deep_tree():
+    return (
+        tree(
+            DEEP_TREE,
+            node=_node,
+            link={"curve": "straight", "stroke": "#5f6b7a", "stroke_width": 1.5},
+            parent_child=combine(
+                x={"kind": "nest", "pad": 0},
+                # order "reverse" puts the parent at HIGH y = the bottom in
+                # y-down free space, so the root sits at the bottom and
+                # leaves climb upward (matching the reference). See issue
+                # #143/#16.
+                y={"kind": "distribute", "spacing": 80, "order": "reverse"},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 22},
+                y={"kind": "align", "alignment": "start"},
+            ),
+        ),
+        {"w": 900, "h": 520},
+    )

--- a/tests/python-stories/gotree/gallery/test_cascaded_treemap.py
+++ b/tests/python-stories/gotree/gallery/test_cascaded_treemap.py
@@ -1,0 +1,94 @@
+"""Equivalent of gofish-gotree/stories/gallery/CascadedTreemap.stories.tsx —
+GoTree / Gallery / CascadedTreemap.
+
+`alternate([dice, slice])` swaps subdivision slice<->dice every level — the
+cascade: each depth subdivides on the opposite axis. `parent_child` nests on
+BOTH axes (constant per depth) so internal nodes are UNSIZED on both axes
+(the parent box grows to enclose its subtree); a small nest pad adds a
+nested inset border at every level (the visible "cascade"). Only leaves
+carry intrinsic size, driven by the datum value.
+"""
+
+from gofish import rect
+from gofish.gotree import alternate, combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        size = 18 + d["value"] * 10
+        return rect(w=size, h=size, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+    return rect(fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+_P = 6  # small nest pad -> visible cascade inset border per level
+_G = 8  # sibling spacing
+
+# dice: siblings spread on X, share a vertical center.
+_DICE = combine(
+    x={"kind": "distribute", "spacing": _G},
+    y={"kind": "align", "alignment": "middle"},
+)
+# slice: siblings spread on Y, share a horizontal center.
+_SLICE = combine(
+    x={"kind": "align", "alignment": "middle"},
+    y={"kind": "distribute", "spacing": _G},
+)
+
+
+def story_cascaded_treemap():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            # nest on both axes -> parent rect encloses its subtree with a
+            # small pad.
+            parent_child=combine(
+                x={"kind": "nest", "pad": _P},
+                y={"kind": "nest", "pad": _P},
+            ),
+            # siblings alternate subdivision axis per depth (the cascade).
+            sibling=alternate([_DICE, _SLICE]),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_cheops.py
+++ b/tests/python-stories/gotree/gallery/test_cheops.py
@@ -1,0 +1,91 @@
+"""Equivalent of gofish-gotree/stories/gallery/Cheops.stories.tsx —
+GoTree / Gallery / cheops.
+
+"Cheops" = pyramid of nested triangles; the negative sibling spacing overlaps
+adjacent siblings, and nest is on X ONLY (internal nodes unsized on x, fixed
+height) so each parent grows horizontally to wrap its subtree while every
+level keeps a fixed row height.
+
+TODO (ported faithfully from the JS story, not fixed here): gofish has no
+triangle mark, so the JS story renders `rect` placeholders for the paper's
+triangles — this port keeps that placeholder rather than "improving" it.
+"""
+
+from gofish import rect
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# Triangle-placeholder nodes (rect — see module docstring TODO), colored by
+# depth. Internal nodes are left UNSIZED on x (the nest axis) so the parent
+# box grows to wrap its subtree horizontally; height is fixed on every node
+# so levels stack as equal-height rows. White stroke stands in for the gaps
+# between the reference's triangles.
+_ROW_H = 80
+_LEAF_W = 26
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(w=_LEAF_W, h=_ROW_H, fill=_by_depth(d), stroke="white", strokeWidth=1)
+    return rect(h=_ROW_H, fill=_by_depth(d), stroke="white", strokeWidth=1)
+
+
+def story_cheops():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                x={"kind": "nest", "pad": 0},
+                y={"kind": "distribute", "spacing": 2},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": -8},
+                # Align siblings to the TOP of their bands (y-down free space:
+                # "start" = near/top edge) so same-depth nodes share a row.
+                y={"kind": "align", "alignment": "start"},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_clock_tree.py
+++ b/tests/python-stories/gotree/gallery/test_clock_tree.py
@@ -1,0 +1,111 @@
+"""Equivalent of gofish-gotree/stories/gallery/ClockTree.stories.tsx —
+GoTree / Gallery / ClockTree.
+
+Nodes arranged around a clock-face ring. Under polar(): x = theta (radians
+0..2pi), y = r (radius). Both parentChild and sibling distribute on theta and
+align on r -- i.e. every node (parents and children alike) gets its own
+angular slot, and they all share one radial band (the bottom-up "flatten").
+
+Wedge node: thetaSize is a unit angular WEIGHT (every node an equal slot).
+The coord is the sigma-scale-root: it sums the weights and fits them to the
+angular budget, so the ring closes exactly with no hand-set 2*pi/N. emX/emY
+make theta sweep an arc and r a radial band. Height grows with reverse-depth
+(d["height"]): the root is the tallest wedge, leaves the shortest.
+
+See the JS story for the full fidelity-gap notes (no angular auto-fit across
+the nested distribute layers, no bottom-up root-alignment, no polar theta/r
+axis swap) -- ported verbatim, not re-derived.
+"""
+
+from gofish import polar, rect, datum
+from gofish.gotree import combine, tree
+
+# Same tree as the JS story's local `clockTree` (a moderately bushy tree so
+# the rim is densely populated).
+CLOCK_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [{"name": "A1"}, {"name": "A2"}, {"name": "A3"}],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1"},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a"},
+                        {"name": "B2b"},
+                        {"name": "B2c"},
+                    ],
+                },
+                {"name": "B3"},
+            ],
+        },
+        {"name": "C", "children": [{"name": "C1"}, {"name": "C2"}]},
+        {
+            "name": "D",
+            "children": [
+                {"name": "D1"},
+                {
+                    "name": "D2",
+                    "children": [{"name": "D2a"}, {"name": "D2b"}],
+                },
+                {"name": "D3"},
+                {"name": "D4"},
+            ],
+        },
+        {
+            "name": "E",
+            "children": [{"name": "E1"}, {"name": "E2"}, {"name": "E3"}],
+        },
+    ],
+}
+
+# Sequential blue ramp, dark at the root -> light at the leaves.
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+_BAND_UNIT = 26  # radial thickness unit; node height = (rdepth+1)*bandUnit
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return rect(
+        thetaSize=datum(1),
+        h=(d["height"] + 1) * _BAND_UNIT,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=1.5,
+    )
+
+
+def story_clock_tree():
+    return (
+        tree(
+            CLOCK_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                # theta: parent and its child-group take adjacent angular slots.
+                x={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+                # r: parent and group share the radial band.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            sibling=combine(
+                # theta: siblings tile angularly (edge mode sums theta-widths).
+                x={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+                # r: siblings share the same radial band.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            # InnerRadius:0.72 -- the hollow clock rim.
+            coord=polar(inner_radius=0.72),
+        ),
+        {"w": 540, "h": 540},
+    )

--- a/tests/python-stories/gotree/gallery/test_clock_tree_with_link.py
+++ b/tests/python-stories/gotree/gallery/test_clock_tree_with_link.py
@@ -1,0 +1,83 @@
+"""Equivalent of gofish-gotree/stories/gallery/ClockTreeWithLink.stories.tsx —
+GoTree / Gallery / ClockTreeWithLink.
+
+A clock-face ring of nodes whose links bend inward across the disc. Both
+parentChild and sibling distribute on theta and align on r, so the whole tree
+flattens onto a single ring (every node -- root, internals, leaves -- gets one
+angular slot at the same radius). Links then connect parent -> child across
+the disc.
+
+JS `curveStepBefore` (an orthogonal radial-then-angular step) is unsupported
+by gofish-gotree links (only `{curve: "straight"}` is supported under polar),
+so links are drawn as straight chords through the hollow center, per the JS
+story's own note -- ported verbatim, not "fixed".
+"""
+
+from gofish import polar, rect, datum
+from gofish.gotree import combine, tree
+
+
+def _branch(prefix, n):
+    return [{"name": f"{prefix}{i}"} for i in range(n)]
+
+
+CLOCK_DATA = {
+    "name": "root",
+    "children": [
+        {"name": "a", "children": _branch("a", 3)},
+        {"name": "b", "children": _branch("b", 2)},
+        {"name": "c", "children": _branch("c", 4)},
+        {"name": "d", "children": _branch("d", 1)},
+        {"name": "e", "children": _branch("e", 3)},
+        {"name": "f", "children": _branch("f", 2)},
+        {"name": "g", "children": _branch("g", 3)},
+        {"name": "h", "children": _branch("h", 2)},
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+_BAND_HEIGHT = 60  # radial thickness of the ring band
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return rect(
+        thetaSize=datum(1),
+        h=_BAND_HEIGHT,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=1.5,
+    )
+
+
+def story_clock_tree_with_link():
+    return (
+        tree(
+            CLOCK_DATA,
+            node=_node,
+            # curveStepBefore is unsupported -> straight chord (bows under polar).
+            link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 1},
+            parent_child=combine(
+                # theta: parent at the start of its subtree's slot, group after it.
+                x={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+                # r: parent and subtree share the ring.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            sibling=combine(
+                # theta: siblings tile angularly (edge mode sums theta-widths).
+                x={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+                # r: siblings share the ring.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            # InnerRadius:0.79 -- the thin outer clock rim with an empty center
+            # that the step/arc links route through.
+            coord=polar(inner_radius=0.79),
+        ),
+        {"w": 520, "h": 520},
+    )

--- a/tests/python-stories/gotree/gallery/test_deep_tree.py
+++ b/tests/python-stories/gotree/gallery/test_deep_tree.py
@@ -1,0 +1,108 @@
+"""Equivalent of gofish-gotree/stories/gallery/DeepTree.stories.tsx —
+GoTree / Gallery / deep-tree (a deep radial node-link, sunburst family).
+
+dsl: node=circle, color=depth, link=curve; CoordinateSystem polar
+  (Direction clockwise, PolarAxis y-axis, InnerRadius 0, CentralAngle 1).
+  Layout AxisIndependent, Mode top-down:
+    X.Root include  / X.Subtree flatten  -> parentChild nest, sibling distribute
+    Y.Root juxtapose / Y.Subtree align   -> parentChild distribute, sibling align
+Under polar(): x = theta (radians, 0..2*pi), y = r (radius). So the brief
+mapping is:
+  parentChild = (nest theta, distribute r):
+    - theta nest -> parent centered over its subtree's angular span (a
+      circle is a point, so nest only re-centers the parent; it doesn't
+      grow it).
+    - r distribute -> one ring per depth (parent inner, children outward).
+  sibling = (distribute theta, align r):
+    - theta distribute -> siblings spread angularly (spacing in radians).
+    - r align -> all siblings share a radius (same ring).
+Point-like circle nodes => anchor "middle" on every distribute so spacing
+is read in domain units (radians for theta, r-units for r) and pixel bboxes
+don't accumulate.
+
+NOTES -- polar limitations (no hacks; flagged for follow-up), from the JS
+story:
+ - Links: the dsl asks for "curve" links with depth-driven width. Curved
+   link interpolation isn't wired through the coord transform yet, so this
+   falls back to fixed-width {curve: "straight"}.
+ - No angular auto-fit for POINT nodes: sibling theta spacing is a fixed
+   per-level constant that does NOT shrink with the number of nodes at a
+   depth (tracked in JS issue #627). The tree below is kept modest so the
+   structure stays legible.
+ - polar() axis-swap (PolarAxis y-axis) and PolarCenter "bottom" from the
+   dsl are not expressible; plain polar() is used.
+"""
+
+import math
+
+from gofish import circle, polar
+from gofish.gotree import combine, tree
+
+# A deep tree -- 4 levels below the root (depth 0..4) so several rings show
+# the "deep" structure. Branching kept low (binary) so the fixed angular
+# budget isn't blown out completely. 16 leaves at the outer ring.
+
+
+def _make_deep(depth, prefix):
+    if depth == 0:
+        return {"name": prefix}
+    return {
+        "name": prefix,
+        "children": [
+            _make_deep(depth - 1, prefix + "a"),
+            _make_deep(depth - 1, prefix + "b"),
+        ],
+    }
+
+
+DEEP_TREE = _make_deep(4, "r")
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# circle nodes, depth-colored (dark blue root -> light blue leaves).
+def _node(d):
+    return circle(r=6, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_deep_tree():
+    return (
+        tree(
+            DEEP_TREE,
+            node=_node,
+            # NOTE: dsl wants curve links (LinkWidth=depth); falling back
+            # to linear, matching the JS story.
+            link={"curve": "straight", "stroke": "#5f6b7a", "stroke_width": 1.5},
+            parent_child=combine(
+                # theta: nest centers the parent circle over its subtree's
+                # angular span.
+                x={"kind": "nest", "pad": 0},
+                # r: one ring per depth (center mode -> spacing in
+                # r-units).
+                y={
+                    "kind": "distribute",
+                    "spacing": 72,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+            ),
+            sibling=combine(
+                # theta: spread siblings angularly (spacing in radians,
+                # center mode).
+                x={
+                    "kind": "distribute",
+                    "spacing": (2 * math.pi) / 10,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+                # r: all siblings share a radius (same ring).
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 560, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_dendrogram.py
+++ b/tests/python-stories/gotree/gallery/test_dendrogram.py
@@ -1,0 +1,89 @@
+"""Equivalent of gofish-gotree/stories/gallery/Dendrogram.stories.tsx —
+GoTree / Gallery / dendrogram.
+
+Hidden internal nodes (zero-area transparent rects, just to anchor the
+links) with bracket-style connectors, as used for clustering trees. nest is
+on X ONLY so internal nodes are unsized on x (the parent box grows to span
+its subtree) but keep a fixed (tiny) height; leaves are fully fixed-size.
+
+TODO (ported faithfully from the JS story, not fixed here): curveStepAfter
+(right-angle brackets) is unsupported by the bridge, so — matching the JS
+story's own fallback — this uses {curve: "straight"} (straight diagonal
+edges) instead of the reference's right-angle brackets.
+"""
+
+from gofish import rect
+from gofish.gotree import combine, tree
+
+
+def _sub(prefix, n):
+    return [{"name": f"{prefix}{i}"} for i in range(n)]
+
+
+DENDRO_DATA = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A0", "children": _sub("A0", 3)},
+                {"name": "A1", "children": _sub("A1", 2)},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B0", "children": _sub("B0", 2)},
+                {"name": "B1", "children": _sub("B1", 3)},
+                {"name": "B2", "children": _sub("B2", 2)},
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C0", "children": _sub("C0", 3)},
+                {"name": "C1", "children": _sub("C1", 2)},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# Hidden node: a zero-area transparent rect that still gives the link
+# endpoints something to anchor to.
+def _node(d):
+    if d["height"] == 0:
+        return rect(w=1, h=1, fill="transparent", strokeWidth=0)
+    return rect(h=1, fill="transparent", strokeWidth=0)
+
+
+# color=depth: the hidden nodes carry no visible color, so honor it on the
+# links — each link colored by its target node's depth.
+def _link(src, tgt):
+    return {"curve": "straight", "stroke": _by_depth(tgt), "strokeWidth": 1.5}
+
+
+def story_dendrogram():
+    return (
+        tree(
+            DENDRO_DATA,
+            node=_node,
+            link=_link,
+            parent_child=combine(
+                x={"kind": "nest", "pad": 0},
+                y={"kind": "distribute", "spacing": 70},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 22},
+                # "bottom" alignment: y-up -> screen bottom is low y -> "start".
+                y={"kind": "align", "alignment": "start"},
+            ),
+        ),
+        {"w": 900, "h": 520},
+    )

--- a/tests/python-stories/gotree/gallery/test_elastic_hierarchy.py
+++ b/tests/python-stories/gotree/gallery/test_elastic_hierarchy.py
@@ -1,0 +1,85 @@
+"""Equivalent of gofish-gotree/stories/gallery/ElasticHierarchy.stories.tsx —
+GoTree / Gallery / ElasticHierarchy.
+
+Each parent box ENCLOSES its subtree on both axes (nest); the larger Y pad
+leaves a "header" band of empty space above/below the contained children,
+while siblings sit side-by-side in a row (distribute x, aligned middle on
+y). Leaves are sized by datum (value); internal/parent rects are UNSIZED on
+both axes (the nest axes) so each box grows to wrap its subtree.
+"""
+
+from gofish import rect
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# rectangle nodes, colored by depth. Leaves carry the size (height scaled by
+# `value`); internal nodes are left unsized on both axes so nest grows the
+# parent box to inner.intrinsicDims + 2*pad.
+def _node(d):
+    if d["height"] == 0:
+        v = d["value"] if d["value"] is not None else 1
+        return rect(w=26, h=24 + v * 12, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+    return rect(fill=_by_depth(d), stroke="#08306b", strokeWidth=1.5)
+
+
+def story_elastic_hierarchy():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            # include on both axes -> nest. Larger y pad makes the parent
+            # "header" band of empty space; small x pad hugs the subtree
+            # horizontally.
+            parent_child=combine(
+                x={"kind": "nest", "pad": 8},
+                y={"kind": "nest", "pad": 22},
+            ),
+            # flatten x -> distribute (margin -> spacing); align y -> align middle.
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 8},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_flower_tree.py
+++ b/tests/python-stories/gotree/gallery/test_flower_tree.py
@@ -1,0 +1,101 @@
+"""Equivalent of gofish-gotree/stories/gallery/FlowerTree.stories.tsx —
+GoTree / Gallery / FlowerTree.
+
+Polar circle clusters ("petals"). Under polar(): x = theta, y = r.
+parentChild = (x: nest, y: align) -- the parent's angular wedge ENCLOSES the
+angular span of its child group, while align on r keeps parent and children
+on the SAME radial band (no radial growth between levels). sibling =
+(x: distribute, y: align) -- siblings distribute angularly on a shared
+radius.
+
+Radius is scaled by subtree leaf count (`d["width"]`) so parents visibly wrap
+their cluster of child circles -- the petal. Ported verbatim, including the
+JS story's flagged gaps (no angular auto-fit for point/circle nodes -- fixed
+per-level spacing constant, not derived from node count; nest on theta is a
+flat radian pad, not a true wedge inset).
+"""
+
+import math
+
+from gofish import circle, polar
+from gofish.gotree import combine, tree
+
+# Same sample tree as gofish-gotree/stories/data.ts::sampleTree.
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(
+        r=6 + math.sqrt(d.get("width") or 1) * 6,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=2,
+    )
+
+
+def story_flower_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 1.5},
+            parent_child=combine(
+                # theta: parent wedge encloses (nests) the child group's angular span.
+                x={"kind": "nest", "pad": 0.04},
+                # r: parent on the same radial band as its children (no growth).
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            sibling=combine(
+                # theta: spread siblings angularly (spacing in radians, center
+                # mode so point-like circles don't accumulate bboxes around the
+                # ring).
+                x={
+                    "kind": "distribute",
+                    "spacing": (2 * math.pi) / 7,
+                    "anchor": "middle",
+                },
+                # r: siblings share a radius band.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 520, "h": 520},
+    )

--- a/tests/python-stories/gotree/gallery/test_garden_layout.py
+++ b/tests/python-stories/gotree/gallery/test_garden_layout.py
@@ -1,0 +1,83 @@
+"""Equivalent of gofish-gotree/stories/gallery/GardenLayout.stories.tsx —
+GoTree / Gallery / GardenLayout (the "ReadableTreeLayout" subtree).
+
+dsl: Mode bottom-up ; node=circle, color=class, link=orthogonal.
+  X.Root within / X.Subtree flatten ; Y.Root juxtapose / Y.Subtree align.
+Mapped (include->nest, juxtapose/flatten->distribute, within/align->align):
+  parentChild = combine({ x: align(middle, "within"), y: distribute("juxtapose") })
+  sibling     = combine({ x: distribute("flatten"),    y: align(middle, "align") })
+-> parent sits centered above its child row (x align), separated
+  vertically (y distribute); siblings spread horizontally in a single row
+  (x distribute) on a shared baseline (y align). Structurally a classic
+  node-link tree.
+
+TODO (carried from the JS story): needs orthogonal links implemented --
+GoTree's spec asks for "orthogonal" (elbow) links, but the JS story itself
+falls back to `{curve: "straight"}` -- ported faithfully as such here.
+"""
+
+from gofish import circle
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=10, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_garden_layout():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 1.5},
+            parent_child=combine(
+                x={"kind": "align", "alignment": "middle"},
+                y={"kind": "distribute", "spacing": 48},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 24},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_hierarchical_sector_chart.py
+++ b/tests/python-stories/gotree/gallery/test_hierarchical_sector_chart.py
@@ -1,0 +1,104 @@
+"""Equivalent of
+gofish-gotree/stories/gallery/HierarchicalSectorChart.stories.tsx —
+GoTree / Gallery / HierarchicalSectorChart.
+
+Sunburst-of-sectors: concentric filled rect wedges, colored by depth. Under
+polar(): x = theta, y = r. parentChild = (nest theta, distribute r) -- the
+parent wedge spans the combined angular extent of its children (nest, pad 0
+-> no gap) while the child group sits one ring out from the parent (distribute
+r, edge mode, spacing 0 -> rings touch with no radial gap). sibling =
+(distribute theta, align r) -- siblings pack angularly into their parent's
+arc and share the same ring.
+
+Wedge node: width in theta-units (emX) sweeps an arc; height in r-units (emY)
+is the ring thickness. Leaves carry the explicit theta-share (unit weight,
+auto-fit via nest summing them up the tree); internal nodes leave width to
+nest. Ported verbatim, including the flagged gaps (no innerRadius/direction/
+startAngle/centralAngle applied, no polar theta/r axis swap, link "none" per
+the dsl's Link:hidden).
+"""
+
+from gofish import polar, rect, datum
+from gofish.gotree import combine, tree
+
+# Orange -> yellow depth ramp (dsl ColorRange ["#DE4006","#EFD648"]), sampled
+# at the 3 depths this tree uses.
+_SECTOR_RAMP = ["#DE4006", "#E87B11", "#EFD648"]
+
+# Moderately uneven 3-level tree matching the JS story's local `sectorTree`.
+SECTOR_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [{"name": "A1"}, {"name": "A2"}, {"name": "A3"}],
+        },
+        {"name": "B", "children": [{"name": "B1"}, {"name": "B2"}]},
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1"},
+                {"name": "C2"},
+                {"name": "C3"},
+                {"name": "C4"},
+            ],
+        },
+        {"name": "D", "children": [{"name": "D1"}, {"name": "D2"}]},
+        {
+            "name": "E",
+            "children": [{"name": "E1"}, {"name": "E2"}, {"name": "E3"}],
+        },
+    ],
+}
+
+_BAND_HEIGHT = 56  # radial thickness of one ring
+
+
+def _by_depth(d):
+    return _SECTOR_RAMP[min(d["depth"], len(_SECTOR_RAMP) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            thetaSize=datum(1),
+            h=_BAND_HEIGHT,
+            emX=True,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="white",
+            strokeWidth=1.5,
+        )
+    return rect(
+        h=_BAND_HEIGHT,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=1.5,
+    )
+
+
+def story_hierarchical_sector_chart():
+    return (
+        tree(
+            SECTOR_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                # theta: parent wedge encloses its subtree's arc (pad 0 -> exact tiling).
+                x={"kind": "nest", "pad": 0},
+                # r: parent inner ring, child group on the next ring out (edge
+                # mode, spacing 0 -> rings touch with no radial gap).
+                y={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+            ),
+            sibling=combine(
+                # theta: siblings tile their parent's arc (edge mode sums theta-widths).
+                x={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+                # r: siblings share the same ring.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 560, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_htree_layout.py
+++ b/tests/python-stories/gotree/gallery/test_htree_layout.py
@@ -1,0 +1,83 @@
+"""Equivalent of gofish-gotree/stories/gallery/HTreeLayout.stories.tsx —
+GoTree / Gallery / HTreeLayout (the recursive H-tree fractal).
+
+GoTree builds this (gallery dsl0) by ALTERNATING two templates by depth:
+  dsl2 HorizontalLinearLayout: X.Subtree flatten / Y.Subtree align  -> spread x
+  dsl1 VerticalLinearLayout:   X.Subtree align   / Y.Subtree flatten -> spread y
+Both keep Root `within` on both axes -> parent centered inside its
+child-group.
+
+gofish-gotree's depth-aware combiner `alternate([A, B])` resolves at each
+node's depth, so the SIBLING spread axis swaps every level -- exactly what
+the H-fractal needs. parentChild stays a constant (parent centered on both
+axes); only the sibling spread axis alternates H <-> V. Mapping rules:
+within -> align(middle); flatten/juxtapose -> distribute.
+"""
+
+from gofish import circle
+from gofish.gotree import alternate, combine, tree
+
+# Circle nodes, colored by depth (dark root -> light leaves), static size
+# 14 (r = 7), matching the dsl Element block.
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=7, fill=_by_depth(d))
+
+
+# A deep balanced binary tree so the fractal has enough levels to read as
+# an H-tree (the reference uses a deep balanced tree).
+def _make_balanced(depth, prefix="r"):
+    if depth == 0:
+        return {"name": prefix}
+    return {
+        "name": prefix,
+        "children": [
+            _make_balanced(depth - 1, prefix + "L"),
+            _make_balanced(depth - 1, prefix + "R"),
+        ],
+    }
+
+
+BALANCED_TREE = _make_balanced(4)
+
+# Sibling spacing: the alternating axes need different reach so the
+# squares nest cleanly (classic H-tree halves the segment length each
+# level, but a fixed spacing already reads as the recursive H).
+_S = 64
+
+# Even depths spread siblings horizontally, odd depths vertically -- the
+# H <-> V swap that draws the H-tree.
+_H = combine(
+    x={"kind": "distribute", "spacing": _S},
+    y={"kind": "align", "alignment": "middle"},
+)
+_V = combine(
+    x={"kind": "align", "alignment": "middle"},
+    y={"kind": "distribute", "spacing": _S},
+)
+
+
+def story_htree_layout():
+    return (
+        tree(
+            BALANCED_TREE,
+            node=_node,
+            link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 2},
+            # Parent centered inside its child-group on BOTH axes (Root
+            # `within`).
+            parent_child=combine(
+                x={"kind": "align", "alignment": "middle"},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            # Sibling spread axis alternates by depth -> the recursive
+            # H-fractal.
+            sibling=alternate([_H, _V]),
+        ),
+        {"w": 720, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_hvdrawing.py
+++ b/tests/python-stories/gotree/gallery/test_hvdrawing.py
@@ -1,0 +1,93 @@
+"""Equivalent of gofish-gotree/stories/gallery/HVDrawing.stories.tsx —
+GoTree / Gallery / HVDrawing (horizontal/vertical alternating tree).
+
+The original alternates two templates by depth (gallery dsl1 <-> dsl2, axes
+swapped):
+  dsl1: X juxtapose/flatten, Y within/align  -> spread on X, align on Y  ("H")
+  dsl2: X within/align, Y juxtapose/flatten  -> spread on Y, align on X  ("V")
+Expressed with `alternate([H, V])` so every level swaps the spread axis --
+THIS is what makes the HV drawing (a single fixed template collapses to a
+line).
+
+NOTE: the JS story also sets `mode: "bottomUp"` on the spec object, but
+`mode` is a dead field -- grep of gofish-gotree/src/tree.tsx and
+recursion.ts confirms it's declared on the `GoTreeSpec` type but never read
+anywhere in the layout logic. It has zero effect on the JS render, so it's
+omitted here rather than faked (the Python `tree()` signature has no
+`mode` kwarg to begin with).
+"""
+
+from gofish import circle
+from gofish.gotree import alternate, combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=7, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+_S = 34
+# H: parent left of subtree, children in a row (spread x, centered y).
+_H = combine(
+    x={"kind": "distribute", "spacing": _S},
+    y={"kind": "align", "alignment": "middle"},
+)
+# V: parent above subtree, children in a column (spread y, centered x).
+_V = combine(
+    x={"kind": "align", "alignment": "middle"},
+    y={"kind": "distribute", "spacing": _S},
+)
+
+
+def story_hvdrawing():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 1.5},
+            # Both relations alternate in sync (resolved at the same node
+            # depth).
+            parent_child=alternate([_H, _V]),
+            sibling=alternate([_H, _V]),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_icicleplot.py
+++ b/tests/python-stories/gotree/gallery/test_icicleplot.py
@@ -1,0 +1,110 @@
+"""Equivalent of gofish-gotree/stories/gallery/IciclePlotPolar.stories.tsx —
+GoTree / Gallery / icicleplot.
+
+A POLAR icicle plot: concentric wedge bands. Under polar(): x = theta,
+y = r. parentChild = (nest theta, distribute r) -- parent spans its
+children's angular extent (nest theta) and sits one ring in from the child
+group (distribute r, edge mode). sibling = (distribute theta, align r) --
+siblings pack angularly and share the same ring. This is the same point in
+combine({x,y}) space as the Sunburst template, just an icicle framing.
+
+dsl Node="circle" but the reference renders filled wedges, so each node is a
+polar wedge (rect swept through theta), matching the JS story. Leaves carry a
+unit theta-size weight (auto-fit via nest summing up the tree); internal
+nodes leave theta unsized.
+"""
+
+from gofish import polar, rect, datum
+from gofish.gotree import combine, tree
+
+# Same sample tree as gofish-gotree/stories/data.ts::sampleTree.
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+# Sequential blue ramp matching the dsl ColorRange (#2171b5 dark -> #deebf7
+# light), dark at the root, lightening outward by depth.
+_ICICLE_BLUES = ["#2171b5", "#6baed6", "#9ecae1", "#c6dbef", "#deebf7"]
+
+_BAND_HEIGHT = 46  # radial thickness of one depth ring
+
+
+def _by_depth(d):
+    return _ICICLE_BLUES[min(d["depth"], len(_ICICLE_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            thetaSize=datum(1),
+            emX=True,
+            h=_BAND_HEIGHT,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="white",
+            strokeWidth=2,
+        )
+    return rect(
+        emX=True,
+        h=_BAND_HEIGHT,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=2,
+    )
+
+
+def story_icicle_plot():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            # parentChild: distribute r (juxtapose -> adjacent rings, parent
+            # inner -> children outward) + align theta middle (parent centered
+            # over its subtree; the embedded width already gives it the
+            # subtree's full angular span).
+            parent_child=combine(
+                x={"kind": "nest", "pad": 0},
+                y={"kind": "distribute", "spacing": 0},
+            ),
+            # sibling: distribute theta (flatten -> pack around the circle) +
+            # align r middle (siblings share one ring).
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 0},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 560, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_indented_tree.py
+++ b/tests/python-stories/gotree/gallery/test_indented_tree.py
@@ -1,0 +1,82 @@
+"""Equivalent of gofish-gotree/stories/gallery/IndentedTree.stories.tsx —
+GoTree / Gallery / IndentedTree.
+
+The classic indented / outline tree: every node is a row, children stack
+directly below their parent (distribute y) and every node shares the same
+left edge (align x "start"). There is no indentation — depth is instead
+encoded via bar width (RootWidth = "rdepth": widest at the root, narrowest
+at the leaves) plus color = depth.
+"""
+
+from gofish import rect
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# sampleTree's deepest path is root -> B -> B2 -> B2b, so maxDepth = 3.
+# "rdepth" => bar width grows toward the root (widest) and shrinks toward the
+# leaves (narrowest), approximated with a depth-based linear width.
+_MAX_DEPTH = 3
+
+
+def _node(d):
+    return rect(w=16 + (_MAX_DEPTH - d["depth"]) * 26, h=16, fill=_by_depth(d))
+
+
+_LAYOUT = combine(
+    x={"kind": "align", "alignment": "start"},
+    y={"kind": "distribute", "spacing": 4},
+)
+
+
+def story_indented_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            # gotree link = "none" -> no connectors in the indented/outline layout.
+            link="none",
+            parent_child=_LAYOUT,
+            sibling=_LAYOUT,
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_iptp.py
+++ b/tests/python-stories/gotree/gallery/test_iptp.py
@@ -1,0 +1,79 @@
+"""Equivalent of gofish-gotree/stories/gallery/Iptp.stories.tsx —
+GoTree / Gallery / iptp.
+
+An indented pixel-tree plot that lays out the hierarchy as a dense grid of
+nested rectangles. parent_child distributes on BOTH axes (each level steps
+down and across); siblings flatten along x and share a top edge.
+"""
+
+from gofish import rect
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# Uniform tall-bar rectangle nodes, colored by depth (dark root -> light leaves).
+def _node(d):
+    return rect(w=16, h=90, fill=_by_depth(d))
+
+
+def story_iptp():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 6},
+                # puts the parent at HIGH y (top of screen, y-up) so the
+                # root sits above its subtree.
+                y={"kind": "distribute", "spacing": 6},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 6},
+                # Align siblings to the TOP of their bands (y-down free
+                # space: "start" = near/top edge) so same-depth nodes share
+                # a row.
+                y={"kind": "align", "alignment": "start"},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_jewelry.py
+++ b/tests/python-stories/gotree/gallery/test_jewelry.py
@@ -1,0 +1,85 @@
+"""Equivalent of gofish-gotree/stories/gallery/Jewelry.stories.tsx —
+GoTree / Gallery / Jewelry.
+
+Each parent CONTAINS its subtree horizontally (nest on X only) and is
+centered on it vertically (align y); siblings string out left->right
+(distribute x) sharing a vertical center (align y) — beads on a string.
+
+NOTE (ported faithfully from the JS story, not fixed here): nest grows a
+bbox, and a circle is sized by a single radius, so an internal "circle"
+can't grow on X only. Internal nodes are therefore rects left UNSIZED on X
+(fixed height) so the parent box wraps its subtree horizontally; leaves
+stay circles sized by value. The light internal fill reads as the enclosing
+"setting" around the darker leaf "stones".
+"""
+
+from gofish import circle, rect
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+# Darker-than-default ramp so deep leaves stay visible as "stones" against
+# the light enclosing "settings" (the default blue ramp fades to near-white).
+_STONE_BLUES = ["#08306b", "#08519c", "#2171b5", "#4292c6", "#6baed6"]
+
+
+def _by_depth(d, range_=_STONE_BLUES):
+    return range_[min(d["depth"], len(range_) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        v = d["value"] if d["value"] is not None else 1
+        return circle(r=7 + v * 2, fill=_by_depth(d))
+    return rect(h=30, rx=15, fill="#c6dbef", stroke="#6baed6", strokeWidth=1)
+
+
+def story_jewelry():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "straight", "stroke": "#6baed6", "stroke_width": 2},
+            parent_child=combine(
+                x={"kind": "nest", "pad": 6},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 4},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_nested_pie_tree.py
+++ b/tests/python-stories/gotree/gallery/test_nested_pie_tree.py
@@ -1,0 +1,98 @@
+"""Equivalent of gofish-gotree/stories/gallery/NestedPieTree.stories.tsx —
+GoTree / Gallery / NestedPieTree.
+
+This is the CARTESIAN nested-rectangle form (the original gallery entry is a
+polar nested-pie under a polar coordinate system, covered separately by a
+different story). Every parent rectangle CONTAINS its children on both
+axes; `alternate([slice, dice])` swaps the subdivision direction slice<->dice
+at each depth — the cartesian analogue of the radial slice/dice nesting.
+"""
+
+from gofish import rect
+from gofish.gotree import alternate, combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# rectangle nodes, colored by depth. Leaves are sized by their datum value
+# (height proportional to value, fixed width); internal nodes are left
+# UNSIZED on both axes (the nest axes) so each parent box grows to enclose
+# its whole subtree.
+def _node(d):
+    if d["height"] == 0:
+        v = d["value"] if d["value"] is not None else (d["width"] or 1)
+        return rect(w=40, h=v * 16, fill=_by_depth(d))
+    return rect(fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+_P = 6  # nest padding (Root include pad)
+_G = 8  # sibling distribute spacing (Subtree flatten margin)
+
+# dice: siblings stack vertically (distribute y), sharing an x-center.
+_DICE = combine(
+    x={"kind": "align", "alignment": "middle"},
+    y={"kind": "distribute", "spacing": _G},
+)
+# slice: siblings stack horizontally (distribute x), sharing a y-center.
+_SLICE = combine(
+    x={"kind": "distribute", "spacing": _G},
+    y={"kind": "align", "alignment": "middle"},
+)
+
+
+def story_nested_pie_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            # include -> nest on both axes at every level: the parent
+            # rectangle wraps its subtree group horizontally and vertically
+            # with a small padding.
+            parent_child=combine(
+                x={"kind": "nest", "pad": _P},
+                y={"kind": "nest", "pad": _P},
+            ),
+            # Alternate the subdivision axis by depth: slice <-> dice every level.
+            sibling=alternate([_SLICE, _DICE]),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_node_link_tree.py
+++ b/tests/python-stories/gotree/gallery/test_node_link_tree.py
@@ -1,0 +1,82 @@
+"""Equivalent of gofish-gotree/stories/gallery/NodeLinkTree.stories.tsx —
+GoTree / Gallery / NodeLinkTree (classic top-down node-link diagram).
+
+dsl: node=circle, link=straight, color=depth, mode=bottom-up.
+  X.Root within   / X.Subtree flatten (margin 0.3w)
+  Y.Root juxtapose (margin 0.2) / Y.Subtree align (alignment top)
+Mapping (include->nest, juxtapose/flatten->distribute, within/align->align):
+  parentChild = combine({ x: align middle (parent centered over subtree),
+                          y: distribute (parent stacked above its subtree) })
+                 on y puts the root at the TOP (y-up).
+  sibling     = combine({ x: distribute (siblings laid out flat side-by-side),
+                          y: align start (siblings share a baseline/row) })
+"""
+
+from gofish import circle
+from gofish.gotree import combine, tree
+
+# A uniform-depth tree (root -> many depth-1 nodes -> leaves), matching the
+# reference's clean two-tier topology. Some depth-1 nodes are childless
+# and sit on the same row as their siblings; the rest fan out to a few
+# leaves.
+
+
+def _leaves(n, p):
+    return [{"name": f"{p}{i}"} for i in range(n)]
+
+
+NODE_LINK_DATA = {
+    "name": "root",
+    "children": [
+        {"name": "a", "children": _leaves(3, "a")},
+        {"name": "b", "children": _leaves(2, "b")},
+        {"name": "c"},
+        {"name": "d", "children": _leaves(2, "d")},
+        {"name": "e", "children": _leaves(2, "e")},
+        {"name": "f"},
+        {"name": "g"},
+        {"name": "h", "children": _leaves(4, "h")},
+        {"name": "i", "children": _leaves(4, "i")},
+        {"name": "j"},
+        {"name": "k", "children": _leaves(4, "k")},
+        {"name": "l"},
+        {"name": "m", "children": _leaves(4, "m")},
+        {"name": "n", "children": _leaves(3, "n")},
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# Circle nodes, colored by depth (dark root -> light leaves).
+def _node(d):
+    return circle(r=9, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_node_link_tree():
+    return (
+        tree(
+            NODE_LINK_DATA,
+            node=_node,
+            # straight links -> linear interpolation.
+            link={"curve": "straight", "stroke": "#555", "stroke_width": 1.5},
+            parent_child=combine(
+                x={"kind": "align", "alignment": "middle"},
+                y={"kind": "distribute", "spacing": 90},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 24},
+                # Align siblings to the TOP of their bands so every
+                # depth-1 node (even childless ones) sits on one row. In
+                # y-down free space the top is the near edge -> "start";
+                # otherwise a childless node bottom-aligns down to the
+                # leaf row. See issue #143/#16.
+                y={"kind": "align", "alignment": "start"},
+            ),
+        ),
+        {"w": 900, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_oak_tree_vis.py
+++ b/tests/python-stories/gotree/gallery/test_oak_tree_vis.py
@@ -1,0 +1,126 @@
+"""Equivalent of gofish-gotree/stories/gallery/OakTreeVis.stories.tsx —
+GoTree / Gallery / OakTreeVis (polar node-link, depth-colored circles).
+
+dsl: Node=circle, Color=depth, StaticSize=8, Link=curveStepBefore,
+  CoordinateSystem=polar, PolarAxis=x-axis, PolarCenter=right,
+  Layout AxisIndependent (bottom-up):
+    X: Root=within/align(left)  Subtree=flatten (-> distribute)
+    Y: Root=include  (-> nest)   Subtree=flatten (-> distribute)
+Under polar(): x = theta (radians, 0..2*pi), y = r (radius). So the
+combine brief is:
+  parentChild = (align theta,       nest r)
+  sibling     = (distribute theta,  distribute r)
+Distinctive vs. the other radial ports: the SIBLING relation distributes
+on BOTH axes -- siblings step outward in r as they fan in theta. That
+radial stagger (plus the step-link corners in the dsl) is what gives the
+reference its spiral / oak-branch silhouette: each level's children climb
+to larger radii rather than sharing one ring.
+
+POLAR GAPS (no hacks; flagged for follow-up, carried from the JS story):
+ 1. nest on r (y) is the "embedded dimension" hard case, here on the
+    RADIAL axis: the dsl's Y Root=include wants the parent's radial band
+    to ENCLOSE its subtree, but a fixed circle is a point and cannot grow
+    on r. The JS story tried align-r (collapses the tree into a single
+    spiral string, no branching) and settled on DISTRIBUTE on r (parent
+    inner, subtree outer) as the only option that yields a branching
+    radial tree with point nodes -- ported faithfully as such.
+ 2. No angular auto-fit for POINT nodes: sibling theta spacing is a fixed
+    per-level constant (2*pi/6 rad between centers) that does NOT shrink
+    with the number of nodes at a depth (tracked in JS issue #627).
+ 3. polar()'s PolarAxis=x-axis swap and PolarCenter=right are not
+    expressible; plain polar() is used, matching the JS story.
+ 4. Link=curveStepBefore (orthogonal step links) is NOT supported ->
+    {curve: "straight"}, matching the JS story's fallback.
+ 5. anchor "middle" on every distribute treats circles as points (no bbox
+    accumulation) so spacing reads in domain units -- radians for theta,
+    r-units for r.
+"""
+
+import math
+
+from gofish import circle, polar
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# Node=circle, Color=depth, StaticSize=8 -> radius ~5.
+def _node(d):
+    return circle(r=5, fill=_by_depth(d), stroke="#1f3a5f", strokeWidth=1)
+
+
+def story_oak_tree_vis():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            # curveStepBefore unsupported -> linear (see GAP 4).
+            link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 2},
+            parent_child=combine(
+                # theta: parent angularly centered over its subtree's span
+                # (dsl within/align).
+                x={"kind": "align", "alignment": "middle"},
+                # r: dsl wants nest (radial containment); approximated
+                # with distribute (parent inner, children outward) -- see
+                # GAP 1. mode center -> r-units.
+                y={
+                    "kind": "distribute",
+                    "spacing": 60,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+            ),
+            sibling=combine(
+                # theta: fan siblings angularly (radians between centers,
+                # center mode).
+                x={
+                    "kind": "distribute",
+                    "spacing": (2 * math.pi) / 6,
+                    "anchor": "middle",
+                },
+                # r: stagger siblings radially -- the spiral/oak stagger
+                # (dsl flatten).
+                y={"kind": "distribute", "spacing": 30, "anchor": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 520, "h": 520},
+    )

--- a/tests/python-stories/gotree/gallery/test_orthogonal_grid_embedding.py
+++ b/tests/python-stories/gotree/gallery/test_orthogonal_grid_embedding.py
@@ -1,0 +1,117 @@
+"""Equivalent of gofish-gotree/stories/gallery/OrthogonalGridEmbedding.stories.tsx —
+GoTree / Gallery / OrthogonalGridEmbedding (polar node-link).
+
+dsl: CoordinateSystem polar; Node circle; Link orthogonal; Color depth.
+  Layout X (= theta): Root within / Subtree flatten ;
+         Y (= r): Root juxtapose / Subtree align.
+Relation -> combine kind: within/align -> align, juxtapose/flatten ->
+distribute. Root relation = parentChild ; Subtree relation = sibling. So:
+  parentChild = (align theta, distribute r)   -- parent centered angularly
+    over its subtree's wedge; parent inner, children one ring outward.
+  sibling     = (distribute theta, align r)   -- siblings spread around
+    the circle on a shared radius.
+Under polar(): x = theta (radians, 0..2*pi), y = r (radius). Point-like
+circle nodes => anchor "middle" on the distribute axes so spacing is read
+in domain units (radians for theta, r-units for r) and bboxes don't
+accumulate. Color byDepth (sequential blue ramp, dark root -> light
+leaves).
+
+NOTES -- features in the dsl that gofish-gotree cannot express here (no
+hacks, carried from the JS story):
+ - Orthogonal links: the dsl's Link is "orthogonal" (right-angle elbow
+   connectors). The link renderer has no orthogonal mode under polar, so
+   links fall back to {curve: "straight"} (straight segments that still
+   bow along arcs under the polar transform).
+ - No angular auto-fit for POINT nodes: angular spacing is a fixed
+   per-level constant that does NOT shrink with the number of nodes at a
+   depth (tracked in JS issue #627). Spacing is hand-tuned for the small
+   sample tree.
+ - The PolarAxis theta/r swap from the dsl is still NOT expressible (no
+   transposed variant).
+"""
+
+import math
+
+from gofish import circle, polar
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=7, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_orthogonal_grid_embedding():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            # Orthogonal links unsupported -> linear fallback (see NOTES).
+            link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 1.5},
+            parent_child=combine(
+                # theta: parent centered over its subtree's angular span.
+                x={"kind": "align", "alignment": "middle"},
+                # r: parent inner, children one ring outward (center mode
+                # -> spacing in r-units).
+                y={
+                    "kind": "distribute",
+                    "spacing": 70,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+            ),
+            sibling=combine(
+                # theta: spread siblings angularly (spacing in radians,
+                # center mode).
+                x={
+                    "kind": "distribute",
+                    "spacing": (2 * math.pi) / 6,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+                # r: siblings share a radius.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 480, "h": 480},
+    )

--- a/tests/python-stories/gotree/gallery/test_orthogonal_tree.py
+++ b/tests/python-stories/gotree/gallery/test_orthogonal_tree.py
@@ -1,0 +1,92 @@
+"""Equivalent of gofish-gotree/stories/gallery/OrthogonalTree.stories.tsx —
+GoTree / Gallery / OrthogonalTree.
+
+Every relationship distributes on BOTH axes: a parent sits up-left of its
+subtree and each sibling steps further down-right, so the whole tree
+cascades along a diagonal — the classic orthogonal node-link "staircase"
+grid. Links use the `orthogonal` route: right-angle elbows bending at the
+parent<->child midpoint (GoTree's orthogonal link, `ue`).
+
+Node color depends on hierarchy depth (`byDepth` in the JS story's shared
+`data.ts`), not on a field of the tree data itself — that can't be expressed
+as a channel accessor over the node's own row, so it's ported as a whole
+`node=` callable (mark-fn) rather than a static mark template with
+field-accessor channels. See `_node` below.
+"""
+
+from gofish import circle
+from gofish.gotree import combine, tree
+
+# Same sample tree as gofish-gotree/stories/data.ts::sampleTree (the leaf
+# `value`s are unused by this story, but kept for byte-parity with the
+# shared fixture).
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+# Sequential blue ramp, dark at the root -> light at the leaves — same as
+# data.ts::depthBlues.
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=7, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_orthogonal_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "orthogonal", "stroke": "#90a4ae", "stroke_width": 1.5},
+            # parent up-left of its subtree: distribute x forward (parent at
+            # low x = left), distribute y forward too (matches the JS story's
+            # combine() call — GoFish's y-down default puts the parent at
+            # low y = top of screen).
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 18},
+                y={"kind": "distribute", "spacing": 18},
+            ),
+            # siblings step down-right: each later sibling further right (x
+            # forward) and lower (y forward) -> the diagonal cascade.
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 18},
+                y={"kind": "distribute", "spacing": 18},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_readable_tree_layout.py
+++ b/tests/python-stories/gotree/gallery/test_readable_tree_layout.py
@@ -1,0 +1,82 @@
+"""Equivalent of gofish-gotree/stories/gallery/ReadableTreeLayout.stories.tsx —
+GoTree / Gallery / ReadableTreeLayout.
+
+dsl: node=circle, link=orthogonal, color=depth, mode=bottom-up, cartesian.
+  X.Root = within (centered) ; X.Subtree = flatten (margin 0.3w)
+  Y.Root = juxtapose (margin 0.2) ; Y.Subtree = align (alignment top)
+Mapping (within->align middle, juxtapose/flatten->distribute, align->align):
+  parentChild = (align middle x, distribute y)  -> parent centered over
+                its subtree and offset vertically from it.
+  sibling     = (distribute x, align top y)      -> siblings spread
+                across, their tops aligned on a level.
+This is a node-link tree (same layout family as NodeLinkTree). The root
+lands at the top of the frame, leaves at the bottom, matching the
+reference. Links use the `orthogonal` route (elbow connectors), matching
+the dsl's orthogonal links.
+"""
+
+from gofish import circle
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=8, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_readable_tree_layout():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "orthogonal", "stroke": "#555555", "stroke_width": 2},
+            parent_child=combine(
+                x={"kind": "align", "alignment": "middle"},
+                y={"kind": "distribute", "spacing": 60},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 18},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_sector_tree.py
+++ b/tests/python-stories/gotree/gallery/test_sector_tree.py
@@ -1,0 +1,98 @@
+"""Equivalent of gofish-gotree/stories/gallery/SectorTree.stories.tsx —
+GoTree / Gallery / SectorTree.
+
+Concentric rings of thin sector wedges. Under polar(): x = theta, y = r.
+sibling = (distribute theta, align r): siblings pack angularly into their
+parent's arc and share one radial ring. parentChild diverges from the dsl's
+literal Y.Root = within/align (which would collapse the tree to one ring):
+the reference's concentric rings come from GoTree's RootHeight:rdepth
+encoding, which polar() cannot express, so distribute-r (parent inner ring,
+child group one ring out) is used instead -- the same divergence the JS
+story documents, ported verbatim (not "fixed" further).
+
+Wedge node (theta auto-fit): leaves carry a unit angular weight; internal
+nodes leave theta unsized so nest-theta grows each to its children's combined
+arc.
+"""
+
+from gofish import polar, rect, datum
+from gofish.gotree import combine, tree
+
+_SECTOR_BLUES = [
+    "#eff6fb",
+    "#d6e7f3",
+    "#b6d4ea",
+    "#8fbfe0",
+    "#6aa8d6",
+    "#4a90c8",
+    "#2f78b8",
+]
+
+
+def _make_balanced(depth, prefix="root"):
+    if depth == 0:
+        return {"name": prefix}
+    return {
+        "name": prefix,
+        "children": [
+            _make_balanced(depth - 1, prefix + "L"),
+            _make_balanced(depth - 1, prefix + "R"),
+        ],
+    }
+
+
+# Balanced binary tree, 6 levels deep -> 64 leaves.
+DEEP_BALANCED_TREE = _make_balanced(6)
+
+_RING_THICKNESS = 3  # thin radial band (approximates StaticThickness 2)
+_RING_GAP = 13  # radial gap between consecutive rings
+
+
+def _by_depth(d):
+    return _SECTOR_BLUES[min(d["depth"], len(_SECTOR_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            thetaSize=datum(1),
+            h=_RING_THICKNESS,
+            emX=True,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="#2f78b8",
+            strokeWidth=0.75,
+        )
+    return rect(
+        h=_RING_THICKNESS,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="#2f78b8",
+        strokeWidth=0.75,
+    )
+
+
+def story_sector_tree():
+    return (
+        tree(
+            DEEP_BALANCED_TREE,
+            node=_node,
+            link="none",
+            # parentChild: nest theta (include -> parent's arc spans its
+            # children's; nest grows the unsized parent theta) + distribute r
+            # (parent inner ring -> child group one ring out, gap = RING_GAP).
+            parent_child=combine(
+                x={"kind": "nest", "pad": 0},
+                y={"kind": "distribute", "spacing": _RING_GAP, "anchor": "edge"},
+            ),
+            # sibling: distribute theta (pack angularly into the parent's arc)
+            # + align r middle (siblings share one ring).
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 560, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_sector_tree2.py
+++ b/tests/python-stories/gotree/gallery/test_sector_tree2.py
@@ -1,0 +1,87 @@
+"""Equivalent of gofish-gotree/stories/gallery/SectorTree2.stories.tsx —
+GoTree / Gallery / SectorTree2.
+
+Concentric filled sector/wedge rings. Under polar(): x = theta, y = r.
+parentChild = (nest theta, distribute r) -- parent wedge spans its children's
+arc (nest, pad 0), sitting one ring in from the child group (distribute r,
+edge mode, spacing = ring thickness). sibling = (distribute theta, align r)
+-- siblings tile the parent's arc and share one ring. Identical axis
+decomposition to the gallery Sunburst.
+
+The JS story's PolarAxis:x-axis / PolarCenter:right (a right-centered
+half-disc orientation) is NOT expressible -- polar() has no transposed
+variant and no polar-space anchor -- so this renders a full upright disc,
+per the JS story's own note. Ported verbatim.
+"""
+
+from gofish import polar, rect, datum
+from gofish.gotree import combine, tree
+
+
+def _make_balanced(depth, prefix="root"):
+    if depth == 0:
+        return {"name": prefix}
+    return {
+        "name": prefix,
+        "children": [
+            _make_balanced(depth - 1, prefix + "L"),
+            _make_balanced(depth - 1, prefix + "R"),
+        ],
+    }
+
+
+# Balanced binary tree, 4 levels deep -> 16 leaves.
+DEEP_BALANCED_TREE = _make_balanced(4)
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+_BAND_HEIGHT = 42  # radial thickness of one ring
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            thetaSize=datum(1),
+            h=_BAND_HEIGHT,
+            emX=True,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="white",
+            strokeWidth=2,
+        )
+    return rect(
+        h=_BAND_HEIGHT,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=2,
+    )
+
+
+def story_sector_tree2():
+    return (
+        tree(
+            DEEP_BALANCED_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                # theta: parent wedge encloses its subtree's arc (pad 0 -> exact tiling).
+                x={"kind": "nest", "pad": 0},
+                # r: parent inner ring, child group one ring out.
+                y={"kind": "distribute", "spacing": _BAND_HEIGHT, "anchor": "edge"},
+            ),
+            sibling=combine(
+                # theta: siblings tile their parent's arc (edge mode sums theta-widths).
+                x={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+                # r: siblings share the same ring.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 540, "h": 540},
+    )

--- a/tests/python-stories/gotree/gallery/test_side_tree.py
+++ b/tests/python-stories/gotree/gallery/test_side_tree.py
@@ -1,0 +1,111 @@
+"""Equivalent of gofish-gotree/stories/gallery/SideTree.stories.tsx —
+GoTree / Gallery / SideTree (polar node-link, "side-leaning" tree).
+
+dsl: gallery/SideTree/dsl.json
+  Node: circle, StaticSize 6 ; Link: straight ; Color: depth
+  CoordinateSystem: polar, StartAngle 0.17
+  Layout (AxisIndependent, bottom-up):
+    X.Root = juxtapose, X.Subtree = align
+    Y.Root = juxtapose, Y.Subtree = flatten
+  Relation -> combine kind: juxtapose/flatten -> distribute, align ->
+  align. GoTree "Root" = parent<->child relation, "Subtree" = among-
+  siblings relation, so:
+    parentChild = (distribute X, distribute Y)
+    sibling     = (align X,      distribute Y)
+
+Under polar(): x = theta (radians, 0..2*pi), y = r (radius). Map brief
+x=theta, y=r:
+  - parentChild distributes on BOTH theta and r: a child moves outward in
+    r AND sweeps a little in theta from its parent -> the characteristic
+    diagonal "lean".
+  - siblings ALIGN in theta (share one angle / lie on a common spoke) and
+    DISTRIBUTE in r -> a sibling group stacks radially along a single
+    ray, reading as the long straight spines in the reference image.
+Point-like circle nodes => anchor "middle" on every distribute axis so
+spacing is read in domain units (radians for theta, r-units for r) and
+bboxes don't accumulate.
+
+POLAR LIMITATIONS (no hacks here -- flagged for follow-up, carried from
+the JS story):
+ - The dsl's StartAngle 0.17 (and any InnerRadius / Direction /
+   CentralAngle) are expressible via `polar(start_angle=0.17, ...)`, but
+   the JS story itself does not apply them (uses plain polar()) -- ported
+   faithfully as plain polar() too.
+ - No angular auto-fit for POINT nodes: theta spacing is a fixed per-level
+   constant, it does not shrink with node count, so wide/deep trees can
+   overflow the 2*pi budget and wrap (tracked in JS issue #627); spacings
+   here are hand-tuned.
+ - The dsl's bottom-up Mode and per-relation Margins are not modeled --
+   only the relation->constraint-kind mapping is ported.
+"""
+
+from gofish import circle, polar
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=6, fill=_by_depth(d), stroke="#1f3a5f", strokeWidth=1)
+
+
+def story_side_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "straight", "stroke": "#607d8b", "stroke_width": 1.5},
+            # parentChild = (distribute theta, distribute r): child leans
+            # away in angle and steps outward in radius from its parent.
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 0.5, "anchor": "middle"},
+                y={"kind": "distribute", "spacing": 70, "anchor": "middle"},
+            ),
+            # sibling = (align theta, distribute r): siblings share a
+            # spoke (one angle) and stack out along the radius.
+            sibling=combine(
+                x={"kind": "align", "alignment": "middle"},
+                y={"kind": "distribute", "spacing": 90, "anchor": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 560, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_spiral_layout.py
+++ b/tests/python-stories/gotree/gallery/test_spiral_layout.py
@@ -1,0 +1,129 @@
+"""Equivalent of gofish-gotree/stories/gallery/SpiralLayout.stories.tsx —
+GoTree / Gallery / SpiralLayout (polar spiral node-link).
+
+dsl: AxisIndependent, X[subtree=flatten, root=juxtapose] Y[subtree=flatten,
+  root=juxtapose] under CoordinateSystem polar. Both flatten and juxtapose
+  map to `distribute`, so EVERY axis of BOTH relations distributes:
+    parentChild = (distribute x, distribute y)
+    sibling     = (distribute x, distribute y)
+Under polar(): x = theta (radians, 0..2*pi), y = r (radius). Distributing
+on both axes for both relations means each child steps BOTH around
+(theta) AND outward (r) relative to its parent and to its previous
+sibling -- the points walk a spiral.
+  - parentChild: child sits one theta-step around and one r-step out from
+    parent.
+  - sibling: each next sibling is one theta-step around and one r-step out
+    from the prior sibling, so a fan of children itself spirals.
+Point-like circle nodes => anchor "middle" so spacing is read in domain
+units (radians for theta, r-units for r) and bboxes don't accumulate.
+Color = depth. Links straight.
+
+NOTES -- polar gaps (no hacks; flagged for follow-up, carried from the JS
+story):
+ - InnerRadius (spiral start radius), Direction (CW/CCW winding), and
+   CentralAngle are expressible via polar(), but the JS story does not
+   apply them (uses plain polar()) -- ported faithfully as plain polar().
+   Only the theta/r axis swap remains inexpressible regardless.
+ - No angular auto-fit: theta spacing is a fixed per-step constant, so the
+   total angle is (#steps * spacing) and freely exceeds 2*pi -- the
+   spiral wraps past a full turn. For a spiral this overflow is partly
+   intended, but it is uncontrolled (tracked in JS issue #627 for
+   point/circle-node layouts generally).
+ - Combined theta+r distribution on the SAME relation is what yields the
+   spiral, but the per-step r and theta increments are independent
+   constants rather than a single Archimedean-spiral parameterization, so
+   the pitch is only roughly constant.
+"""
+
+import math
+
+from gofish import circle, polar
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=7, fill=_by_depth(d), stroke="#1f3a5f", strokeWidth=1)
+
+
+def story_spiral_layout():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link={"curve": "straight", "stroke": "#90a4ae", "stroke_width": 1.5},
+            # parentChild: step around (theta) and outward (r) from the
+            # parent.
+            parent_child=combine(
+                x={
+                    "kind": "distribute",
+                    "spacing": (2 * math.pi) / 9,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+                y={
+                    "kind": "distribute",
+                    "spacing": 50,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+            ),
+            # sibling: each next sibling spirals one theta-step around and
+            # one r-step out.
+            sibling=combine(
+                x={
+                    "kind": "distribute",
+                    "spacing": (2 * math.pi) / 9,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+                y={
+                    "kind": "distribute",
+                    "spacing": 26,
+                    "anchor": "middle",
+                    "alignment": "middle",
+                },
+            ),
+            coord=polar(),
+        ),
+        {"w": 520, "h": 520},
+    )

--- a/tests/python-stories/gotree/gallery/test_stair_tree.py
+++ b/tests/python-stories/gotree/gallery/test_stair_tree.py
@@ -1,0 +1,78 @@
+"""Equivalent of gofish-gotree/stories/gallery/StairTree.stories.tsx —
+GoTree / Gallery / StairTree.
+
+Each parent sits left of its subtree (distribute x) and its box wraps the
+subtree vertically (nest y); siblings step diagonally (distribute on both
+axes) — producing the cascading staircase.
+"""
+
+from gofish import rect
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# rectangle nodes, colored by depth. Internal nodes are left UNSIZED on y
+# (the nest axis) so the parent box grows to wrap its subtree; leaves are
+# fixed.
+def _node(d):
+    if d["height"] == 0:
+        return rect(w=34, h=18, fill=_by_depth(d))
+    return rect(w=34, fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+def story_stair_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 6},
+                y={"kind": "nest", "pad": 6},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 6},
+                y={"kind": "distribute", "spacing": 6},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_sunburst.py
+++ b/tests/python-stories/gotree/gallery/test_sunburst.py
@@ -1,0 +1,88 @@
+"""Equivalent of gofish-gotree/stories/gallery/Sunburst.stories.tsx —
+GoTree / Gallery / sunburst.
+
+Concentric filled wedges. Under polar(): x = theta, y = r. parentChild =
+(nest theta, distribute r) -- parent wedge spans its children's combined
+angular extent (nest, pad 0) and sits on the ring just inside the child
+group (distribute r, edge mode, spacing = ring thickness). sibling =
+(distribute theta, align r) -- siblings tile the parent's arc and share one
+ring.
+
+Wedge node (theta auto-fit): leaves carry a unit thetaSize weight that the
+coord sums and fits to the budget; internal nodes leave theta unsized so nest
+grows them to their children's combined arc. dsl Node:circle, but the
+reference (and a real sunburst) is filled arc wedges -- rendered as rect
+wedges, matching the JS story.
+"""
+
+from gofish import polar, rect, datum
+from gofish.gotree import combine, tree
+
+
+def _make_balanced(depth, prefix="root"):
+    if depth == 0:
+        return {"name": prefix}
+    return {
+        "name": prefix,
+        "children": [
+            _make_balanced(depth - 1, prefix + "L"),
+            _make_balanced(depth - 1, prefix + "R"),
+        ],
+    }
+
+
+# Balanced binary tree, 4 levels deep -> 16 leaves.
+DEEP_BALANCED_TREE = _make_balanced(4)
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+_BAND_HEIGHT = 42  # radial thickness of one ring
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            thetaSize=datum(1),
+            h=_BAND_HEIGHT,
+            emX=True,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="white",
+            strokeWidth=1.5,
+        )
+    return rect(
+        h=_BAND_HEIGHT,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=1.5,
+    )
+
+
+def story_sunburst():
+    return (
+        tree(
+            DEEP_BALANCED_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                # theta: parent wedge encloses its subtree's arc (pad 0 -> exact tiling).
+                x={"kind": "nest", "pad": 0},
+                # r: parent inner ring, child group one ring out.
+                y={"kind": "distribute", "spacing": _BAND_HEIGHT, "anchor": "edge"},
+            ),
+            sibling=combine(
+                # theta: siblings tile their parent's arc (edge mode sums theta-widths).
+                x={"kind": "distribute", "spacing": 0, "anchor": "edge"},
+                # r: siblings share the same ring.
+                y={"kind": "align", "alignment": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 540, "h": 540},
+    )

--- a/tests/python-stories/gotree/gallery/test_tornado_tree.py
+++ b/tests/python-stories/gotree/gallery/test_tornado_tree.py
@@ -1,0 +1,109 @@
+"""Equivalent of gofish-gotree/stories/gallery/TornadoTree.stories.tsx —
+GoTree / Gallery / TornadoTree.
+
+Polar, nested-radial spiral. Under polar(): x = theta, y = r.
+parentChild = (distribute theta, NEST r) -- parent's radial band ENCLOSES
+its subtree, while parent and subtree are offset angularly (the spiral
+"twist"). sibling = (distribute theta, distribute r) -- siblings step in
+BOTH angle and radius, fanning each level outward into the tornado curl.
+
+Nest-on-r is the hard case: internal nodes get a rect with no `h` (unsized on
+r, the nest axis) and a fixed theta-width (emX). There is no angular
+auto-fit here -- theta spacing is a fixed per-level constant, so the spiral
+overflows 2*pi and wraps; that wrap is on-theme (the reference is itself a
+spiral winding past 2*pi) but not principled allocation. Ported verbatim,
+including this uncontrolled overflow.
+"""
+
+from gofish import polar, rect
+from gofish.gotree import combine, tree
+
+# Same sample tree as gofish-gotree/stories/data.ts::sampleTree.
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+_TH = 0.13  # fixed angular width per node (radians, via emX) -- thin slivers
+_LEAF_H = 12  # leaf radial thickness (r units, via emY)
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            w=_TH,
+            h=_LEAF_H,
+            emX=True,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="white",
+            strokeWidth=1,
+        )
+    # internal node: NO h -> grows on r via nest (radial containment).
+    return rect(
+        w=_TH,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=1,
+    )
+
+
+def story_tornado_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                # theta: offset parent from its subtree -> the spiral twist.
+                x={"kind": "distribute", "spacing": 0.55, "anchor": "middle"},
+                # r: parent's band ENCLOSES the subtree (dsl Root "include").
+                y={"kind": "nest", "pad": 9},
+            ),
+            sibling=combine(
+                # theta: step siblings angularly (tight -> packs the curl).
+                x={"kind": "distribute", "spacing": 0.42, "anchor": "middle"},
+                # r: step siblings radially too -> fans the level outward.
+                y={"kind": "distribute", "spacing": 9, "anchor": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 480, "h": 480},
+    )

--- a/tests/python-stories/gotree/gallery/test_tornado_tree2.py
+++ b/tests/python-stories/gotree/gallery/test_tornado_tree2.py
@@ -1,0 +1,111 @@
+"""Equivalent of gofish-gotree/stories/gallery/TornadoTree2.stories.tsx —
+GoTree / Gallery / TornadoTree2.
+
+A variant of TornadoTree: every node is a thin arc, and each deeper level
+both twists angularly and grows radially, so the whole tree spirals outward
+from the center. parentChild = (distribute theta, nest r) -- each child group
+is twisted a bit angularly off its parent and nested radially inside it.
+sibling = (distribute theta, distribute r) -- siblings fan out on theta AND
+step outward on r, producing the spiral.
+
+Internal nodes are left unsized on r so `nest` can grow them to wrap their
+subtree; only the theta-width is fixed. No angular auto-fit (fixed per-level
+spacing), so deep/wide branches overflow 2*pi and wrap -- this is the
+"tornado" overflow from the reference, kept uncontrolled per the JS story.
+"""
+
+from gofish import polar, rect
+from gofish.gotree import combine, tree
+
+# Same sample tree as gofish-gotree/stories/data.ts::sampleTree.
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+_LEAF_THETA = 0.12  # angular width of a node (radians)
+_LEAF_R = 14  # radial thickness of a leaf (px in r)
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            w=_LEAF_THETA,
+            h=_LEAF_R,
+            emX=True,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="white",
+            strokeWidth=1,
+        )
+    # internal node: fixed theta-width, UNSIZED on r so `nest` grows it
+    # radially to enclose its subtree.
+    return rect(
+        w=_LEAF_THETA,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=1,
+    )
+
+
+def story_tornado_tree2():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                # theta: twist the child group off its parent -- a large
+                # per-level twist is what makes successive rings spiral around.
+                x={"kind": "distribute", "spacing": 0.5, "anchor": "middle"},
+                # r: child group nested radially inside the parent. Small pad
+                # keeps parent arcs from spiking too far out.
+                y={"kind": "nest", "pad": 6},
+            ),
+            sibling=combine(
+                # theta: fan siblings out angularly.
+                x={"kind": "distribute", "spacing": 0.32, "anchor": "middle"},
+                # r: step each sibling outward radially -> the spiral.
+                y={"kind": "distribute", "spacing": 12, "anchor": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 560, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_treemap.py
+++ b/tests/python-stories/gotree/gallery/test_treemap.py
@@ -1,0 +1,95 @@
+"""Equivalent of gofish-gotree/stories/gallery/Treemap.stories.tsx —
+GoTree / Gallery / Treemap.
+
+`parent_child` is CONSTANT nest x nest (every parent box wraps its subtree
+on both axes); only the sibling subdivision alternates slice<->dice every
+level via `alternate([dice, slice])`. That swap is the essence of a
+squarified-looking treemap — it avoids the tall-thin-column look of a
+single fixed template. Node = rectangle, link = none, color = depth (blue
+ramp, dark root -> light leaf).
+"""
+
+from gofish import rect
+from gofish.gotree import alternate, combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# Internal/parent nodes nest on BOTH axes, so they must be UNSIZED on both x
+# and y — the rect grows to wrap its subtree. Leaves are sized by data so
+# areas read proportionally (height proportional to d.data.value).
+def _node(d):
+    if d["height"] == 0:
+        return rect(w=92, h=14 * d["value"], fill=_by_depth(d))
+    return rect(fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+_P = 9  # parent->subtree pad (small, constant)
+_G = 9  # sibling spacing
+
+# DICE: siblings side-by-side on x, centered on y.
+_DICE = combine(
+    x={"kind": "distribute", "spacing": _G},
+    y={"kind": "align", "alignment": "middle"},
+)
+# SLICE: siblings stacked on y, centered on x.
+_SLICE = combine(
+    x={"kind": "align", "alignment": "middle"},
+    y={"kind": "distribute", "spacing": _G},
+)
+
+
+def story_treemap():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            # Parent box wraps its subtree on both axes at every depth (constant).
+            parent_child=combine(
+                x={"kind": "nest", "pad": _P},
+                y={"kind": "nest", "pad": _P},
+            ),
+            # Siblings subdivide the parent, swapping dice<->slice every level.
+            sibling=alternate([_DICE, _SLICE]),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_treemap_oval.py
+++ b/tests/python-stories/gotree/gallery/test_treemap_oval.py
@@ -1,0 +1,97 @@
+"""Equivalent of gofish-gotree/stories/gallery/TreemapOval.stories.tsx —
+GoTree / Gallery / TreemapOval.
+
+A treemap with ELLIPSE nodes instead of rectangles: nested ovals. Both axes
+nest so each parent oval grows to wrap its subtree's bounding box. Leaves
+are sized by their datum value. `alternate([dice, slice])` swaps the
+subdivision slice<->dice at every level — a rounder, more 2D-filled nesting
+than a single stretched template.
+
+NOTE (ported faithfully from the JS story, not fixed here): because nest
+sizes a bounding box, an ellipse wrapping children overflows visually at
+its corners — expected for oval treemaps, per the JS story's own comment.
+"""
+
+from gofish import ellipse
+from gofish.gotree import alternate, combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+# ellipse nodes, colored by depth. Internal nodes are left UNSIZED on both x
+# and y (the nest axes) so each parent oval grows to wrap its subtree;
+# leaves are sized by their datum value (area-ish ramp).
+def _node(d):
+    if d["height"] == 0:
+        return ellipse(w=22 + d["value"] * 14, h=22 + d["value"] * 14, fill=_by_depth(d))
+    return ellipse(fill=_by_depth(d), stroke="#08306b", strokeWidth=1)
+
+
+_P = 10
+_G = 8
+# dice: siblings stack vertically (spread y), share an x-center.
+_DICE = combine(
+    x={"kind": "align", "alignment": "middle"},
+    y={"kind": "distribute", "spacing": _G},
+)
+# slice: siblings spread horizontally (spread x), share a y-center.
+_SLICE = combine(
+    x={"kind": "distribute", "spacing": _G},
+    y={"kind": "align", "alignment": "middle"},
+)
+
+
+def story_treemap_oval():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            # Both axes nest so each parent oval wraps its subtree's bbox.
+            parent_child=combine(
+                x={"kind": "nest", "pad": _P},
+                y={"kind": "nest", "pad": _P},
+            ),
+            # Subdivision alternates slice<->dice every level (depth-indexed).
+            sibling=alternate([_SLICE, _DICE]),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/python-stories/gotree/gallery/test_treemap_slice.py
+++ b/tests/python-stories/gotree/gallery/test_treemap_slice.py
@@ -1,0 +1,88 @@
+"""Equivalent of gofish-gotree/stories/gallery/TreemapSlice.stories.tsx —
+GoTree / Gallery / treemap-slice.
+
+A slice-and-dice treemap. `parent_child` nests on BOTH axes (parent box
+contains its subtree on both axes, so every level is a slice within its
+parent). `sibling` distributes on x and aligns middle on y — siblings are
+sliced side by side along x and centered vertically. Leaves are sized in x
+by their datum value and given a fixed height; internal nodes are UNSIZED
+on both axes (the nest constraint grows each parent box to wrap its sliced
+subtree).
+"""
+
+from gofish import rect
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+# Blue depth ramp matching the gotree ColorRange (dark root -> light leaves).
+_SLICES = ["#2171b5", "#4292c6", "#6baed6", "#9ecae1", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d, range_=_SLICES):
+    return range_[min(d["depth"], len(range_) - 1)]
+
+
+_LEAF_HEIGHT = 320  # adaptive height -> fixed pixel height per leaf
+_VALUE_SCALE = 30  # leaf width = datum value * scale (slice by value)
+
+
+# rectangle nodes, colored by depth, white slice borders. Leaves are sized
+# by data (width = value, fixed height); internal/parent rects are left
+# UNSIZED on both axes so each nest grows the box to wrap its sliced subtree.
+def _node(d):
+    if d["height"] == 0:
+        v = d["value"] if d["value"] is not None else d["width"]
+        return rect(w=v * _VALUE_SCALE, h=_LEAF_HEIGHT, fill=_by_depth(d), stroke="white", strokeWidth=4)
+    return rect(fill=_by_depth(d), stroke="white", strokeWidth=4)
+
+
+def story_treemap_slice():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            parent_child=combine(
+                x={"kind": "nest", "pad": 6},
+                y={"kind": "nest", "pad": 22},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 14},
+                y={"kind": "align", "alignment": "middle"},
+            ),
+        ),
+        {"w": 900, "h": 360},
+    )

--- a/tests/python-stories/gotree/gallery/test_tyre_tree.py
+++ b/tests/python-stories/gotree/gallery/test_tyre_tree.py
@@ -1,0 +1,95 @@
+"""Equivalent of gofish-gotree/stories/gallery/TyreTree.stories.tsx —
+GoTree / Gallery / TyreTree.
+
+Concentric tyre-like rings of wedges, where a parent's wedge INCLUDES its
+children radially: the outermost ring is the root, and each level nests one
+band further toward the center. Under polar(): x = theta, y = r.
+parentChild = (nest theta, align r) ; sibling = (distribute theta, align r).
+
+Unlike the sunburst/icicle (own ring per depth via distribute-r), here every
+node is ALIGNED on r at the same inner edge ("start") and its radial height
+encodes its reverse-depth: a node at rdepth k spans (k+1) bands outward from
+the shared inner edge, so shallower levels progressively overpaint deeper
+ones toward the center -- the concentric "tyre".
+
+REQUIRES a depth-balanced tree (align-r needs every leaf at the same depth
+so the radial bands line up) -- ported the JS story's balanced `sampleTree`
+(depth 3, 8 leaves), not the shared uneven fixture.
+"""
+
+from gofish import polar, rect, datum
+from gofish.gotree import combine, tree
+
+
+def _make_balanced(depth, prefix="root"):
+    if depth == 0:
+        return {"name": prefix}
+    return {
+        "name": prefix,
+        "children": [
+            _make_balanced(depth - 1, prefix + "L"),
+            _make_balanced(depth - 1, prefix + "R"),
+        ],
+    }
+
+
+# Balanced binary tree, depth 3 -> 8 leaves, 4 levels.
+SAMPLE_TREE = _make_balanced(3)
+
+# Sequential blue ramp, dark at the root (outer rim) -> light at the leaves
+# (inner).
+_TYRE_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+_BAND = 34  # radial thickness of one inclusion band
+
+
+def _by_depth(d):
+    return _TYRE_BLUES[min(d["depth"], len(_TYRE_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            thetaSize=datum(1),
+            emX=True,
+            h=(d["height"] + 1) * _BAND,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="white",
+            strokeWidth=2,
+        )
+    return rect(
+        emX=True,
+        h=(d["height"] + 1) * _BAND,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=2,
+    )
+
+
+def story_tyre_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            # parentChild: nest theta realizes the dsl's X.Root=include (parent's
+            # arc spans its children's). align r "start" pins every node's INNER
+            # edge to the same radius, so the taller (lower-depth) wedge reaches
+            # OUTWARD past its children.
+            parent_child=combine(
+                x={"kind": "nest", "pad": 0},
+                y={"kind": "align", "alignment": "start"},
+            ),
+            # sibling: distribute theta (pack siblings around the circle) +
+            # align r "start" (siblings share the same inner edge / band).
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 0},
+                y={"kind": "align", "alignment": "start"},
+            ),
+            # InnerRadius:0.25 -- the donut hole (tyre hub).
+            coord=polar(inner_radius=0.25),
+        ),
+        {"w": 560, "h": 560},
+    )

--- a/tests/python-stories/gotree/gallery/test_violin_tree.py
+++ b/tests/python-stories/gotree/gallery/test_violin_tree.py
@@ -1,0 +1,108 @@
+"""Equivalent of gofish-gotree/stories/gallery/ViolinTree.stories.tsx —
+GoTree / Gallery / ViolinTree.
+
+Polar nested bands, no links. parentChild = (distribute theta, nest r) --
+the parent's rect grows RADIALLY to embed its subtree (the embedded radial
+dimension). sibling = (distribute theta, distribute r).
+
+Internal nodes are left UNSIZED on r (h) so nest-on-r grows them to wrap
+their subtree; leaves are sized on r by `d["value"]`, so the radial
+thickness varies leaf-to-leaf -- the violin silhouette. theta-width is a
+fixed per-node constant (no angular auto-fit): sizes/spacings are hand-tuned
+for the 8-leaf sampleTree, exactly as in the JS story.
+"""
+
+import math
+
+from gofish import polar, rect
+from gofish.gotree import combine, tree
+
+# Same sample tree as gofish-gotree/stories/data.ts::sampleTree.
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+_LEAF_THETA = (2 * math.pi) / 9  # fixed theta-width per node (~9 slots)
+_VALUE_R = 14  # r-units per unit of value (violin thickness)
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    if d["height"] == 0:
+        return rect(
+            w=_LEAF_THETA,
+            h=d["value"] * _VALUE_R,  # leaf radial thickness proportional to value
+            emX=True,
+            emY=True,
+            fill=_by_depth(d),
+            stroke="white",
+            strokeWidth=1,
+        )
+    # internal: unsized on r (h) -> nest grows it to embed the subtree.
+    return rect(
+        w=_LEAF_THETA,
+        emX=True,
+        emY=True,
+        fill=_by_depth(d),
+        stroke="white",
+        strokeWidth=1,
+    )
+
+
+def story_violin_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            link="none",
+            # parentChild: X juxtapose -> distribute theta ; Y include -> nest r.
+            # spacing:0/center on theta keeps parent theta-centered over its
+            # subtree; nest on r grows the parent's rect to embed the subtree.
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 0, "anchor": "middle"},
+                y={"kind": "nest", "pad": 6},
+            ),
+            # sibling: X flatten -> distribute theta ; Y flatten -> distribute r.
+            sibling=combine(
+                x={"kind": "distribute", "spacing": _LEAF_THETA, "anchor": "middle"},
+                y={"kind": "distribute", "spacing": 0, "anchor": "middle"},
+            ),
+            coord=polar(),
+        ),
+        {"w": 520, "h": 520},
+    )

--- a/tests/python-stories/gotree/gallery/test_weave_tree.py
+++ b/tests/python-stories/gotree/gallery/test_weave_tree.py
@@ -1,0 +1,85 @@
+"""Equivalent of gofish-gotree/stories/gallery/WeaveTree.stories.tsx —
+GoTree / Gallery / WeaveTree.
+
+dsl: X.Root juxtapose(margin 0) / X.Subtree flatten(margin 0.15) ;
+     Y.Root within(top) / Y.Subtree flatten ; mode bottom-up.
+  parentChild = (distribute x, align y top)   sibling = (distribute x, distribute y)
+Mapping: juxtapose/flatten->distribute, within->align, "top"->high y in
+y-up->"end".
+Each parent sits left of its subtree (distribute x) and aligns to its
+subtree's top edge (align y "end"); siblings spread on BOTH axes
+(distribute x and y) so every sibling steps diagonally -- the woven,
+braided look.
+
+TODO (carried from the JS story): needs curve links implemented -- dsl
+Link is "curve" but the gotree LinkSpec only supports interpolation
+linear/bezier/orthogonal/arc, so this falls back to {curve: "straight"},
+matching the JS story.
+"""
+
+from gofish import circle
+from gofish.gotree import combine, tree
+
+SAMPLE_TREE = {
+    "name": "root",
+    "children": [
+        {
+            "name": "A",
+            "children": [
+                {"name": "A1", "value": 4},
+                {"name": "A2", "value": 2},
+                {"name": "A3", "value": 3},
+            ],
+        },
+        {
+            "name": "B",
+            "children": [
+                {"name": "B1", "value": 5},
+                {
+                    "name": "B2",
+                    "children": [
+                        {"name": "B2a", "value": 2},
+                        {"name": "B2b", "value": 1},
+                    ],
+                },
+            ],
+        },
+        {
+            "name": "C",
+            "children": [
+                {"name": "C1", "value": 3},
+                {"name": "C2", "value": 2},
+            ],
+        },
+    ],
+}
+
+_DEPTH_BLUES = ["#08306b", "#2171b5", "#6baed6", "#c6dbef", "#deebf7"]
+
+
+def _by_depth(d):
+    return _DEPTH_BLUES[min(d["depth"], len(_DEPTH_BLUES) - 1)]
+
+
+def _node(d):
+    return circle(r=6, fill=_by_depth(d))
+
+
+def story_weave_tree():
+    return (
+        tree(
+            SAMPLE_TREE,
+            node=_node,
+            # TODO: needs curve links implemented
+            link={"curve": "straight", "stroke": "#666", "stroke_width": 1},
+            parent_child=combine(
+                x={"kind": "distribute", "spacing": 8},
+                y={"kind": "align", "alignment": "end"},
+            ),
+            sibling=combine(
+                x={"kind": "distribute", "spacing": 12},
+                y={"kind": "distribute", "spacing": 12},
+            ),
+        ),
+        {"w": 640, "h": 420},
+    )

--- a/tests/scripts/capture-diff.ts
+++ b/tests/scripts/capture-diff.ts
@@ -178,6 +178,16 @@ async function main() {
       stdio: "inherit",
     });
 
+    // --ignore-scripts also skips gofish-ir's `prepare`, but the harness
+    // imports gofish-ir via its built dist/ — build it explicitly (when the
+    // base ref has the package at all).
+    if (existsSync(join(wtPath, "packages/gofish-ir/package.json"))) {
+      execSync("pnpm --filter gofish-ir build", {
+        cwd: wtPath,
+        stdio: "inherit",
+      });
+    }
+
     console.log(`\n=== Capturing ${baseRef} (${baseShort}) ===\n`);
     baseResult = await captureStories({
       harnessDir: join(wtPath, "tests/harness"),

--- a/tests/scripts/check-python-sync.ts
+++ b/tests/scripts/check-python-sync.ts
@@ -184,11 +184,16 @@ function isSpecNeutralChange(jsFile: string, baseRef: string): boolean {
 }
 
 // ---------------------------------------------------------------------------
-// Walk all JS stories under packages/gofish-graphics/stories/.
+// Walk all JS stories under packages/gofish-graphics/stories/ and
+// packages/gofish-gotree/stories/ (the tree-DSL package — see #792).
 // ---------------------------------------------------------------------------
 
+const JS_STORY_ROOTS = [
+  "packages/gofish-graphics/stories",
+  "packages/gofish-gotree/stories",
+];
+
 function walkJsStories(): string[] {
-  const root = join(ROOT_DIR, "packages/gofish-graphics/stories");
   const out: string[] = [];
   function walk(dir: string) {
     if (!existsSync(dir)) return;
@@ -200,7 +205,7 @@ function walkJsStories(): string[] {
       }
     }
   }
-  walk(root);
+  for (const root of JS_STORY_ROOTS) walk(join(ROOT_DIR, root));
   return out.sort();
 }
 

--- a/tests/scripts/check-python-sync.ts
+++ b/tests/scripts/check-python-sync.ts
@@ -408,15 +408,14 @@ console.log(`Checking Python story sync against ${baseRef}...`);
 
 const exemptSet = loadExemptSet();
 
-const addedJs = gitDiff("A", baseRef).filter((f) =>
-  f.match(/^packages\/gofish-graphics\/stories\/.*\.stories\.tsx$/)
+const jsStoryPathRe = new RegExp(
+  `^(${JS_STORY_ROOTS.map((r) => r.replace(/\//g, "\\/")).join(
+    "|"
+  )})\\/.*\\.stories\\.tsx$`
 );
-const deletedJs = gitDiff("D", baseRef).filter((f) =>
-  f.match(/^packages\/gofish-graphics\/stories\/.*\.stories\.tsx$/)
-);
-const modifiedJs = gitDiff("M", baseRef).filter((f) =>
-  f.match(/^packages\/gofish-graphics\/stories\/.*\.stories\.tsx$/)
-);
+const addedJs = gitDiff("A", baseRef).filter((f) => f.match(jsStoryPathRe));
+const deletedJs = gitDiff("D", baseRef).filter((f) => f.match(jsStoryPathRe));
+const modifiedJs = gitDiff("M", baseRef).filter((f) => f.match(jsStoryPathRe));
 const allChangedFiles = new Set(gitDiff("ACDMRT", baseRef));
 
 const results: SyncResult[] = [];

--- a/tests/scripts/derive-server.py
+++ b/tests/scripts/derive-server.py
@@ -63,6 +63,80 @@ sys.path.insert(0, os.path.join(PROJECT_ROOT, "tests"))
 # Registry: lambdaId → Python function
 _registry: dict = {}
 
+
+def _collect_raw_accessor_lambdas(mark) -> list:
+    """Like `gofish.ast._collect_mark_lambdas`, but yields `(lambda_id,
+    raw_fn)` pairs — the bare `(row) -> value` callable itself, not the
+    rows-batched `lambda rows: [fn(r) for r in rows]` wrapper.
+
+    Used only for gotree node templates (#792): a channel lambda embedded
+    directly in a gotree `node=` Mark template is resolved one row at a
+    time via the `__gofish_args` positional-call convention (see
+    `_register_gotree_lambdas`/`_handle_derive`), never batched, so the
+    registry must hold the raw callable.
+    """
+    from gofish.ast import _PendingAccessor
+
+    pairs: list = []
+    for val in mark.kwargs.values():
+        if isinstance(val, _PendingAccessor):
+            pairs.append((val.lambda_id, val.fn))
+    if mark._children is not None:
+        for child in mark._children:
+            pairs.extend(_collect_raw_accessor_lambdas(child))
+    return pairs
+
+
+def _register_gotree_lambdas(tree_obj) -> list:
+    """Register the lambdas hanging off a `gofish.gotree.Tree` (#792):
+    a `node=` mark-fn callable, a `node=` template's own channel
+    accessors, and/or a `link=` callable. All three are invoked by the JS
+    reconstruction (`reconstructGotreeTree` in
+    `packages/gofish-gotree/src/serialize.ts`) as single positional-arg
+    RPCs (`ctx.applyLambda(id, args)`), never as row batches — see
+    `makeGotreeApplyLambda`'s doc comment in
+    `packages/gofish-python/widget-src/index.ts` for the wire convention
+    (`{"__gofish_args": args}`) and `_handle_derive` below for the
+    Python-side unwrap. Returns the registered lambda ids.
+    """
+    from gofish.ast import Mark, _MarkFn, _PendingAccessor, _collect_mark_lambdas
+
+    derive_ids: list = []
+
+    node = tree_obj._node
+    if isinstance(node, _MarkFn):
+        user_fn = node.fn
+
+        def _node_fn(row, _fn=user_fn):
+            mark = _fn(row)
+            if not isinstance(mark, Mark):
+                raise TypeError(
+                    "gotree.tree(): node= callable must return a gofish "
+                    f"Mark, got {type(mark).__name__}"
+                )
+            # The returned mark may itself carry channel accessors (fresh
+            # `_PendingAccessor`s minted inside the call) — register them
+            # under the ordinary rows-batched contract, since those are
+            # resolved by `mapMark`'s normal DeriveBridge, not by another
+            # `ctx.applyLambda` round trip.
+            for lam_id, rows_fn in _collect_mark_lambdas(mark):
+                _registry[lam_id] = rows_fn
+            return mark.to_dict()
+
+        _registry[node.lambda_id] = _node_fn
+        derive_ids.append(node.lambda_id)
+    elif isinstance(node, Mark):
+        for lam_id, fn in _collect_raw_accessor_lambdas(node):
+            _registry[lam_id] = fn
+            derive_ids.append(lam_id)
+
+    link = tree_obj._link
+    if isinstance(link, _PendingAccessor):
+        _registry[link.lambda_id] = link.fn
+        derive_ids.append(link.lambda_id)
+
+    return derive_ids
+
 # Track where the `python_stories` package was registered from, so a /load
 # request with a different pythonStoriesDir can re-register against the new
 # path instead of silently reusing a stale registration.
@@ -172,6 +246,21 @@ class DeriveHandler(BaseHTTPRequestHandler):
                 _MarkFn,
                 _InputRef,
             )
+            from gofish.gotree import Tree
+
+            if isinstance(builder, Tree):
+                # A gotree Tree is a standalone top-level render, like a
+                # raw Mark story (#792) — it is never a ChartBuilder/
+                # LayerBuilder, and its lambdas (node mark-fn/template
+                # accessors, link callable) use the positional
+                # `__gofish_args` convention, not the rows-batched one.
+                self._json_response(200, {
+                    "_kind": "raw-mark",
+                    "mark": builder.to_dict(),
+                    "options": options,
+                    "deriveIds": _register_gotree_lambdas(builder),
+                })
+                return
 
             def serialize_chart(child) -> tuple:
                 """Return (child_payload, derive_ids) for one layer tier.
@@ -355,6 +444,25 @@ class DeriveHandler(BaseHTTPRequestHandler):
         try:
             data = json.loads(body)
             fn = _registry[lambda_id]
+
+            # gotree lambda calls (#792): the JS adapter
+            # (`makeGotreeApplyLambda`/`applyGotreeLambda`) sends a single
+            # positional-arg call as a one-row batch, `[{"__gofish_args":
+            # args}]`, because gofish-gotree's own `applyLambda(id, args)`
+            # contract is one-call/positional-args, not rows-in/rows-out.
+            # Ordinary derive/channel lambdas never send this shape, so
+            # this unwrap only ever fires for `_register_gotree_lambdas`-
+            # registered callables, which expect their args positionally.
+            if (
+                isinstance(data, list)
+                and len(data) == 1
+                and isinstance(data[0], dict)
+                and set(data[0].keys()) == {"__gofish_args"}
+            ):
+                result = fn(*data[0]["__gofish_args"])
+                self._json_response(200, [result])
+                return
+
             result = fn(data)
 
             # Ensure result is JSON-serializable

--- a/tests/scripts/normalize-dom.ts
+++ b/tests/scripts/normalize-dom.ts
@@ -13,22 +13,69 @@
 /**
  * Extract the meaningful chart content from wrapper divs.
  * Storybook wraps charts in `#storybook-root > div[style="margin: 20px"]`.
+ * The gotree gallery stories additionally wrap in a
+ * `div[style="margin: 16px; width: ...px; height: ...px"]` via
+ * `initializeContainer()` (packages/gofish-gotree/stories/helper.ts).
  * The harness wraps in `#gofish-harness-root`.
- * We want just the first child's innerHTML (the SVG + axes etc.).
+ *
+ * Rather than fingerprint each scaffolding variant, strip *any* outermost
+ * `<div style="...">...</div>` wrapper that fully encloses the content —
+ * scaffolding is, by construction, a styled div wrapper around the real
+ * chart markup. Applied iteratively so nested scaffolding wrappers (e.g. a
+ * Storybook margin div around a gotree helper margin div) all get peeled.
  */
 export function stripWrapper(html: string): string {
-  // Remove the outermost div with margin:20px that initializeContainer() adds
   let s = html.trim();
 
-  // Strip <div style="margin: 20px;"> wrapper (Storybook only)
-  const marginWrap =
-    /^<div\s+style="margin:\s*20px;?">\s*([\s\S]*?)\s*<\/div>$/i;
-  const m = s.match(marginWrap);
-  if (m) {
+  const styledDivWrap = /^<div\s+style="[^"]*">\s*([\s\S]*?)\s*<\/div>$/i;
+  for (;;) {
+    const m = s.match(styledDivWrap);
+    if (!m) break;
     s = m[1].trim();
   }
 
   return s;
+}
+
+// ---------------------------------------------------------------------------
+// 1b. Strip display-projection attributes from the ROOT <svg> only
+// ---------------------------------------------------------------------------
+
+const ROOT_SVG_PROJECTION_ATTRS = new Set([
+  "width",
+  "height",
+  "viewbox",
+  "preserveaspectratio",
+]);
+
+/**
+ * Strip `width`, `height`, `viewBox`, and `preserveAspectRatio` from the
+ * ROOT `<svg>` element only (nested `<svg>` elements, if any, are untouched).
+ *
+ * Parity compares content geometry, not display sizing. The root svg's
+ * width/height/viewBox/preserveAspectRatio are a *display projection* —
+ * how the chart's already-solved coordinate space gets mapped onto the
+ * page/viewport — and story scaffolding legitimately rewrites them (e.g.
+ * gotree's `fitToContent` sets `width="100%" height="100%"` plus a
+ * content-fitted `viewBox` on a RAF after mount; the Python harness path
+ * never runs that scaffolding). Any real sizing bug in the chart itself
+ * shows up in the content coordinates (x/y/d/transform/etc. on the actual
+ * marks) that layout solved against, which this normalizer still compares
+ * byte-for-byte. So this rule is applied uniformly to every capture, JS and
+ * Python alike, before the two sides are ever diffed.
+ */
+export function stripRootSvgProjectionAttrs(html: string): string {
+  let replaced = false;
+  return html.replace(/<svg\b([^>]*)>/i, (whole, attrs: string) => {
+    if (replaced) return whole; // only the first (root) <svg>
+    replaced = true;
+    const kept = attrs.replace(
+      /\s+([\w:.-]+)="[^"]*"/g,
+      (attrMatch: string, name: string) =>
+        ROOT_SVG_PROJECTION_ATTRS.has(name.toLowerCase()) ? "" : attrMatch
+    );
+    return `<svg${kept}>`;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -60,13 +107,20 @@ const NUMERIC_ATTRS = new Set([
   "stroke-opacity",
 ]);
 
-/** Round a single number string to `decimals` places. */
+/**
+ * Round a single number string to `decimals` places, preserving any trailing
+ * unit suffix (`%`, `px`, `em`, ...) rather than silently dropping it —
+ * `width="100%"` must stay `100%`, not become `100`.
+ */
 function roundNum(numStr: string, decimals: number): string {
-  const n = parseFloat(numStr);
+  const m = numStr.match(/^(-?\d+\.?\d*(?:e[+-]?\d+)?)([a-z%]*)$/i);
+  const [numPart, unit] = m ? [m[1], m[2]] : [numStr, ""];
+  const n = parseFloat(numPart);
   if (Number.isNaN(n)) return numStr;
   // Avoid -0
   const rounded = Math.round(n * 10 ** decimals) / 10 ** decimals;
-  return Object.is(rounded, -0) ? "0" : String(rounded);
+  const roundedStr = Object.is(rounded, -0) ? "0" : String(rounded);
+  return roundedStr + unit;
 }
 
 /** Round numbers inside an SVG `d` attribute (path data). */
@@ -322,6 +376,7 @@ export function normalizeDom(
 
   let s = html;
   s = stripWrapper(s);
+  s = stripRootSvgProjectionAttrs(s);
   s = roundFloats(s, decimals);
   s = normalizeIds(s);
   s = normalizeImageHrefs(s);

--- a/tests/scripts/path-mapping.ts
+++ b/tests/scripts/path-mapping.ts
@@ -22,18 +22,30 @@ const ROOT_DIR = dirname(TESTS_DIR);
  * this fold, resolving a `.python-sync-exempt` `file::Export` line through
  * `storyToPath` kept the underscore (`spread-x_center-to-center`) and the
  * parity-skip set never matched the captured DOM path. */
-export const toKebab = (s: string) =>
-  s
+export const toKebab = (s: string) => {
+  // "GoTree" (the gofish-gotree package's title segment on every one of its
+  // story titles, e.g. "GoTree / Gallery / arc-tree") is a single proper-noun
+  // token, not two English words — the general CamelCase-split rule below
+  // would otherwise mangle it to "go-tree", diverging from the package's own
+  // "gotree" name (and from the tests/python-stories/gotree/ convention).
+  // Declared exception, not a generalizable rule: no other title segment
+  // needs this.
+  if (s.trim() === "GoTree") return "gotree";
+  return s
     .replace(/([a-z])([A-Z])/g, "$1-$2")
     .replace(/[\s_]+/g, "-")
     .toLowerCase();
+};
 
 /**
  * Storybook title → file-level story id used by capture + parity review.
  * e.g. "atom/TitanicUnitDots" → "atom/titanic-unit-dots"
  */
 export function titleToStoryId(title: string): string {
-  return title.split("/").map(toKebab).join("/");
+  return title
+    .split("/")
+    .map((seg) => toKebab(seg.trim()))
+    .join("/");
 }
 
 /**
@@ -46,7 +58,7 @@ export function titleToStoryId(title: string): string {
  * the two stay in lockstep if the kebab-casing rule ever changes.
  */
 export function storyToPath(title: string, name: string): string {
-  const segments = title.split("/").map(toKebab);
+  const segments = title.split("/").map((seg) => toKebab(seg.trim()));
   return `${segments.join("/")}--${toKebab(name)}`;
 }
 
@@ -55,6 +67,11 @@ export function storyToPath(title: string, name: string): string {
  *
  * e.g. "packages/gofish-graphics/stories/forwardsyntax/Bar/BarBasic.stories.tsx"
  *   →  "tests/python-stories/forwardsyntax/bar/test_bar_basic.py"
+ *
+ * gofish-gotree stories title their first segment "GoTree" (e.g. "GoTree /
+ * Gallery / arc-tree"), which kebab-cases to "gotree" — so this same rule
+ * naturally lands them under tests/python-stories/gotree/gallery/test_*.py
+ * with no gotree-specific special case.
  */
 export function mapJsToPython(jsFile: string): string {
   // Read the Storybook title from the JS file and derive the Python path from it.
@@ -63,21 +80,34 @@ export function mapJsToPython(jsFile: string): string {
   let title: string | null = null;
   try {
     const content = readFileSync(absPath, "utf-8");
-    const m = content.match(/title:\s*["'](.+?)["']/);
+    // Anchor the search to the `meta: Meta` object rather than matching the
+    // first `title:` in the file — some gallery stories (gofish-gotree) also
+    // carry a `parameters.gallery.title` (the gallery-card caption) that can
+    // appear earlier in the file than the Storybook nav `meta.title` this
+    // function needs.
+    const metaIdx = content.search(/:\s*Meta\b/);
+    const searchFrom = metaIdx >= 0 ? content.slice(metaIdx) : content;
+    const m = searchFrom.match(/title:\s*["'](.+?)["']/);
     if (m) title = m[1];
   } catch {
     /* file unreadable — fall through to path-based fallback */
   }
 
   if (title) {
-    const segments = title.split("/").map(toKebab);
+    // Storybook titles are `/`-delimited nav paths; gofish-gotree writes them
+    // with spaces around the slash ("GoTree / Gallery / arc-tree"), so each
+    // segment is trimmed before kebab-casing (otherwise the surrounding
+    // whitespace folds into stray leading/trailing dashes — see toKebab).
+    const segments = title.split("/").map((seg) => toKebab(seg.trim()));
     const dirPath = segments.slice(0, -1).join("/");
     const basePart = segments[segments.length - 1].replace(/-/g, "_");
     return `tests/python-stories/${dirPath}/test_${basePart}.py`;
   }
 
   // Fallback: derive from file path (CamelCase → snake_case, flatten one level)
-  let rel = jsFile.replace(/^packages\/gofish-graphics\/stories\//, "");
+  let rel = jsFile
+    .replace(/^packages\/gofish-graphics\/stories\//, "")
+    .replace(/^packages\/gofish-gotree\/stories\//, "");
   rel = rel.replace(/\.stories\.tsx$/, "");
   const lastSlash = rel.lastIndexOf("/");
   const dirPart = lastSlash >= 0 ? rel.slice(0, lastSlash) : ".";


### PR DESCRIPTION
Closes #792

Brings the `gofish-gotree` tree DSL to Python, end to end.

## What's here

- **IR + reconstruction** (238ebdd4): gotree tree specs serialize to the shared IR schema (`gofish-ir`), with JS-side reconstruction (`fromJSON` / registry) so a spec built in Python renders through the exact same engine as the JS stories. Parity plumbing (path mapping, sync checking, derive-server support) extended to the gotree package.
- **`gofish.gotree` module**: `tree(data, node=, link=, parent_child=, sibling=, coord=)` plus the five combiner builders (`spread`, `distribute`, `nest`, `combine`, `alternate`), snake_case mirror of the JS API. `perDepth` is deliberately not exposed (a raw `depth -> Combiner` function can't cross the wire; `alternate` covers every gallery use).
- **40/40 gallery ports** (99b4ab58): every gotree DSL gallery story ported to `tests/python-stories/gotree/`, all rendering **byte-identical** to their JS counterparts. Includes three uniform normalizer rules (zero regressions across the 215 pre-existing parity stories) and delta-mode sync checking extended to gotree.
- **Docs** (84e0567c): new `/python/gotree` guide mirroring `/js/gotree`, Python sidebar entry, and the story-title → parity-port mapping fixes ("GoTree" proper-noun kebab exception + segment trimming) so the generated `/python/examples` pages pick up the gotree ports.
- **Tooling fix** (d4456031): `capture-diff` now builds `gofish-ir`'s dist in the base-ref worktree (`--ignore-scripts` skipped its `prepare`, breaking capture against any base ref that includes the package).

## Verification

- Python↔JS parity: 40/40 gotree stories byte-identical; 215 existing parity stories unaffected (the 2 non-identical are pre-existing documented exemptions)
- `pytest`: 164 passed, 1 xfailed
- `gofish-ir` schema/display-list/descriptor tests: 30 passed
- `validate-python-ir`: clean (5 pre-existing warnings on unrelated stories)
- `check-python-sync --all`: full-coverage check passed
- `capture-diff origin/main gotree`: 56 stories, no layout changes — the JS render path is untouched
- `docs:build`: passes (validates the new page's `example:` ids); `check-backlinks` in sync
- Both code examples on the new docs page executed against the real `gofish.gotree` API

No new visuals: the parity ports and docs page render existing gallery stories through the existing JS engine, byte-identical to what's on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)