### PR TITLE
gofish-neo: hierarchical & multi-output confusion matrices (clean-room Neo algebra over GoTree margins)

### DIFF
--- a/apps/docs/components/storyRender.ts
+++ b/apps/docs/components/storyRender.ts
@@ -27,6 +27,9 @@ const storyModules: Record<string, () => Promise<unknown>> = import.meta.env.SSR
       ...import.meta.glob(
         "../../../packages/gofish-gotree/stories/**/*.stories.tsx"
       ),
+      ...import.meta.glob(
+        "../../../packages/gofish-neo/stories/**/*.stories.tsx"
+      ),
     };
 
 /** Harness story id — mirrors tests/harness + storyExamples.ts. */

--- a/apps/docs/docs/.vitepress/config.mts
+++ b/apps/docs/docs/.vitepress/config.mts
@@ -9,7 +9,7 @@ import vueJsx from "@vitejs/plugin-vue-jsx";
 import solidPlugin from "vite-plugin-solid";
 import { loadStoryExamples } from "./data/storyExamples";
 import { readdirSync, readFileSync } from "fs";
-import { dirname, join, relative } from "path";
+import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
 
@@ -225,6 +225,19 @@ export default defineConfig({
         { find: /^solid-js\/web$/, replacement: SOLID_WEB_CLIENT },
         { find: /^solid-js\/jsx-runtime$/, replacement: SOLID_CORE_CLIENT },
         { find: /^solid-js$/, replacement: SOLID_CORE_CLIENT },
+        // gofish-gotree and gofish-neo aren't prebuilt (no dist/) in the docs
+        // CI job — only gofish-graphics gets a `pnpm build` step there. Bare
+        // imports of these two (gofish-neo's confusionMatrix.tsx imports
+        // `gofish-gotree`; its RadialConfusionMatrix story imports it too)
+        // resolve straight to source, mirroring tests/harness/vite.config.ts.
+        {
+          find: /^gofish-gotree$/,
+          replacement: resolve(GOFISH_PKG_DIR, "../gofish-gotree/src/index.ts"),
+        },
+        {
+          find: /^gofish-neo$/,
+          replacement: resolve(GOFISH_PKG_DIR, "../gofish-neo/src/index.ts"),
+        },
       ],
     },
     plugins: [
@@ -235,9 +248,11 @@ export default defineConfig({
       // owns only the library package's .ts(x) sources and its .stories.tsx files.
       // `generate: "dom"` forces DOM codegen even in the SSR bundle (the stories
       // only execute client-side, so SSR-flavoured codegen is never needed).
-      vueJsx({ exclude: [/packages\/gofish-(graphics|gotree)\/.*\.[jt]sx?$/] }),
+      vueJsx({
+        exclude: [/packages\/gofish-(graphics|gotree|neo)\/.*\.[jt]sx?$/],
+      }),
       solidPlugin({
-        include: [/packages\/gofish-(graphics|gotree)\/.*\.[jt]sx?$/],
+        include: [/packages\/gofish-(graphics|gotree|neo)\/.*\.[jt]sx?$/],
         solid: { generate: "dom", hydratable: false },
       }),
       // vue-jsx's config() narrows vite's esbuild to `/\.ts$/` (it expects to own

--- a/apps/docs/docs/.vitepress/data/storyExamples.data.js
+++ b/apps/docs/docs/.vitepress/data/storyExamples.data.js
@@ -10,6 +10,7 @@ export default {
   watch: [
     "../../../../../packages/gofish-graphics/stories/**/*.stories.tsx",
     "../../../../../packages/gofish-gotree/stories/**/*.stories.tsx",
+    "../../../../../packages/gofish-neo/stories/**/*.stories.tsx",
   ],
   load() {
     const examples = loadStoryExamples();

--- a/apps/docs/docs/.vitepress/data/storyExamples.ts
+++ b/apps/docs/docs/.vitepress/data/storyExamples.ts
@@ -1,9 +1,10 @@
 /**
  * storyExamples.ts — build-time data layer for the docs example gallery.
  *
- * Scans `packages/gofish-graphics/stories/**\/*.stories.tsx` for story exports
- * tagged `tags: ["gallery"]` with `parameters.gallery.{title,description}`, and
- * for each one synthesizes a standalone, runnable TypeScript snippet by
+ * Scans `packages/gofish-graphics/stories/**\/*.stories.tsx` (and the same under
+ * `packages/gofish-gotree/stories/` and `packages/gofish-neo/stories/`) for story
+ * exports tagged `tags: ["gallery"]` with `parameters.gallery.{title,description}`,
+ * and for each one synthesizes a standalone, runnable TypeScript snippet by
  * transforming the story's source:
  *
  *   - library imports (`../../src/lib`, `../../src/color`, `clock`, …)  → `"gofish-graphics"`
@@ -55,10 +56,11 @@ export interface StoryExample {
   isFallback: boolean;
   /**
    * true when the live Sandpack editor should be suppressed for this example.
-   * Set for gofish-gotree examples: that package isn't published to npm yet, so
-   * the in-browser editor can't resolve `import ... from "gofish-gotree"`. The
-   * static example page still renders the chart. Re-enable once the package is
-   * published (see the npm-publish tracking issue).
+   * Set for gofish-gotree and gofish-neo examples: neither package is published
+   * to npm yet, so the in-browser editor can't resolve `import ... from
+   * "gofish-gotree"` / `"gofish-neo"`. The static example page still renders
+   * the chart. Re-enable once the packages are published (see the npm-publish
+   * tracking issue).
    */
   noLiveEditor?: boolean;
 }
@@ -80,6 +82,13 @@ const GOFISH_PKG_JSON = join(
 const GOTREE_STORIES_DIR = join(REPO_ROOT, "packages/gofish-gotree/stories");
 const GOTREE_SRC_DIR = join(REPO_ROOT, "packages/gofish-gotree/src");
 const GOTREE_DATA_MODULE = join(GOTREE_STORIES_DIR, "data"); // stories/data.ts
+
+// Same shape for the gofish-neo hierarchical-confusion-matrix package: stories
+// import the algebra from `../src` (rewritten to the bare "gofish-neo" package)
+// and sample data from `./data`.
+const NEO_STORIES_DIR = join(REPO_ROOT, "packages/gofish-neo/stories");
+const NEO_SRC_DIR = join(REPO_ROOT, "packages/gofish-neo/src");
+const NEO_DATA_MODULE = join(NEO_STORIES_DIR, "data"); // stories/data.ts
 
 const ASSET_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp"];
 
@@ -142,12 +151,14 @@ function classifyModule(spec: string, storyFile: string): ImportTarget {
 
   if (spec.startsWith(".")) {
     const absolute = resolve(dirname(storyFile), spec);
-    // Dataset modules: gofish-graphics' src/data, or the gotree stories' data.ts
+    // Dataset modules: gofish-graphics' src/data, or the gotree/neo stories' data.ts
     if (
       absolute.startsWith(DATA_DIR + "/") ||
       absolute.startsWith(DATA_DIR) ||
       absolute === GOTREE_DATA_MODULE ||
-      absolute.startsWith(GOTREE_DATA_MODULE + "/")
+      absolute.startsWith(GOTREE_DATA_MODULE + "/") ||
+      absolute === NEO_DATA_MODULE ||
+      absolute.startsWith(NEO_DATA_MODULE + "/")
     ) {
       // resolve to the actual .ts file path
       const modulePath = resolveModuleFile(absolute);
@@ -168,6 +179,10 @@ function classifyModule(spec: string, storyFile: string): ImportTarget {
       absolute.startsWith(GOTREE_SRC_DIR + "/")
     ) {
       return { kind: "keep", module: "gofish-gotree" };
+    }
+    // gofish-neo algebra imports (`../src`) → the bare package name.
+    if (absolute === NEO_SRC_DIR || absolute.startsWith(NEO_SRC_DIR + "/")) {
+      return { kind: "keep", module: "gofish-neo" };
     }
     // A local helper module next to the story — cannot be made standalone.
     return { kind: "local" };
@@ -917,7 +932,11 @@ let cache: StoryExample[] | undefined;
 export function loadStoryExamples(): StoryExample[] {
   if (cache) return cache;
 
-  const files = [...walk(STORIES_DIR), ...walk(GOTREE_STORIES_DIR)].sort();
+  const files = [
+    ...walk(STORIES_DIR),
+    ...walk(GOTREE_STORIES_DIR),
+    ...walk(NEO_STORIES_DIR),
+  ].sort();
   const examples: StoryExample[] = [];
   const seenIds = new Map<string, string>();
 
@@ -972,8 +991,11 @@ export function loadStoryExamples(): StoryExample[] {
         datasetCode: result.datasetCode,
         npmDeps: computeNpmDeps(result.code, result.datasetCode),
         isFallback: result.isFallback,
-        // gofish-gotree isn't on npm yet → the in-browser editor can't resolve it.
-        noLiveEditor: storyFile.startsWith(GOTREE_STORIES_DIR),
+        // gofish-gotree/gofish-neo aren't on npm yet → the in-browser editor
+        // can't resolve them.
+        noLiveEditor:
+          storyFile.startsWith(GOTREE_STORIES_DIR) ||
+          storyFile.startsWith(NEO_STORIES_DIR),
       });
     }
   }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,7 +10,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "gallery:thumbnails": "pnpm --filter @gofish/tests capture-gallery",
     "docs:dev": "pnpm run docs:types && vitepress dev docs",
-    "docs:build": "pnpm run gallery:thumbnails && pnpm run docs:types && NODE_OPTIONS=--max-old-space-size=8192 vitepress build docs",
+    "docs:build": "pnpm run gallery:thumbnails && pnpm run docs:types && NODE_OPTIONS=--max-old-space-size=12288 vitepress build docs",
     "docs:preview": "vitepress preview docs",
     "docs:types": "typedoc",
     "sync-backlinks": "node scripts/sync-backlinks.mjs sync",

--- a/packages/gofish-gotree/stories/NeoAlignmentSpike.stories.tsx
+++ b/packages/gofish-gotree/stories/NeoAlignmentSpike.stories.tsx
@@ -1,0 +1,229 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import {
+  chart,
+  table,
+  scatter,
+  rect,
+  text,
+  field,
+  Layer,
+  Constraint,
+  layer,
+} from "gofish-graphics";
+import { tree, distribute } from "../src";
+import { initializeContainer } from "./helper";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Alignment spike for issue #639 (gofish-neo). This story does NOT need to be
+// beautiful — it exists to prove (or disprove) that three INDEPENDENTLY built
+// structures can share one per-leaf scale on the y axis:
+//
+//   (a) a tree-shaped row-label header, built with gofish-gotree's `tree()`
+//   (b) a 5×5 confusion-matrix grid body, built with v3 `table()`
+//   (c) a marginal "recall" bar strip, built with v3 `scatter()` + `rect()`
+//
+// Mechanism that worked: MATCHED PITCH + a single anchor offset (not per-leaf
+// pinning). All three structures use the same 5-row pitch (80px): the grid
+// divides its 400px height into 5 equal 80px bands (spacing: 0), the measure
+// strip's rows are given explicit `start`/`end` fields at the same 80px
+// bands, and the tree's leaf nodes are fixed at 24px tall with 56px of
+// sibling spacing (24 + 56 = 80). Because `tree()`'s default sibling combiner
+// (`distribute` with the default "edge" anchor) STACKS BBOXES ADDITIVELY AT
+// EVERY LEVEL OF THE RECURSION — not just at the leaf level — an unbalanced
+// tree (vehicle: 2 children, animal: 3 children) still produces perfectly
+// uniform 80px leaf-to-leaf pitch in traversal order, with NO manual
+// per-node spacing arithmetic beyond picking one spacing constant. That
+// result generalizes: uniform `spacing` at every sibling level + uniform
+// leaf size ⇒ uniform leaf pitch, regardless of subtree shape.
+//
+// Per-leaf pinning (aligning named grid cells / tree path nodes via
+// `Constraint.align`) was NOT needed here and was not attempted — matched
+// pitch alone was sufficient and is simpler. See the final report for notes
+// on when per-leaf pinning would still be required (e.g. non-uniform row
+// heights driven by data, like a value-proportional mosaic row).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const meta: Meta = {
+  title: "GoTree/Neo Alignment Spike",
+};
+export default meta;
+
+// 5 leaves, in the exact order they must appear as matrix rows: car, truck,
+// cat, dog, bird. The tree groups them 2-and-3 (unbalanced) on purpose — that
+// is the case that would break a naive "center each subtree" layout (see
+// `helpers.ts`' `distribute({anchor: "middle"})` vs the default "edge").
+const treeData = {
+  name: "root",
+  children: [
+    { name: "vehicle", children: [{ name: "car" }, { name: "truck" }] },
+    {
+      name: "animal",
+      children: [{ name: "cat" }, { name: "dog" }, { name: "bird" }],
+    },
+  ],
+};
+
+const leaves = ["car", "truck", "cat", "dog", "bird"];
+
+// ─── Shared row geometry ────────────────────────────────────────────────────
+const H = 400;
+const N = leaves.length;
+const ROW_PITCH = H / N; // 80 — uniform row pitch shared by all three structures
+
+// ─── (a) Tree header ────────────────────────────────────────────────────────
+const NODE_H = 24;
+const TREE_SPACING = ROW_PITCH - NODE_H; // 56 — leaf pitch = NODE_H + TREE_SPACING = 80
+
+const labeledNode = (w: number, fill: string) => (d: any) =>
+  Layer({ w, h: NODE_H }, [
+    rect({ w, h: NODE_H, rx: 4, fill, stroke: "#4682b4", strokeWidth: 1 }).name(
+      "box"
+    ),
+    text({
+      text: d.data.name,
+      fontSize: 12,
+      fontFamily: "ui-sans-serif, system-ui, sans-serif",
+      fill: "#1d3557",
+    }).name("label"),
+  ]).constrain(({ box, label }: any) => [
+    Constraint.align({ x: "middle", y: "middle" }, [box, label]),
+  ]);
+
+const treeNode = (d: any) => {
+  if (d.height === 0) return labeledNode(70, "#eef3fa")(d);
+  if (d.depth === 0) return labeledNode(50, "#4682b4")(d);
+  return labeledNode(90, "#c8dcef")(d);
+};
+
+// ─── (b) Confusion-matrix grid body ─────────────────────────────────────────
+// Row/col order = first-occurrence order in the data array, so the cell
+// array is built row-major with `leaves` (the tree's traversal order) as
+// BOTH the row and column key sequence.
+const cells = leaves.flatMap((actual, ri) =>
+  leaves.map((observed, ci) => ({
+    actual,
+    observed,
+    count: actual === observed ? 30 + ri * 6 : 3 + ((ri + ci) % 4) * 2,
+  }))
+);
+
+// ─── (c) Marginal "recall" strip ───────────────────────────────────────────
+// One bar per row, at the SAME `start`/`end` bands as the grid's rows
+// (0..400 split into 5 equal 80px slices) so `scatter`'s yMin/yMax placement
+// reproduces the grid's row geometry exactly.
+const recallByLeaf: Record<string, number> = {
+  car: 0.82,
+  truck: 0.74,
+  cat: 0.9,
+  dog: 0.68,
+  bird: 0.95,
+};
+// NOTE: `scatter`'s yMin/yMax is a continuous position channel, which (unlike
+// `table`'s ordinal row axis) maps increasing values UPWARD (standard
+// Cartesian, y-up) rather than top-down — so row 0 ("car") must get the
+// HIGHEST band to land at the top of the canvas, matching the tree/grid's
+// top-down traversal order. This is a real gotcha: two v3 operators
+// (ordinal `table` vs continuous `scatter`) disagree on which screen edge
+// "first" maps to.
+const measureRows = leaves.map((leaf, i) => ({
+  leaf,
+  recall: recallByLeaf[leaf],
+  start: (N - 1 - i) * ROW_PITCH,
+  end: (N - i) * ROW_PITCH,
+}));
+
+const TREE_W = 300;
+const GRID_W = 5 * 50; // 250
+const STRIP_W = 140;
+const GAP = 20;
+
+export const NeoAlignmentSpike: StoryObj = {
+  name: "Neo Alignment Spike",
+  render: () => {
+    const container = initializeContainer({
+      w: TREE_W + GAP + GRID_W + GAP + STRIP_W,
+      h: H + 20,
+    });
+
+    (async () => {
+      // (a) tree header — grows left→right (parentChild dir "x"), siblings
+      // stacked top→bottom (sibling dir "y") with the shared row pitch.
+      const treeHeader = tree(
+        {
+          node: treeNode,
+          link: "none",
+          parentChild: distribute({
+            dir: "x",
+            spacing: 40,
+            alignment: "middle",
+          }),
+          sibling: distribute({
+            dir: "y",
+            spacing: TREE_SPACING,
+            alignment: "start",
+          }),
+        },
+        treeData
+      ) as any;
+      treeHeader.name("treeHeader");
+
+      // (b) confusion matrix
+      const grid = await chart(cells, { w: GRID_W, h: H, axes: false })
+        .flow(table({ by: { x: "observed", y: "actual" }, spacing: 0 }))
+        .mark(
+          rect({ fill: "count" }).label("count", {
+            position: "center",
+            fontSize: 11,
+            color: "white",
+          })
+        )
+        .resolve();
+      grid.name("grid");
+
+      // (c) marginal recall strip
+      const strip = await chart(measureRows, { w: STRIP_W, h: H })
+        .flow(
+          scatter({
+            yMin: field("start", "rowPos"),
+            yMax: field("end", "rowPos"),
+          } as any)
+        )
+        .mark(
+          rect({ w: "recall", fill: "#4682b4" } as any).label("recall", {
+            position: "right",
+            fontSize: 10,
+          } as any)
+        )
+        .resolve();
+      strip.name("strip");
+
+      // The tree header's own bbox spans [0, N*NODE_H + (N-1)*TREE_SPACING]
+      // = [0, 400] top-to-bottom with the FIRST leaf ("car") centered at
+      // NODE_H / 2 = 12 from the top of that span. The grid's first row is
+      // centered at ROW_PITCH / 2 = 40. So the tree header needs a constant
+      // y offset of (ROW_PITCH - NODE_H) / 2 = 28 to line up row centers —
+      // this falls out of the shared-pitch construction, not a per-leaf fit.
+      const TREE_Y_OFFSET = (ROW_PITCH - NODE_H) / 2;
+
+      await layer([treeHeader, grid, strip])
+        .constrain(({ treeHeader, grid, strip }: any) => [
+          Constraint.position({ x: 0, y: TREE_Y_OFFSET, anchor: "start" }, [
+            treeHeader,
+          ]),
+          Constraint.position({ x: TREE_W + GAP, y: 0, anchor: "start" }, [
+            grid,
+          ]),
+          Constraint.position(
+            { x: TREE_W + GAP + GRID_W + GAP, y: 0, anchor: "start" },
+            [strip]
+          ),
+        ])
+        .render(container, {
+          w: TREE_W + GAP + GRID_W + GAP + STRIP_W,
+          h: H + 20,
+        } as any);
+    })();
+
+    return container;
+  },
+};

--- a/packages/gofish-neo/.storybook/main.ts
+++ b/packages/gofish-neo/.storybook/main.ts
@@ -1,0 +1,15 @@
+import type { StorybookConfig } from "storybook-solidjs-vite";
+
+const config: StorybookConfig = {
+  stories: [
+    "../src/**/*.mdx",
+    "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../stories/**/*.stories.@(js|jsx|ts|tsx)",
+  ],
+  addons: ["@storybook/addon-docs"],
+  framework: {
+    name: "storybook-solidjs-vite",
+    options: {},
+  },
+};
+export default config;

--- a/packages/gofish-neo/.storybook/preview.ts
+++ b/packages/gofish-neo/.storybook/preview.ts
@@ -1,0 +1,14 @@
+import type { Preview } from "storybook-solidjs-vite";
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/packages/gofish-neo/README.md
+++ b/packages/gofish-neo/README.md
@@ -1,0 +1,74 @@
+# gofish-neo
+
+Hierarchical and multi-output confusion matrices for GoFish, based on the
+published algebra from Neo (Görtler et al., "Neo: Generalizing Confusion
+Matrix Visualization to Hierarchical and Multi-Output Labels", CHI 2022).
+
+A confusion matrix cross-tabulates what a classifier predicted against what
+was actually true. Neo generalizes it in three ways:
+
+- Class labels can be hierarchical. A label is a colon-delimited path such as
+  `"animal:mammal:cat"`, and the labels form a tree. Any subtree can be
+  collapsed into a single row and column whose counts are the sums over its
+  descendants.
+- A classifier can have several outputs per record. The `actual` and
+  `observed` fields are arrays with one label per output. The spec can
+  marginalize the extra outputs away, condition on one of them, or nest one
+  output inside another as extra hierarchy levels.
+- Counts can be renormalized by row, by column, or over the visible cells,
+  and per-class measures (precision, recall, accuracy, and raw counts) render
+  as strips beside the matrix.
+
+## Usage
+
+```ts
+import { confusionMatrix } from "gofish-neo";
+
+const data = [
+  { actual: ["animal:mammal:cat"], observed: ["animal:mammal:cat"], count: 46 },
+  { actual: ["animal:mammal:cat"], observed: ["animal:mammal:dog"], count: 7 },
+  // ...
+];
+
+const node = await confusionMatrix(
+  { classes: ["animal"], measures: ["precision", "recall"] },
+  data
+);
+node.render(container, { w: 800, h: 600 });
+```
+
+The spec fields are `classes`, `where`, `filter`, `normalization` ("total",
+"row", or "column"), `encoding` ("color" or "size"), `collapsed` (node ids to
+render as aggregated leaves), and `measures`, plus rendering options such as
+`cellSize`, `spacing`, `colors`, `showCounts`, and `excludeDiagonal`.
+
+The renderer composes three kinds of GoFish structure on one shared row and
+column pitch: a `table()` grid for the matrix body, `gofish-gotree` trees for
+the hierarchical margin labels, and bar strips for the measures. The pure
+data algebra (path parsing, label tree, pipeline, matrix, normalization,
+measures) is exported separately from `src/index.ts`, so you can build other
+views from it. The `stories/` directory has examples, including a radial
+matrix built directly on the algebra with a polar coordinate frame.
+
+## License and provenance
+
+This package is an independent reimplementation of the algebra described in
+the Neo paper. Apple's reference implementation
+([apple/ml-hierarchical-confusion-matrix](https://github.com/apple/ml-hierarchical-confusion-matrix))
+is under Apple's own sample code license, which is not compatible with this
+repository's MIT license. No code was copied or ported from it. The input
+data format (`actual`, `observed`, `count`, colon-delimited paths) is kept
+compatible on purpose.
+
+The implementation diverges from the reference implementation in three
+declared places, each documented at the definition site:
+
+- `filter` matches subpaths on both the `actual` and `observed` sides with
+  segment-aware prefix tests. The reference implementation only inspects the
+  `actual` side and matches raw substrings.
+- `trueNegatives` uses the standard one-vs-rest definition (total minus TP,
+  FP, and FN), so the four quantities partition the grand total. The
+  reference implementation subtracts TP from the whole-matrix diagonal sum
+  instead.
+- Zero denominators (an empty row or column, or a measure over an empty
+  class) yield 0 rather than NaN.

--- a/packages/gofish-neo/package.json
+++ b/packages/gofish-neo/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "gofish-neo",
+  "version": "0.1.0",
+  "description": "Neo: a clean-room reimplementation of the Neo (Görtler et al., CHI 2022) hierarchical confusion matrix data algebra, embedded in GoFish",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "keywords": [
+    "confusion-matrix",
+    "hierarchical",
+    "visualization",
+    "gofish",
+    "neo"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gofish-graphics/gofish-graphics"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "storybook": "storybook dev -p 6008",
+    "build-storybook": "storybook build",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@storybook/addon-docs": "^9.1.6",
+    "@storybook/html": "^9.1.6",
+    "storybook": "^9.1.6",
+    "storybook-solidjs-vite": "^9.0.3",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.0",
+    "vite-plugin-solid": "^2.11.6",
+    "vitest": "^3.2.4"
+  },
+  "dependencies": {
+    "gofish-gotree": "workspace:*",
+    "gofish-graphics": "workspace:*",
+    "solid-js": "^1.9.5"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.9.5"
+  }
+}

--- a/packages/gofish-neo/src/buildMatrix.test.ts
+++ b/packages/gofish-neo/src/buildMatrix.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { frontier } from "./labelTree";
+import { buildMatrix, frequency, total } from "./matrix";
+import type { Confusion } from "./pipeline";
+import type { NeoSpec } from "./spec";
+
+describe("buildMatrix end-to-end", () => {
+  it("builds a tree + matrix for a simple one-dimensional spec", () => {
+    const records: Confusion[] = [
+      { actual: ["class:cat"], observed: ["class:cat"], count: 5 },
+      { actual: ["class:cat"], observed: ["class:dog"], count: 1 },
+      { actual: ["class:dog"], observed: ["class:dog"], count: 4 },
+    ];
+    const spec: NeoSpec = { classes: ["class"] };
+    const { tree, matrix } = buildMatrix(records, spec);
+    expect(total(matrix)).toBe(10);
+    // tree: root -> class -> {cat, dog}
+    const classNode = tree.children[0]!;
+    const cat = classNode.children.find((n) => n.name === "cat")!;
+    const dog = classNode.children.find((n) => n.name === "dog")!;
+    expect(frequency(matrix, cat, cat)).toBe(5);
+    expect(frequency(matrix, cat, dog)).toBe(1);
+    expect(frequency(matrix, dog, dog)).toBe(4);
+  });
+
+  it("collapsing a node yields the expected frontier and a block-summed cell", () => {
+    const records: Confusion[] = [
+      {
+        actual: ["class:animal:cat"],
+        observed: ["class:animal:cat"],
+        count: 3,
+      },
+      {
+        actual: ["class:animal:cat"],
+        observed: ["class:animal:dog"],
+        count: 2,
+      },
+      {
+        actual: ["class:animal:dog"],
+        observed: ["class:animal:cat"],
+        count: 1,
+      },
+      {
+        actual: ["class:animal:dog"],
+        observed: ["class:animal:dog"],
+        count: 4,
+      },
+      { actual: ["class:plant"], observed: ["class:plant"], count: 6 },
+    ];
+    const spec: NeoSpec = { classes: ["class"] };
+    const { tree, matrix } = buildMatrix(records, spec);
+
+    // tree: root -> class -> {animal -> {cat, dog}, plant}
+    const classNode = tree.children[0]!;
+    const animal = classNode.children.find((n) => n.name === "animal")!;
+    const front = frontier(tree, [animal.id]);
+    expect(front.map((n) => n.name).sort()).toEqual(["animal", "plant"].sort());
+
+    // animal x animal is the block sum of cat/dog x cat/dog: 3+2+1+4 = 10.
+    expect(frequency(matrix, animal, animal)).toBe(10);
+  });
+});

--- a/packages/gofish-neo/src/confusionMatrix.tsx
+++ b/packages/gofish-neo/src/confusionMatrix.tsx
@@ -63,10 +63,20 @@ export interface ConfusionMatrixSpec extends NeoSpec {
 
 const DEFAULT_CELL_SIZE = 44;
 const DEFAULT_SPACING = 0;
-const DEFAULT_COLORS: [string, string] = ["#e6f5f8", "#0b5394"];
-const ZERO_FILL = "#f2f2f3";
 
-const PALETTE_DEPTH = ["#1d3557", "#3d6ea5", "#7ba7d1", "#b7d0e8"];
+/** Sequential gradient endpoints used as the body cells' default color encoding. */
+export const DEFAULT_COLORS: [string, string] = ["#e6f5f8", "#0b5394"];
+/** Fill for a zero-count cell (never gradient-encoded — zero is categorical, not a scaled value). */
+export const ZERO_FILL = "#f2f2f3";
+
+/** Per-tree-depth fill for margin nodes, darkest at the root. */
+export const PALETTE_DEPTH = ["#1d3557", "#3d6ea5", "#7ba7d1", "#b7d0e8"];
+
+// Rough estimate of a rendered glyph's width as a fraction of its font size,
+// used to decide whether a margin-node label needs to shrink to fit its box.
+// gofish-graphics doesn't yet expose its real text measurement to callers;
+// this is a placeholder pending that (an issue should be filed to track it).
+const CHAR_W_RATIO = 0.62;
 
 const PC_GAP = 16; // parent<->child-group gap in both tree margins
 const NODE_W_ROW = 88; // row-tree node width, uniform across levels
@@ -143,10 +153,13 @@ function marginNodeFactory(opts: {
     const last = String(d.data.name).split(":").pop()!;
     const displayName = axis === "w" ? last : full;
     const available = w - 6;
-    const estCharW = fontSize * 0.62;
+    const estCharW = fontSize * CHAR_W_RATIO;
     const shrunk =
       displayName.length * estCharW > available
-        ? Math.max(7, Math.floor(available / (displayName.length * 0.62)))
+        ? Math.max(
+            7,
+            Math.floor(available / (displayName.length * CHAR_W_RATIO))
+          )
         : fontSize;
     return Layer({ w, h }, [
       rect({
@@ -256,7 +269,7 @@ export async function confusionMatrix(
   const cells = rows.flatMap((rowNode) =>
     cols.map((colNode) => {
       const count = frequency(matrix, rowNode, colNode);
-      const norm = normalizer(rowNode, colNode);
+      const norm = normalizer(rowNode, colNode, count);
       const isZero = count === 0;
       const fillColor = isZero
         ? ZERO_FILL
@@ -323,11 +336,14 @@ export async function confusionMatrix(
         ]);
       }) as any);
 
-  const grid = await chart(cells, { w: gridExtent, h: gridExtent, axes: false })
+  const gridPromise = chart(cells, {
+    w: gridExtent,
+    h: gridExtent,
+    axes: false,
+  })
     .flow(table({ by: { x: "observed", y: "actual" }, spacing }))
     .mark(bodyMark as any)
     .resolve();
-  grid.name("grid");
 
   // ─── row + column margins ───────────────────────────────────────────────
   // The tree root is a synthetic wrapper with exactly one child (the
@@ -337,49 +353,42 @@ export async function confusionMatrix(
   const goTreeData = toGoTreeData(dimRoot, collapsedIds);
   const levels = levelCount(dimRoot, collapsedIds);
 
-  const rowMargin = tree(
-    {
-      node: marginNodeFactory({
-        pitch,
-        spacing,
-        cross: NODE_W_ROW,
-        axis: "h",
-        fontSize: 10,
-      }),
-      link: "none",
-      parentChild: distribute({
-        dir: "x",
-        spacing: PC_GAP,
-        alignment: "middle",
-      }),
-      sibling: distribute({ dir: "y", spacing, alignment: "start" }),
-    },
-    goTreeData as any
-  ) as any;
-  rowMargin.name("rowMargin");
-  const rowTreeW = levels * NODE_W_ROW + (levels - 1) * PC_GAP;
+  // Both margins are the same shape, transposed: a "row" margin grows along
+  // x (parent<->child) and stacks siblings along y, with a fixed-width
+  // cross-axis node column; a "col" margin is the same recipe with x/y (and
+  // their per-axis constants) swapped.
+  function buildMargin(axis: "row" | "col"): { node: any; size: number } {
+    const cross = axis === "row" ? NODE_W_ROW : NODE_H_COL;
+    const fontSize = axis === "row" ? 10 : 9;
+    const parentChildDir = axis === "row" ? "x" : "y";
+    const siblingDir = axis === "row" ? "y" : "x";
 
-  const colMargin = tree(
-    {
-      node: marginNodeFactory({
-        pitch,
-        spacing,
-        cross: NODE_H_COL,
-        axis: "w",
-        fontSize: 9,
-      }),
-      link: "none",
-      parentChild: distribute({
-        dir: "y",
-        spacing: PC_GAP,
-        alignment: "middle",
-      }),
-      sibling: distribute({ dir: "x", spacing, alignment: "start" }),
-    },
-    goTreeData as any
-  ) as any;
-  colMargin.name("colMargin");
-  const colTreeH = levels * NODE_H_COL + (levels - 1) * PC_GAP;
+    const node = tree(
+      {
+        node: marginNodeFactory({
+          pitch,
+          spacing,
+          cross,
+          axis: axis === "row" ? "h" : "w",
+          fontSize,
+        }),
+        link: "none",
+        parentChild: distribute({
+          dir: parentChildDir,
+          spacing: PC_GAP,
+          alignment: "middle",
+        }),
+        sibling: distribute({ dir: siblingDir, spacing, alignment: "start" }),
+      },
+      goTreeData as any
+    ) as any;
+    node.name(axis === "row" ? "rowMargin" : "colMargin");
+    const size = levels * cross + (levels - 1) * PC_GAP;
+    return { node, size };
+  }
+
+  const { node: rowMargin, size: rowTreeW } = buildMargin("row");
+  const { node: colMargin, size: colTreeH } = buildMargin("col");
 
   // Leaves in both margins are laid out at the SAME uniform pitch as the
   // grid's own rows/columns (a leaf's cross-axis-orthogonal size is exactly
@@ -391,7 +400,7 @@ export async function confusionMatrix(
   const STRIP_W = 84;
   const HEADER_H = 14;
 
-  const strips = await Promise.all(
+  const stripsPromise = Promise.all(
     resolved.measures.map(async (measure) => {
       const values = rows.map((node) => computeMeasure(measure, matrix, node));
       const isRatio = RATIO_MEASURES.has(measure);
@@ -414,8 +423,12 @@ export async function confusionMatrix(
     })
   );
 
+  // The grid and the measure strips are independent resolves — run them
+  // concurrently instead of sequentially.
+  const [grid, strips] = await Promise.all([gridPromise, stripsPromise]);
+  grid.name("grid");
+
   // ─── compose ─────────────────────────────────────────────────────────────
-  const rowMarginX = 0;
   const gridX = rowTreeW + MARGIN_GAP;
   const gridY = colTreeH + MARGIN_GAP;
 
@@ -430,7 +443,7 @@ export async function confusionMatrix(
   const composed = layer(pieces).constrain(({ ...refs }: any) => {
     const constraints: any[] = [
       Constraint.position({ x: gridX, y: gridY, anchor: "start" }, [refs.grid]),
-      Constraint.position({ x: rowMarginX, y: gridY, anchor: "start" }, [
+      Constraint.position({ x: 0, y: gridY, anchor: "start" }, [
         refs.rowMargin,
       ]),
       Constraint.position({ x: gridX, y: 0, anchor: "start" }, [

--- a/packages/gofish-neo/src/confusionMatrix.tsx
+++ b/packages/gofish-neo/src/confusionMatrix.tsx
@@ -10,25 +10,26 @@
  *
  * Alignment recipe (see gofish-gotree's `NeoAlignmentSpike` story, issue
  * #639, for the proof-of-concept this generalizes): every structure — the
- * table-body grid, the gotree row/column margins, and the scatter-based
- * measure strips — shares one leaf `pitch` (cellSize + spacing). The grid
- * divides its extent into `N` equal `pitch`-wide tracks; the trees use a
- * UNIFORM `spacing` at every sibling level plus a node size that spans
- * exactly `leafCount * pitch - spacing` (so a leaf, with leafCount 1,
- * measures exactly `pitch - spacing`) — matched pitch falls out of the
- * recursion with no per-node arithmetic. The measure strips use `scatter`'s
- * `yMin`/`yMax` continuous channel, which is y-UP even though the grid's
- * `table` rows are top-down, so row `i`'s band is
- * `[(N-1-i)*pitch, (N-i)*pitch]` (flipped from the grid's own top-down `i`).
+ * table-body grid, the gotree row/column margins, and the measure strips —
+ * shares one leaf `pitch` (cellSize + spacing). The grid divides its extent
+ * into `N` equal `pitch`-wide tracks; the trees use a UNIFORM `spacing` at
+ * every sibling level plus a node size that spans exactly
+ * `leafCount * pitch - spacing` (so a leaf, with leafCount 1, measures
+ * exactly `pitch - spacing`) — matched pitch falls out of the recursion with
+ * no per-node arithmetic. The measure strips are themselves an ordinal,
+ * one-column `table()` (see gofish-neo's `PinningSpike` scratch story): a
+ * `table({by:{x:<const>, y:"row"}})` orders its single column of rows
+ * top-down in data order, same as the grid's own rows, so strip row `i`
+ * lines up with grid row `i` directly — no y-flip arithmetic (that used to
+ * be needed for the old `scatter`-based strips, see historical issue #812)
+ * and no measure-tagged field workaround.
  */
 
 import {
   chart,
   table,
-  scatter,
   rect,
   text,
-  field,
   Layer,
   Constraint,
   layer,
@@ -192,43 +193,50 @@ const RATIO_MEASURES: ReadonlySet<Measure> = new Set([
 async function buildMeasureStrip(opts: {
   values: number[];
   n: number;
-  pitch: number;
+  cellSize: number;
+  spacing: number;
   stripW: number;
   format: (v: number) => string;
 }) {
-  const { values, n, pitch, format } = opts;
-  // `rect`'s `w` field, under `scatter`, resolves through a continuous
-  // 0-anchored domain that fills the chart's own declared width at the max
-  // value (gotcha: unlike `table`'s grid — which treats a numeric field as a
-  // literal pixel claim — `scatter` maps a size field through a domain/range
-  // scale, same as its position channels). `headroom` keeps the longest bar
-  // short of the full container so an inset label never crowds the edge.
-  const headroom = 1.15;
+  const { values, n, cellSize, spacing, stripW, format } = opts;
   const maxVal = Math.max(...values, 1e-9);
   const rows = values.map((v, i) => ({
-    barValue: v / (maxVal * headroom),
+    row: i,
+    col: "v",
+    barW: Math.max(0, (v / maxVal) * stripW),
     labelStr: format(v),
-    start: (n - 1 - i) * pitch,
-    end: (n - i) * pitch,
   }));
-  return chart(rows, { w: opts.stripW, h: n * pitch, axes: false })
-    .flow(
-      scatter({
-        yMin: field("start", "rowPos"),
-        yMax: field("end", "rowPos"),
-      } as any)
-    )
-    .mark(
-      rect({
-        w: "barValue",
-        h: Math.max(4, pitch * 0.5),
-        fill: "#3d6ea5",
-      } as any).label("labelStr", {
-        position: "inset-right",
-        fontSize: 9,
-        color: "white",
-      })
-    )
+  // The bar fills the full row track height (cellSize) — matching what the
+  // old scatter-based strip actually rendered (its `yMin`/`yMax` interval
+  // constraint stretched the box to span the whole band regardless of its
+  // own declared `h`).
+  //
+  // A per-row varying bar `w` would break `table`'s uniform-track sizing (it
+  // claims a track's width from the max cell in it) and centering it in the
+  // track would defeat the left-anchored look — so, same workaround as
+  // `bodyMark`'s size encoding below (and issue #813): a per-row FUNCTION
+  // mark building an invisible full-strip-width reference plus the concrete
+  // bar, left-aligned to the reference's left edge. `table`'s per-cell leaf
+  // is a length-1 bucket (`[row]`), not the bare row — unwrap it.
+  const stripMark = (leaf: any) => {
+    const d = Array.isArray(leaf) ? leaf[0] : leaf;
+    return layer([
+      rect({ w: stripW, h: cellSize, fill: "transparent" } as any).name("ref"),
+      rect({ w: d.barW, h: cellSize, fill: "#3d6ea5" } as any)
+        .name("bar")
+        .label(() => d.labelStr, {
+          position: "inset-right",
+          fontSize: 9,
+          color: "white",
+        }),
+    ]).constrain(({ ref, bar }: any) => [
+      Constraint.align({ x: "start", y: "middle" }, [ref, bar]),
+    ]);
+  };
+  const stripExtent = n * cellSize + (n - 1) * spacing;
+  return chart(rows, { w: stripW, h: stripExtent, axes: false })
+    .flow(table({ by: { x: "col", y: "row" }, spacing }))
+    .mark(stripMark as any)
     .resolve();
 }
 
@@ -407,7 +415,8 @@ export async function confusionMatrix(
       const chartNode = await buildMeasureStrip({
         values,
         n,
-        pitch,
+        cellSize,
+        spacing,
         stripW: STRIP_W,
         format: (v) => (isRatio ? v.toFixed(2) : String(Math.round(v))),
       });

--- a/packages/gofish-neo/src/confusionMatrix.tsx
+++ b/packages/gofish-neo/src/confusionMatrix.tsx
@@ -1,0 +1,459 @@
+/**
+ * The Neo renderer: composes the pure data algebra (buildMatrix/frontier/
+ * buildNormalizer/computeMeasure) into a rendered GoFish node — a
+ * hierarchical confusion matrix with tree-shaped row/column margins and
+ * per-row measure strips.
+ *
+ * Mirrors gofish-gotree's `tree(spec, data)` shape: `confusionMatrix(spec,
+ * data)` returns a Promise of a composed node a caller can `.render(...)` or
+ * fold into a larger `layer([...])`.
+ *
+ * Alignment recipe (see gofish-gotree's `NeoAlignmentSpike` story, issue
+ * #639, for the proof-of-concept this generalizes): every structure — the
+ * table-body grid, the gotree row/column margins, and the scatter-based
+ * measure strips — shares one leaf `pitch` (cellSize + spacing). The grid
+ * divides its extent into `N` equal `pitch`-wide tracks; the trees use a
+ * UNIFORM `spacing` at every sibling level plus a node size that spans
+ * exactly `leafCount * pitch - spacing` (so a leaf, with leafCount 1,
+ * measures exactly `pitch - spacing`) — matched pitch falls out of the
+ * recursion with no per-node arithmetic. The measure strips use `scatter`'s
+ * `yMin`/`yMax` continuous channel, which is y-UP even though the grid's
+ * `table` rows are top-down, so row `i`'s band is
+ * `[(N-1-i)*pitch, (N-i)*pitch]` (flipped from the grid's own top-down `i`).
+ */
+
+import {
+  chart,
+  table,
+  scatter,
+  rect,
+  text,
+  field,
+  Layer,
+  Constraint,
+  layer,
+  assignGradientColor,
+} from "gofish-graphics";
+import { tree, distribute } from "gofish-gotree";
+
+import { frontier, type TreeNode } from "./labelTree";
+import { frequency, buildMatrix } from "./matrix";
+import { buildNormalizer } from "./normalize";
+import { computeMeasure, type Measure } from "./measures";
+import { applyDefaults, type NeoSpec } from "./spec";
+import type { Confusion } from "./pipeline";
+
+export interface ConfusionMatrixSpec extends NeoSpec {
+  /** Side length of a body cell, in pixels. @default 44 */
+  cellSize?: number;
+  /** Gap between body cells (and, correspondingly, tree/strip leaf gaps). @default 0 */
+  spacing?: number;
+  /** Sequential gradient endpoints for the color encoding. */
+  colors?: [string, string];
+  /** Show the raw count inside each cell. @default true */
+  showCounts?: boolean;
+  /**
+   * Exclude the diagonal from the color/size scale's domain (see
+   * `buildNormalizer`'s `excludeDiagonal` option) — diagonal cells still
+   * render, clamped to the domain max, so a few dominant correct-prediction
+   * cells don't wash out the contrast among the confusions.
+   */
+  excludeDiagonal?: boolean;
+}
+
+const DEFAULT_CELL_SIZE = 44;
+const DEFAULT_SPACING = 0;
+const DEFAULT_COLORS: [string, string] = ["#e6f5f8", "#0b5394"];
+const ZERO_FILL = "#f2f2f3";
+
+const PALETTE_DEPTH = ["#1d3557", "#3d6ea5", "#7ba7d1", "#b7d0e8"];
+
+const PC_GAP = 16; // parent<->child-group gap in both tree margins
+const NODE_W_ROW = 88; // row-tree node width, uniform across levels
+const NODE_H_COL = 22; // col-tree node height, uniform across levels
+const MARGIN_GAP = 14; // gap between margin/strip blocks and the grid
+
+// ─── gotree data conversion ─────────────────────────────────────────────────
+
+/** A node in the gotree-consumable label hierarchy (pruned to the frontier). */
+interface GoTreeLabelData {
+  id: string;
+  name: string;
+  children?: GoTreeLabelData[];
+}
+
+/**
+ * Converts a pruned subtree of the shared label tree into gotree's TreeData
+ * shape, stopping descent at collapsed node ids (a collapsed node renders as
+ * a leaf in the margin, matching its frontier row/column).
+ */
+function toGoTreeData(
+  node: TreeNode,
+  collapsedIds: Set<string>
+): GoTreeLabelData {
+  if (collapsedIds.has(node.id) || node.children.length === 0) {
+    return { id: node.id, name: node.name };
+  }
+  return {
+    id: node.id,
+    name: node.name,
+    children: node.children.map((c) => toGoTreeData(c, collapsedIds)),
+  };
+}
+
+/** Number of margin "levels" (root through frontier leaves, inclusive) under `collapsedIds`. */
+function levelCount(node: TreeNode, collapsedIds: Set<string>): number {
+  if (collapsedIds.has(node.id) || node.children.length === 0) return 1;
+  return 1 + Math.max(...node.children.map((c) => levelCount(c, collapsedIds)));
+}
+
+// ─── tree-margin node factories ─────────────────────────────────────────────
+// Both margins use the same "span the leaf count" sizing rule: a node's size
+// along the tree's growth axis is `d.width * pitch - spacing` (gotree's
+// `HierarchyDatum.width` is the node's own leaf count) — a leaf (width 1)
+// measures `pitch - spacing`; an internal node spans exactly its children
+// group's rendered extent, so parent and child-group bboxes agree with no
+// separate bookkeeping. The cross axis is a fixed per-margin constant.
+
+function marginNodeFactory(opts: {
+  pitch: number;
+  spacing: number;
+  cross: number;
+  axis: "w" | "h";
+  fontSize: number;
+}) {
+  const { pitch, spacing, cross, axis, fontSize } = opts;
+  return (d: any) => {
+    const along = Math.max(4, d.width * pitch - spacing);
+    const w = axis === "w" ? along : cross;
+    const h = axis === "w" ? cross : along;
+    const depth: number = d.depth;
+    const fill = PALETTE_DEPTH[Math.min(depth, PALETTE_DEPTH.length - 1)];
+    const isLeaf = d.height === 0;
+    // A degenerate single-leaf-child chain gets pruned into one node named
+    // "parent:child" (see labelTree.ts's pruneDegenerateChains) — render that
+    // with a friendlier separator, and shrink the font when the available
+    // cross-axis room can't fit it at the base size (avoids text spilling
+    // past its own box, e.g. a pruned "reptile:lizard" node).
+    // The column margin is much tighter on width (one grid-column pitch per
+    // leaf) than the row margin (a fixed, comfortably wide node column), so a
+    // pruned compound name that fits fine in the row margin can still
+    // overflow there — fall back to just the name's last segment.
+    const full = String(d.data.name).replace(/:/g, " / ");
+    const last = String(d.data.name).split(":").pop()!;
+    const displayName = axis === "w" ? last : full;
+    const available = w - 6;
+    const estCharW = fontSize * 0.62;
+    const shrunk =
+      displayName.length * estCharW > available
+        ? Math.max(7, Math.floor(available / (displayName.length * 0.62)))
+        : fontSize;
+    return Layer({ w, h }, [
+      rect({
+        w,
+        h,
+        rx: 3,
+        fill,
+        stroke: isLeaf ? "#ffffff" : "none",
+        strokeWidth: 1,
+      }).name("box"),
+      text({
+        text: displayName,
+        fontSize: shrunk,
+        fill: depth === 0 ? "#ffffff" : "#0f1f30",
+      }).name("label"),
+    ]).constrain(({ box, label }: any) => [
+      Constraint.align({ x: "middle", y: "middle" }, [box, label]),
+    ]);
+  };
+}
+
+// ─── measure strips ─────────────────────────────────────────────────────────
+
+const RATIO_MEASURES: ReadonlySet<Measure> = new Set([
+  "precision",
+  "recall",
+  "accuracy",
+]);
+
+async function buildMeasureStrip(opts: {
+  values: number[];
+  n: number;
+  pitch: number;
+  stripW: number;
+  format: (v: number) => string;
+}) {
+  const { values, n, pitch, format } = opts;
+  // `rect`'s `w` field, under `scatter`, resolves through a continuous
+  // 0-anchored domain that fills the chart's own declared width at the max
+  // value (gotcha: unlike `table`'s grid — which treats a numeric field as a
+  // literal pixel claim — `scatter` maps a size field through a domain/range
+  // scale, same as its position channels). `headroom` keeps the longest bar
+  // short of the full container so an inset label never crowds the edge.
+  const headroom = 1.15;
+  const maxVal = Math.max(...values, 1e-9);
+  const rows = values.map((v, i) => ({
+    barValue: v / (maxVal * headroom),
+    labelStr: format(v),
+    start: (n - 1 - i) * pitch,
+    end: (n - i) * pitch,
+  }));
+  return chart(rows, { w: opts.stripW, h: n * pitch, axes: false })
+    .flow(
+      scatter({
+        yMin: field("start", "rowPos"),
+        yMax: field("end", "rowPos"),
+      } as any)
+    )
+    .mark(
+      rect({
+        w: "barValue",
+        h: Math.max(4, pitch * 0.5),
+        fill: "#3d6ea5",
+      } as any).label("labelStr", {
+        position: "inset-right",
+        fontSize: 9,
+        color: "white",
+      })
+    )
+    .resolve();
+}
+
+// ─── main entry ─────────────────────────────────────────────────────────────
+
+export async function confusionMatrix(
+  spec: ConfusionMatrixSpec,
+  data: Confusion[]
+): Promise<any> {
+  const resolved = applyDefaults(spec);
+  const cellSize = spec.cellSize ?? DEFAULT_CELL_SIZE;
+  const spacing = spec.spacing ?? DEFAULT_SPACING;
+  const colors = spec.colors ?? DEFAULT_COLORS;
+  const showCounts = spec.showCounts ?? true;
+  const excludeDiagonal = spec.excludeDiagonal ?? false;
+
+  const { tree: labelTree, matrix } = buildMatrix(data, resolved);
+  const collapsedIds = new Set(resolved.collapsed);
+  const rows = frontier(labelTree, collapsedIds);
+  const cols = rows; // shared tree: same frontier serves both axes
+  const n = rows.length;
+
+  const normalizer = buildNormalizer(
+    labelTree,
+    matrix,
+    resolved.normalization,
+    collapsedIds,
+    {
+      excludeDiagonal,
+    }
+  );
+
+  const pitch = cellSize + spacing;
+  const gridExtent = n * cellSize + (n - 1) * spacing;
+
+  // ─── body cells ───────────────────────────────────────────────────────
+  const isColor = resolved.encoding === "color";
+  const cells = rows.flatMap((rowNode) =>
+    cols.map((colNode) => {
+      const count = frequency(matrix, rowNode, colNode);
+      const norm = normalizer(rowNode, colNode);
+      const isZero = count === 0;
+      const fillColor = isZero
+        ? ZERO_FILL
+        : isColor
+          ? assignGradientColor({ _tag: "gradient", stops: colors }, norm)
+          : "#2b6cb0";
+      const side = isZero
+        ? 0
+        : cellSize * Math.sqrt(Math.max(0, Math.min(1, norm)));
+      return {
+        actual: rowNode.id,
+        observed: colNode.id,
+        count,
+        fillColor,
+        sizeW: side,
+        sizeH: side,
+        labelText: isZero ? "–" : showCounts ? String(count) : "",
+      };
+    })
+  );
+
+  const labelFontSize = Math.max(9, Math.round(cellSize * 0.24));
+
+  // The size encoding needs each cell's visible box to vary while the grid
+  // TRACK stays uniform (cellSize) — table's grid sizes a track to the max
+  // claim among its cells (see grid.ts), so a directly claim-bearing `w`/`h`
+  // would make rows/columns non-uniform. The usual fix is an invisible
+  // full-size reference sibling to dominate the claim, but resolving a
+  // per-row size FIELD NAME ("sizeW") on a shape nested inside a `layer([...])`
+  // under `table` does not reach the per-cell datum reliably — it's a
+  // per-row FUNCTION mark (below), which sidesteps field-name channel
+  // inference entirely by building each cell's shapes from already-concrete
+  // per-row numbers, so it isn't affected the same way. `table`'s per-cell
+  // leaf is a length-1 bucket (`[row]`), not the bare row, so unwrap it.
+  const bodyMark = isColor
+    ? rect({ w: cellSize, h: cellSize, fill: "fillColor" } as any).label(
+        "labelText",
+        {
+          position: "center",
+          fontSize: labelFontSize,
+        }
+      )
+    : (((leaf: any) => {
+        const d = Array.isArray(leaf) ? leaf[0] : leaf;
+        // The label sits at the fixed cell center on an always-transparent
+        // reference shape (so its position doesn't depend on the box's own
+        // variable size), so it can't lean on fill-based auto-contrast — pick
+        // the color explicitly instead: a light dash for a true zero, a dark
+        // count otherwise (dark reads fine both on the page background and
+        // on the encoding's fixed medium-blue box).
+        return layer([
+          rect({ w: cellSize, h: cellSize, fill: "transparent" } as any)
+            .name("ref")
+            .label(() => d.labelText, {
+              position: "center",
+              fontSize: labelFontSize,
+              color: d.count === 0 ? "#b0b4ba" : "#0f1f30",
+            }),
+          rect({ w: d.sizeW, h: d.sizeH, fill: d.fillColor } as any).name(
+            "box"
+          ),
+        ]).constrain(({ ref, box }: any) => [
+          Constraint.align({ x: "middle", y: "middle" }, [ref, box]),
+        ]);
+      }) as any);
+
+  const grid = await chart(cells, { w: gridExtent, h: gridExtent, axes: false })
+    .flow(table({ by: { x: "observed", y: "actual" }, spacing }))
+    .mark(bodyMark as any)
+    .resolve();
+  grid.name("grid");
+
+  // ─── row + column margins ───────────────────────────────────────────────
+  // The tree root is a synthetic wrapper with exactly one child (the
+  // primary class dimension, `classes[0]`) — start the margins there so we
+  // don't draw a blank, id-less root box.
+  const dimRoot = labelTree.children[0] ?? labelTree;
+  const goTreeData = toGoTreeData(dimRoot, collapsedIds);
+  const levels = levelCount(dimRoot, collapsedIds);
+
+  const rowMargin = tree(
+    {
+      node: marginNodeFactory({
+        pitch,
+        spacing,
+        cross: NODE_W_ROW,
+        axis: "h",
+        fontSize: 10,
+      }),
+      link: "none",
+      parentChild: distribute({
+        dir: "x",
+        spacing: PC_GAP,
+        alignment: "middle",
+      }),
+      sibling: distribute({ dir: "y", spacing, alignment: "start" }),
+    },
+    goTreeData as any
+  ) as any;
+  rowMargin.name("rowMargin");
+  const rowTreeW = levels * NODE_W_ROW + (levels - 1) * PC_GAP;
+
+  const colMargin = tree(
+    {
+      node: marginNodeFactory({
+        pitch,
+        spacing,
+        cross: NODE_H_COL,
+        axis: "w",
+        fontSize: 9,
+      }),
+      link: "none",
+      parentChild: distribute({
+        dir: "y",
+        spacing: PC_GAP,
+        alignment: "middle",
+      }),
+      sibling: distribute({ dir: "x", spacing, alignment: "start" }),
+    },
+    goTreeData as any
+  ) as any;
+  colMargin.name("colMargin");
+  const colTreeH = levels * NODE_H_COL + (levels - 1) * PC_GAP;
+
+  // Leaves in both margins are laid out at the SAME uniform pitch as the
+  // grid's own rows/columns (a leaf's cross-axis-orthogonal size is exactly
+  // `pitch - spacing`, matching a grid cell's `cellSize`), so the margins
+  // need no extra per-axis offset to line up with the grid — see the module
+  // doc-comment.
+
+  // ─── measure strips ──────────────────────────────────────────────────────
+  const STRIP_W = 84;
+  const HEADER_H = 14;
+
+  const strips = await Promise.all(
+    resolved.measures.map(async (measure) => {
+      const values = rows.map((node) => computeMeasure(measure, matrix, node));
+      const isRatio = RATIO_MEASURES.has(measure);
+      const chartNode = await buildMeasureStrip({
+        values,
+        n,
+        pitch,
+        stripW: STRIP_W,
+        format: (v) => (isRatio ? v.toFixed(2) : String(Math.round(v))),
+      });
+      chartNode.name(`strip_${measure}`);
+      const header = text({
+        text: measure,
+        fontSize: 10,
+        fontWeight: 600,
+        fill: "#0f1f30",
+        textAnchor: "middle",
+      }).name(`stripHeader_${measure}`) as any;
+      return { measure, chartNode, header };
+    })
+  );
+
+  // ─── compose ─────────────────────────────────────────────────────────────
+  const rowMarginX = 0;
+  const gridX = rowTreeW + MARGIN_GAP;
+  const gridY = colTreeH + MARGIN_GAP;
+
+  const pieces: any[] = [
+    rowMargin,
+    grid,
+    colMargin,
+    ...strips.map((s) => s.chartNode),
+    ...strips.map((s) => s.header),
+  ];
+
+  const composed = layer(pieces).constrain(({ ...refs }: any) => {
+    const constraints: any[] = [
+      Constraint.position({ x: gridX, y: gridY, anchor: "start" }, [refs.grid]),
+      Constraint.position({ x: rowMarginX, y: gridY, anchor: "start" }, [
+        refs.rowMargin,
+      ]),
+      Constraint.position({ x: gridX, y: 0, anchor: "start" }, [
+        refs.colMargin,
+      ]),
+    ];
+    let stripX = gridX + gridExtent + MARGIN_GAP;
+    for (const s of strips) {
+      constraints.push(
+        Constraint.position({ x: stripX, y: gridY, anchor: "start" }, [
+          refs[`strip_${s.measure}`],
+        ])
+      );
+      constraints.push(
+        Constraint.position(
+          { x: stripX + STRIP_W / 2, y: gridY - HEADER_H - 4, anchor: "start" },
+          [refs[`stripHeader_${s.measure}`]]
+        )
+      );
+      stripX += STRIP_W + MARGIN_GAP;
+    }
+    return constraints;
+  });
+
+  return composed;
+}

--- a/packages/gofish-neo/src/index.ts
+++ b/packages/gofish-neo/src/index.ts
@@ -67,5 +67,10 @@ export type { Measure } from "./measures";
 export { applyDefaults } from "./spec";
 export type { NeoSpec, ResolvedNeoSpec, Normalization, Encoding } from "./spec";
 
-export { confusionMatrix } from "./confusionMatrix";
+export {
+  confusionMatrix,
+  DEFAULT_COLORS,
+  ZERO_FILL,
+  PALETTE_DEPTH,
+} from "./confusionMatrix";
 export type { ConfusionMatrixSpec } from "./confusionMatrix";

--- a/packages/gofish-neo/src/index.ts
+++ b/packages/gofish-neo/src/index.ts
@@ -1,0 +1,71 @@
+/**
+ * gofish-neo: a clean-room reimplementation of the Neo (Görtler et al.,
+ * CHI 2022) hierarchical-confusion-matrix data algebra.
+ *
+ * This module (Part A/B of the package) exposes only the pure data algebra:
+ * path parsing, the shared label tree, the condition/filter/linearize/
+ * nest/marginalize pipeline, the dense matrix + block-sum queries,
+ * normalization scaling, and classification measures. A renderer (a later
+ * package addition) consumes `buildMatrix`'s `{ tree, matrix }`, the
+ * `frontier()`/`leaves()` traversal utilities, `buildNormalizer`, and
+ * `computeMeasure`.
+ */
+
+export {
+  tokenize,
+  parsePath,
+  segments,
+  dimension,
+  isPathPrefix,
+} from "./paths";
+export type { Token, Chain } from "./paths";
+
+export {
+  buildLabelTree,
+  isLeaf,
+  preorder,
+  postorder,
+  leaves,
+  frontier,
+  findNode,
+} from "./labelTree";
+export type { TreeNode } from "./labelTree";
+
+export {
+  dimensions,
+  normalizeRecords,
+  condition,
+  filter,
+  linearize,
+  linearizeRecords,
+  nestPaths,
+  nest,
+  marginalize,
+} from "./pipeline";
+export type { Confusion, Condition, Cell } from "./pipeline";
+
+export { buildMatrix, frequency, total, totalRow, totalColumn } from "./matrix";
+export type { Matrix, Built } from "./matrix";
+
+export { buildNormalizer } from "./normalize";
+export type { Normalizer } from "./normalize";
+
+export {
+  truePositives,
+  falsePositives,
+  falseNegatives,
+  trueNegatives,
+  countActual,
+  countObserved,
+  precision,
+  recall,
+  accuracy,
+  computeMeasure,
+} from "./measures";
+export type { Measure } from "./measures";
+
+export { applyDefaults } from "./spec";
+export type { NeoSpec, ResolvedNeoSpec, Normalization, Encoding } from "./spec";
+
+export { confusionMatrix } from "./confusionMatrix";
+export type { ConfusionMatrixSpec } from "./confusionMatrix";

--- a/packages/gofish-neo/src/labelTree.test.ts
+++ b/packages/gofish-neo/src/labelTree.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLabelTree,
+  findNode,
+  frontier,
+  isLeaf,
+  leaves,
+  postorder,
+  preorder,
+} from "./labelTree";
+
+describe("buildLabelTree", () => {
+  it("shares a common prefix across labels (trie merge)", () => {
+    const tree = buildLabelTree(["a:b", "a:c"]);
+    // root -> a -> {b, c}
+    expect(tree.children).toHaveLength(1);
+    const a = tree.children[0]!;
+    expect(a.name).toBe("a");
+    expect(a.children.map((c) => c.name)).toEqual(["b", "c"]);
+  });
+
+  it("assigns contiguous, children-concatenated postorder leaf ranges (3-level tree)", () => {
+    // root -> x -> {p -> {m, n}, q:leaf2}, root -> y -> {leaf3, leaf4}
+    // (p:{m,n} has 2 children so it survives; q:leaf2 is a single-leaf
+    // chain and gets pruned into one "q:leaf2" leaf — see the prune test.)
+    const tree = buildLabelTree([
+      "x:p:m",
+      "x:p:n",
+      "x:q:leaf2",
+      "y:leaf3",
+      "y:leaf4",
+    ]);
+
+    // Every leaf gets a unit range, and every internal node's range is
+    // exactly the union of its children's ranges (first child's start to
+    // last child's end) — checked recursively over the whole tree.
+    function checkInvariant(node: typeof tree) {
+      if (isLeaf(node)) {
+        expect(node.end - node.start).toBe(1);
+        return;
+      }
+      expect(node.start).toBe(node.children[0]!.start);
+      expect(node.end).toBe(node.children[node.children.length - 1]!.end);
+      // Children's ranges concatenate with no gaps or overlaps.
+      for (let i = 1; i < node.children.length; i++) {
+        expect(node.children[i]!.start).toBe(node.children[i - 1]!.end);
+      }
+      for (const c of node.children) checkInvariant(c);
+    }
+    checkInvariant(tree);
+
+    // The root's total range width equals the number of true leaves.
+    expect(tree.end - tree.start).toBe(leaves(tree).length);
+  });
+
+  it("prunes single-leaf-child chains into one joined-name node", () => {
+    // "a:b:c" alone -> root -> a -> b -> c, with a and b each single-child
+    // chains down to the leaf c; should collapse to root -> "a:b:c" leaf.
+    const tree = buildLabelTree(["a:b:c"]);
+    expect(tree.children).toHaveLength(1);
+    const collapsed = tree.children[0]!;
+    expect(collapsed.name).toBe("a:b:c");
+    expect(collapsed.id).toBe("a:b:c");
+    expect(isLeaf(collapsed)).toBe(true);
+  });
+
+  it("does not collapse a node with more than one child", () => {
+    const tree = buildLabelTree(["a:b", "a:c"]);
+    const a = tree.children[0]!;
+    expect(a.name).toBe("a");
+    expect(a.children).toHaveLength(2);
+  });
+});
+
+describe("preorder / postorder", () => {
+  it("visits every node", () => {
+    const tree = buildLabelTree(["a:b", "a:c"]);
+    const pre: string[] = [];
+    preorder(tree, (n) => pre.push(n.name));
+    expect(pre[0]).toBe(""); // synthetic root has empty name
+    expect(pre).toContain("a");
+    expect(pre).toContain("b");
+    expect(pre).toContain("c");
+
+    const post: string[] = [];
+    postorder(tree, (n) => post.push(n.name));
+    expect(post[post.length - 1]).toBe(""); // root visited last
+  });
+});
+
+describe("leaves / frontier", () => {
+  it("reports true leaves by default", () => {
+    const tree = buildLabelTree(["a:b", "a:c"]);
+    const a = tree.children[0]!;
+    expect(
+      leaves(tree)
+        .map((n) => n.name)
+        .sort()
+    ).toEqual(["b", "c"]);
+    expect(a.children.every(isLeaf)).toBe(true);
+  });
+
+  it("reports a blocked (don't-descend) node itself as a leaf", () => {
+    const tree = buildLabelTree(["a:b", "a:c"]);
+    const a = tree.children[0]!;
+    const blocked = leaves(tree, (n) => n.id !== a.id);
+    expect(blocked.map((n) => n.name)).toEqual(["a"]);
+  });
+
+  it("frontier() collapses given node ids", () => {
+    // "x:y" is a single-leaf-child chain, so it prunes into one "x:y" leaf.
+    const tree = buildLabelTree(["a:b", "a:c", "x:y"]);
+    const a = tree.children.find((n) => n.name === "a")!;
+    const result = frontier(tree, [a.id]);
+    expect(result.map((n) => n.name).sort()).toEqual(["a", "x:y"]);
+  });
+});
+
+describe("findNode", () => {
+  it("finds a node by id", () => {
+    const tree = buildLabelTree(["a:b", "a:c"]);
+    expect(findNode(tree, "a")?.name).toBe("a");
+    expect(findNode(tree, "a:b")?.name).toBe("b");
+    expect(findNode(tree, "nope")).toBeUndefined();
+  });
+});

--- a/packages/gofish-neo/src/labelTree.ts
+++ b/packages/gofish-neo/src/labelTree.ts
@@ -1,0 +1,227 @@
+/**
+ * The shared label tree: one hierarchy of labels built from every label
+ * string seen on either axis (actual and observed both walk the same tree),
+ * with leaves assigned contiguous postorder ranges so that any
+ * (rowNode, colNode) frequency is a rectangular block-sum over the dense
+ * matrix.
+ */
+
+import { segments } from "./paths";
+
+/** A node in the shared label tree. */
+export interface TreeNode {
+  /** Cumulative colon-joined id, e.g. "animal:walking:cat". Unique per node. */
+  id: string;
+  /** This node's own label segment (last segment of `id`, post-pruning may be joined). */
+  name: string;
+  parent: TreeNode | undefined;
+  children: TreeNode[];
+  /** Half-open leaf-index range `[start, end)` this node covers. */
+  start: number;
+  end: number;
+}
+
+/** True if `node` is a leaf (has no children) in the full, unpruned/uncollapsed sense. */
+export function isLeaf(node: TreeNode): boolean {
+  return node.children.length === 0;
+}
+
+interface MutableNode {
+  id: string;
+  name: string;
+  parent: MutableNode | undefined;
+  children: MutableNode[];
+  start: number;
+  end: number;
+}
+
+function makeNode(
+  id: string,
+  name: string,
+  parent: MutableNode | undefined
+): MutableNode {
+  return { id, name, parent, children: [], start: -1, end: -1 };
+}
+
+/**
+ * Builds the shared label tree from a list of label strings (e.g. every
+ * resolved actual/observed path in the dataset). Each string is split on
+ * `:` into a chain of segments; chains are trie-merged under a synthetic
+ * root, matching children by cumulative id. Sibling order follows first
+ * occurrence. Leaves get postorder-assigned half-open ranges starting at 0;
+ * internal nodes' ranges are the union of their children's (first child's
+ * start to last child's end) — this is what makes block-sum lookups valid.
+ * Finally, degenerate single-leaf-child chains are pruned (see
+ * {@link pruneDegenerateChains}).
+ */
+export function buildLabelTree(labels: string[]): TreeNode {
+  const root: MutableNode = makeNode("", "", undefined);
+
+  for (const label of labels) {
+    const segs = segments(label);
+    let cur = root;
+    let id = "";
+    for (const seg of segs) {
+      id = id === "" ? seg : `${id}:${seg}`;
+      let child = cur.children.find((c) => c.id === id);
+      if (!child) {
+        child = makeNode(id, seg, cur);
+        cur.children.push(child);
+      }
+      cur = child;
+    }
+  }
+
+  assignPostorderRanges(root);
+  return prune(freeze(root));
+}
+
+function assignPostorderRanges(node: MutableNode): number {
+  let counter = 0;
+  function visit(n: MutableNode): void {
+    if (n.children.length === 0) {
+      n.start = counter;
+      n.end = counter + 1;
+      counter++;
+      return;
+    }
+    for (const c of n.children) visit(c);
+    n.start = n.children[0]!.start;
+    n.end = n.children[n.children.length - 1]!.end;
+  }
+  visit(node);
+  return counter;
+}
+
+function freeze(node: MutableNode): TreeNode {
+  const out: TreeNode = {
+    id: node.id,
+    name: node.name,
+    parent: undefined,
+    children: [],
+    start: node.start,
+    end: node.end,
+  };
+  out.children = node.children.map((c) => {
+    const child = freeze(c);
+    child.parent = out;
+    return child;
+  });
+  return out;
+}
+
+/**
+ * Postorder-collapses any internal node with exactly one child, where that
+ * child is a leaf, into a single node named `"parent:child"` (using the
+ * dropped child's id as the surviving node's id, so downstream lookups by
+ * leaf id remain valid). The synthetic root itself is never collapsed away.
+ */
+function pruneDegenerateChains(root: TreeNode): TreeNode {
+  function visit(node: TreeNode): TreeNode {
+    node.children = node.children.map(visit);
+    if (
+      node.parent !== undefined &&
+      node.children.length === 1 &&
+      isLeaf(node.children[0]!)
+    ) {
+      const onlyChild = node.children[0]!;
+      const collapsed: TreeNode = {
+        id: onlyChild.id,
+        name: `${node.name}:${onlyChild.name}`,
+        parent: node.parent,
+        children: [],
+        start: onlyChild.start,
+        end: onlyChild.end,
+      };
+      return collapsed;
+    }
+    return node;
+  }
+  const newRoot = visit(root);
+  // Re-parent children to point at (possibly replaced) parents.
+  reparent(newRoot, undefined);
+  return newRoot;
+}
+
+function reparent(node: TreeNode, parent: TreeNode | undefined): void {
+  node.parent = parent;
+  for (const c of node.children) reparent(c, node);
+}
+
+function prune(root: TreeNode): TreeNode {
+  return pruneDegenerateChains(root);
+}
+
+/**
+ * Walks the tree in preorder (node before children), calling `visit` on
+ * each node. `descend(node)` decides whether to recurse into a node's
+ * children; if it returns false, the node's subtree is not visited further
+ * (but `visit` still fires for the node itself).
+ */
+export function preorder(
+  root: TreeNode,
+  visit: (node: TreeNode) => void,
+  descend: (node: TreeNode) => boolean = () => true
+): void {
+  visit(root);
+  if (descend(root)) {
+    for (const c of root.children) preorder(c, visit, descend);
+  }
+}
+
+/** Walks the tree in postorder (children before node). */
+export function postorder(
+  root: TreeNode,
+  visit: (node: TreeNode) => void
+): void {
+  for (const c of root.children) postorder(c, visit);
+  visit(root);
+}
+
+/**
+ * Returns the *frontier* of leaves under `descend`'s control: a node whose
+ * `descend` predicate returns false is reported as a leaf itself (even if it
+ * has children in the full tree), and its subtree is not explored further.
+ * True leaves (no children) are always reported. This is the mechanism
+ * behind both plain leaf enumeration (`descend: () => true`) and collapse
+ * (`descend: (n) => !collapsedIds.has(n.id)`).
+ */
+export function leaves(
+  root: TreeNode,
+  descend: (node: TreeNode) => boolean = () => true
+): TreeNode[] {
+  const out: TreeNode[] = [];
+  function visit(node: TreeNode): void {
+    if (isLeaf(node) || !descend(node)) {
+      out.push(node);
+      return;
+    }
+    for (const c of node.children) visit(c);
+  }
+  visit(root);
+  return out;
+}
+
+/**
+ * Computes the rendering frontier given a set of collapsed node ids: true
+ * leaves plus any collapsed node, stopping descent at collapsed ids.
+ * Collapse only changes which nodes are treated as frontier leaves for
+ * rendering/aggregation purposes — it never changes the underlying tree or
+ * data.
+ */
+export function frontier(
+  root: TreeNode,
+  collapsed: Iterable<string> = []
+): TreeNode[] {
+  const collapsedIds = new Set(collapsed);
+  return leaves(root, (n) => !collapsedIds.has(n.id));
+}
+
+/** Finds a node by id via a simple tree walk, or undefined if absent. */
+export function findNode(root: TreeNode, id: string): TreeNode | undefined {
+  let found: TreeNode | undefined;
+  preorder(root, (n) => {
+    if (n.id === id) found = n;
+  });
+  return found;
+}

--- a/packages/gofish-neo/src/labelTree.ts
+++ b/packages/gofish-neo/src/labelTree.ts
@@ -217,11 +217,26 @@ export function frontier(
   return leaves(root, (n) => !collapsedIds.has(n.id));
 }
 
-/** Finds a node by id via a simple tree walk, or undefined if absent. */
+/** Finds a node by id via a tree walk that stops as soon as it's found. */
 export function findNode(root: TreeNode, id: string): TreeNode | undefined {
-  let found: TreeNode | undefined;
+  if (root.id === id) return root;
+  for (const child of root.children) {
+    const found = findNode(child, id);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/**
+ * Builds an id -> node lookup `Map` for the whole tree in one O(size) walk,
+ * for callers that look up many ids against the same tree (e.g.
+ * `buildMatrix`'s per-cell `actual`/`observed` lookups) — an O(1) map lookup
+ * per id instead of an O(size) `findNode` walk per id.
+ */
+export function nodeIndex(root: TreeNode): Map<string, TreeNode> {
+  const index = new Map<string, TreeNode>();
   preorder(root, (n) => {
-    if (n.id === id) found = n;
+    index.set(n.id, n);
   });
-  return found;
+  return index;
 }

--- a/packages/gofish-neo/src/matrix.test.ts
+++ b/packages/gofish-neo/src/matrix.test.ts
@@ -1,32 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
-import { frequency, total, totalColumn, totalRow, type Matrix } from "./matrix";
-
-/**
- * Canonical fixture used across matrix/normalize/measures tests: a tree
- * root -> {A, BC -> {B, C}}, with A=[0,1), B=[1,2), C=[2,3), BC=[1,3), and a
- * raw actual(row)×observed(col) matrix over [A,B,C].
- */
-function fixture(): {
-  tree: TreeNode;
-  matrix: Matrix;
-  A: TreeNode;
-  B: TreeNode;
-  C: TreeNode;
-  BC: TreeNode;
-} {
-  const tree = buildLabelTree(["A", "BC:B", "BC:C"]);
-  const A = findNode(tree, "A")!;
-  const B = findNode(tree, "BC:B")!;
-  const C = findNode(tree, "BC:C")!;
-  const BC = findNode(tree, "BC")!;
-  const matrix: Matrix = [
-    [3, 5, 2],
-    [3, 4, 3],
-    [1, 2, 7],
-  ];
-  return { tree, matrix, A, B, C, BC };
-}
+import { frequency, total, totalColumn, totalRow } from "./matrix";
+import { fixture } from "./testFixture";
 
 describe("fixture sanity", () => {
   it("has the expected leaf ranges", () => {

--- a/packages/gofish-neo/src/matrix.test.ts
+++ b/packages/gofish-neo/src/matrix.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
+import { frequency, total, totalColumn, totalRow, type Matrix } from "./matrix";
+
+/**
+ * Canonical fixture used across matrix/normalize/measures tests: a tree
+ * root -> {A, BC -> {B, C}}, with A=[0,1), B=[1,2), C=[2,3), BC=[1,3), and a
+ * raw actual(row)×observed(col) matrix over [A,B,C].
+ */
+function fixture(): {
+  tree: TreeNode;
+  matrix: Matrix;
+  A: TreeNode;
+  B: TreeNode;
+  C: TreeNode;
+  BC: TreeNode;
+} {
+  const tree = buildLabelTree(["A", "BC:B", "BC:C"]);
+  const A = findNode(tree, "A")!;
+  const B = findNode(tree, "BC:B")!;
+  const C = findNode(tree, "BC:C")!;
+  const BC = findNode(tree, "BC")!;
+  const matrix: Matrix = [
+    [3, 5, 2],
+    [3, 4, 3],
+    [1, 2, 7],
+  ];
+  return { tree, matrix, A, B, C, BC };
+}
+
+describe("fixture sanity", () => {
+  it("has the expected leaf ranges", () => {
+    const { A, B, C, BC } = fixture();
+    expect([A.start, A.end]).toEqual([0, 1]);
+    expect([B.start, B.end]).toEqual([1, 2]);
+    expect([C.start, C.end]).toEqual([2, 3]);
+    expect([BC.start, BC.end]).toEqual([1, 3]);
+  });
+});
+
+describe("total / totalRow / totalColumn", () => {
+  it("matches the worked totals", () => {
+    const { matrix, tree, A, BC, B, C } = fixture();
+    expect(total(matrix)).toBe(30);
+    expect(totalRow(matrix, tree)).toBe(30);
+    expect(totalRow(matrix, A)).toBe(10);
+    expect(totalRow(matrix, BC)).toBe(20);
+    expect(totalRow(matrix, B)).toBe(10);
+    expect(totalRow(matrix, C)).toBe(10);
+
+    expect(totalColumn(matrix, tree)).toBe(30);
+    expect(totalColumn(matrix, A)).toBe(7);
+    expect(totalColumn(matrix, BC)).toBe(23);
+    expect(totalColumn(matrix, B)).toBe(11);
+    expect(totalColumn(matrix, C)).toBe(12);
+  });
+});
+
+describe("frequency (block sum)", () => {
+  it("slices BC x BC as a 2x2 block", () => {
+    const { matrix, BC } = fixture();
+    expect(frequency(matrix, BC, BC)).toBe(16); // 4+3+2+7
+  });
+
+  it("agrees with a single cell for leaf x leaf", () => {
+    const { matrix, A, B } = fixture();
+    expect(frequency(matrix, A, B)).toBe(matrix[0]![1]);
+  });
+});

--- a/packages/gofish-neo/src/matrix.ts
+++ b/packages/gofish-neo/src/matrix.ts
@@ -4,7 +4,7 @@
  * frequency is a rectangular sum over `matrix[row.start:row.end][col.start:col.end]`.
  */
 
-import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
+import { buildLabelTree, nodeIndex, type TreeNode } from "./labelTree";
 import {
   condition,
   dimensions,
@@ -51,9 +51,10 @@ export function buildMatrix(records: Confusion[], spec: NeoSpec): Built {
 
   const n = tree.end; // root always covers [0, n)
   const matrix: Matrix = Array.from({ length: n }, () => new Array(n).fill(0));
+  const index = nodeIndex(tree);
   for (const cell of cells) {
-    const rowNode = findNode(tree, cell.actual);
-    const colNode = findNode(tree, cell.observed);
+    const rowNode = index.get(cell.actual);
+    const colNode = index.get(cell.observed);
     if (!rowNode || !colNode) {
       throw new Error(
         `marginalized label "${cell.actual}"/"${cell.observed}" not found in built tree`

--- a/packages/gofish-neo/src/matrix.ts
+++ b/packages/gofish-neo/src/matrix.ts
@@ -1,0 +1,114 @@
+/**
+ * Dense leaf×leaf matrix construction and block-sum queries. The tree is
+ * shared between axes (see labelTree.ts), so any (rowNode, colNode)
+ * frequency is a rectangular sum over `matrix[row.start:row.end][col.start:col.end]`.
+ */
+
+import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
+import {
+  condition,
+  dimensions,
+  filter as filterRecords,
+  linearizeRecords,
+  marginalize,
+  nest,
+  normalizeRecords,
+  type Confusion,
+} from "./pipeline";
+import { applyDefaults, type NeoSpec } from "./spec";
+
+/** Dense leaf×leaf count matrix: `matrix[actualLeafIndex][observedLeafIndex]`. */
+export type Matrix = number[][];
+
+/** Result of running the full pipeline: the shared label tree and its dense matrix. */
+export interface Built {
+  tree: TreeNode;
+  matrix: Matrix;
+}
+
+/**
+ * Runs the fixed pipeline (condition → filter → linearize → nest →
+ * marginalize) over `records` according to `spec`, then builds the shared
+ * label tree from the resulting leaf labels and a dense leaf×leaf matrix of
+ * summed counts.
+ */
+export function buildMatrix(records: Confusion[], spec: NeoSpec): Built {
+  const resolved = applyDefaults(spec);
+  const dims = dimensions(records);
+  let recs = normalizeRecords(records, dims);
+  if (resolved.where) recs = condition(recs, resolved.where);
+  if (resolved.filter && resolved.filter.length > 0)
+    recs = filterRecords(recs, resolved.filter);
+  recs = linearizeRecords(recs);
+  recs = nest(recs, resolved.classes);
+  const cells = marginalize(recs, resolved.classes[0]!);
+
+  const labels: string[] = [];
+  for (const cell of cells) {
+    labels.push(cell.actual, cell.observed);
+  }
+  const tree = buildLabelTree(labels);
+
+  const n = tree.end; // root always covers [0, n)
+  const matrix: Matrix = Array.from({ length: n }, () => new Array(n).fill(0));
+  for (const cell of cells) {
+    const rowNode = findNode(tree, cell.actual);
+    const colNode = findNode(tree, cell.observed);
+    if (!rowNode || !colNode) {
+      throw new Error(
+        `marginalized label "${cell.actual}"/"${cell.observed}" not found in built tree`
+      );
+    }
+    // Cells are leaves of the tree by construction (they were exactly the
+    // labels the tree was built from), so each spans exactly one index.
+    matrix[rowNode.start]![colNode.start]! += cell.count;
+  }
+
+  return { tree, matrix };
+}
+
+/** Block-sum frequency for the (rowNode, colNode) cell — the value shown at their intersection. */
+export function frequency(
+  matrix: Matrix,
+  rowNode: TreeNode,
+  colNode: TreeNode
+): number {
+  let sum = 0;
+  for (let r = rowNode.start; r < rowNode.end; r++) {
+    for (let c = colNode.start; c < colNode.end; c++) {
+      sum += matrix[r]![c]!;
+    }
+  }
+  return sum;
+}
+
+/** Grand total over the whole matrix. */
+export function total(matrix: Matrix): number {
+  let sum = 0;
+  for (const row of matrix) {
+    for (const v of row) sum += v;
+  }
+  return sum;
+}
+
+/** Sum over `node`'s row block (its leaves as actual/rows) across ALL columns. */
+export function totalRow(matrix: Matrix, node: TreeNode): number {
+  let sum = 0;
+  for (let r = node.start; r < node.end; r++) {
+    for (let c = 0; c < matrix.length; c++) {
+      sum += matrix[r]![c]!;
+    }
+  }
+  return sum;
+}
+
+/** Sum over `node`'s column block (its leaves as observed/columns) across ALL rows. */
+export function totalColumn(matrix: Matrix, node: TreeNode): number {
+  let sum = 0;
+  for (let c = node.start; c < node.end; c++) {
+    for (let r = 0; r < matrix.length; r++) {
+      sum += matrix[r]![c]!;
+    }
+  }
+  return sum;
+}

--- a/packages/gofish-neo/src/measures.test.ts
+++ b/packages/gofish-neo/src/measures.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
+import { buildLabelTree, findNode } from "./labelTree";
 import type { Matrix } from "./matrix";
 import {
   accuracy,
@@ -10,28 +10,7 @@ import {
   trueNegatives,
   truePositives,
 } from "./measures";
-
-/** See matrix.test.ts for the canonical-fixture description. */
-function fixture(): {
-  tree: TreeNode;
-  matrix: Matrix;
-  A: TreeNode;
-  B: TreeNode;
-  C: TreeNode;
-  BC: TreeNode;
-} {
-  const tree = buildLabelTree(["A", "BC:B", "BC:C"]);
-  const A = findNode(tree, "A")!;
-  const B = findNode(tree, "BC:B")!;
-  const C = findNode(tree, "BC:C")!;
-  const BC = findNode(tree, "BC")!;
-  const matrix: Matrix = [
-    [3, 5, 2],
-    [3, 4, 3],
-    [1, 2, 7],
-  ];
-  return { tree, matrix, A, B, C, BC };
-}
+import { fixture } from "./testFixture";
 
 describe("per-leaf measures", () => {
   it("matches the worked TP/FP/FN/TN", () => {

--- a/packages/gofish-neo/src/measures.test.ts
+++ b/packages/gofish-neo/src/measures.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
+import type { Matrix } from "./matrix";
+import {
+  accuracy,
+  falseNegatives,
+  falsePositives,
+  precision,
+  recall,
+  trueNegatives,
+  truePositives,
+} from "./measures";
+
+/** See matrix.test.ts for the canonical-fixture description. */
+function fixture(): {
+  tree: TreeNode;
+  matrix: Matrix;
+  A: TreeNode;
+  B: TreeNode;
+  C: TreeNode;
+  BC: TreeNode;
+} {
+  const tree = buildLabelTree(["A", "BC:B", "BC:C"]);
+  const A = findNode(tree, "A")!;
+  const B = findNode(tree, "BC:B")!;
+  const C = findNode(tree, "BC:C")!;
+  const BC = findNode(tree, "BC")!;
+  const matrix: Matrix = [
+    [3, 5, 2],
+    [3, 4, 3],
+    [1, 2, 7],
+  ];
+  return { tree, matrix, A, B, C, BC };
+}
+
+describe("per-leaf measures", () => {
+  it("matches the worked TP/FP/FN/TN", () => {
+    const { matrix, A, B, C } = fixture();
+    expect([
+      truePositives(matrix, A),
+      truePositives(matrix, B),
+      truePositives(matrix, C),
+    ]).toEqual([3, 4, 7]);
+    expect([
+      falsePositives(matrix, A),
+      falsePositives(matrix, B),
+      falsePositives(matrix, C),
+    ]).toEqual([4, 7, 5]);
+    expect([
+      falseNegatives(matrix, A),
+      falseNegatives(matrix, B),
+      falseNegatives(matrix, C),
+    ]).toEqual([7, 6, 3]);
+    expect([
+      trueNegatives(matrix, A),
+      trueNegatives(matrix, B),
+      trueNegatives(matrix, C),
+    ]).toEqual([16, 13, 15]);
+  });
+
+  it("precision/recall/accuracy match the worked fractions", () => {
+    const { matrix, A, B, C } = fixture();
+    expect(precision(matrix, A)).toBeCloseTo(3 / 7);
+    expect(precision(matrix, B)).toBeCloseTo(4 / 11);
+    expect(precision(matrix, C)).toBeCloseTo(7 / 12);
+
+    expect(recall(matrix, A)).toBeCloseTo(3 / 10);
+    expect(recall(matrix, B)).toBeCloseTo(4 / 10);
+    expect(recall(matrix, C)).toBeCloseTo(7 / 10);
+
+    expect(accuracy(matrix, A)).toBeCloseTo((3 + 16) / 30);
+    expect(accuracy(matrix, B)).toBeCloseTo((4 + 13) / 30);
+    expect(accuracy(matrix, C)).toBeCloseTo((7 + 15) / 30);
+  });
+
+  it("guards zero denominators to 0, never NaN", () => {
+    const zero: Matrix = [
+      [0, 0],
+      [0, 0],
+    ];
+    const tree = buildLabelTree(["X", "Y"]);
+    const X = findNode(tree, "X")!;
+    expect(precision(zero, X)).toBe(0);
+    expect(recall(zero, X)).toBe(0);
+    expect(accuracy(zero, X)).toBe(0);
+  });
+});
+
+describe("internal-node measures (block-excluding TP)", () => {
+  it("TP(BC) excludes the B<->C off-diagonal confusions", () => {
+    const { matrix, BC } = fixture();
+    // M[B,B] + M[C,C] = 4 + 7 = 11, NOT the full block sum (16).
+    expect(truePositives(matrix, BC)).toBe(11);
+    expect(falsePositives(matrix, BC)).toBe(23 - 11);
+    expect(falseNegatives(matrix, BC)).toBe(20 - 11);
+  });
+});

--- a/packages/gofish-neo/src/measures.ts
+++ b/packages/gofish-neo/src/measures.ts
@@ -1,0 +1,129 @@
+/**
+ * Per-node classification measures over the shared label tree. Every
+ * measure is defined "one node vs. the rest": `n` plays the role of a class
+ * (possibly an aggregate of several leaf classes, for an internal node).
+ */
+
+import type { TreeNode } from "./labelTree";
+import { total, totalColumn, totalRow, type Matrix } from "./matrix";
+
+export type Measure =
+  | "precision"
+  | "recall"
+  | "accuracy"
+  | "countActual"
+  | "countObserved"
+  | "truePositives"
+  | "trueNegatives"
+  | "falsePositives"
+  | "falseNegatives";
+
+/**
+ * True positives for `node`: the sum of the leaf-diagonal `M[c,c]` for each
+ * individual LEAF `c` in `node`'s range — NOT the full row/column block sum.
+ * For an internal node covering leaves {B, C}, this is `M[B,B] + M[C,C]`,
+ * excluding the off-diagonal confusions `M[B,C]` / `M[C,B]` between B and C.
+ */
+export function truePositives(matrix: Matrix, node: TreeNode): number {
+  let sum = 0;
+  for (let i = node.start; i < node.end; i++) {
+    sum += matrix[i]![i]!;
+  }
+  return sum;
+}
+
+/** False positives for `node`: everything predicted as `node` that wasn't actually `node`. */
+export function falsePositives(matrix: Matrix, node: TreeNode): number {
+  return totalColumn(matrix, node) - truePositives(matrix, node);
+}
+
+/** False negatives for `node`: everything actually `node` that wasn't predicted as `node`. */
+export function falseNegatives(matrix: Matrix, node: TreeNode): number {
+  return totalRow(matrix, node) - truePositives(matrix, node);
+}
+
+/**
+ * True negatives for `node`, using the standard one-vs-rest definition:
+ * `total() - TP - FP - FN`.
+ *
+ * Declared divergence from the reference implementation: Apple's
+ * ml-hierarchical-confusion-matrix defines TN as
+ * `(whole-matrix leaf-diagonal sum) - TP`, i.e. every OTHER class's own
+ * diagonal cell counts as a true negative for `node`, while confusions
+ * BETWEEN two other classes (neither of which is `node`) are silently
+ * excluded from `node`'s true negatives — under that definition
+ * `TP + TN + FP + FN` does not equal the grand total. We use the textbook
+ * one-vs-rest definition instead, so the four quantities partition the
+ * grand total exactly.
+ */
+export function trueNegatives(matrix: Matrix, node: TreeNode): number {
+  const tp = truePositives(matrix, node);
+  const fp = falsePositives(matrix, node);
+  const fn = falseNegatives(matrix, node);
+  return total(matrix) - tp - fp - fn;
+}
+
+/** `countActual(node)` = totalRow(node): how many records were actually `node`. */
+export function countActual(matrix: Matrix, node: TreeNode): number {
+  return totalRow(matrix, node);
+}
+
+/** `countObserved(node)` = totalColumn(node): how many records were predicted/observed as `node`. */
+export function countObserved(matrix: Matrix, node: TreeNode): number {
+  return totalColumn(matrix, node);
+}
+
+function safeDivide(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : numerator / denominator;
+}
+
+/** `precision(node)` = TP / countObserved(node), guarded to 0 when the denominator is 0. */
+export function precision(matrix: Matrix, node: TreeNode): number {
+  return safeDivide(truePositives(matrix, node), countObserved(matrix, node));
+}
+
+/** `recall(node)` = TP / countActual(node), guarded to 0 when the denominator is 0. */
+export function recall(matrix: Matrix, node: TreeNode): number {
+  return safeDivide(truePositives(matrix, node), countActual(matrix, node));
+}
+
+/**
+ * `accuracy(node)` = (TP + TN) / (TP + TN + FP + FN). With our textbook TN
+ * definition, `TP + TN + FP + FN` equals the grand total, so this is
+ * equivalently `(TP + TN) / total()`. Guarded to 0 when the total is 0.
+ */
+export function accuracy(matrix: Matrix, node: TreeNode): number {
+  const tp = truePositives(matrix, node);
+  const tn = trueNegatives(matrix, node);
+  const fp = falsePositives(matrix, node);
+  const fn = falseNegatives(matrix, node);
+  return safeDivide(tp + tn, tp + tn + fp + fn);
+}
+
+/** Computes the named `measure` for `node` against `matrix`. */
+export function computeMeasure(
+  measure: Measure,
+  matrix: Matrix,
+  node: TreeNode
+): number {
+  switch (measure) {
+    case "precision":
+      return precision(matrix, node);
+    case "recall":
+      return recall(matrix, node);
+    case "accuracy":
+      return accuracy(matrix, node);
+    case "countActual":
+      return countActual(matrix, node);
+    case "countObserved":
+      return countObserved(matrix, node);
+    case "truePositives":
+      return truePositives(matrix, node);
+    case "trueNegatives":
+      return trueNegatives(matrix, node);
+    case "falsePositives":
+      return falsePositives(matrix, node);
+    case "falseNegatives":
+      return falseNegatives(matrix, node);
+  }
+}

--- a/packages/gofish-neo/src/measures.ts
+++ b/packages/gofish-neo/src/measures.ts
@@ -32,14 +32,30 @@ export function truePositives(matrix: Matrix, node: TreeNode): number {
   return sum;
 }
 
+/**
+ * Computes TP/FP/FN for `node` from the underlying matrix primitives exactly
+ * once each — the shared basis for `falsePositives`/`falseNegatives`/
+ * `trueNegatives`/`accuracy`, so a caller that needs more than one of these
+ * quantities (e.g. `accuracy`) never recomputes `truePositives` per quantity.
+ */
+function tpFpFn(
+  matrix: Matrix,
+  node: TreeNode
+): { tp: number; fp: number; fn: number } {
+  const tp = truePositives(matrix, node);
+  const fp = totalColumn(matrix, node) - tp;
+  const fn = totalRow(matrix, node) - tp;
+  return { tp, fp, fn };
+}
+
 /** False positives for `node`: everything predicted as `node` that wasn't actually `node`. */
 export function falsePositives(matrix: Matrix, node: TreeNode): number {
-  return totalColumn(matrix, node) - truePositives(matrix, node);
+  return tpFpFn(matrix, node).fp;
 }
 
 /** False negatives for `node`: everything actually `node` that wasn't predicted as `node`. */
 export function falseNegatives(matrix: Matrix, node: TreeNode): number {
-  return totalRow(matrix, node) - truePositives(matrix, node);
+  return tpFpFn(matrix, node).fn;
 }
 
 /**
@@ -57,9 +73,7 @@ export function falseNegatives(matrix: Matrix, node: TreeNode): number {
  * grand total exactly.
  */
 export function trueNegatives(matrix: Matrix, node: TreeNode): number {
-  const tp = truePositives(matrix, node);
-  const fp = falsePositives(matrix, node);
-  const fn = falseNegatives(matrix, node);
+  const { tp, fp, fn } = tpFpFn(matrix, node);
   return total(matrix) - tp - fp - fn;
 }
 
@@ -93,10 +107,8 @@ export function recall(matrix: Matrix, node: TreeNode): number {
  * equivalently `(TP + TN) / total()`. Guarded to 0 when the total is 0.
  */
 export function accuracy(matrix: Matrix, node: TreeNode): number {
-  const tp = truePositives(matrix, node);
-  const tn = trueNegatives(matrix, node);
-  const fp = falsePositives(matrix, node);
-  const fn = falseNegatives(matrix, node);
+  const { tp, fp, fn } = tpFpFn(matrix, node);
+  const tn = total(matrix) - tp - fp - fn;
   return safeDivide(tp + tn, tp + tn + fp + fn);
 }
 

--- a/packages/gofish-neo/src/normalize.test.ts
+++ b/packages/gofish-neo/src/normalize.test.ts
@@ -1,45 +1,29 @@
 import { describe, expect, it } from "vitest";
 import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
-import type { Matrix } from "./matrix";
+import { frequency, type Matrix } from "./matrix";
 import { buildNormalizer } from "./normalize";
+import { fixture } from "./testFixture";
 
-/** See matrix.test.ts for the canonical-fixture description. */
-function fixture(): {
-  tree: TreeNode;
-  matrix: Matrix;
-  A: TreeNode;
-  B: TreeNode;
-  C: TreeNode;
-  BC: TreeNode;
-} {
-  const tree = buildLabelTree(["A", "BC:B", "BC:C"]);
-  const A = findNode(tree, "A")!;
-  const B = findNode(tree, "BC:B")!;
-  const C = findNode(tree, "BC:C")!;
-  const BC = findNode(tree, "BC")!;
-  const matrix: Matrix = [
-    [3, 5, 2],
-    [3, 4, 3],
-    [1, 2, 7],
-  ];
-  return { tree, matrix, A, B, C, BC };
+/** `frequency` is precomputed by callers now that `Normalizer` takes `count`. */
+function f(matrix: Matrix, rowNode: TreeNode, colNode: TreeNode): number {
+  return frequency(matrix, rowNode, colNode);
 }
 
 describe("row / column normalization", () => {
   it("normalizes each row to fractions of its row total", () => {
     const { tree, matrix, A, B, C } = fixture();
     const normalize = buildNormalizer(tree, matrix, "row");
-    expect(normalize(A, A)).toBeCloseTo(3 / 10);
-    expect(normalize(A, B)).toBeCloseTo(5 / 10);
-    expect(normalize(A, C)).toBeCloseTo(2 / 10);
+    expect(normalize(A, A, f(matrix, A, A))).toBeCloseTo(3 / 10);
+    expect(normalize(A, B, f(matrix, A, B))).toBeCloseTo(5 / 10);
+    expect(normalize(A, C, f(matrix, A, C))).toBeCloseTo(2 / 10);
   });
 
   it("normalizes each column to fractions of its column total", () => {
     const { tree, matrix, A, B, C } = fixture();
     const normalize = buildNormalizer(tree, matrix, "column");
-    expect(normalize(A, A)).toBeCloseTo(3 / 7);
-    expect(normalize(B, A)).toBeCloseTo(3 / 7);
-    expect(normalize(C, A)).toBeCloseTo(1 / 7);
+    expect(normalize(A, A, f(matrix, A, A))).toBeCloseTo(3 / 7);
+    expect(normalize(B, A, f(matrix, B, A))).toBeCloseTo(3 / 7);
+    expect(normalize(C, A, f(matrix, C, A))).toBeCloseTo(1 / 7);
   });
 
   it("guards a zero-total row/column to 0, not NaN", () => {
@@ -51,16 +35,16 @@ describe("row / column normalization", () => {
       [1, 1],
     ];
     const rowNorm = buildNormalizer(tree, zeroRowMatrix, "row");
-    expect(rowNorm(X, X)).toBe(0);
-    expect(Number.isNaN(rowNorm(X, X))).toBe(false);
+    expect(rowNorm(X, X, f(zeroRowMatrix, X, X))).toBe(0);
+    expect(Number.isNaN(rowNorm(X, X, f(zeroRowMatrix, X, X)))).toBe(false);
 
     const zeroColMatrix: Matrix = [
       [0, 1],
       [0, 1],
     ];
     const colNorm = buildNormalizer(tree, zeroColMatrix, "column");
-    expect(colNorm(X, X)).toBe(0);
-    expect(Number.isNaN(colNorm(X, X))).toBe(false);
+    expect(colNorm(X, X, f(zeroColMatrix, X, X))).toBe(0);
+    expect(Number.isNaN(colNorm(X, X, f(zeroColMatrix, X, X)))).toBe(false);
   });
 });
 
@@ -70,9 +54,9 @@ describe("total normalization", () => {
     const normalize = buildNormalizer(tree, matrix, "total", [BC.id]);
     // Frontier is [A, BC]; positive frequencies: A×A=3, A×BC=7, BC×A=4, BC×BC=16.
     // domain = [3, 16].
-    expect(normalize(A, A)).toBeCloseTo(0); // at the min
-    expect(normalize(BC, BC)).toBeCloseTo(1); // at the max
-    expect(normalize(BC, A)).toBeCloseTo((4 - 3) / (16 - 3));
+    expect(normalize(A, A, f(matrix, A, A))).toBeCloseTo(0); // at the min
+    expect(normalize(BC, BC, f(matrix, BC, BC))).toBeCloseTo(1); // at the max
+    expect(normalize(BC, A, f(matrix, BC, A))).toBeCloseTo((4 - 3) / (16 - 3));
   });
 
   it("respects the collapsed frontier (full leaf frontier gives a different domain)", () => {
@@ -80,8 +64,8 @@ describe("total normalization", () => {
     // Without collapsing BC, the frontier is the true leaves [A, B, C].
     const normalize = buildNormalizer(tree, matrix, "total");
     // Positive leaf x leaf frequencies range over the whole matrix: min=1, max=7.
-    expect(normalize(C, C)).toBeCloseTo(1); // matrix[2][2] = 7, the max
-    expect(normalize(B, C)).toBeCloseTo((3 - 1) / (7 - 1)); // matrix[1][2] = 3
+    expect(normalize(C, C, f(matrix, C, C))).toBeCloseTo(1); // matrix[2][2] = 7, the max
+    expect(normalize(B, C, f(matrix, B, C))).toBeCloseTo((3 - 1) / (7 - 1)); // matrix[1][2] = 3
   });
 
   it("excludeDiagonal: domain skips diagonal cells, which still render clamped to the max", () => {
@@ -92,11 +76,11 @@ describe("total normalization", () => {
     const normalize = buildNormalizer(tree, matrix, "total", [], {
       excludeDiagonal: true,
     });
-    expect(normalize(A, B)).toBeCloseTo(1); // 5, the off-diagonal max
-    expect(normalize(C, A)).toBeCloseTo(0); // 1, the off-diagonal min
+    expect(normalize(A, B, f(matrix, A, B))).toBeCloseTo(1); // 5, the off-diagonal max
+    expect(normalize(C, A, f(matrix, C, A))).toBeCloseTo(0); // 1, the off-diagonal min
     // Diagonal cells are clamped to the domain max (1), not extrapolated past it.
-    expect(normalize(C, C)).toBeCloseTo(1); // 7 > max(5) => clamped
-    expect(normalize(A, A)).toBeCloseTo((3 - 1) / (5 - 1));
+    expect(normalize(C, C, f(matrix, C, C))).toBeCloseTo(1); // 7 > max(5) => clamped
+    expect(normalize(A, A, f(matrix, A, A))).toBeCloseTo((3 - 1) / (5 - 1));
   });
 
   it("maps every cell to 0 when the frontier domain is degenerate (all zero)", () => {
@@ -108,8 +92,8 @@ describe("total normalization", () => {
       [0, 0],
     ];
     const normalize = buildNormalizer(tree, zeroMatrix, "total");
-    expect(normalize(X, X)).toBe(0);
-    expect(normalize(X, Y)).toBe(0);
-    expect(Number.isNaN(normalize(X, Y))).toBe(false);
+    expect(normalize(X, X, f(zeroMatrix, X, X))).toBe(0);
+    expect(normalize(X, Y, f(zeroMatrix, X, Y))).toBe(0);
+    expect(Number.isNaN(normalize(X, Y, f(zeroMatrix, X, Y)))).toBe(false);
   });
 });

--- a/packages/gofish-neo/src/normalize.test.ts
+++ b/packages/gofish-neo/src/normalize.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
+import type { Matrix } from "./matrix";
+import { buildNormalizer } from "./normalize";
+
+/** See matrix.test.ts for the canonical-fixture description. */
+function fixture(): {
+  tree: TreeNode;
+  matrix: Matrix;
+  A: TreeNode;
+  B: TreeNode;
+  C: TreeNode;
+  BC: TreeNode;
+} {
+  const tree = buildLabelTree(["A", "BC:B", "BC:C"]);
+  const A = findNode(tree, "A")!;
+  const B = findNode(tree, "BC:B")!;
+  const C = findNode(tree, "BC:C")!;
+  const BC = findNode(tree, "BC")!;
+  const matrix: Matrix = [
+    [3, 5, 2],
+    [3, 4, 3],
+    [1, 2, 7],
+  ];
+  return { tree, matrix, A, B, C, BC };
+}
+
+describe("row / column normalization", () => {
+  it("normalizes each row to fractions of its row total", () => {
+    const { tree, matrix, A, B, C } = fixture();
+    const normalize = buildNormalizer(tree, matrix, "row");
+    expect(normalize(A, A)).toBeCloseTo(3 / 10);
+    expect(normalize(A, B)).toBeCloseTo(5 / 10);
+    expect(normalize(A, C)).toBeCloseTo(2 / 10);
+  });
+
+  it("normalizes each column to fractions of its column total", () => {
+    const { tree, matrix, A, B, C } = fixture();
+    const normalize = buildNormalizer(tree, matrix, "column");
+    expect(normalize(A, A)).toBeCloseTo(3 / 7);
+    expect(normalize(B, A)).toBeCloseTo(3 / 7);
+    expect(normalize(C, A)).toBeCloseTo(1 / 7);
+  });
+
+  it("guards a zero-total row/column to 0, not NaN", () => {
+    const tree = buildLabelTree(["X", "Y"]);
+    const X = findNode(tree, "X")!;
+
+    const zeroRowMatrix: Matrix = [
+      [0, 0],
+      [1, 1],
+    ];
+    const rowNorm = buildNormalizer(tree, zeroRowMatrix, "row");
+    expect(rowNorm(X, X)).toBe(0);
+    expect(Number.isNaN(rowNorm(X, X))).toBe(false);
+
+    const zeroColMatrix: Matrix = [
+      [0, 1],
+      [0, 1],
+    ];
+    const colNorm = buildNormalizer(tree, zeroColMatrix, "column");
+    expect(colNorm(X, X)).toBe(0);
+    expect(Number.isNaN(colNorm(X, X))).toBe(false);
+  });
+});
+
+describe("total normalization", () => {
+  it("linearly rescales over [min positive, max] frontier-cell counts", () => {
+    const { tree, matrix, A, BC } = fixture();
+    const normalize = buildNormalizer(tree, matrix, "total", [BC.id]);
+    // Frontier is [A, BC]; positive frequencies: A×A=3, A×BC=7, BC×A=4, BC×BC=16.
+    // domain = [3, 16].
+    expect(normalize(A, A)).toBeCloseTo(0); // at the min
+    expect(normalize(BC, BC)).toBeCloseTo(1); // at the max
+    expect(normalize(BC, A)).toBeCloseTo((4 - 3) / (16 - 3));
+  });
+
+  it("respects the collapsed frontier (full leaf frontier gives a different domain)", () => {
+    const { tree, matrix, B, C } = fixture();
+    // Without collapsing BC, the frontier is the true leaves [A, B, C].
+    const normalize = buildNormalizer(tree, matrix, "total");
+    // Positive leaf x leaf frequencies range over the whole matrix: min=1, max=7.
+    expect(normalize(C, C)).toBeCloseTo(1); // matrix[2][2] = 7, the max
+    expect(normalize(B, C)).toBeCloseTo((3 - 1) / (7 - 1)); // matrix[1][2] = 3
+  });
+
+  it("excludeDiagonal: domain skips diagonal cells, which still render clamped to the max", () => {
+    const { tree, matrix, A, B, C } = fixture();
+    // Full leaf frontier [A, B, C]; diagonal cells are A×A=3, B×B=4, C×C=7.
+    // Off-diagonal positive frequencies: A×B=5, A×C=2, B×A=3, B×C=3, C×A=1, C×B=2.
+    // Excluding the diagonal, domain = [1, 5].
+    const normalize = buildNormalizer(tree, matrix, "total", [], {
+      excludeDiagonal: true,
+    });
+    expect(normalize(A, B)).toBeCloseTo(1); // 5, the off-diagonal max
+    expect(normalize(C, A)).toBeCloseTo(0); // 1, the off-diagonal min
+    // Diagonal cells are clamped to the domain max (1), not extrapolated past it.
+    expect(normalize(C, C)).toBeCloseTo(1); // 7 > max(5) => clamped
+    expect(normalize(A, A)).toBeCloseTo((3 - 1) / (5 - 1));
+  });
+
+  it("maps every cell to 0 when the frontier domain is degenerate (all zero)", () => {
+    const tree = buildLabelTree(["X", "Y"]);
+    const X = findNode(tree, "X")!;
+    const Y = findNode(tree, "Y")!;
+    const zeroMatrix: Matrix = [
+      [0, 0],
+      [0, 0],
+    ];
+    const normalize = buildNormalizer(tree, zeroMatrix, "total");
+    expect(normalize(X, X)).toBe(0);
+    expect(normalize(X, Y)).toBe(0);
+    expect(Number.isNaN(normalize(X, Y))).toBe(false);
+  });
+});

--- a/packages/gofish-neo/src/normalize.ts
+++ b/packages/gofish-neo/src/normalize.ts
@@ -1,0 +1,85 @@
+/**
+ * Visual-scaling normalizers: map a (rowNode, colNode) cell's raw count to
+ * a `[0, 1]` scale for encoding (color/size). These never change the
+ * displayed raw counts — they only describe how the renderer should scale
+ * a cell visually.
+ */
+
+import { frontier, type TreeNode } from "./labelTree";
+import { frequency, totalColumn, totalRow, type Matrix } from "./matrix";
+import type { Normalization } from "./spec";
+
+/** Maps a (rowNode, colNode) cell to a `[0, 1]` visual-scale value. */
+export type Normalizer = (rowNode: TreeNode, colNode: TreeNode) => number;
+
+/**
+ * Builds a normalizer of the given kind:
+ *  - `"row"`: value = count / totalRow(rowNode). Guarded to 0 for a
+ *    zero-total row (declared divergence: the reference implementation lets
+ *    a degenerate 0/0 domain produce NaN; we treat "no data" as 0, never NaN).
+ *  - `"column"`: symmetric, over totalColumn(colNode).
+ *  - `"total"`: linear rescale over the domain
+ *    `[min positive frontier-cell count, max frontier-cell count]`, computed
+ *    only over frontier×frontier cells (given `collapsed`). A cell at or
+ *    below 0 maps to 0. If every frontier cell is 0 (degenerate domain),
+ *    every cell maps to 0 rather than NaN.
+ */
+export interface NormalizerOptions {
+  /**
+   * "total" mode only: exclude diagonal (rowNode === colNode) frontier cells
+   * from the domain computation, so a handful of dominant correct-prediction
+   * cells don't wash out the color/size contrast among the (usually more
+   * interesting) confusions. Diagonal cells still render — their value is
+   * clamped to the domain max rather than excluded from the output. Ignored
+   * for "row"/"column" normalization, which has no shared domain to exclude
+   * cells from.
+   */
+  excludeDiagonal?: boolean;
+}
+
+export function buildNormalizer(
+  tree: TreeNode,
+  matrix: Matrix,
+  normalization: Normalization,
+  collapsed: Iterable<string> = [],
+  options: NormalizerOptions = {}
+): Normalizer {
+  if (normalization === "row") {
+    return (rowNode, colNode) => {
+      const denom = totalRow(matrix, rowNode);
+      return denom === 0 ? 0 : frequency(matrix, rowNode, colNode) / denom;
+    };
+  }
+  if (normalization === "column") {
+    return (rowNode, colNode) => {
+      const denom = totalColumn(matrix, colNode);
+      return denom === 0 ? 0 : frequency(matrix, rowNode, colNode) / denom;
+    };
+  }
+
+  // "total": domain is over frontier x frontier cells (optionally excluding
+  // the diagonal).
+  const frontierNodes = frontier(tree, collapsed);
+  let min = Infinity;
+  let max = -Infinity;
+  for (const r of frontierNodes) {
+    for (const c of frontierNodes) {
+      if (options.excludeDiagonal && r === c) continue;
+      const v = frequency(matrix, r, c);
+      if (v > 0) {
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+    }
+  }
+  const degenerate = !Number.isFinite(min) || !Number.isFinite(max);
+
+  return (rowNode, colNode) => {
+    const v = frequency(matrix, rowNode, colNode);
+    if (degenerate || v <= 0) return 0;
+    if (max === min) return 1;
+    // A diagonal cell excluded from the domain can exceed it; clamp rather
+    // than let it run past 1.
+    return Math.min(1, (v - min) / (max - min));
+  };
+}

--- a/packages/gofish-neo/src/normalize.ts
+++ b/packages/gofish-neo/src/normalize.ts
@@ -9,8 +9,17 @@ import { frontier, type TreeNode } from "./labelTree";
 import { frequency, totalColumn, totalRow, type Matrix } from "./matrix";
 import type { Normalization } from "./spec";
 
-/** Maps a (rowNode, colNode) cell to a `[0, 1]` visual-scale value. */
-export type Normalizer = (rowNode: TreeNode, colNode: TreeNode) => number;
+/**
+ * Maps a (rowNode, colNode) cell to a `[0, 1]` visual-scale value. `count`
+ * is that cell's already-computed `frequency(matrix, rowNode, colNode)` —
+ * every call site has it in hand already, so the normalizer never
+ * recomputes it internally.
+ */
+export type Normalizer = (
+  rowNode: TreeNode,
+  colNode: TreeNode,
+  count: number
+) => number;
 
 /**
  * Builds a normalizer of the given kind:
@@ -45,15 +54,25 @@ export function buildNormalizer(
   options: NormalizerOptions = {}
 ): Normalizer {
   if (normalization === "row") {
-    return (rowNode, colNode) => {
-      const denom = totalRow(matrix, rowNode);
-      return denom === 0 ? 0 : frequency(matrix, rowNode, colNode) / denom;
+    const rowTotals = new Map<string, number>();
+    return (rowNode, _colNode, count) => {
+      let denom = rowTotals.get(rowNode.id);
+      if (denom === undefined) {
+        denom = totalRow(matrix, rowNode);
+        rowTotals.set(rowNode.id, denom);
+      }
+      return denom === 0 ? 0 : count / denom;
     };
   }
   if (normalization === "column") {
-    return (rowNode, colNode) => {
-      const denom = totalColumn(matrix, colNode);
-      return denom === 0 ? 0 : frequency(matrix, rowNode, colNode) / denom;
+    const colTotals = new Map<string, number>();
+    return (_rowNode, colNode, count) => {
+      let denom = colTotals.get(colNode.id);
+      if (denom === undefined) {
+        denom = totalColumn(matrix, colNode);
+        colTotals.set(colNode.id, denom);
+      }
+      return denom === 0 ? 0 : count / denom;
     };
   }
 
@@ -74,12 +93,11 @@ export function buildNormalizer(
   }
   const degenerate = !Number.isFinite(min) || !Number.isFinite(max);
 
-  return (rowNode, colNode) => {
-    const v = frequency(matrix, rowNode, colNode);
-    if (degenerate || v <= 0) return 0;
+  return (_rowNode, _colNode, count) => {
+    if (degenerate || count <= 0) return 0;
     if (max === min) return 1;
     // A diagonal cell excluded from the domain can exceed it; clamp rather
     // than let it run past 1.
-    return Math.min(1, (v - min) / (max - min));
+    return Math.min(1, (count - min) / (max - min));
   };
 }

--- a/packages/gofish-neo/src/paths.test.ts
+++ b/packages/gofish-neo/src/paths.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import {
+  dimension,
+  isPathPrefix,
+  parsePath,
+  segments,
+  tokenize,
+} from "./paths";
+
+describe("tokenize", () => {
+  it("tokenizes a single label", () => {
+    expect(tokenize("aber")).toEqual([{ label: "aber" }]);
+  });
+
+  it("tokenizes a path with colons and a bracketed multi-group", () => {
+    expect(tokenize("a:ber:[c,d]")).toEqual([
+      { label: "a" },
+      ":",
+      { label: "ber" },
+      ":",
+      "[",
+      { label: "c" },
+      ",",
+      { label: "d" },
+      "]",
+    ]);
+  });
+});
+
+describe("parsePath", () => {
+  it("parses a single label", () => {
+    expect(parsePath("a")).toEqual([["a"]]);
+  });
+
+  it("parses a simple chain", () => {
+    expect(parsePath("a:b:c")).toEqual([["a", "b", "c"]]);
+  });
+
+  it("parses a bracketed multi-group into two roots", () => {
+    expect(parsePath("[a:b,c:d]")).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ]);
+  });
+
+  it("parses same-named roots as two separate chains (no merge in the parser)", () => {
+    expect(parsePath("[a:b,a:c]")).toEqual([
+      ["a", "b"],
+      ["a", "c"],
+    ]);
+  });
+
+  it("distributes a trailing multi-group across the chain (a:[b,c])", () => {
+    expect(parsePath("a:[b,c]")).toEqual([
+      ["a", "b"],
+      ["a", "c"],
+    ]);
+  });
+});
+
+describe("segments / dimension", () => {
+  it("splits on colons", () => {
+    expect(segments("animal:walking:cat")).toEqual([
+      "animal",
+      "walking",
+      "cat",
+    ]);
+  });
+
+  it("dimension is the first segment", () => {
+    expect(dimension("animal:walking:cat")).toBe("animal");
+    expect(dimension("animal")).toBe("animal");
+  });
+});
+
+describe("isPathPrefix", () => {
+  it("is true for equal paths", () => {
+    expect(isPathPrefix("state:open", "state:open")).toBe(true);
+  });
+
+  it("is true for a segment-aware ancestor", () => {
+    expect(isPathPrefix("state", "state:open")).toBe(true);
+  });
+
+  it("is false for a mere string prefix that isn't segment-aligned", () => {
+    expect(isPathPrefix("stat", "state:open")).toBe(false);
+  });
+
+  it("is false when the candidate is longer than the path", () => {
+    expect(isPathPrefix("state:open:extra", "state:open")).toBe(false);
+  });
+
+  it("is false for a divergent sibling", () => {
+    expect(isPathPrefix("state:closed", "state:open")).toBe(false);
+  });
+});

--- a/packages/gofish-neo/src/paths.ts
+++ b/packages/gofish-neo/src/paths.ts
@@ -1,0 +1,145 @@
+/**
+ * Path grammar and parser for Neo's colon-delimited label paths.
+ *
+ * Grammar:
+ *   path  ::= label | multi | label ":" path
+ *   multi ::= "[" path "," path ("," path)* "]"
+ *   label ::= run of characters other than `:`, `,`, `[`, `]`
+ *
+ * A single path string can therefore describe a small *forest* of chains
+ * (via the `multi` production), e.g. `"[a:b,c:d]"` describes two top-level
+ * chains: `a:b` and `c:d`.
+ */
+
+/** A single token produced by {@link tokenize}. */
+export type Token = ":" | "," | "[" | "]" | { label: string };
+
+/**
+ * Splits a path string into tokens. `:`, `,`, `[`, `]` are single-character
+ * tokens; every other run of characters accumulates into a `{ label }`
+ * token.
+ */
+export function tokenize(input: string): Token[] {
+  const tokens: Token[] = [];
+  let buf = "";
+  const flush = () => {
+    if (buf.length > 0) {
+      tokens.push({ label: buf });
+      buf = "";
+    }
+  };
+  for (const ch of input) {
+    if (ch === ":" || ch === "," || ch === "[" || ch === "]") {
+      flush();
+      tokens.push(ch as Token);
+    } else {
+      buf += ch;
+    }
+  }
+  flush();
+  return tokens;
+}
+
+/** A parsed chain of labels, e.g. `"a:b:c"` → `["a", "b", "c"]`. */
+export type Chain = string[];
+
+/**
+ * Parses one path string into a forest of label chains. Each top-level
+ * chain is one root-to-leaf sequence of labels. `"a:b:c"` yields a single
+ * chain `["a","b","c"]`; `"[a:b,c:d]"` yields two chains
+ * `["a","b"], ["c","d"]`; `"[a:b,a:c]"` yields two *separate* chains that
+ * both start with `"a"` — merging same-named roots is a tree-building
+ * concern, not a parsing one (see labelTree.ts).
+ */
+export function parsePath(input: string): Chain[] {
+  const tokens = tokenize(input);
+  let pos = 0;
+
+  const peek = (): Token | undefined => tokens[pos];
+  const next = (): Token => {
+    const t = tokens[pos];
+    if (t === undefined) throw new Error(`Unexpected end of path: "${input}"`);
+    pos++;
+    return t;
+  };
+
+  // A `segment` is either a single label or a bracketed multi-group; both
+  // produce one or more chains rooted at that position.
+  function parseSegment(): Chain[] {
+    const t = peek();
+    if (t === undefined) {
+      throw new Error(`Unexpected end of path: "${input}"`);
+    }
+    if (t === "[") {
+      next(); // consume "["
+      const groups: Chain[] = [];
+      groups.push(...parseTail());
+      while (peek() === ",") {
+        next(); // consume ","
+        groups.push(...parseTail());
+      }
+      const closing = next();
+      if (closing !== "]") {
+        throw new Error(`Expected "]" in path: "${input}"`);
+      }
+      return groups;
+    }
+    if (typeof t === "object" && "label" in t) {
+      next();
+      return [[t.label]];
+    }
+    throw new Error(`Unexpected token in path: "${input}"`);
+  }
+
+  // A `tail` is a segment optionally followed by `: path`.
+  function parseTail(): Chain[] {
+    const heads = parseSegment();
+    if (peek() === ":") {
+      next(); // consume ":"
+      const rests = parseTail();
+      // Every head chain gets every rest chain appended (cross product),
+      // matching Neo's semantics where a multi-group at a position expands
+      // into parallel chains sharing the same suffix.
+      const out: Chain[] = [];
+      for (const head of heads) {
+        for (const rest of rests) {
+          out.push([...head, ...rest]);
+        }
+      }
+      return out;
+    }
+    return heads;
+  }
+
+  const result = parseTail();
+  if (pos !== tokens.length) {
+    throw new Error(`Trailing tokens in path: "${input}"`);
+  }
+  return result;
+}
+
+/** Splits a colon-joined path string into its segments (no bracket parsing). */
+export function segments(path: string): string[] {
+  return path.split(":");
+}
+
+/** The dimension of a path is its first colon-delimited segment. */
+export function dimension(path: string): string {
+  return segments(path)[0] ?? path;
+}
+
+/**
+ * True if `prefix` is a segment-aware prefix of `path`: either the two are
+ * equal, or `path`'s leading segments exactly match all of `prefix`'s
+ * segments. This is NOT substring matching — `"stat"` is not a prefix of
+ * `"state:open"` even though it is a string prefix.
+ */
+export function isPathPrefix(prefix: string, path: string): boolean {
+  const p = segments(prefix);
+  const s = segments(path);
+  if (p.length > s.length) return false;
+  for (let i = 0; i < p.length; i++) {
+    if (p[i] !== s[i]) return false;
+  }
+  return true;
+}

--- a/packages/gofish-neo/src/pipeline.test.ts
+++ b/packages/gofish-neo/src/pipeline.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  condition,
+  dimensions,
+  filter,
+  linearize,
+  marginalize,
+  nest,
+  nestPaths,
+  normalizeRecords,
+  type Confusion,
+} from "./pipeline";
+
+describe("dimensions", () => {
+  it("collects dimensions across actual and observed, in first-occurrence order", () => {
+    const data: Confusion[] = [
+      { actual: ["a:1"], observed: ["b:2"], count: 1 },
+      { actual: ["c:3", "a:4"], observed: ["a:5"], count: 1 },
+    ];
+    expect(dimensions(data)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("normalizeRecords", () => {
+  it("fills in missing dimensions with <dim>:none", () => {
+    const data: Confusion[] = [
+      { actual: ["a:1"], observed: ["b:2"], count: 1 },
+    ];
+    const out = normalizeRecords(data, ["a", "b"]);
+    expect(out).toEqual([
+      { actual: ["a:1", "b:none"], observed: ["b:2", "a:none"], count: 1 },
+    ]);
+  });
+
+  it("leaves records with every dimension present untouched", () => {
+    const data: Confusion[] = [
+      { actual: ["a:1", "b:2"], observed: ["a:3", "b:4"], count: 1 },
+    ];
+    expect(normalizeRecords(data, ["a", "b"])).toEqual(data);
+  });
+});
+
+describe("condition (beverage/state worked example)", () => {
+  const records: Confusion[] = [
+    {
+      actual: ["beverage:soda", "state:open"],
+      observed: ["beverage:soda", "state:open"],
+      count: 5,
+    },
+    {
+      actual: ["beverage:water", "state:closed"],
+      observed: ["beverage:soda", "state:closed"],
+      count: 2,
+    },
+    {
+      actual: ["beverage:soda", "state:closed"],
+      observed: ["beverage:water", "state:closed"],
+      count: 1,
+    },
+  ];
+
+  it("keeps only the matching record and strips its qualifier-side dimension", () => {
+    const out = condition(records, {
+      qualifier: "actual",
+      label: "state",
+      is: "state:open",
+    });
+    expect(out).toEqual([
+      {
+        actual: ["beverage:soda"],
+        observed: ["beverage:soda", "state:open"],
+        count: 5,
+      },
+    ]);
+  });
+});
+
+describe("filter", () => {
+  const records: Confusion[] = [
+    { actual: ["a:1"], observed: ["b:2"], count: 1 },
+    { actual: ["a:2"], observed: ["b:1"], count: 1 },
+    { actual: ["c:1"], observed: ["c:1"], count: 1 },
+  ];
+
+  it("keeps records where every filter matches on either side (segment-aware)", () => {
+    expect(filter(records, ["a:1"])).toEqual([records[0]]);
+    // matches the observed side, not the actual side, for the second record
+    expect(filter(records, ["b:1"])).toEqual([records[1]]);
+  });
+
+  it("requires ALL filters to match (each on some side)", () => {
+    expect(filter(records, ["a:1", "b:2"])).toEqual([records[0]]);
+    expect(filter(records, ["a:1", "c:1"])).toEqual([]);
+  });
+
+  it("uses segment boundaries, not substring matching", () => {
+    const data: Confusion[] = [
+      { actual: ["state:open"], observed: ["x:y"], count: 1 },
+    ];
+    expect(filter(data, ["stat"])).toEqual([]);
+    expect(filter(data, ["state"])).toEqual(data);
+  });
+});
+
+describe("linearize", () => {
+  it("collapses a shared-dimension branch into a brace leaf", () => {
+    expect(linearize(["a:b", "a:c"])).toEqual(["a:{b,c}"]);
+  });
+
+  it("leaves unrelated top-level branches unchanged", () => {
+    expect(linearize(["a:b", "x:y"])).toEqual(["a:b", "x:y"]);
+  });
+
+  it("collapses an inline multi-group the same way", () => {
+    expect(linearize(["a:[b,c]"])).toEqual(["a:{b,c}"]);
+  });
+});
+
+describe("nestPaths", () => {
+  it("appends the secondary dimension's whole path onto the primary", () => {
+    expect(nestPaths(["abc:a", "xy:x"], ["abc", "xy"])).toEqual(["abc:a:xy:x"]);
+  });
+
+  it("leaves paths alone when the secondary dimension is absent", () => {
+    expect(nestPaths(["abc:a"], ["abc", "xy"])).toEqual(["abc:a"]);
+  });
+
+  it("nests through multiple secondary classes in order", () => {
+    expect(nestPaths(["abc:a", "xy:x", "z:z1"], ["abc", "xy", "z"])).toEqual([
+      "abc:a:xy:x:z:z1",
+    ]);
+  });
+});
+
+describe("nest (records)", () => {
+  it("applies nestPaths to both sides", () => {
+    const records: Confusion[] = [
+      { actual: ["abc:a", "xy:x"], observed: ["abc:b", "xy:y"], count: 3 },
+    ];
+    expect(nest(records, ["abc", "xy"])).toEqual([
+      { actual: ["abc:a:xy:x"], observed: ["abc:b:xy:y"], count: 3 },
+    ]);
+  });
+});
+
+describe("marginalize", () => {
+  it("sums counts per (actual, observed) bucket, using 'none' for a missing dimension", () => {
+    const records: Confusion[] = [
+      { actual: ["k:A"], observed: ["k:B"], count: 3 },
+      { actual: ["k:A"], observed: ["k:B"], count: 2 },
+      { actual: ["other:1"], observed: ["k:B"], count: 1 },
+    ];
+    expect(marginalize(records, "k")).toEqual([
+      { actual: "k:A", observed: "k:B", count: 5 },
+      { actual: "none", observed: "k:B", count: 1 },
+    ]);
+  });
+});

--- a/packages/gofish-neo/src/pipeline.ts
+++ b/packages/gofish-neo/src/pipeline.ts
@@ -1,0 +1,276 @@
+/**
+ * The Neo data pipeline: condition → filter → linearize → nest → marginalize.
+ * Each stage is a pure function over `Confusion` records; `buildMatrix` (see
+ * matrix.ts) runs them in this fixed order.
+ */
+
+import { dimension, isPathPrefix, parsePath } from "./paths";
+
+/** One row of input data: which path(s) were the true label(s) vs. the predicted (observed) label(s), and how many records shared this combination. */
+export interface Confusion {
+  actual: string[];
+  observed: string[];
+  count: number;
+}
+
+/** A condition restricting the dataset to records where one side's dimension takes a given value. */
+export interface Condition {
+  qualifier: "actual" | "observed";
+  label: string;
+  is: string;
+}
+
+/**
+ * Collects every dimension (first path segment) that appears anywhere in
+ * `records`, across both `actual` and `observed`, in first-occurrence order.
+ */
+export function dimensions(records: Confusion[]): string[] {
+  const seen: string[] = [];
+  const has = new Set<string>();
+  const scan = (paths: string[]) => {
+    for (const p of paths) {
+      const d = dimension(p);
+      if (!has.has(d)) {
+        has.add(d);
+        seen.push(d);
+      }
+    }
+  };
+  for (const r of records) {
+    scan(r.actual);
+    scan(r.observed);
+  }
+  return seen;
+}
+
+/**
+ * Ensures every record has exactly one path per dimension in `dims`, on
+ * both sides: any side missing a dimension gets a synthetic `"<dim>:none"`
+ * path appended for it.
+ */
+export function normalizeRecords(
+  records: Confusion[],
+  dims: string[]
+): Confusion[] {
+  const fill = (paths: string[]): string[] => {
+    const present = new Set(paths.map(dimension));
+    const missing = dims.filter((d) => !present.has(d)).map((d) => `${d}:none`);
+    return [...paths, ...missing];
+  };
+  return records.map((r) => ({
+    actual: fill(r.actual),
+    observed: fill(r.observed),
+    count: r.count,
+  }));
+}
+
+/**
+ * Restricts to records where `where.qualifier`'s side contains a path equal
+ * to, or a segment-aware descendant of, `where.is`; then removes every path
+ * whose dimension is `where.label` from that side (only the qualifier side
+ * is touched). Records left with an empty `actual` or `observed` are
+ * dropped.
+ */
+export function condition(records: Confusion[], where: Condition): Confusion[] {
+  const out: Confusion[] = [];
+  for (const r of records) {
+    const side = r[where.qualifier];
+    const matches = side.some(
+      (p) => p === where.is || isPathPrefix(where.is, p)
+    );
+    if (!matches) continue;
+    const strippedSide = side.filter((p) => dimension(p) !== where.label);
+    const next: Confusion = {
+      actual: where.qualifier === "actual" ? strippedSide : r.actual,
+      observed: where.qualifier === "observed" ? strippedSide : r.observed,
+      count: r.count,
+    };
+    if (next.actual.length === 0 || next.observed.length === 0) continue;
+    out.push(next);
+  }
+  return out;
+}
+
+/**
+ * Keeps records where, for EACH string in `filters`, some path in `actual`
+ * OR `observed` equals it or segment-aware descends from it.
+ *
+ * Declared divergence from the reference implementation: Apple's
+ * ml-hierarchical-confusion-matrix filter only inspected the `actual` side
+ * (an apparent copy/paste bug) and used raw substring matching (so e.g.
+ * `"stat"` would incorrectly match `"state:open"`). This is evidently not
+ * the intended semantics, so we implement what filtering is clearly meant
+ * to do: check both sides, with proper `:`-segment boundaries.
+ */
+export function filter(records: Confusion[], filters: string[]): Confusion[] {
+  const matchesSide = (side: string[], s: string) =>
+    side.some((p) => p === s || isPathPrefix(s, p));
+  return records.filter((r) =>
+    filters.every((s) => matchesSide(r.actual, s) || matchesSide(r.observed, s))
+  );
+}
+
+// --- linearize -------------------------------------------------------------
+
+interface LinNode {
+  name: string;
+  children: Map<string, LinNode>;
+  order: string[];
+}
+
+function linMakeNode(name: string): LinNode {
+  return { name, children: new Map(), order: [] };
+}
+
+function linMergeChain(root: LinNode, chain: string[]): void {
+  let cur = root;
+  for (const name of chain) {
+    let child = cur.children.get(name);
+    if (!child) {
+      child = linMakeNode(name);
+      cur.children.set(name, child);
+      cur.order.push(name);
+    }
+    cur = child;
+  }
+}
+
+function collectLeafNames(node: LinNode): string[] {
+  if (node.order.length === 0) return [node.name];
+  const out: string[] = [];
+  for (const key of node.order) {
+    out.push(...collectLeafNames(node.children.get(key)!));
+  }
+  return out;
+}
+
+/** Postorder-collapses any node with more than one child into a single synthetic `{leaf,names}` leaf. */
+function linCollapse(node: LinNode): void {
+  for (const key of node.order) {
+    linCollapse(node.children.get(key)!);
+  }
+  if (node.order.length > 1) {
+    const leafNames = node.order.flatMap((key) =>
+      collectLeafNames(node.children.get(key)!)
+    );
+    const syntheticName = `{${leafNames.join(",")}}`;
+    node.children = new Map();
+    node.order = [syntheticName];
+    node.children.set(syntheticName, linMakeNode(syntheticName));
+  }
+}
+
+function linSerialize(node: LinNode): string {
+  const names: string[] = [];
+  let cur: LinNode = node;
+  for (;;) {
+    names.push(cur.name);
+    if (cur.order.length === 0) break;
+    cur = cur.children.get(cur.order[0]!)!;
+  }
+  return names.join(":");
+}
+
+/**
+ * Linearizes one side's paths: parses every path (a path may itself encode
+ * multiple chains via `[a,b]` syntax) into chains, trie-merges them, then
+ * collapses any node with more than one child (only possible via bracket
+ * syntax within one path, or two paths sharing a dimension) into a single
+ * synthetic leaf named `{x,y,...}` (brace-joined names of that node's
+ * descendant leaves). Returns one linear colon-joined path per surviving
+ * top-level branch.
+ */
+export function linearize(paths: string[]): string[] {
+  const superRoot = linMakeNode("");
+  for (const path of paths) {
+    for (const chain of parsePath(path)) {
+      linMergeChain(superRoot, chain);
+    }
+  }
+  for (const key of superRoot.order) {
+    linCollapse(superRoot.children.get(key)!);
+  }
+  return superRoot.order.map((key) =>
+    linSerialize(superRoot.children.get(key)!)
+  );
+}
+
+/** Applies {@link linearize} to both sides of every record. */
+export function linearizeRecords(records: Confusion[]): Confusion[] {
+  return records.map((r) => ({
+    actual: linearize(r.actual),
+    observed: linearize(r.observed),
+    count: r.count,
+  }));
+}
+
+// --- nest --------------------------------------------------------------
+
+/**
+ * For each dimension `classes[i]` (i >= 1) in turn: finds the entry with
+ * dimension `classes[0]` and the entry with dimension `classes[i]`; if the
+ * latter exists, appends its whole path (dimension segment included) onto
+ * the `classes[0]` entry with a `:` separator and removes the standalone
+ * entry. Leaves other paths untouched. Pure — returns a new array.
+ */
+export function nestPaths(paths: string[], classes: string[]): string[] {
+  let out = [...paths];
+  const [primary, ...rest] = classes;
+  if (primary === undefined) return out;
+  for (const secondaryDim of rest) {
+    const primaryIdx = out.findIndex((p) => dimension(p) === primary);
+    const secondaryIdx = out.findIndex((p) => dimension(p) === secondaryDim);
+    if (primaryIdx === -1 || secondaryIdx === -1) continue;
+    const merged = `${out[primaryIdx]}:${out[secondaryIdx]}`;
+    out = out.filter((_, i) => i !== secondaryIdx);
+    const newPrimaryIdx =
+      primaryIdx > secondaryIdx ? primaryIdx - 1 : primaryIdx;
+    out[newPrimaryIdx] = merged;
+  }
+  return out;
+}
+
+/** Applies {@link nestPaths} to both sides of every record. */
+export function nest(records: Confusion[], classes: string[]): Confusion[] {
+  return records.map((r) => ({
+    actual: nestPaths(r.actual, classes),
+    observed: nestPaths(r.observed, classes),
+    count: r.count,
+  }));
+}
+
+// --- marginalize ---------------------------------------------------------
+
+/** One reduced (actual-label, observed-label, summed-count) bucket, ready for tree/matrix construction. */
+export interface Cell {
+  actual: string;
+  observed: string;
+  count: number;
+}
+
+/**
+ * Groups records by (actual path of dimension `keep`, observed path of
+ * dimension `keep`) — using `"none"` when a side lacks that dimension
+ * entirely — and sums counts per bucket, in first-occurrence order.
+ */
+export function marginalize(records: Confusion[], keep: string): Cell[] {
+  const pick = (paths: string[]): string => {
+    const found = paths.find((p) => dimension(p) === keep);
+    return found ?? "none";
+  };
+  const order: string[] = [];
+  const buckets = new Map<string, Cell>();
+  for (const r of records) {
+    const actual = pick(r.actual);
+    const observed = pick(r.observed);
+    const key = `${actual} ${observed}`;
+    let cell = buckets.get(key);
+    if (!cell) {
+      cell = { actual, observed, count: 0 };
+      buckets.set(key, cell);
+      order.push(key);
+    }
+    cell.count += r.count;
+  }
+  return order.map((key) => buckets.get(key)!);
+}

--- a/packages/gofish-neo/src/property.test.ts
+++ b/packages/gofish-neo/src/property.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { buildMatrix, total } from "./matrix";
+import type { Confusion } from "./pipeline";
+import type { NeoSpec } from "./spec";
+
+// Fixed (not Math.random) synthetic dataset across 3 dimensions with small
+// 0/1 counts, so the test is deterministic while still exercising the full
+// pipeline shape.
+const CLASSES = ["species", "habitat", "diet"];
+const SPECIES = ["cat", "dog", "bird"];
+const HABITATS = ["indoor", "outdoor"];
+const DIETS = ["carnivore", "omnivore"];
+
+// A fixed pseudo-random 0/1 sequence (not Math.random) driving which
+// combinations get a count, so the fixture is reproducible.
+const BITS = [
+  1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 1,
+];
+
+function buildRecords(): Confusion[] {
+  const records: Confusion[] = [];
+  let i = 0;
+  for (const s of SPECIES) {
+    for (const h of HABITATS) {
+      for (const d of DIETS) {
+        const count = BITS[i % BITS.length]!;
+        i++;
+        if (count === 0) continue;
+        // actual and observed diverge for some combos, sharing habitat/diet.
+        const observedSpecies =
+          SPECIES[
+            (SPECIES.indexOf(s) + (count % 2 === 0 ? 1 : 0)) % SPECIES.length
+          ];
+        records.push({
+          actual: [`species:${s}`, `habitat:${h}`, `diet:${d}`],
+          observed: [`species:${observedSpecies}`, `habitat:${h}`, `diet:${d}`],
+          count,
+        });
+      }
+    }
+  }
+  return records;
+}
+
+describe("property: pipeline never throws and preserves total count", () => {
+  const specs: NeoSpec[] = [
+    { classes: CLASSES },
+    { classes: ["species", "habitat"] },
+    { classes: ["species", "habitat", "diet"], filter: ["habitat:indoor"] },
+    {
+      classes: ["species", "diet"],
+      where: { qualifier: "actual", label: "habitat", is: "habitat:indoor" },
+    },
+  ];
+
+  for (const [i, spec] of specs.entries()) {
+    it(`spec #${i} runs without throwing and has non-negative, count-conserving matrix entries`, () => {
+      const records = buildRecords();
+      const inputTotal = records.reduce((sum, r) => sum + r.count, 0);
+
+      let built: ReturnType<typeof buildMatrix>;
+      expect(() => {
+        built = buildMatrix(records, spec);
+      }).not.toThrow();
+
+      const { matrix } = built!;
+      for (const row of matrix) {
+        for (const v of row) {
+          expect(v).toBeGreaterThanOrEqual(0);
+        }
+      }
+
+      // Filters/conditions can drop records, so the grand total is at most
+      // the input total; for the unfiltered specs it must equal it exactly.
+      const grandTotal = total(matrix);
+      expect(grandTotal).toBeLessThanOrEqual(inputTotal);
+      if (!spec.filter && !spec.where) {
+        expect(grandTotal).toBe(inputTotal);
+      }
+    });
+  }
+});

--- a/packages/gofish-neo/src/spec.ts
+++ b/packages/gofish-neo/src/spec.ts
@@ -1,0 +1,42 @@
+/** Declarative specification for a Neo hierarchical-confusion-matrix chart. */
+
+import type { Condition } from "./pipeline";
+import type { Measure } from "./measures";
+
+export type Normalization = "total" | "row" | "column";
+export type Encoding = "color" | "size";
+
+export interface NeoSpec {
+  /** classes[0] is the primary axis; the rest are nested into it by `nest()`. */
+  classes: string[];
+  where?: Condition;
+  filter?: string[];
+  /** @default "total" */
+  normalization?: Normalization;
+  /** @default "color" */
+  encoding?: Encoding;
+  /** Node ids (not names) whose subtrees are collapsed in the rendering frontier. */
+  collapsed?: string[];
+  /** @default ["precision", "recall", "accuracy"] */
+  measures?: Measure[];
+}
+
+/**
+ * A `NeoSpec` with every optional field filled in with its default value.
+ * `where` stays optional — there is no meaningful default condition.
+ */
+export type ResolvedNeoSpec = Required<Omit<NeoSpec, "where">> &
+  Pick<NeoSpec, "where">;
+
+/** Fills in default values for a `NeoSpec`'s optional fields. */
+export function applyDefaults(spec: NeoSpec): ResolvedNeoSpec {
+  return {
+    classes: spec.classes,
+    where: spec.where,
+    filter: spec.filter ?? [],
+    normalization: spec.normalization ?? "total",
+    encoding: spec.encoding ?? "color",
+    collapsed: spec.collapsed ?? [],
+    measures: spec.measures ?? ["precision", "recall", "accuracy"],
+  };
+}

--- a/packages/gofish-neo/src/testFixture.ts
+++ b/packages/gofish-neo/src/testFixture.ts
@@ -1,0 +1,28 @@
+import { buildLabelTree, findNode, type TreeNode } from "./labelTree";
+import type { Matrix } from "./matrix";
+
+/**
+ * Canonical fixture used across matrix/normalize/measures tests: a tree
+ * root -> {A, BC -> {B, C}}, with A=[0,1), B=[1,2), C=[2,3), BC=[1,3), and a
+ * raw actual(row)×observed(col) matrix over [A,B,C].
+ */
+export function fixture(): {
+  tree: TreeNode;
+  matrix: Matrix;
+  A: TreeNode;
+  B: TreeNode;
+  C: TreeNode;
+  BC: TreeNode;
+} {
+  const tree = buildLabelTree(["A", "BC:B", "BC:C"]);
+  const A = findNode(tree, "A")!;
+  const B = findNode(tree, "BC:B")!;
+  const C = findNode(tree, "BC:C")!;
+  const BC = findNode(tree, "BC")!;
+  const matrix: Matrix = [
+    [3, 5, 2],
+    [3, 4, 3],
+    [1, 2, 7],
+  ];
+  return { tree, matrix, A, B, C, BC };
+}

--- a/packages/gofish-neo/stories/ConfusionMatrix.stories.tsx
+++ b/packages/gofish-neo/stories/ConfusionMatrix.stories.tsx
@@ -32,8 +32,11 @@ export const Flat: StoryObj = {
         "A hierarchical confusion matrix for a flat 5-class animal classifier, with tree-shaped row/column margins and per-class precision/recall/accuracy strips.",
     },
   },
-  render: () =>
-    renderInto(() => confusionMatrix({ classes: ["animal"] }, animalsFlat)),
+  render: () => {
+    return renderInto(() =>
+      confusionMatrix({ classes: ["animal"] }, animalsFlat)
+    );
+  },
 };
 
 export const Hierarchical: StoryObj = {
@@ -46,13 +49,14 @@ export const Hierarchical: StoryObj = {
         "A confusion matrix over a 2-level animal-class hierarchy (mammal/bird/reptile groups), where the tree-shaped margins make within-group confusion (cat/dog/fox) visually distinct from rarer across-group mistakes.",
     },
   },
-  render: () =>
-    renderInto(() =>
+  render: () => {
+    return renderInto(() =>
       confusionMatrix(
         { classes: ["animal"], measures: ["precision", "recall", "accuracy"] },
         animalsHierarchical
       )
-    ),
+    );
+  },
 };
 
 export const CollapsedSubtree: StoryObj = {
@@ -98,10 +102,11 @@ export const MultiOutputNested: StoryObj = {
         "A checkout classifier's beverage and size predictions nested into a single matrix — size confusions surface within each beverage's own block instead of being averaged away.",
     },
   },
-  render: () =>
-    renderInto(() =>
+  render: () => {
+    return renderInto(() =>
       confusionMatrix({ classes: ["beverage", "size"] }, checkoutMultiOutput)
-    ),
+    );
+  },
 };
 
 export const Conditioned: StoryObj = {

--- a/packages/gofish-neo/stories/ConfusionMatrix.stories.tsx
+++ b/packages/gofish-neo/stories/ConfusionMatrix.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import { confusionMatrix } from "../src";
+import { initializeContainer } from "./helper";
+import { animalsFlat, animalsHierarchical, checkoutMultiOutput } from "./data";
+
+const meta: Meta = {
+  title: "Neo/Confusion Matrix",
+};
+export default meta;
+
+// Every story renders into an oversized container; `initializeContainer`
+// auto-fits the SVG's viewBox to content on the next frame, so we don't need
+// to hand-compute the composed node's exact pixel footprint here.
+const CONTAINER_SIZE = { w: 900, h: 700 };
+
+function renderInto(build: () => Promise<any>) {
+  const container = initializeContainer(CONTAINER_SIZE);
+  (async () => {
+    const node = await build();
+    node.render(container, CONTAINER_SIZE);
+  })();
+  return container;
+}
+
+export const Flat: StoryObj = {
+  name: "Flat",
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Confusion Matrix",
+      description:
+        "A hierarchical confusion matrix for a flat 5-class animal classifier, with tree-shaped row/column margins and per-class precision/recall/accuracy strips.",
+    },
+  },
+  render: () =>
+    renderInto(() => confusionMatrix({ classes: ["animal"] }, animalsFlat)),
+};
+
+export const Hierarchical: StoryObj = {
+  name: "Hierarchical",
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Hierarchical Confusion Matrix",
+      description:
+        "A confusion matrix over a 2-level animal-class hierarchy (mammal/bird/reptile groups), where the tree-shaped margins make within-group confusion (cat/dog/fox) visually distinct from rarer across-group mistakes.",
+    },
+  },
+  render: () =>
+    renderInto(() =>
+      confusionMatrix(
+        { classes: ["animal"], measures: ["precision", "recall", "accuracy"] },
+        animalsHierarchical
+      )
+    ),
+};
+
+export const CollapsedSubtree: StoryObj = {
+  name: "Collapsed Subtree",
+  render: () =>
+    renderInto(() =>
+      confusionMatrix(
+        { classes: ["animal"], collapsed: ["animal:mammal"] },
+        animalsHierarchical
+      )
+    ),
+};
+
+export const SizeEncoding: StoryObj = {
+  name: "Size Encoding",
+  render: () =>
+    renderInto(() =>
+      confusionMatrix(
+        { classes: ["animal"], encoding: "size" },
+        animalsHierarchical
+      )
+    ),
+};
+
+export const RowNormalized: StoryObj = {
+  name: "Row Normalized",
+  render: () =>
+    renderInto(() =>
+      confusionMatrix(
+        { classes: ["animal"], normalization: "row" },
+        animalsHierarchical
+      )
+    ),
+};
+
+export const MultiOutputNested: StoryObj = {
+  name: "Multi-Output Nested",
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Multi-Output Confusion Matrix",
+      description:
+        "A checkout classifier's beverage and size predictions nested into a single matrix — size confusions surface within each beverage's own block instead of being averaged away.",
+    },
+  },
+  render: () =>
+    renderInto(() =>
+      confusionMatrix({ classes: ["beverage", "size"] }, checkoutMultiOutput)
+    ),
+};
+
+export const Conditioned: StoryObj = {
+  name: "Conditioned",
+  render: () =>
+    renderInto(() =>
+      confusionMatrix(
+        {
+          classes: ["beverage"],
+          where: { qualifier: "actual", label: "size", is: "size:large" },
+        },
+        checkoutMultiOutput
+      )
+    ),
+};

--- a/packages/gofish-neo/stories/RadialConfusionMatrix.stories.tsx
+++ b/packages/gofish-neo/stories/RadialConfusionMatrix.stories.tsx
@@ -1,0 +1,261 @@
+import type { Meta, StoryObj } from "@storybook/html";
+import {
+  Frame,
+  Layer,
+  rect,
+  text,
+  polar,
+  assignGradientColor,
+} from "gofish-graphics";
+import {
+  buildMatrix,
+  frontier,
+  frequency,
+  buildNormalizer,
+  applyDefaults,
+} from "../src";
+import { initializeContainer } from "./helper";
+import { animalsHierarchical } from "./data";
+
+// A radial (polar) hierarchical confusion matrix — the showpiece from issue
+// #639: observed classes (columns) map to ANGLE, actual classes (rows) map to
+// RADIUS as concentric rings, and the label tree's internal groups render as
+// sunburst-style arc headers around the outer rim. This is deliberately NOT
+// built on `confusionMatrix.tsx` (the Cartesian renderer, which lays its grid
+// out with `table()`): a polar grid has no ordinal x/y axes to hang a `table`
+// off, so this composes the SAME algebra (buildMatrix/frontier/frequency/
+// buildNormalizer) directly into hand-placed polar wedges instead, following
+// gofish-gotree's MultilevelSilhouetteTree idiom (issue #627) — bypass the
+// tree()/combine() DSL, compute each mark's angular/radial slice directly,
+// and emit it into a `Frame({ coord: polar() })`.
+
+const meta: Meta = {
+  title: "Neo/Radial Confusion Matrix",
+};
+export default meta;
+
+const CONTAINER_SIZE = { w: 900, h: 900 };
+
+// ─── palette (matches the Cartesian ConfusionMatrix stories' sequential ramp) ──
+const COLORS: [string, string] = ["#e6f5f8", "#0b5394"];
+const ZERO_FILL = "#f2f2f3";
+const HEADER_FILL = "#1d3557"; // same navy as the flat version's root tree-box
+
+// ─── geometry ───────────────────────────────────────────────────────────────
+// A full 2π sweep degenerates (a rect spanning exactly 2π collapses to a
+// zero-width sliver — see gofish-gotree's Sunburst/MultilevelSilhouetteTree
+// notes), so leave a real angular gap. 300° sweep / 60° gap doubles as the
+// spot for the ring (actual-class) legend.
+const SWEEP_DEG = 300;
+const SWEEP = (SWEEP_DEG / 180) * Math.PI;
+// `polar()`'s screen angle is `startAngle - theta` (default direction -1), so
+// the untouched arc [SWEEP, 2π) sits immediately counter-clockwise of theta=0.
+// Offsetting startAngle by half the swept angle rotates that leftover gap to
+// point straight down, regardless of how wide the sweep is:
+//   screenAngle(gapMid) = startAngle - (SWEEP + (2π−SWEEP)/2) := −π/2 (down)
+//   ⇒ startAngle = π/2 + SWEEP/2
+const START_ANGLE = Math.PI / 2 + SWEEP / 2;
+
+const HEADER_R_OUTER = 280; // outer edge of the rim's group-header arcs
+const HEADER_THICKNESS = 26;
+const BODY_R_OUTER = HEADER_R_OUTER - HEADER_THICKNESS; // outer edge of the body rings
+const DONUT_FRACTION = 0.3; // hole radius as a fraction of BODY_R_OUTER (~28% of the full disc)
+const BODY_R_INNER = BODY_R_OUTER * DONUT_FRACTION;
+
+async function radialConfusionMatrix() {
+  const resolved = applyDefaults({ classes: ["animal"] });
+  const { tree: labelTree, matrix } = buildMatrix(
+    animalsHierarchical,
+    resolved
+  );
+  const rows = frontier(labelTree); // 6 leaves; the shared tree serves both axes
+  const cols = rows;
+  const n = rows.length;
+  const normalizer = buildNormalizer(labelTree, matrix, resolved.normalization);
+
+  const perLeafAngle = SWEEP / n;
+  const ringThickness = (BODY_R_OUTER - BODY_R_INNER) / n;
+
+  const polarCoord = polar({
+    centralAngle: SWEEP,
+    startAngle: START_ANGLE,
+    direction: -1,
+  });
+
+  const marks: any[] = [];
+
+  // ─── body cells: annular sectors. Row → ring (row 0, the first actual class,
+  // is the OUTERMOST ring — more area for the earlier/larger classes), col → angle.
+  rows.forEach((rowNode, ri) => {
+    const ringPos = n - 1 - ri;
+    const rInner = BODY_R_INNER + ringPos * ringThickness;
+    cols.forEach((colNode) => {
+      const count = frequency(matrix, rowNode, colNode);
+      const norm = normalizer(rowNode, colNode);
+      const isZero = count === 0;
+      const fill = isZero
+        ? ZERO_FILL
+        : assignGradientColor({ _tag: "gradient", stops: COLORS } as any, norm);
+      marks.push(
+        rect({
+          x: colNode.start * perLeafAngle,
+          w: (colNode.end - colNode.start) * perLeafAngle,
+          y: rInner,
+          h: ringThickness,
+          emX: true,
+          emY: true,
+          fill,
+          stroke: "white",
+          strokeWidth: 1,
+        } as any)
+      );
+      if (!isZero) {
+        const midTheta = ((colNode.start + colNode.end) / 2) * perLeafAngle;
+        const midR = rInner + ringThickness / 2;
+        const [tx, ty] = polarCoord.transform([midTheta, midR]);
+        marks.push(
+          text({
+            x: tx,
+            y: ty,
+            text: String(count),
+            fontSize: 9,
+            fill: norm > 0.55 ? "#ffffff" : "#0f1f30",
+            textAnchor: "middle",
+          } as any)
+        );
+      }
+    });
+  });
+
+  // ─── outer-rim header arcs: one per top-level group under the primary class
+  // dimension (e.g. mammal/bird/reptile:lizard) — a sunburst-style parent arc
+  // spanning exactly its children's angular extent (the same leaf-index range
+  // the body rings use, read straight off the shared label tree).
+  const dimRoot = labelTree.children[0] ?? labelTree;
+  for (const group of dimRoot.children) {
+    marks.push(
+      rect({
+        x: group.start * perLeafAngle,
+        w: (group.end - group.start) * perLeafAngle,
+        y: BODY_R_OUTER,
+        h: HEADER_THICKNESS,
+        emX: true,
+        emY: true,
+        fill: HEADER_FILL,
+        stroke: "white",
+        strokeWidth: 1.5,
+      } as any)
+    );
+  }
+
+  // Header + ring labels: `text()`'s plain x/y bypass the coord's warp (only
+  // EMBEDDED dims get warped — see ellipse.tsx's `space.transform(center)`
+  // special-case, which text has no equivalent of), so the point itself must
+  // be pre-transformed by hand — the same recipe `coord.tsx` uses for its own
+  // polar-axis tick labels (`effectiveTransform.transform([theta, r])`, then
+  // plain x/y).
+  for (const group of dimRoot.children) {
+    const mid = ((group.start + group.end) / 2) * perLeafAngle;
+    // Clear of the rim, on the plain background: placing the anchor just
+    // past HEADER_R_OUTER is not enough on its own — for a group whose mid-
+    // angle points nearly straight left/right (its "outward" direction is
+    // almost horizontal), a wide CENTERED label's other half reaches back
+    // toward the origin and re-overlaps the dark arc (dark-on-dark). Anchor
+    // the text so it only grows AWAY from center — the same rule coord.tsx
+    // uses for its own polar axis-tick labels (sign/magnitude of the
+    // transformed screen x) — so growth always increases radius, never
+    // dips back into the ring, regardless of the group's angle.
+    const r = HEADER_R_OUTER + 22;
+    const [tx, ty] = polarCoord.transform([mid, r]);
+    const label =
+      group.children.length > 0 ? group.name : group.name.replace(/:/g, " / ");
+    marks.push(
+      text({
+        x: tx,
+        y: ty,
+        text: label,
+        fontSize: 11,
+        fontWeight: 600,
+        fill: "#0f1f30",
+        textAnchor: tx < -6 ? "end" : tx > 6 ? "start" : "middle",
+      } as any)
+    );
+  }
+
+  // Ring (actual-class) labels: stacked along the single radial spoke at the
+  // gap's center angle (straight down), one per ring at that ring's mid-radius
+  // — "along a radius", as the gap widens outward the labels never crowd.
+  const gapMidTheta = SWEEP + (2 * Math.PI - SWEEP) / 2;
+  rows.forEach((rowNode, ri) => {
+    const ringPos = n - 1 - ri;
+    const rMid = BODY_R_INNER + (ringPos + 0.5) * ringThickness;
+    const [tx, ty] = polarCoord.transform([gapMidTheta, rMid]);
+    marks.push(
+      text({
+        x: tx,
+        y: ty,
+        text: rowNode.name.replace(/:/g, " / "),
+        fontSize: 10,
+        fill: "#0f1f30",
+        textAnchor: "middle",
+      } as any)
+    );
+  });
+
+  // Invisible margin markers: `fitToContent` (the story harness's viewBox
+  // auto-fit) crops tightly to the content bbox with only a fixed 10px pad,
+  // which puts the header labels — the widest things in the piece, since they
+  // sit right at the rim — flush against the crop edge. A ring of small,
+  // unembedded (position-only) points at a larger radius pads the bbox on
+  // every side without drawing anything visible. Unlike `text`, a shape's
+  // (x, y) here IS still routed through the coord transform when neither
+  // dimension is embedded (see ellipse.tsx's `space.transform(center)`), so
+  // these are genuine (θ, r) pairs, not pre-transformed pixels.
+  const MARGIN_R = HEADER_R_OUTER + 150;
+  for (let i = 0; i < 8; i++) {
+    const theta = (i * 2 * Math.PI) / 8;
+    marks.push(
+      rect({
+        x: theta,
+        y: MARGIN_R,
+        w: 2,
+        h: 2,
+        fill: "none",
+        stroke: "none",
+      } as any)
+    );
+  }
+
+  return Frame(
+    {
+      w: CONTAINER_SIZE.w,
+      h: CONTAINER_SIZE.h,
+      coord: polarCoord as any,
+      // A truthy `axes` (even with both rings suppressed) centers the polar
+      // content at the Frame's own (w/2, h/2) instead of tight-fitting its
+      // bbox — see coord.tsx's `useAllocated` branch — with no ticks drawn.
+      axes: { x: false, y: false },
+    },
+    [Layer(marks)]
+  );
+}
+
+export const Radial: StoryObj = {
+  name: "Radial Confusion Matrix",
+  tags: ["gallery"],
+  parameters: {
+    gallery: {
+      title: "Radial Confusion Matrix",
+      description:
+        "A hierarchical confusion matrix bent into a polar donut — actual classes as concentric rings, observed classes as angular sectors, and sunburst-style arcs marking each animal group around the rim.",
+    },
+  },
+  render: () => {
+    const container = initializeContainer(CONTAINER_SIZE);
+    (async () => {
+      const node = await radialConfusionMatrix();
+      node.render(container, CONTAINER_SIZE);
+    })();
+    return container;
+  },
+};

--- a/packages/gofish-neo/stories/RadialConfusionMatrix.stories.tsx
+++ b/packages/gofish-neo/stories/RadialConfusionMatrix.stories.tsx
@@ -13,6 +13,9 @@ import {
   frequency,
   buildNormalizer,
   applyDefaults,
+  DEFAULT_COLORS,
+  ZERO_FILL,
+  PALETTE_DEPTH,
 } from "../src";
 import { initializeContainer } from "./helper";
 import { animalsHierarchical } from "./data";
@@ -35,11 +38,18 @@ const meta: Meta = {
 export default meta;
 
 const CONTAINER_SIZE = { w: 900, h: 900 };
+// `fitToContent` (the story harness's viewBox auto-fit) crops tightly to the
+// content bbox with only a small default pad, which would put the header
+// labels — the widest things in the piece, since they sit right at the rim —
+// flush against the crop edge. Pass a larger pad through `initializeContainer`
+// instead of padding the bbox with invisible marker marks: ~150px of the
+// breathing room the old markers provided, minus the harness's own 10px
+// default (already folded into that 150px), so the total margin is roughly
+// unchanged.
+const RADIAL_PAD = 150 - 10;
 
-// ─── palette (matches the Cartesian ConfusionMatrix stories' sequential ramp) ──
-const COLORS: [string, string] = ["#e6f5f8", "#0b5394"];
-const ZERO_FILL = "#f2f2f3";
-const HEADER_FILL = "#1d3557"; // same navy as the flat version's root tree-box
+// ─── palette (shared with the Cartesian renderer, confusionMatrix.tsx) ──────
+const HEADER_FILL = PALETTE_DEPTH[0]; // same navy as the flat version's root tree-box
 
 // ─── geometry ───────────────────────────────────────────────────────────────
 // A full 2π sweep degenerates (a rect spanning exactly 2π collapses to a
@@ -91,11 +101,14 @@ async function radialConfusionMatrix() {
     const rInner = BODY_R_INNER + ringPos * ringThickness;
     cols.forEach((colNode) => {
       const count = frequency(matrix, rowNode, colNode);
-      const norm = normalizer(rowNode, colNode);
+      const norm = normalizer(rowNode, colNode, count);
       const isZero = count === 0;
       const fill = isZero
         ? ZERO_FILL
-        : assignGradientColor({ _tag: "gradient", stops: COLORS } as any, norm);
+        : assignGradientColor(
+            { _tag: "gradient", stops: DEFAULT_COLORS } as any,
+            norm
+          );
       marks.push(
         rect({
           x: colNode.start * perLeafAngle,
@@ -202,30 +215,6 @@ async function radialConfusionMatrix() {
     );
   });
 
-  // Invisible margin markers: `fitToContent` (the story harness's viewBox
-  // auto-fit) crops tightly to the content bbox with only a fixed 10px pad,
-  // which puts the header labels — the widest things in the piece, since they
-  // sit right at the rim — flush against the crop edge. A ring of small,
-  // unembedded (position-only) points at a larger radius pads the bbox on
-  // every side without drawing anything visible. Unlike `text`, a shape's
-  // (x, y) here IS still routed through the coord transform when neither
-  // dimension is embedded (see ellipse.tsx's `space.transform(center)`), so
-  // these are genuine (θ, r) pairs, not pre-transformed pixels.
-  const MARGIN_R = HEADER_R_OUTER + 150;
-  for (let i = 0; i < 8; i++) {
-    const theta = (i * 2 * Math.PI) / 8;
-    marks.push(
-      rect({
-        x: theta,
-        y: MARGIN_R,
-        w: 2,
-        h: 2,
-        fill: "none",
-        stroke: "none",
-      } as any)
-    );
-  }
-
   return Frame(
     {
       w: CONTAINER_SIZE.w,
@@ -251,7 +240,7 @@ export const Radial: StoryObj = {
     },
   },
   render: () => {
-    const container = initializeContainer(CONTAINER_SIZE);
+    const container = initializeContainer(CONTAINER_SIZE, RADIAL_PAD);
     (async () => {
       const node = await radialConfusionMatrix();
       node.render(container, CONTAINER_SIZE);

--- a/packages/gofish-neo/stories/data.ts
+++ b/packages/gofish-neo/stories/data.ts
@@ -1,0 +1,160 @@
+// Sample datasets for the gofish-neo confusion-matrix stories. Kept as a
+// standalone module (not in `src/`) so the docs example scanner treats it as
+// a dataset — gallery snippets import from here and its contents are shown
+// alongside the example.
+
+import type { Confusion } from "../src";
+
+/** Builds one `Confusion` record per (actual, observed) pair with a nonzero
+ *  count; pairs absent from `counts` are left at 0 in the built matrix — the
+ *  simplest way to author "at least one zero cell" (just omit the pair). */
+function fromCounts(
+  counts: Record<string, Record<string, number>>
+): Confusion[] {
+  const out: Confusion[] = [];
+  for (const actual of Object.keys(counts)) {
+    for (const [observed, count] of Object.entries(counts[actual]!)) {
+      if (count <= 0) continue;
+      out.push({ actual: [actual], observed: [observed], count });
+    }
+  }
+  return out;
+}
+
+// ─── animalsFlat: single dimension, 5 flat classes ─────────────────────────
+// A strong diagonal (mostly-correct classifier) with plausible cross-class
+// confusion and one true zero cell (dog↔fish never confused).
+export const animalsFlat: Confusion[] = fromCounts({
+  "animal:cat": {
+    "animal:cat": 42,
+    "animal:dog": 5,
+    "animal:bird": 1,
+    "animal:fish": 2,
+  },
+  "animal:dog": { "animal:dog": 38, "animal:cat": 6, "animal:bird": 1 },
+  "animal:bird": {
+    "animal:bird": 30,
+    "animal:cat": 2,
+    "animal:fish": 1,
+    "animal:snake": 1,
+  },
+  "animal:fish": { "animal:fish": 25, "animal:snake": 3, "animal:bird": 2 },
+  "animal:snake": { "animal:snake": 20, "animal:fish": 2, "animal:bird": 1 },
+});
+
+// ─── animalsHierarchical: one dimension, 2-level hierarchy, 6 leaves ───────
+// animal → mammal{cat, dog, fox}, bird{owl, crow}, reptile{lizard}. More
+// confusion WITHIN a parent group (cat/dog/fox, owl/crow) than ACROSS groups
+// — the story a hierarchical matrix is meant to tell — plus several zero
+// cells (e.g. lizard is never confused with a bird).
+export const animalsHierarchical: Confusion[] = fromCounts({
+  "animal:mammal:cat": {
+    "animal:mammal:cat": 46,
+    "animal:mammal:dog": 7,
+    "animal:mammal:fox": 4,
+    "animal:bird:owl": 1,
+  },
+  "animal:mammal:dog": {
+    "animal:mammal:dog": 40,
+    "animal:mammal:cat": 8,
+    "animal:mammal:fox": 3,
+  },
+  "animal:mammal:fox": {
+    "animal:mammal:fox": 22,
+    "animal:mammal:dog": 5,
+    "animal:mammal:cat": 3,
+  },
+  "animal:bird:owl": {
+    "animal:bird:owl": 28,
+    "animal:bird:crow": 6,
+    "animal:mammal:cat": 1,
+  },
+  "animal:bird:crow": {
+    "animal:bird:crow": 24,
+    "animal:bird:owl": 5,
+  },
+  "animal:reptile:lizard": {
+    "animal:reptile:lizard": 18,
+    "animal:mammal:fox": 1,
+  },
+});
+
+// ─── checkoutMultiOutput: two output dimensions per record ─────────────────
+// A point-of-sale classifier predicts both `beverage` (soda/water/coffee) and
+// `size` (small/large) for the same transaction; actual/observed can each
+// carry both dimensions, so nesting (`classes: ["beverage", "size"]`) and
+// conditioning (`where: {qualifier, label: "size", is: "size:large"}`) both
+// have something interesting to show.
+export const checkoutMultiOutput: Confusion[] = [
+  // beverage correct, size correct (the bulk of the traffic)
+  {
+    actual: ["beverage:soda", "size:small"],
+    observed: ["beverage:soda", "size:small"],
+    count: 50,
+  },
+  {
+    actual: ["beverage:soda", "size:large"],
+    observed: ["beverage:soda", "size:large"],
+    count: 34,
+  },
+  {
+    actual: ["beverage:water", "size:small"],
+    observed: ["beverage:water", "size:small"],
+    count: 40,
+  },
+  {
+    actual: ["beverage:water", "size:large"],
+    observed: ["beverage:water", "size:large"],
+    count: 18,
+  },
+  {
+    actual: ["beverage:coffee", "size:small"],
+    observed: ["beverage:coffee", "size:small"],
+    count: 30,
+  },
+  {
+    actual: ["beverage:coffee", "size:large"],
+    observed: ["beverage:coffee", "size:large"],
+    count: 36,
+  },
+  // beverage correct, size confused
+  {
+    actual: ["beverage:soda", "size:small"],
+    observed: ["beverage:soda", "size:large"],
+    count: 6,
+  },
+  {
+    actual: ["beverage:soda", "size:large"],
+    observed: ["beverage:soda", "size:small"],
+    count: 4,
+  },
+  {
+    actual: ["beverage:coffee", "size:small"],
+    observed: ["beverage:coffee", "size:large"],
+    count: 8,
+  },
+  {
+    actual: ["beverage:coffee", "size:large"],
+    observed: ["beverage:coffee", "size:small"],
+    count: 5,
+  },
+  // beverage confused (water/coffee mix-up — both hot-cup-shaped at checkout),
+  // size held correct
+  {
+    actual: ["beverage:water", "size:small"],
+    observed: ["beverage:coffee", "size:small"],
+    count: 7,
+  },
+  {
+    actual: ["beverage:coffee", "size:small"],
+    observed: ["beverage:water", "size:small"],
+    count: 5,
+  },
+  {
+    actual: ["beverage:water", "size:large"],
+    observed: ["beverage:coffee", "size:large"],
+    count: 4,
+  },
+  // soda is never confused with water/coffee (different packaging) — leaves
+  // real zero cells at the beverage level once collapsed/marginalized.
+];

--- a/packages/gofish-neo/stories/helper.ts
+++ b/packages/gofish-neo/stories/helper.ts
@@ -6,14 +6,13 @@
 
 // Scale the rendered SVG to fill the container by setting its viewBox to the
 // content bounding box (so small charts are centered and large ones don't clip).
-export const fitToContent = (host: HTMLElement) => {
+export const fitToContent = (host: HTMLElement, pad = 10) => {
   requestAnimationFrame(() => {
     const svg = host.querySelector("svg");
     if (!svg) return;
     try {
       const bb = (svg as SVGSVGElement).getBBox();
       if (!bb.width || !bb.height) return;
-      const pad = 10;
       svg.setAttribute(
         "viewBox",
         `${bb.x - pad} ${bb.y - pad} ${bb.width + 2 * pad} ${bb.height + 2 * pad}`
@@ -31,13 +30,14 @@ export const fitToContent = (host: HTMLElement) => {
 // rendered into it on the next frame. Stories call this, then render their
 // chart into the returned element.
 export const initializeContainer = (
-  size: { w: number; h: number } = { w: 640, h: 420 }
+  size: { w: number; h: number } = { w: 640, h: 420 },
+  pad?: number
 ) => {
   const c = document.createElement("div");
   c.style.margin = "16px";
   c.style.width = `${size.w}px`;
   c.style.height = `${size.h}px`;
   document.body.appendChild(c);
-  fitToContent(c);
+  fitToContent(c, pad);
   return c;
 };

--- a/packages/gofish-neo/stories/helper.ts
+++ b/packages/gofish-neo/stories/helper.ts
@@ -1,0 +1,43 @@
+// Rendering scaffolding for the Neo gallery stories. Named `helper` so the
+// docs example scanner drops it from synthesized snippets (and rewrites
+// `initializeContainer()` → `document.getElementById("app")`); see apps/docs
+// CLAUDE.md. The real story execution (Storybook, visual-diff capture, docs
+// GoFishExample) uses these directly.
+
+// Scale the rendered SVG to fill the container by setting its viewBox to the
+// content bounding box (so small charts are centered and large ones don't clip).
+export const fitToContent = (host: HTMLElement) => {
+  requestAnimationFrame(() => {
+    const svg = host.querySelector("svg");
+    if (!svg) return;
+    try {
+      const bb = (svg as SVGSVGElement).getBBox();
+      if (!bb.width || !bb.height) return;
+      const pad = 10;
+      svg.setAttribute(
+        "viewBox",
+        `${bb.x - pad} ${bb.y - pad} ${bb.width + 2 * pad} ${bb.height + 2 * pad}`
+      );
+      svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
+      svg.setAttribute("width", "100%");
+      svg.setAttribute("height", "100%");
+    } catch {
+      /* getBBox throws before paint; ignore */
+    }
+  });
+};
+
+// Create a fresh sized container, append it, and auto-fit whatever SVG gets
+// rendered into it on the next frame. Stories call this, then render their
+// chart into the returned element.
+export const initializeContainer = (
+  size: { w: number; h: number } = { w: 640, h: 420 }
+) => {
+  const c = document.createElement("div");
+  c.style.margin = "16px";
+  c.style.width = `${size.w}px`;
+  c.style.height = `${size.h}px`;
+  document.body.appendChild(c);
+  fitToContent(c);
+  return c;
+};

--- a/packages/gofish-neo/tsconfig.json
+++ b/packages/gofish-neo/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "jsxImportSource": "solid-js",
+    "types": ["vite/client"],
+    "noEmit": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/gofish-neo/vite.config.ts
+++ b/packages/gofish-neo/vite.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from "vite";
+import solidPlugin from "vite-plugin-solid";
+
+export default defineConfig({
+  plugins: [solidPlugin()],
+  server: {
+    port: 3002,
+  },
+  build: {
+    target: "esnext",
+    lib: {
+      entry: "src/index.ts",
+      name: "GoFishNeo",
+      fileName: "index",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: ["solid-js", "gofish-graphics", "gofish-gotree"],
+      output: {
+        globals: {
+          "solid-js": "SolidJS",
+          "gofish-graphics": "GoFishGraphics",
+          "gofish-gotree": "GoFishGoTree",
+        },
+      },
+    },
+  },
+});

--- a/packages/gofish-neo/vitest.config.ts
+++ b/packages/gofish-neo/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -283,6 +283,43 @@ importers:
         specifier: ^5.7.2
         version: 5.9.3
 
+  packages/gofish-neo:
+    dependencies:
+      gofish-gotree:
+        specifier: workspace:*
+        version: link:../gofish-gotree
+      gofish-graphics:
+        specifier: workspace:*
+        version: link:../gofish-graphics
+      solid-js:
+        specifier: ^1.9.5
+        version: 1.9.11
+    devDependencies:
+      '@storybook/addon-docs':
+        specifier: ^9.1.6
+        version: 9.1.6(@types/react@19.1.13)(storybook@9.1.6(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)))
+      '@storybook/html':
+        specifier: ^9.1.6
+        version: 9.1.6(storybook@9.1.6(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)))
+      storybook:
+        specifier: ^9.1.6
+        version: 9.1.6(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0))
+      storybook-solidjs-vite:
+        specifier: ^9.0.3
+        version: 9.0.3(@testing-library/jest-dom@6.8.0)(solid-js@1.9.11)(storybook@9.1.6(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)))(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0))
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite-plugin-solid:
+        specifier: ^2.11.6
+        version: 2.11.10(@testing-library/jest-dom@6.8.0)(solid-js@1.9.11)(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0))
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@24.10.1)(happy-dom@20.10.6)(tsx@4.21.0)(yaml@2.9.0)
+
   packages/gofish-python:
     dependencies:
       apache-arrow:
@@ -2031,8 +2068,22 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -2045,11 +2096,26 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -2349,6 +2415,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -2749,6 +2819,9 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
     peerDependencies:
@@ -2862,6 +2935,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
@@ -3105,6 +3182,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@3.14.2:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
@@ -3762,6 +3842,9 @@ packages:
     resolution: {integrity: sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q==}
     engines: {node: '>=20'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -3813,8 +3896,14 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   static-browser-server@1.0.3:
     resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   storybook-solidjs-vite@9.0.3:
     resolution: {integrity: sha512-buPxAw8ED0rhx2YjYLM/Eh55uyoTn70LthQBFDet+TJMnQ4gWltGIy5tNCstTQPp8OyfDTlEmLRvKsxbYpg3RQ==}
@@ -3886,6 +3975,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
   style-mod@4.1.3:
     resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
@@ -3908,6 +4000,12 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
@@ -3915,6 +4013,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -4224,6 +4326,11 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-plugin-dts@5.0.1:
     resolution: {integrity: sha512-1L+x8bVPDhlI4kLzRIIGqO+b1VnvtY6CoHrU+riaipHJUAxayM0i1HObqeBv33Svil9hW64Z2KNiOn6UrKWCbA==}
     peerDependencies:
@@ -4409,6 +4516,34 @@ packages:
       postcss:
         optional: true
 
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -4448,6 +4583,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wicked-good-xpath@1.3.0:
@@ -6161,6 +6301,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/mocker@3.2.4(vite@6.0.0(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -6177,17 +6325,51 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)
 
+  '@vitest/mocker@3.2.7(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.3
+
+  '@vitest/spy@3.2.7':
     dependencies:
       tinyspy: 4.0.3
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -6555,6 +6737,8 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  cac@6.7.14: {}
 
   callsites@3.1.0: {}
 
@@ -6938,6 +7122,8 @@ snapshots:
 
   environment@1.1.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   esbuild-register@3.6.0(esbuild@0.24.0):
     dependencies:
       debug: 4.3.7
@@ -7149,6 +7335,8 @@ snapshots:
   esutils@2.0.3: {}
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.4.0: {}
 
   exsolve@1.0.8: {}
 
@@ -7372,6 +7560,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@3.14.2:
     dependencies:
@@ -8204,6 +8394,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   slice-ansi@7.1.2:
@@ -8266,12 +8458,16 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  stackback@0.0.2: {}
+
   static-browser-server@1.0.3:
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
       dotenv: 16.6.1
       mime-db: 1.54.0
       outvariant: 1.4.0
+
+  std-env@3.10.0: {}
 
   storybook-solidjs-vite@9.0.3(@testing-library/jest-dom@6.8.0)(solid-js@1.9.11)(storybook@9.1.6(@testing-library/dom@10.4.1)(prettier@3.8.1)(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)))(typescript@5.9.3)(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
@@ -8401,6 +8597,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   style-mod@4.1.3: {}
 
   superjson@2.2.5:
@@ -8425,12 +8625,18 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
@@ -8917,6 +9123,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-plugin-dts@5.0.1(esbuild@0.27.2)(rollup@4.59.0)(typescript@5.7.2)(vite@6.0.0(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       unplugin-dts: 1.0.1(esbuild@0.27.2)(rollup@4.59.0)(typescript@5.7.2)(vite@6.0.0(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0))
@@ -9083,6 +9310,49 @@ snapshots:
       - typescript
       - universal-cookie
 
+  vitest@3.2.7(@types/debug@4.1.13)(@types/node@24.10.1)(happy-dom@20.10.6)(tsx@4.21.0)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.1(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@24.10.1)(tsx@4.21.0)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.13
+      '@types/node': 24.10.1
+      happy-dom: 20.10.6
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vscode-uri@3.1.0: {}
 
   vue-resize@2.0.0-alpha.1(vue@3.5.24(typescript@6.0.3)):
@@ -9126,6 +9396,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wicked-good-xpath@1.3.0: {}
 

--- a/tests/harness/stories-runner.ts
+++ b/tests/harness/stories-runner.ts
@@ -5,9 +5,10 @@
  */
 
 // Import all story modules eagerly so they're available synchronously after page
-// load. Both workspace packages with stories are scanned: gofish-graphics and the
-// gofish-gotree tree-DSL package (the latter compiles its SolidJS source directly
-// via the relative `../../src` import in its stories, so no built dist is needed).
+// load. Three workspace packages with stories are scanned: gofish-graphics, the
+// gofish-gotree tree-DSL package, and the gofish-neo hierarchical-confusion-matrix
+// package (the latter two compile their SolidJS source directly via the relative
+// `../../src` import in their stories, so no built dist is needed).
 const storyModules = {
   ...import.meta.glob(
     "../../packages/gofish-graphics/stories/**/*.stories.tsx",
@@ -16,6 +17,9 @@ const storyModules = {
     }
   ),
   ...import.meta.glob("../../packages/gofish-gotree/stories/**/*.stories.tsx", {
+    eager: true,
+  }),
+  ...import.meta.glob("../../packages/gofish-neo/stories/**/*.stories.tsx", {
     eager: true,
   }),
 } as Record<string, any>;

--- a/tests/harness/vite.config.ts
+++ b/tests/harness/vite.config.ts
@@ -43,6 +43,21 @@ export default defineConfig({
       : undefined,
     alias: {
       "gofish-graphics": gofishAlias,
+      // gofish-gotree and gofish-neo are never built (no dist/) in the CI jobs
+      // that spin up this harness (visual-test, bench, docs' capture-gallery-
+      // thumbnails step) — only gofish-graphics gets a prerelease build there.
+      // Bare imports of these two packages (e.g. gofish-neo's confusionMatrix.tsx
+      // importing `gofish-gotree`) resolve straight to source instead, same as
+      // the gofishAlias above. Unconditional (not BENCH_PROD-gated): bench only
+      // instruments gofish-graphics.
+      "gofish-gotree": resolve(
+        __dirname,
+        "../../packages/gofish-gotree/src/index.ts"
+      ),
+      "gofish-neo": resolve(
+        __dirname,
+        "../../packages/gofish-neo/src/index.ts"
+      ),
     },
   },
 });


### PR DESCRIPTION
## Summary

New sibling package `packages/gofish-neo`: an independent, clean-room reimplementation of the data algebra from **Neo** (Görtler et al., CHI 2022) rendered with GoFish, following the plan in #639 (alignment spike → package → radial showpiece).

- **Pure data algebra** (`src/`): colon-path parser (incl. `[a,b]` multi-label groups), shared label tree with contiguous leaf ranges (any cell at any level = rectangular block sum), pipeline `condition → filter → linearize → nest → marginalize`, dense leaf×leaf matrix, normalization (`total`/`row`/`column`), measures (precision/recall/accuracy + raw counts). 59 vitest tests, written from an independently-derived spec.
- **Renderer** (`src/confusionMatrix.tsx`): computes the frontier for both axes, then registers three independently built GoFish structures on one shared per-row/per-column pixel pitch — a `table()` grid for the body, `gofish-gotree` `tree()` calls for the two hierarchical margins (leaf size + sibling spacing chosen so leaf pitch equals grid pitch), and one ordinal one-column `table()` per measure strip (which orders rows top-down in data order like the body, so there is no direction-flipping arithmetic anywhere). They are composed with `layer([...]).constrain()` using plain position constraints.

**Why matched pitch and not something more declarative.** Both principled alternatives were spiked and are blocked upstream, with the exact failure points filed:

- Per-leaf constraint pinning (align each margin leaf / strip row to its named grid cell and let the solver register the rows): constraint *refs* resolve deep names across the composed structures, but the placement solve only exposes a layer's direct children, so deep-name constraints are silently discarded (#818, and #819 for the silent no-op itself). Matched pitch is currently the only cross-structure registration mechanism the library offers.
- The radial view as "the same body wrapped in `polar()`": the coord boundary has no fit path for ORDINAL/grid axes, so a `table()` under `polar()` collapses (pixel tracks are read as radians, #816), and `.label()` under a coord boundary aborts the solve outright (#817). The radial story therefore stays hand-placed on the algebra, following the same idiom as the existing gotree polar gallery stories, until #816/#817 land.

The endgame for the margins is the recursive-axes design direction from #639 (the grid's own axes elaborate the label tree), which would dissolve the composition-of-three-structures shape entirely; this package is structured so that migration only touches the renderer, not the algebra.

## License

Apple's reference implementation is under Apple's sample-code license (MIT-incompatible). Per the verdict on #639: algorithms were learned from it, **no code was copied or ported**; the algebra here was implemented from a paraphrased semantic spec. Three deliberate divergences (both-sides segment-aware `filter`, textbook one-vs-rest `trueNegatives`, zero-guards instead of NaN) are documented in the README and at each definition site.

## Follow-ups filed

Upstream gofish-graphics quirks hit along the way, worked around locally and filed rather than fixed here: #812 (table vs scatter y-direction; no longer exercised by this package after the ordinal-strip rewrite), #813 (field channels under table+nested layer), #814 (export text measurement), #816 (no ORDINAL fit path in coord boundaries — blocks table-under-polar), #817 (.label() under a coord boundary crashes the solve), #818 (deep-name constraints silently no-op — blocks per-leaf cross-structure pinning), #819 (zero-placeable constraints should error loudly).

## Notes

- `tests/harness/stories-runner.ts` now globs `gofish-neo/stories` (visual regression coverage; Python parity structurally exempt, same as gofish-gotree).
- Screenshots below.

Closes #639

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

**Hierarchical (flagship)** — 3-level GoTree margins in exact register with the grid, measure strips per class:

![hierarchical](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-815/hierarchical.png)

**Radial showpiece** — same algebra, hand-placed polar frame; observed → angle (sunburst headers), actual → rings:

![radial](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-815/radial.png)

**Flat** | **Collapsed subtree** (mammal aggregated) | **Size encoding** | **Multi-output nest** (size under beverage):

![flat](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-815/flat.png)
![collapsed](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-815/collapsed-subtree.png)
![size](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-815/size-encoding.png)
![nested](https://raw.githubusercontent.com/gofish-graphics/gofish-graphics/pr-assets/pr-815/multi-output-nested.png)


