### PR TITLE
Cleanup pass on #823: linear-time kernel schedule + paint-schedule tests

### DIFF
--- a/packages/gofish-graphics/src/ast/layoutKernel.ts
+++ b/packages/gofish-graphics/src/ast/layoutKernel.ts
@@ -731,16 +731,29 @@ function schedule(
   }
   for (const next of graph.values()) next.sort(compare);
 
+  // Determinism requires always dequeuing the lexicographically smallest
+  // ready node. Rather than `shift()` (O(n) per dequeue) and re-sorting the
+  // whole array whenever a node becomes ready, track a cursor past the
+  // already-emitted prefix and insert newly-ready nodes into their sorted
+  // position within the remaining (not-yet-dequeued) tail via binary search
+  // + a single splice.
   const ready = nodes.filter((node) => degree.get(node) === 0).sort(compare);
   const order: NodeId[] = [];
-  while (ready.length > 0) {
-    const node = ready.shift()!;
+  let cursor = 0;
+  while (cursor < ready.length) {
+    const node = ready[cursor++];
     order.push(node);
     for (const next of graph.get(node)!) {
       degree.set(next, degree.get(next)! - 1);
       if (degree.get(next) === 0) {
-        ready.push(next);
-        ready.sort(compare);
+        let lo = cursor;
+        let hi = ready.length;
+        while (lo < hi) {
+          const mid = (lo + hi) >>> 1;
+          if (compare(ready[mid], next) < 0) lo = mid + 1;
+          else hi = mid;
+        }
+        ready.splice(lo, 0, next);
       }
     }
   }

--- a/packages/gofish-graphics/src/tests/layoutKernel.test.ts
+++ b/packages/gofish-graphics/src/tests/layoutKernel.test.ts
@@ -21,6 +21,7 @@ import {
   placedPortRef,
   relation,
   scheduleDependencies,
+  schedulePaint,
   solveFragment,
   solvedMin,
   translateFragment,
@@ -360,6 +361,40 @@ test("dependency scheduling is invariant and cycle diagnostics are canonical", (
   assertEqual(firstConflict, secondConflict, "canonical cycle conflict");
   assert(
     firstConflict.conflict.message === "Dependency cycle: A -> B -> A",
+    firstConflict.conflict.message
+  );
+});
+
+test("paint scheduling is invariant and cycle diagnostics are canonical", () => {
+  const nodes = [node(C), node(A), node(B)];
+  const ab = paintBefore(A, C);
+  const bb = paintBefore(B, C);
+  const first = schedulePaint(fragment({ nodes, paint: [ab, bb] }));
+  const second = schedulePaint(
+    fragment({ nodes: [...nodes].reverse(), paint: [bb, ab] })
+  );
+  assert(first.status === "scheduled", json(first));
+  assert(second.status === "scheduled", json(second));
+  assertEqual(first.order, [A, B, C], "canonical paint order");
+  assertEqual(first, second, "paint permutation");
+
+  const cycle1 = schedulePaint(
+    fragment({
+      nodes: [node(A), node(B)],
+      paint: [paintBefore(B, A), paintBefore(A, B)],
+    })
+  );
+  const cycle2 = schedulePaint(
+    fragment({
+      nodes: [node(B), node(A)],
+      paint: [paintBefore(A, B), paintBefore(B, A)],
+    })
+  );
+  const firstConflict = expectConflict(cycle1, "paint-cycle");
+  const secondConflict = expectConflict(cycle2, "paint-cycle");
+  assertEqual(firstConflict, secondConflict, "canonical paint cycle conflict");
+  assert(
+    firstConflict.conflict.message === "Paint cycle: A -> B -> A",
     firstConflict.conflict.message
   );
 });


### PR DESCRIPTION
Stacked on #823 (base is `codex/layout-kernel-semantics`, not `main`). This is the applied output of a `/simplify` review pass over that PR: quality cleanups only, no bug hunting and no behavior changes.

## Applied

**`schedule()` in `src/ast/layoutKernel.ts` was O(n^2 log n).** The Kahn's-algorithm loop dequeued with `Array.shift()` (O(n) per dequeue, shifting every remaining element) and re-sorted the whole ready list every time a node's in-degree reached zero. It now keeps a cursor past the already-emitted prefix and binary-searches each newly ready node into the sorted tail. The emitted order is byte-identical: the tail stays sorted, so the node at the cursor is still the lexicographically smallest ready node, which is what the determinism laws rely on.

**`schedulePaint` had no direct test.** It was exported but only exercised indirectly through `solveFragment`, which left the `paint-cycle` conflict branch unasserted while its `dependency-cycle` sibling was covered. Added a paint-scheduling test mirroring the existing dependency one, covering both the canonical order and the cycle diagnostic.

## Validation

Full `pnpm -C packages/gofish-graphics test` passes: 15 suites, 0 failures, including 15 layout-kernel tests (up from 14), 17 layout-claim tests, 27 underlying-space tests, and the 98 constraint-confluence tests. `pnpm typecheck` is clean.

## Reported, not applied

Four independent reviewers looked at #823 for reuse, simplification, efficiency, and altitude. Three findings are left for the author of #823, because acting on them would change what that PR is trying to do.

**`layoutClaims.ts` duplicates `src/util/monotonic.ts`.** Both represent the same object, the upper envelope of finitely many affine pieces, and both supply the same operations: canonicalization (`canonicalPieces` vs `pruneDominated` plus `piecewise`), max (`maxClaims` vs `max`), add (`addClaims` vs `add`), scale (`scaleClaim` vs `smul`), shift (`shiftClaim` vs `adds`), evaluation (`runClaim` vs `run`), and fit (`fitClaim` vs `inverse`). Two things in the new module are genuinely new: a real convex-hull reduction, where `pruneDominated` only removes exactly dominated pieces, and `fitClaim`'s structured outcome (`exact` / `underdetermined` / `slack` / `overflow`) in place of `number | undefined`. Both look like improvements that `Monotonic` should absorb. Collapsing the two is a design decision that touches the live layout path, so it is not a cleanup and is not something this PR should do unilaterally.

**Neither new module has a production caller.** `layoutClaims.ts` and `layoutKernel.ts` are imported only by their own test files. #823 is explicit that this is intended, and the essay says so too, so this is a declared staging step rather than a hidden one. Worth noting that the law tests will stay green no matter what the real solver does, so they do not yet constrain shipping behavior. A tracked follow-up issue for the wiring would make the gap harder to lose.

**Seven of the twelve `ConflictKind` branches are unexercised.** `invalid-number`, `unknown-node`, `unknown-placed-port`, `placed-port-axis-mismatch`, `read-only-port-write`, and `inconsistent-placed-relation` have no test. (`paint-cycle` was the seventh; this PR covers it.) For a module whose whole point is to be proof-bearing, over half the validation surface is currently unproven.

One thing worth calling out positively: all four reviewers independently agreed that the `MIXED_MEASURE` change in `underlyingSpace.ts` is at the right depth. Making `undefined` the identity and `MIXED_MEASURE` the absorbing top turns the permissive fold into a proper join-semilattice, which is what actually fixes the `[A, A, B]` versus `[A, B, A]` ordering bug, and every call site was threaded through to `spaceMeasureState` rather than left on a shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)